### PR TITLE
Do not block folding of unsigned (and unordered) comparisons in value numbering

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -790,6 +790,29 @@ int ValueNumStore::EvalComparison<double>(VNFunc vnf, double v0, double v1)
                 break;
         }
     }
+    else // must be a VNF_ function
+    {
+        if (hasNanArg)
+        {
+            // unordered comparisons with NaNs always return true
+            return true;
+        }
+
+        switch (vnf)
+        {
+            case VNF_GT_UN:
+                return v0 > v1;
+            case VNF_GE_UN:
+                return v0 >= v1;
+            case VNF_LT_UN:
+                return v0 < v1;
+            case VNF_LE_UN:
+                return v0 <= v1;
+            default:
+                // For any other value of 'vnf', we will assert below
+                break;
+        }
+    }
     noway_assert(!"Unhandled operation in EvalComparison<double>");
     return 0;
 }
@@ -835,8 +858,8 @@ int ValueNumStore::EvalComparison<float>(VNFunc vnf, float v0, float v1)
     {
         if (hasNanArg)
         {
-            // always returns true
-            return false;
+            // unordered comparisons with NaNs always return true
+            return true;
         }
 
         switch (vnf)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1949,18 +1949,6 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
             canFold = false;
         }
 
-        // NaNs are unordered wrt to other floats. While an ordered
-        // comparison would return false, an unordered comparison
-        // will return true if any operands are a NaN. We only perform
-        // ordered NaN comparison in EvalComparison.
-        if ((arg0IsFloating && (((arg0VNtyp == TYP_FLOAT) && _isnanf(GetConstantSingle(arg0VN))) ||
-                                ((arg0VNtyp == TYP_DOUBLE) && _isnan(GetConstantDouble(arg0VN))))) ||
-            (arg1IsFloating && (((arg1VNtyp == TYP_FLOAT) && _isnanf(GetConstantSingle(arg1VN))) ||
-                                ((arg1VNtyp == TYP_DOUBLE) && _isnan(GetConstantDouble(arg1VN))))))
-        {
-            canFold = true;
-        }
-
         if (typ == TYP_BYREF)
         {
             // We don't want to fold expressions that produce TYP_BYREF

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1958,7 +1958,7 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
             (arg1IsFloating && (((arg1VNtyp == TYP_FLOAT) && _isnanf(GetConstantSingle(arg1VN))) ||
                                 ((arg1VNtyp == TYP_DOUBLE) && _isnan(GetConstantDouble(arg1VN))))))
         {
-            canFold = false;
+            canFold = true;
         }
 
         if (typ == TYP_BYREF)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3117,13 +3117,10 @@ bool ValueNumStore::CanEvalForConstantArgs(VNFunc vnf)
         // some VNF_ that we can evaluate
         switch (vnf)
         {
-            // Consider adding:
-            //   case VNF_GT_UN:
-            //   case VNF_GE_UN:
-            //   case VNF_LT_UN:
-            //   case VNF_LE_UN:
-            //
-
+            case VNF_GT_UN:
+            case VNF_GE_UN:
+            case VNF_LT_UN:
+            case VNF_LE_UN:
             case VNF_Cast:
                 // We can evaluate these.
                 return true;

--- a/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants.cs
+++ b/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants.cs
@@ -1,0 +1,766 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class ValueNumberingUnorderedComparisonsOfConstants
+{
+    private static readonly double _quietDoubleNaN = BitConverter.Int64BitsToDouble(unchecked((long)0xfff8000000000001));
+    private static readonly float _quietFloatNaN = BitConverter.Int32BitsToSingle(unchecked((int)0xffc00001));
+
+    private static int _counter = 100;
+
+    public static int Main()
+    {
+        // The conditions of the loops get reversed and duplicated.
+        // As part of this a comparison like a > b, which is really !IsNaN(a) && !IsNaN(b) && a > b
+        // Gets turned into IsNaN(a) || IsNaN(b) || a <= b.
+        // We are testing that the constant folding of these new unordered comparisons in VN is correct.
+
+        TestDoubleComparisonsEvaluatingToTrue();
+        TestSingleComparisonsEvaluatingToTrue();
+        TestDoubleComparisonsEvaluatingToFalse();
+        TestSingleComparisonsEvaluatingToFalse();
+
+        return _counter;
+    }
+
+    // We rely on these static readonly fields being constants at compile time.
+    // This means that by the time the test methods are being compiled, the static constructor must have run.
+    [ModuleInitializer]
+    internal static void InitializeNaNs() => RuntimeHelpers.RunClassConstructor(typeof(ValueNumberingUnorderedComparisonsOfConstants).TypeHandle);
+
+    private static void TestDoubleComparisonsEvaluatingToTrue()
+    {
+        // The following inverted conditions must be folded to "true".
+        // Meaning the loop body must never execute.
+
+        // Basic scenarios
+        // VNF_LT_UN
+        for (double i = 1.0; i >= 2.0; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = -3.0; i > 4.0; i++)
+            _counter++;
+        for (double i = 5.0; i > 5.0; i++)
+            _counter++;
+        for (double i = 0.0; i > -0.0; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (double i = 6.0; i <= -7.0; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = 8.0; i < -9.0; i++)
+            _counter++;
+        for (double i = 10.0; i < 10.0; i++)
+            _counter++;
+        for (double i = -0.0; i < 0.0; i++)
+            _counter++;
+
+        // Positive infinities on the lhs
+        // VNF_GT_UN
+        for (double i = double.PositiveInfinity; i <= 11.0; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = double.PositiveInfinity; i < 12.0; i++)
+            _counter++;
+
+        // Positive infinities on the rhs
+        // VNF_LT_UN
+        for (double i = 13.0; i >= double.PositiveInfinity; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = -14.0; i > double.PositiveInfinity; i++)
+            _counter++;
+
+        // Positive infinities on both sides
+        // VNF_LE_UN
+        for (double i = double.PositiveInfinity; i > double.PositiveInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = double.PositiveInfinity; i < double.PositiveInfinity; i++)
+            _counter++;
+
+        // Negative infinities on the lhs
+        // VNF_LT_UN
+        for (double i = double.NegativeInfinity; i >= 15.0; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = double.NegativeInfinity; i > 16.0; i++)
+            _counter++;
+
+        // Negative infinities on the rhs
+        // VNF_GT_UN
+        for (double i = 17.0; i <= double.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = 18.0; i < double.NegativeInfinity; i++)
+            _counter++;
+
+        // Negative infinities on both sides
+        // VNF_LE_UN
+        for (double i = double.NegativeInfinity; i > double.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = double.NegativeInfinity; i < double.NegativeInfinity; i++)
+            _counter++;
+
+        // NaN on the lhs
+        // VNF_LT_UN
+        for (double i = double.NaN; i >= 19.0; i++)
+            _counter++;
+        for (double i = double.NaN; i >= double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = double.NaN; i >= double.NegativeInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i >= 19.0; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i >= double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i >= double.NegativeInfinity; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = double.NaN; i > 20.0; i++)
+            _counter++;
+        for (double i = double.NaN; i > double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = double.NaN; i > double.NegativeInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i > 20.0; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i > double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i > double.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (double i = double.NaN; i <= -21.0; i++)
+            _counter++;
+        for (double i = double.NaN; i <= double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = double.NaN; i <= double.NegativeInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i <= -21.0; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i <= double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i <= double.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = double.NaN; i < 22.0; i++)
+            _counter++;
+        for (double i = double.NaN; i < double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = double.NaN; i < double.NegativeInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i < 22.0; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i < double.PositiveInfinity; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i < double.NegativeInfinity; i++)
+            _counter++;
+
+        // NaN on the rhs
+        // VNF_LT_UN
+        for (double i = 23.0; i >= double.NaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i >= double.NaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i >= double.NaN; i++)
+            _counter++;
+        for (double i = 23.0; i >= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i >= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i >= _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = -24.0; i > double.NaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i > double.NaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i > double.NaN; i++)
+            _counter++;
+        for (double i = -24.0; i > _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i > _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i > _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (double i = 25.0; i <= double.NaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i <= double.NaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i <= double.NaN; i++)
+            _counter++;
+        for (double i = 25.0; i <= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i <= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i <= _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = 26.0; i < double.NaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i < double.NaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i < double.NaN; i++)
+            _counter++;
+        for (double i = 26.0; i < _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.NegativeInfinity; i < _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = double.PositiveInfinity; i < _quietDoubleNaN; i++)
+            _counter++;
+
+        // NaN on both sides
+        // VNF_LT_UN
+        for (double i = double.NaN; i >= double.NaN; i++)
+            _counter++;
+        for (double i = double.NaN; i >= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i >= double.NaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i >= _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (double i = double.NaN; i > double.NaN; i++)
+            _counter++;
+        for (double i = double.NaN; i > _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i > double.NaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i > _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (double i = double.NaN; i <= double.NaN; i++)
+            _counter++;
+        for (double i = double.NaN; i <= _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i <= double.NaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i <= _quietDoubleNaN; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (double i = double.NaN; i < double.NaN; i++)
+            _counter++;
+        for (double i = double.NaN; i < _quietDoubleNaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i < double.NaN; i++)
+            _counter++;
+        for (double i = _quietDoubleNaN; i < _quietDoubleNaN; i++)
+            _counter++;
+    }
+
+    private static void TestSingleComparisonsEvaluatingToTrue()
+    {
+        // The following inverted conditions must be folded to "true".
+        // Meaning the loop body must never execute.
+
+        // Basic scenarios
+        // VNF_LT_UN
+        for (float i = 27.0f; i >= 28.0f; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = -29.0f; i > 30.0f; i++)
+            _counter++;
+        for (float i = 31.0f; i > 31.0f; i++)
+            _counter++;
+        for (float i = 0.0f; i > -0.0f; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (float i = 32.0f; i <= -33.0f; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = 34.0f; i < -35.0f; i++)
+            _counter++;
+        for (float i = 36.0f; i < 36.0f; i++)
+            _counter++;
+        for (float i = -0.0f; i < 0.0f; i++)
+            _counter++;
+
+        // Positive infinities on the lhs
+        // VNF_GT_UN
+        for (float i = float.PositiveInfinity; i <= 37.0f; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = float.PositiveInfinity; i < 38.0f; i++)
+            _counter++;
+
+        // Positive infinities on the rhs
+        // VNF_LT_UN
+        for (float i = 39.0f; i >= float.PositiveInfinity; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = -40.0f; i > float.PositiveInfinity; i++)
+            _counter++;
+
+        // Positive infinities on both sides
+        // VNF_LE_UN
+        for (float i = float.PositiveInfinity; i > float.PositiveInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = float.PositiveInfinity; i < float.PositiveInfinity; i++)
+            _counter++;
+
+        // Negative infinities on the lhs
+        // VNF_LT_UN
+        for (float i = float.NegativeInfinity; i >= 41.0f; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = float.NegativeInfinity; i > 42.0f; i++)
+            _counter++;
+
+        // Negative infinities on the rhs
+        // VNF_GT_UN
+        for (float i = 43.0f; i <= float.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = 44.0f; i < float.NegativeInfinity; i++)
+            _counter++;
+
+        // Negative infinities on both sides
+        // VNF_LE_UN
+        for (float i = float.NegativeInfinity; i > float.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = float.NegativeInfinity; i < float.NegativeInfinity; i++)
+            _counter++;
+
+        // NaN on the lhs
+        // VNF_LT_UN
+        for (float i = float.NaN; i >= 45.0f; i++)
+            _counter++;
+        for (float i = float.NaN; i >= float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = float.NaN; i >= float.NegativeInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i >= 45.0f; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i >= float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i >= float.NegativeInfinity; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = float.NaN; i > 46.0f; i++)
+            _counter++;
+        for (float i = float.NaN; i > float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = float.NaN; i > float.NegativeInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i > 46.0f; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i > float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i > float.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (float i = float.NaN; i <= -47.0f; i++)
+            _counter++;
+        for (float i = float.NaN; i <= float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = float.NaN; i <= float.NegativeInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i <= -47.0f; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i <= float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i <= float.NegativeInfinity; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = float.NaN; i < 48.0f; i++)
+            _counter++;
+        for (float i = float.NaN; i < float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = float.NaN; i < float.NegativeInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i < 48.0f; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i < float.PositiveInfinity; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i < float.NegativeInfinity; i++)
+            _counter++;
+
+        // NaN on the rhs
+        // VNF_LT_UN
+        for (float i = 49.0f; i >= float.NaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i >= float.NaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i >= float.NaN; i++)
+            _counter++;
+        for (float i = 49.0f; i >= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i >= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i >= _quietFloatNaN; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = -50.0f; i > float.NaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i > float.NaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i > float.NaN; i++)
+            _counter++;
+        for (float i = -50.0f; i > _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i > _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i > _quietFloatNaN; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (float i = 51.0f; i <= float.NaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i <= float.NaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i <= float.NaN; i++)
+            _counter++;
+        for (float i = 51.0f; i <= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i <= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i <= _quietFloatNaN; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = 52.0f; i < float.NaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i < float.NaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i < float.NaN; i++)
+            _counter++;
+        for (float i = 52.0f; i < _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.NegativeInfinity; i < _quietFloatNaN; i++)
+            _counter++;
+        for (float i = float.PositiveInfinity; i < _quietFloatNaN; i++)
+            _counter++;
+
+        // NaN on both sides
+        // VNF_LT_UN
+        for (float i = float.NaN; i >= float.NaN; i++)
+            _counter++;
+        for (float i = float.NaN; i >= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i >= float.NaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i >= _quietFloatNaN; i++)
+            _counter++;
+        // VNF_LE_UN
+        for (float i = float.NaN; i > float.NaN; i++)
+            _counter++;
+        for (float i = float.NaN; i > _quietFloatNaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i > float.NaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i > _quietFloatNaN; i++)
+            _counter++;
+        // VNF_GT_UN
+        for (float i = float.NaN; i <= float.NaN; i++)
+            _counter++;
+        for (float i = float.NaN; i <= _quietFloatNaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i <= float.NaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i <= _quietFloatNaN; i++)
+            _counter++;
+        // VNF_GE_UN
+        for (float i = float.NaN; i < float.NaN; i++)
+            _counter++;
+        for (float i = float.NaN; i < _quietFloatNaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i < float.NaN; i++)
+            _counter++;
+        for (float i = _quietFloatNaN; i < _quietFloatNaN; i++)
+            _counter++;
+    }
+
+    private static void TestDoubleComparisonsEvaluatingToFalse()
+    {
+        // The following inverted conditions must be folded to "true".
+        // Meaning the loop body must execute.
+        // The "i = double.NaN" pattern is equivalent to "break".
+        // We use it here as it is less likely to be optimized in the future before the loop condition is duplicated.
+
+        // Basic scenarios
+        // VNF_LT_UN
+        for (double i = 54.0; i >= 53.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        for (double i = 55.0; i >= 55.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (double i = 56.0; i > -57.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (double i = -58.0; i <= 59.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        for (double i = -60.0; i <= -60.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (double i = -62.0; i < 61.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on the lhs
+        // VNF_LT_UN
+        for (double i = double.PositiveInfinity; i >= 63.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (double i = double.PositiveInfinity; i > -64.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on the rhs
+        // VNF_GT_UN
+        for (double i = -65.0; i <= double.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (double i = -66.0; i < double.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on both sides
+        // VNF_LT_UN
+        for (double i = double.PositiveInfinity; i >= double.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (double i = double.PositiveInfinity; i <= double.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on the lhs
+        // VNF_GT_UN
+        for (double i = double.NegativeInfinity; i <= 67.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (double i = double.NegativeInfinity; i < 68.0; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on the rhs
+        // VNF_LT_UN
+        for (double i = 69.0; i >= double.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (double i = 70.0; i > double.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on both sides
+        // VNF_LT_UN
+        for (double i = double.NegativeInfinity; i >= double.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (double i = double.NegativeInfinity; i <= double.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = double.NaN;
+        }
+        _counter--;
+    }
+
+    private static void TestSingleComparisonsEvaluatingToFalse()
+    {
+        // The following inverted conditions must be folded to "true".
+        // Meaning the loop body must execute.
+        // The "i = float.NaN" pattern is equivalent to "break".
+        // We use it here as it is less likely to be optimized in the future before the loop condition is duplicated.
+
+        // Basic scenarios
+        // VNF_LT_UN
+        for (float i = 71.0f; i >= 70.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        for (float i = 72.0f; i >= 72.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (float i = 73.0f; i > -74.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (float i = -75.0f; i <= 76.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        for (float i = -77.0f; i <= -77.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (float i = -79.0f; i < 78.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on the lhs
+        // VNF_LT_UN
+        for (float i = float.PositiveInfinity; i >= 80.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (float i = float.PositiveInfinity; i > -81.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on the rhs
+        // VNF_GT_UN
+        for (float i = -82.0f; i <= float.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (float i = -83.0f; i < float.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Positive infinities on both sides
+        // VNF_LT_UN
+        for (float i = float.PositiveInfinity; i >= float.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (float i = float.PositiveInfinity; i <= float.PositiveInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on the lhs
+        // VNF_GT_UN
+        for (float i = float.NegativeInfinity; i <= 84.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GE_UN
+        for (float i = float.NegativeInfinity; i < 85.0f; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on the rhs
+        // VNF_LT_UN
+        for (float i = 86.0f; i >= float.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_LE_UN
+        for (float i = 87.0f; i > float.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+
+        // Negative infinities on both sides
+        // VNF_LT_UN
+        for (float i = float.NegativeInfinity; i >= float.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+        // VNF_GT_UN
+        for (float i = float.NegativeInfinity; i <= float.NegativeInfinity; i++)
+        {
+            _counter++;
+            i = float.NaN;
+        }
+        _counter--;
+    }
+}

--- a/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants_ro.csproj
+++ b/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants_ro.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="value_numbering_unordered_comparisons_of_constants.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.il
@@ -2,10 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 .assembly extern legacy library mscorlib {}
-
-
-
 .assembly extern ConvDLL{}
+
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
 
 .method public static	int32 main(class [mscorlib]System.String[]) {
 .entrypoint
@@ -606,6 +613,457 @@ SS:
 	ldfld float32 [ConvDLL]ConvDLL::NaN_r4
 	ldloc 0
 	ldfld float32 [ConvDLL]ConvDLL::NaN_r4
+	bge.un L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	bge.un L1
+	br FAIL
+
+L1:
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	bge.un L2
+	br FAIL
+
+L2:
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	bge.un L3
+	br FAIL
+
+L3:
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	bge.un L4
+	br FAIL
+
+L4:
+	ldc.r4		POS_INF
+	ldc.r4		float32(0x80000000)
+	bge.un L5
+	br FAIL
+
+L5:
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	bge.un L6
+	br FAIL
+
+L6:
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	bge.un L7
+	br FAIL
+
+L7:
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	bge.un L8
+	br FAIL
+
+L8:
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	bge.un L9
+	br FAIL
+
+
+L9:
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	bge.un L10
+
+	ldc.r4		MAX
+	ldc.r4		MAX
+	bge.un L10
+	br FAIL
+
+L10:
+	ldc.r4		MAX
+	ldc.r4		ONE
+	bge.un L11
+	br FAIL
+
+L11:
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	bge.un L12
+	br FAIL
+
+L12:
+	ldc.r4		MAX
+	ldc.r4		float32(0x80000000)
+	bge.un L13
+	br FAIL
+
+L13:
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	bge.un L14
+	br FAIL
+
+L14:
+	ldc.r4		MAX
+	ldc.r4		MIN
+	bge.un L15
+	br FAIL
+
+L15:
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	bge.un L16
+	br FAIL
+
+L16:
+	ldc.r4		MAX
+	ldc.r4		NAN
+	bge.un L17
+	br FAIL
+
+
+
+L17:
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	bge.un L18
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	bge.un L18
+
+	ldc.r4		ONE
+	ldc.r4		ONE
+	bge.un L18
+	br FAIL
+
+L18:
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	bge.un L19
+	br FAIL
+
+L19:
+	ldc.r4		ONE
+	ldc.r4		float32(0x80000000)
+	bge.un L20
+	br FAIL
+
+L20:
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	bge.un L21
+	br FAIL
+
+L21:
+	ldc.r4		ONE
+	ldc.r4		MIN
+	bge.un L22
+	br FAIL
+
+L22:
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	bge.un L23
+	br FAIL
+
+L23:
+	ldc.r4		ONE
+	ldc.r4		NAN
+	bge.un L24
+	br FAIL
+
+
+
+L24:
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	bge.un L25
+
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	bge.un L25
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	bge.un L25
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	bge.un L25
+	br FAIL
+
+L25:
+	ldc.r4		ZERO
+	ldc.r4		float32(0x80000000)
+	bge.un L26
+	br FAIL
+
+L26:
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	bge.un L27
+	br FAIL
+
+L27:
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	bge.un L28
+	br FAIL
+
+L28:
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	bge.un L29
+	br FAIL
+
+L29:
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	bge.un L30
+	br FAIL
+
+
+
+L30:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		POS_INF
+	bge.un L31
+
+	ldc.r4		float32(0x80000000)
+	ldc.r4		MAX
+	bge.un L31
+
+	ldc.r4		float32(0x80000000)
+	ldc.r4		ONE
+	bge.un L31
+
+	ldc.r4		float32(0x80000000)
+	ldc.r4		ZERO
+	bge.un L31
+	br FAIL
+
+L31:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x80000000)
+	bge.un L32
+	br FAIL
+
+L32:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		MINUS_ONE
+	bge.un L33
+	br FAIL
+
+L33:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		MIN
+	bge.un L34
+	br FAIL
+
+L34:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		NEG_INF
+	bge.un L35
+	br FAIL
+
+L35:
+	ldc.r4		float32(0x80000000)
+	ldc.r4		NAN
+	bge.un L36
+	br FAIL
+
+
+
+L36:
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	bge.un L37
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	bge.un L37
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	bge.un L37
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	bge.un L37
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		float32(0x80000000)
+	bge.un L37
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	bge.un L37
+	br FAIL
+
+L37:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	bge.un L38
+	br FAIL
+
+L38:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	bge.un L39
+	br FAIL
+
+L39:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	bge.un L40
+	br FAIL
+
+
+
+L40:
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		MAX
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		ONE
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		float32(0x80000000)
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	bge.un L41
+
+	ldc.r4		MIN
+	ldc.r4		MIN
+	bge.un L41
+	br FAIL
+
+L41:
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	bge.un L42
+	br FAIL
+
+L42:
+	ldc.r4		MIN
+	ldc.r4		NAN
+	bge.un L43
+	br FAIL
+
+
+
+
+L43:
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		float32(0x80000000)
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	bge.un L44
+
+	ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	bge.un L44
+	br FAIL
+
+L44:
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	bge.un L45
+	br FAIL
+
+
+
+
+L45:
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	bge.un L46
+	br FAIL
+
+L46:
+	ldc.r4		NAN
+	ldc.r4		MAX
+	bge.un L47
+	br FAIL
+
+L47:
+	ldc.r4		NAN
+	ldc.r4		ONE
+	bge.un L48
+	br FAIL
+
+L48:
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	bge.un L49
+	br FAIL
+
+L49:
+	ldc.r4		NAN
+	ldc.r4		float32(0x80000000)
+	bge.un L50
+	br FAIL
+
+L50:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	bge.un L51
+	br FAIL
+
+L51:
+	ldc.r4		NAN
+	ldc.r4		MIN
+	bge.un L52
+	br FAIL
+
+L52:
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	bge.un L53
+	br FAIL
+
+L53:
+	ldc.r4		NAN
+	ldc.r4		NAN
 	bge.un BACKCHECK
 	br FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.il
@@ -2,10 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 .assembly extern legacy library mscorlib {}
-
-
-
 .assembly extern ConvDLL{}
+
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
 
 .method public static	int32 main(class [mscorlib]System.String[]) {
 .entrypoint
@@ -88,7 +95,8 @@ H:
 	br FAIL
 
 
-_H:	ldloc 0
+_H:
+	ldloc 0
 	ldfld float64 [ConvDLL]ConvDLL::max_r8
 	ldloc 0
 	ldfld float64 [ConvDLL]ConvDLL::inf_r8
@@ -605,6 +613,457 @@ SS:
 	ldfld float64 [ConvDLL]ConvDLL::NaN_r8
 	ldloc 0
 	ldfld float64 [ConvDLL]ConvDLL::NaN_r8
+	bge.un L0
+	br FAIL
+
+    // Testing early folding logic
+
+L0:
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	bge.un L1
+	br FAIL
+
+L1:
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	bge.un L2
+	br FAIL
+
+L2:
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	bge.un L3
+	br FAIL
+
+L3:
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	bge.un L4
+	br FAIL
+
+L4:
+	ldc.r8		POS_INF
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L5
+	br FAIL
+
+L5:
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	bge.un L6
+	br FAIL
+
+L6:
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	bge.un L7
+	br FAIL
+
+L7:
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	bge.un L8
+	br FAIL
+
+L8:
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	bge.un L9
+	br FAIL
+
+
+L9:
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	bge.un L10
+
+	ldc.r8		MAX
+	ldc.r8		MAX
+	bge.un L10
+	br FAIL
+
+L10:
+	ldc.r8		MAX
+	ldc.r8		ONE
+	bge.un L11
+	br FAIL
+
+L11:
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	bge.un L12
+	br FAIL
+
+L12:
+	ldc.r8		MAX
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L13
+	br FAIL
+
+L13:
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	bge.un L14
+	br FAIL
+
+L14:
+	ldc.r8		MAX
+	ldc.r8		MIN
+	bge.un L15
+	br FAIL
+
+L15:
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	bge.un L16
+	br FAIL
+
+L16:
+	ldc.r8		MAX
+	ldc.r8		NAN
+	bge.un L17
+	br FAIL
+
+
+
+L17:
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	bge.un L18
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	bge.un L18
+
+	ldc.r8		ONE
+	ldc.r8		ONE
+	bge.un L18
+	br FAIL
+
+L18:
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	bge.un L19
+	br FAIL
+
+L19:
+	ldc.r8		ONE
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L20
+	br FAIL
+
+L20:
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	bge.un L21
+	br FAIL
+
+L21:
+	ldc.r8		ONE
+	ldc.r8		MIN
+	bge.un L22
+	br FAIL
+
+L22:
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	bge.un L23
+	br FAIL
+
+L23:
+	ldc.r8		ONE
+	ldc.r8		NAN
+	bge.un L24
+	br FAIL
+
+
+
+L24:
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	bge.un L25
+
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	bge.un L25
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	bge.un L25
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	bge.un L25
+	br FAIL
+
+L25:
+	ldc.r8		ZERO
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L26
+	br FAIL
+
+L26:
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	bge.un L27
+	br FAIL
+
+L27:
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	bge.un L28
+	br FAIL
+
+L28:
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	bge.un L29
+	br FAIL
+
+L29:
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	bge.un L30
+	br FAIL
+
+
+
+L30:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		POS_INF
+	bge.un L31
+
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		MAX
+	bge.un L31
+
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		ONE
+	bge.un L31
+
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		ZERO
+	bge.un L31
+	br FAIL
+
+L31:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L32
+	br FAIL
+
+L32:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		MINUS_ONE
+	bge.un L33
+	br FAIL
+
+L33:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		MIN
+	bge.un L34
+	br FAIL
+
+L34:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		NEG_INF
+	bge.un L35
+	br FAIL
+
+L35:
+	ldc.r8		float64(0x8000000000000000)
+	ldc.r8		NAN
+	bge.un L36
+	br FAIL
+
+
+
+L36:
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	bge.un L37
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	bge.un L37
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	bge.un L37
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	bge.un L37
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L37
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	bge.un L37
+	br FAIL
+
+L37:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	bge.un L38
+	br FAIL
+
+L38:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	bge.un L39
+	br FAIL
+
+L39:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	bge.un L40
+	br FAIL
+
+
+
+L40:
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		MAX
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		ONE
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	bge.un L41
+
+	ldc.r8		MIN
+	ldc.r8		MIN
+	bge.un L41
+	br FAIL
+
+L41:
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	bge.un L42
+	br FAIL
+
+L42:
+	ldc.r8		MIN
+	ldc.r8		NAN
+	bge.un L43
+	br FAIL
+
+
+
+
+L43:
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	bge.un L44
+
+	ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	bge.un L44
+	br FAIL
+
+L44:
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	bge.un L45
+	br FAIL
+
+
+
+
+L45:
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	bge.un L46
+	br FAIL
+
+L46:
+	ldc.r8		NAN
+	ldc.r8		MAX
+	bge.un L47
+	br FAIL
+
+L47:
+	ldc.r8		NAN
+	ldc.r8		ONE
+	bge.un L48
+	br FAIL
+
+L48:
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	bge.un L49
+	br FAIL
+
+L49:
+	ldc.r8		NAN
+	ldc.r8		float64(0x8000000000000000)
+	bge.un L50
+	br FAIL
+
+L50:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	bge.un L51
+	br FAIL
+
+L51:
+	ldc.r8		NAN
+	ldc.r8		MIN
+	bge.un L52
+	br FAIL
+
+L52:
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	bge.un L53
+	br FAIL
+
+L53:
+	ldc.r8		NAN
+	ldc.r8		NAN
 	bge.un BACKCHECK
 	br FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r4.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
 
 .class public bgt_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 bgt_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 bgt_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 bgt_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 bgt_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 bgt_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 bgt_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 bgt_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 bgt_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 bgt_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 bgt_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 bgt_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 bgt_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 bgt_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 bgt_un::NaN
 	ret
 }
@@ -44,189 +53,189 @@
 .maxstack		10
 	call	void bgt_un::initialize()
 
-	ldsfld	float32 bgt_un::_inf
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::neg_inf
+	ldsfld	float32 bgt_un::min
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::neg_inf
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::neg_inf
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	ldsfld	float32 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	ldsfld	float32 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	ldsfld	float32 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::neg_inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	ldsfld	float32 bgt_un::NaN
 	bgt.un A
 	br FAIL
 A:
-	ldsfld	float32 bgt_un::_min
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::min
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un B
 	br FAIL
 
 B:
-	ldsfld	float32 bgt_un::_min
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
+	ldsfld	float32 bgt_un::min
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::min
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::min
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	ldsfld	float32 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	ldsfld	float32 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	ldsfld	float32 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::min
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	ldsfld	float32 bgt_un::NaN
 	bgt.un C
 	br FAIL
 
 
 C:
-	ldsfld	float32 bgt_un::_one
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::minus_one
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un D
 	br FAIL
 
 D:
-	ldsfld	float32 bgt_un::_one
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::minus_one
+	ldsfld	float32 bgt_un::min
 	bgt.un E
 	br FAIL
 
 E:
-	ldsfld	float32 bgt_un::_one
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_one
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	ldsfld	float32 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	ldsfld	float32 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	ldsfld	float32 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::minus_one
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	ldsfld	float32 bgt_un::NaN
 	bgt.un F
 	br FAIL
 F:
-	ldsfld	float32 bgt_un::_zero
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::minus_zero
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un G
 	br FAIL
 
 G:
-	ldsfld	float32 bgt_un::_zero
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::minus_zero
+	ldsfld	float32 bgt_un::min
 	bgt.un H
 	br FAIL
 
 H:
-	ldsfld	float32 bgt_un::_zero
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_zero
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un I
 	br FAIL
 
 I:
-	ldsfld	float32 bgt_un::_zero
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	ldsfld	float32 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	ldsfld	float32 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	ldsfld	float32 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_zero
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::minus_zero
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	ldsfld	float32 bgt_un::NaN
 	bgt.un J
 	br FAIL
 
 J:
 	ldsfld	float32 bgt_un::zero
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un K
 	br FAIL
 
 K:
 	ldsfld	float32 bgt_un::zero
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	bgt.un L
 	br FAIL
 
 L:
 	ldsfld	float32 bgt_un::zero
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un M
 	br FAIL
 
 M:
 	ldsfld	float32 bgt_un::zero
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::zero
@@ -242,7 +251,7 @@ M:
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::zero
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::zero
@@ -252,25 +261,25 @@ M:
 
 N:
 	ldsfld	float32 bgt_un::one
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un O
 	br FAIL
 
 O:
 	ldsfld	float32 bgt_un::one
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	bgt.un P
 	br FAIL
 
 P:
 	ldsfld	float32 bgt_un::one
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un Q
 	br FAIL
 
 Q:
 	ldsfld	float32 bgt_un::one
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un R
 	br FAIL
 
@@ -290,7 +299,7 @@ S:
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::one
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::one
@@ -300,25 +309,25 @@ S:
 
 T:
 	ldsfld	float32 bgt_un::max
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un U
 	br FAIL
 
 U:
 	ldsfld	float32 bgt_un::max
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	bgt.un V
 	br FAIL
 
 V:
 	ldsfld	float32 bgt_un::max
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un W
 	br FAIL
 
 W:
 	ldsfld	float32 bgt_un::max
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un X
 	br FAIL
 
@@ -340,7 +349,7 @@ Z:
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::max
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float32 bgt_un::max
@@ -349,78 +358,78 @@ Z:
 	br FAIL
 
 AA:
-	ldsfld	float32 bgt_un::inf
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::pos_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un BB
 	br FAIL
 
 BB:
-	ldsfld	float32 bgt_un::inf
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::pos_inf
+	ldsfld	float32 bgt_un::min
 	bgt.un CC
 	br FAIL
 
 CC:
-	ldsfld	float32 bgt_un::inf
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::pos_inf
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un DD
 	br FAIL
 
 DD:
-	ldsfld	float32 bgt_un::inf
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::pos_inf
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un EE
 	br FAIL
 
 EE:
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	ldsfld	float32 bgt_un::zero
 	bgt.un FF
 	br FAIL
 
 FF:
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	ldsfld	float32 bgt_un::one
 	bgt.un GG
 	br FAIL
 
 GG:
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	ldsfld	float32 bgt_un::max
 	bgt.un HH
 	br FAIL
 
 HH:
-	ldsfld	float32 bgt_un::inf
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	ldsfld	float32 bgt_un::NaN
 	bgt.un II
 	br FAIL
 
 II:
 	ldsfld	float32 bgt_un::NaN
-	ldsfld	float32 bgt_un::_inf
+	ldsfld	float32 bgt_un::neg_inf
 	bgt.un JJ
 	br FAIL
 
 JJ:
 	ldsfld	float32 bgt_un::NaN
-	ldsfld	float32 bgt_un::_min
+	ldsfld	float32 bgt_un::min
 	bgt.un KK
 	br FAIL
 
 KK:
 	ldsfld	float32 bgt_un::NaN
-	ldsfld	float32 bgt_un::_one
+	ldsfld	float32 bgt_un::minus_one
 	bgt.un LL
 	br FAIL
 
 LL:
 	ldsfld	float32 bgt_un::NaN
-	ldsfld	float32 bgt_un::_zero
+	ldsfld	float32 bgt_un::minus_zero
 	bgt.un MM
 	br FAIL
 
@@ -444,14 +453,428 @@ OO:
 
 PP:
 	ldsfld	float32 bgt_un::NaN
-	ldsfld	float32 bgt_un::inf
+	ldsfld	float32 bgt_un::pos_inf
 	bgt.un QQ
 	br FAIL
 
 QQ:
 	ldsfld	float32 bgt_un::NaN
 	ldsfld	float32 bgt_un::NaN
-	bgt.un  BACKCHECK
+	bgt.un  L0
+	br FAIL
+
+    // Testing early folding logic
+
+L0:
+	ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	bgt.un L1
+	br FAIL
+
+L1:
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	bgt.un L2
+	br FAIL
+
+L2:
+	ldc.r4		MIN
+	ldc.r4		MIN
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		NAN
+	bgt.un L3
+	br FAIL
+
+L3:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	bgt.un L4
+	br FAIL
+
+L4:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	bgt.un L5
+	br FAIL
+
+L5:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	bgt.un L6
+	br FAIL
+
+L6:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	bgt.un L7
+	br FAIL
+
+L7:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	bgt.un L8
+	br FAIL
+
+L8:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	bgt.un L9
+	br FAIL
+
+L9:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	bgt.un L10
+	br FAIL
+
+L10:
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	bgt.un L11
+	br FAIL
+
+L11:
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	bgt.un L12
+	br FAIL
+
+L12:
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	bgt.un L13
+	br FAIL
+
+L13:
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	bgt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	bgt.un L14
+	br FAIL
+
+L14:
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	bgt.un L15
+	br FAIL
+
+L15:
+	ldc.r4		ONE
+	ldc.r4		MIN
+	bgt.un L16
+	br FAIL
+
+L16:
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	bgt.un L17
+	br FAIL
+
+L17:
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	bgt.un L18
+	br FAIL
+
+L18:
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	bgt.un L19
+	br FAIL
+
+L19:
+	ldc.r4		ONE
+	ldc.r4		ONE
+	bgt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		NAN
+	bgt.un L20
+	br FAIL
+
+L20:
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	bgt.un L21
+	br FAIL
+
+L21:
+	ldc.r4		MAX
+	ldc.r4		MIN
+	bgt.un L22
+	br FAIL
+
+L22:
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	bgt.un L23
+	br FAIL
+
+L23:
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	bgt.un L24
+	br FAIL
+
+L24:
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	bgt.un L25
+	br FAIL
+
+L25:
+	ldc.r4		MAX
+	ldc.r4		ONE
+	bgt.un L26
+	br FAIL
+
+L26:
+	ldc.r4		MAX
+	ldc.r4		MAX
+	bgt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		NAN
+	bgt.un L27
+	br FAIL
+
+L27:
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	bgt.un L28
+	br FAIL
+
+L28:
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	bgt.un L29
+	br FAIL
+
+L29:
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	bgt.un L30
+	br FAIL
+
+L30:
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	bgt.un L31
+	br FAIL
+
+L31:
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	bgt.un L32
+	br FAIL
+
+L32:
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	bgt.un L33
+	br FAIL
+
+L33:
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	bgt.un L34
+	br FAIL
+
+L34:
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	bgt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	bgt.un L35
+	br FAIL
+
+L35:
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	bgt.un L36
+	br FAIL
+
+L36:
+	ldc.r4		NAN
+	ldc.r4		MIN
+	bgt.un L37
+	br FAIL
+
+L37:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	bgt.un L38
+	br FAIL
+
+L38:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	bgt.un L39
+	br FAIL
+
+L39:
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	bgt.un L40
+	br FAIL
+
+L40:
+	ldc.r4		NAN
+	ldc.r4		ONE
+	bgt.un L41
+	br FAIL
+
+L41:
+	ldc.r4		NAN
+	ldc.r4		MAX
+	bgt.un L42
+	br FAIL
+
+L42:
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	bgt.un L43
+	br FAIL
+
+L43:
+	ldc.r4		NAN
+	ldc.r4		NAN
+	bgt.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r8.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
 
 .class public bgt_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 bgt_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 bgt_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 bgt_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 bgt_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 bgt_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 bgt_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 bgt_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 bgt_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 bgt_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 bgt_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 bgt_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 bgt_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 bgt_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 bgt_un::NaN
 	ret
 }
@@ -44,189 +53,189 @@
 .maxstack		10
 	call	void bgt_un::initialize()
 
-	ldsfld	float64 bgt_un::_inf
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::neg_inf
+	ldsfld	float64 bgt_un::min
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::neg_inf
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::neg_inf
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	ldsfld	float64 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	ldsfld	float64 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	ldsfld	float64 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::neg_inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	ldsfld	float64 bgt_un::NaN
 	bgt.un A
 	br FAIL
 A:
-	ldsfld	float64 bgt_un::_min
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::min
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un B
 	br FAIL
 
 B:
-	ldsfld	float64 bgt_un::_min
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
+	ldsfld	float64 bgt_un::min
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::min
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::min
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	ldsfld	float64 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	ldsfld	float64 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	ldsfld	float64 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::min
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	ldsfld	float64 bgt_un::NaN
 	bgt.un C
 	br FAIL
 
 
 C:
-	ldsfld	float64 bgt_un::_one
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::minus_one
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un D
 	br FAIL
 
 D:
-	ldsfld	float64 bgt_un::_one
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::minus_one
+	ldsfld	float64 bgt_un::min
 	bgt.un E
 	br FAIL
 
 E:
-	ldsfld	float64 bgt_un::_one
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_one
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	ldsfld	float64 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	ldsfld	float64 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	ldsfld	float64 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::minus_one
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	ldsfld	float64 bgt_un::NaN
 	bgt.un F
 	br FAIL
 F:
-	ldsfld	float64 bgt_un::_zero
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::minus_zero
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un G
 	br FAIL
 
 G:
-	ldsfld	float64 bgt_un::_zero
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::minus_zero
+	ldsfld	float64 bgt_un::min
 	bgt.un H
 	br FAIL
 
 H:
-	ldsfld	float64 bgt_un::_zero
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_zero
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un I
 	br FAIL
 
 I:
-	ldsfld	float64 bgt_un::_zero
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	ldsfld	float64 bgt_un::zero
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	ldsfld	float64 bgt_un::one
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	ldsfld	float64 bgt_un::max
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_zero
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::minus_zero
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	ldsfld	float64 bgt_un::NaN
 	bgt.un J
 	br FAIL
 
 J:
 	ldsfld	float64 bgt_un::zero
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un K
 	br FAIL
 
 K:
 	ldsfld	float64 bgt_un::zero
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	bgt.un L
 	br FAIL
 
 L:
 	ldsfld	float64 bgt_un::zero
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un M
 	br FAIL
 
 M:
 	ldsfld	float64 bgt_un::zero
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::zero
@@ -242,7 +251,7 @@ M:
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::zero
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::zero
@@ -252,25 +261,25 @@ M:
 
 N:
 	ldsfld	float64 bgt_un::one
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un O
 	br FAIL
 
 O:
 	ldsfld	float64 bgt_un::one
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	bgt.un P
 	br FAIL
 
 P:
 	ldsfld	float64 bgt_un::one
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un Q
 	br FAIL
 
 Q:
 	ldsfld	float64 bgt_un::one
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un R
 	br FAIL
 
@@ -290,7 +299,7 @@ S:
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::one
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::one
@@ -300,25 +309,25 @@ S:
 
 T:
 	ldsfld	float64 bgt_un::max
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un U
 	br FAIL
 
 U:
 	ldsfld	float64 bgt_un::max
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	bgt.un V
 	br FAIL
 
 V:
 	ldsfld	float64 bgt_un::max
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un W
 	br FAIL
 
 W:
 	ldsfld	float64 bgt_un::max
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un X
 	br FAIL
 
@@ -340,7 +349,7 @@ Z:
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::max
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
 	ldsfld	float64 bgt_un::max
@@ -349,78 +358,78 @@ Z:
 	br FAIL
 
 AA:
-	ldsfld	float64 bgt_un::inf
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::pos_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un BB
 	br FAIL
 
 BB:
-	ldsfld	float64 bgt_un::inf
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::pos_inf
+	ldsfld	float64 bgt_un::min
 	bgt.un CC
 	br FAIL
 
 CC:
-	ldsfld	float64 bgt_un::inf
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::pos_inf
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un DD
 	br FAIL
 
 DD:
-	ldsfld	float64 bgt_un::inf
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::pos_inf
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un EE
 	br FAIL
 
 EE:
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	ldsfld	float64 bgt_un::zero
 	bgt.un FF
 	br FAIL
 
 FF:
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	ldsfld	float64 bgt_un::one
 	bgt.un GG
 	br FAIL
 
 GG:
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	ldsfld	float64 bgt_un::max
 	bgt.un HH
 	br FAIL
 
 HH:
-	ldsfld	float64 bgt_un::inf
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un FAIL
 
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	ldsfld	float64 bgt_un::NaN
 	bgt.un II
 	br FAIL
 
 II:
 	ldsfld	float64 bgt_un::NaN
-	ldsfld	float64 bgt_un::_inf
+	ldsfld	float64 bgt_un::neg_inf
 	bgt.un JJ
 	br FAIL
 
 JJ:
 	ldsfld	float64 bgt_un::NaN
-	ldsfld	float64 bgt_un::_min
+	ldsfld	float64 bgt_un::min
 	bgt.un KK
 	br FAIL
 
 KK:
 	ldsfld	float64 bgt_un::NaN
-	ldsfld	float64 bgt_un::_one
+	ldsfld	float64 bgt_un::minus_one
 	bgt.un LL
 	br FAIL
 
 LL:
 	ldsfld	float64 bgt_un::NaN
-	ldsfld	float64 bgt_un::_zero
+	ldsfld	float64 bgt_un::minus_zero
 	bgt.un MM
 	br FAIL
 
@@ -444,14 +453,428 @@ OO:
 
 PP:
 	ldsfld	float64 bgt_un::NaN
-	ldsfld	float64 bgt_un::inf
+	ldsfld	float64 bgt_un::pos_inf
 	bgt.un QQ
 	br FAIL
 
 QQ:
 	ldsfld	float64 bgt_un::NaN
 	ldsfld	float64 bgt_un::NaN
-	bgt.un  BACKCHECK
+	bgt.un  L0
+	br FAIL
+
+    // Testing early folding logic
+
+L0:
+	ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	bgt.un L1
+	br FAIL
+
+L1:
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	bgt.un L2
+	br FAIL
+
+L2:
+	ldc.r8		MIN
+	ldc.r8		MIN
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		NAN
+	bgt.un L3
+	br FAIL
+
+L3:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	bgt.un L4
+	br FAIL
+
+L4:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	bgt.un L5
+	br FAIL
+
+L5:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	bgt.un L6
+	br FAIL
+
+L6:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	bgt.un L7
+	br FAIL
+
+L7:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	bgt.un L8
+	br FAIL
+
+L8:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	bgt.un L9
+	br FAIL
+
+L9:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	bgt.un L10
+	br FAIL
+
+L10:
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	bgt.un L11
+	br FAIL
+
+L11:
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	bgt.un L12
+	br FAIL
+
+L12:
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	bgt.un L13
+	br FAIL
+
+L13:
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	bgt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	bgt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	bgt.un L14
+	br FAIL
+
+L14:
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	bgt.un L15
+	br FAIL
+
+L15:
+	ldc.r8		ONE
+	ldc.r8		MIN
+	bgt.un L16
+	br FAIL
+
+L16:
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	bgt.un L17
+	br FAIL
+
+L17:
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	bgt.un L18
+	br FAIL
+
+L18:
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	bgt.un L19
+	br FAIL
+
+L19:
+	ldc.r8		ONE
+	ldc.r8		ONE
+	bgt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		NAN
+	bgt.un L20
+	br FAIL
+
+L20:
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	bgt.un L21
+	br FAIL
+
+L21:
+	ldc.r8		MAX
+	ldc.r8		MIN
+	bgt.un L22
+	br FAIL
+
+L22:
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	bgt.un L23
+	br FAIL
+
+L23:
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	bgt.un L24
+	br FAIL
+
+L24:
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	bgt.un L25
+	br FAIL
+
+L25:
+	ldc.r8		MAX
+	ldc.r8		ONE
+	bgt.un L26
+	br FAIL
+
+L26:
+	ldc.r8		MAX
+	ldc.r8		MAX
+	bgt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		NAN
+	bgt.un L27
+	br FAIL
+
+L27:
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	bgt.un L28
+	br FAIL
+
+L28:
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	bgt.un L29
+	br FAIL
+
+L29:
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	bgt.un L30
+	br FAIL
+
+L30:
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	bgt.un L31
+	br FAIL
+
+L31:
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	bgt.un L32
+	br FAIL
+
+L32:
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	bgt.un L33
+	br FAIL
+
+L33:
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	bgt.un L34
+	br FAIL
+
+L34:
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	bgt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	bgt.un L35
+	br FAIL
+
+L35:
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	bgt.un L36
+	br FAIL
+
+L36:
+	ldc.r8		NAN
+	ldc.r8		MIN
+	bgt.un L37
+	br FAIL
+
+L37:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	bgt.un L38
+	br FAIL
+
+L38:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	bgt.un L39
+	br FAIL
+
+L39:
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	bgt.un L40
+	br FAIL
+
+L40:
+	ldc.r8		NAN
+	ldc.r8		ONE
+	bgt.un L41
+	br FAIL
+
+L41:
+	ldc.r8		NAN
+	ldc.r8		MAX
+	bgt.un L42
+	br FAIL
+
+L42:
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	bgt.un L43
+	br FAIL
+
+L43:
+	ldc.r8		NAN
+	ldc.r8		NAN
+	bgt.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r4.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
 
 .class public _ble_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 _ble_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 _ble_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 _ble_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 _ble_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 _ble_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 _ble_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 _ble_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 _ble_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 _ble_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 _ble_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 _ble_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 _ble_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 _ble_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 _ble_un::NaN
 	ret
 }
@@ -44,223 +53,223 @@
 .maxstack		10
 	call	void _ble_un::initialize()
 
-	ldsfld	float32 _ble_un::_inf
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un A
 	br FAIL
 
 A:
-	ldsfld	float32 _ble_un::_inf
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::neg_inf
+	ldsfld	float32 _ble_un::min
 	ble.un B
 	br FAIL
 
 B:
-	ldsfld	float32 _ble_un::_inf
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::neg_inf
+	ldsfld	float32 _ble_un::minus_one
 	ble.un C
 	br FAIL
 
 C:
-	ldsfld	float32 _ble_un::_inf
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::neg_inf
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un D
 	br FAIL
 
 D:
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ldsfld	float32 _ble_un::zero
 	ble.un E
 	br FAIL
 
 E:
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ldsfld	float32 _ble_un::one
 	ble.un F
 	br FAIL
 
 F:
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ldsfld	float32 _ble_un::max
 	ble.un G
 	br FAIL
 
 G:
-	ldsfld	float32 _ble_un::_inf
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::neg_inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un H
 	br FAIL
 
 H:
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ldsfld	float32 _ble_un::NaN
 	ble.un K
 	br FAIL
 K:
-	ldsfld	float32 _ble_un::_min
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::min
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_min
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
+	ldsfld	float32 _ble_un::min
 	ble.un L
 	br FAIL
 
 L:
-	ldsfld	float32 _ble_un::_min
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::min
+	ldsfld	float32 _ble_un::minus_one
 	ble.un M
 	br FAIL
 
 M:
-	ldsfld	float32 _ble_un::_min
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::min
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un N
 	br FAIL
 
 N:
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ldsfld	float32 _ble_un::zero
 	ble.un O
 	br FAIL
 
 O:
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ldsfld	float32 _ble_un::one
 	ble.un P
 	br FAIL
 
 P:
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ldsfld	float32 _ble_un::max
 	ble.un Q
 	br FAIL
 
 Q:
-	ldsfld	float32 _ble_un::_min
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::min
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un R
 	br FAIL
 
 R:
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ldsfld	float32 _ble_un::NaN
 	ble.un S
 	br FAIL
 
 
 S:
-	ldsfld	float32 _ble_un::_one
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::minus_one
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_one
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::minus_one
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_one
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
+	ldsfld	float32 _ble_un::minus_one
 	ble.un T
 	br FAIL
 
 T:
-	ldsfld	float32 _ble_un::_one
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_one
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un U
 	br FAIL
 
 U:
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ldsfld	float32 _ble_un::zero
 	ble.un V
 	br FAIL
 
 V:
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ldsfld	float32 _ble_un::one
 	ble.un W
 	br FAIL
 
 W:
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ldsfld	float32 _ble_un::max
 	ble.un X
 	br FAIL
 
 X:
-	ldsfld	float32 _ble_un::_one
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::minus_one
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un Y
 	br FAIL
 
 Y:
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ldsfld	float32 _ble_un::NaN
 	ble.un Z
 	br FAIL
 Z:
-	ldsfld	float32 _ble_un::_zero
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::minus_zero
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_zero
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::minus_zero
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_zero
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_zero
+	ldsfld	float32 _ble_un::minus_one
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::_zero
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un AA
 	br FAIL
 
 AA:
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ldsfld	float32 _ble_un::zero
 	ble.un BB
 	br FAIL
 
 BB:
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ldsfld	float32 _ble_un::one
 	ble.un CC
 	br FAIL
 
 CC:
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ldsfld	float32 _ble_un::max
 	ble.un DD
 	br FAIL
 
 DD:
-	ldsfld	float32 _ble_un::_zero
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::minus_zero
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un EE
 	br FAIL
 
 EE:
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ldsfld	float32 _ble_un::NaN
 	ble.un FF
 	br FAIL
 
 FF:
 	ldsfld	float32 _ble_un::zero
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::zero
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::zero
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::zero
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un GG
 	br FAIL
 
@@ -284,7 +293,7 @@ II:
 
 JJ:
 	ldsfld	float32 _ble_un::zero
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un KK
 	br FAIL
 
@@ -296,19 +305,19 @@ KK:
 
 LL:
 	ldsfld	float32 _ble_un::one
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::one
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::one
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::one
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::one
@@ -328,7 +337,7 @@ MM:
 
 NN:
 	ldsfld	float32 _ble_un::one
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un OO
 	br FAIL
 
@@ -340,19 +349,19 @@ OO:
 
 PP:
 	ldsfld	float32 _ble_un::max
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::max
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::max
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::max
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un FAIL
 
 	ldsfld	float32 _ble_un::max
@@ -370,7 +379,7 @@ PP:
 
 QQ:
 	ldsfld	float32 _ble_un::max
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un RR
 	br FAIL
 
@@ -381,66 +390,66 @@ RR:
 	br FAIL
 
 SS:
-	ldsfld	float32 _ble_un::inf
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::pos_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::pos_inf
+	ldsfld	float32 _ble_un::min
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::pos_inf
+	ldsfld	float32 _ble_un::minus_one
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::pos_inf
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ldsfld	float32 _ble_un::zero
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ldsfld	float32 _ble_un::one
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ldsfld	float32 _ble_un::max
 	ble.un FAIL
 
-	ldsfld	float32 _ble_un::inf
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un TT
 	br FAIL
 
 TT:
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ldsfld	float32 _ble_un::NaN
 	ble.un UU
 	br FAIL
 
 UU:
 	ldsfld	float32 _ble_un::NaN
-	ldsfld	float32 _ble_un::_inf
+	ldsfld	float32 _ble_un::neg_inf
 	ble.un VV
 	br FAIL
 
 VV:
 	ldsfld	float32 _ble_un::NaN
-	ldsfld	float32 _ble_un::_min
+	ldsfld	float32 _ble_un::min
 	ble.un WW
 	br FAIL
 
 WW:
 	ldsfld	float32 _ble_un::NaN
-	ldsfld	float32 _ble_un::_one
+	ldsfld	float32 _ble_un::minus_one
 	ble.un XX
 	br FAIL
 
 XX:
 	ldsfld	float32 _ble_un::NaN
-	ldsfld	float32 _ble_un::_zero
+	ldsfld	float32 _ble_un::minus_zero
 	ble.un YY
 	br FAIL
 
@@ -464,14 +473,448 @@ AAA:
 
 BBB:
 	ldsfld	float32 _ble_un::NaN
-	ldsfld	float32 _ble_un::inf
+	ldsfld	float32 _ble_un::pos_inf
 	ble.un CCC
 	br FAIL
 
 CCC:
 	ldsfld	float32 _ble_un::NaN
 	ldsfld	float32 _ble_un::NaN
-	ble.un  BACKCHECK
+	ble.un  L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	ble.un L1
+	br FAIL
+
+L1:
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	ble.un L2
+	br FAIL
+
+L2:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	ble.un L3
+	br FAIL
+
+L3:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	ble.un L4
+	br FAIL
+
+L4:
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	ble.un L5
+	br FAIL
+
+L5:
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	ble.un L6
+	br FAIL
+
+L6:
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	ble.un L7
+	br FAIL
+
+L7:
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	ble.un L8
+	br FAIL
+
+L8:
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	ble.un L9
+	br FAIL
+
+L9:
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MIN
+	ble.un L10
+	br FAIL
+
+L10:
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	ble.un L11
+	br FAIL
+
+L11:
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	ble.un L12
+	br FAIL
+
+L12:
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	ble.un L13
+	br FAIL
+
+L13:
+	ldc.r4		MIN
+	ldc.r4		ONE
+	ble.un L14
+	br FAIL
+
+L14:
+	ldc.r4		MIN
+	ldc.r4		MAX
+	ble.un L15
+	br FAIL
+
+L15:
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	ble.un L16
+	br FAIL
+
+L16:
+	ldc.r4		MIN
+	ldc.r4		NAN
+	ble.un L17
+	br FAIL
+
+L17:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	ble.un L18
+	br FAIL
+
+L18:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	ble.un L19
+	br FAIL
+
+L19:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	ble.un L20
+	br FAIL
+
+L20:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	ble.un L21
+	br FAIL
+
+L21:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	ble.un L22
+	br FAIL
+
+L22:
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	ble.un L23
+	br FAIL
+
+L23:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	ble.un L24
+	br FAIL
+
+L24:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	ble.un L25
+	br FAIL
+
+L25:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	ble.un L26
+	br FAIL
+
+L26:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	ble.un L27
+	br FAIL
+
+L27:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	ble.un L28
+	br FAIL
+
+L28:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	ble.un L29
+	br FAIL
+
+L29:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	ble.un L30
+	br FAIL
+
+L30:
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	ble.un L31
+	br FAIL
+
+L31:
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	ble.un L32
+	br FAIL
+
+L32:
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	ble.un L33
+	br FAIL
+
+L33:
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	ble.un L34
+	br FAIL
+
+L34:
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	ble.un L35
+	br FAIL
+
+L35:
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	ble.un L36
+	br FAIL
+
+L36:
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	ble.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ONE
+	ble.un L37
+	br FAIL
+
+L37:
+	ldc.r4		ONE
+	ldc.r4		MAX
+	ble.un L38
+	br FAIL
+
+L38:
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	ble.un L39
+	br FAIL
+
+L39:
+	ldc.r4		ONE
+	ldc.r4		NAN
+	ble.un L40
+	br FAIL
+
+L40:
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ONE
+	ble.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MAX
+	ble.un L41
+	br FAIL
+
+L41:
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	ble.un L42
+	br FAIL
+
+L42:
+	ldc.r4		MAX
+	ldc.r4		NAN
+	ble.un L43
+	br FAIL
+
+L43:
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	ble.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	ble.un L44
+	br FAIL
+
+L44:
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	ble.un L45
+	br FAIL
+
+L45:
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	ble.un L46
+	br FAIL
+
+L46:
+	ldc.r4		NAN
+	ldc.r4		MIN
+	ble.un L47
+	br FAIL
+
+L47:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	ble.un L48
+	br FAIL
+
+L48:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	ble.un L49
+	br FAIL
+
+L49:
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	ble.un L50
+	br FAIL
+
+L50:
+	ldc.r4		NAN
+	ldc.r4		ONE
+	ble.un L51
+	br FAIL
+
+L51:
+	ldc.r4		NAN
+	ldc.r4		MAX
+	ble.un L52
+	br FAIL
+
+L52:
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	ble.un L53
+	br FAIL
+
+L53:
+	ldc.r4		NAN
+	ldc.r4		NAN
+	ble.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r8.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
 
 .class public ble_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 ble_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 ble_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 ble_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 ble_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 ble_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 ble_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 ble_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 ble_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 ble_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 ble_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 ble_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 ble_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 ble_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 ble_un::NaN
 	ret
 }
@@ -44,223 +53,223 @@
 .maxstack		10
 	call	void ble_un::initialize()
 
-	ldsfld	float64 ble_un::_inf
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un A
 	br FAIL
 
 A:
-	ldsfld	float64 ble_un::_inf
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::neg_inf
+	ldsfld	float64 ble_un::min
 	ble.un B
 	br FAIL
 
 B:
-	ldsfld	float64 ble_un::_inf
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::neg_inf
+	ldsfld	float64 ble_un::minus_one
 	ble.un C
 	br FAIL
 
 C:
-	ldsfld	float64 ble_un::_inf
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::neg_inf
+	ldsfld	float64 ble_un::minus_zero
 	ble.un D
 	br FAIL
 
 D:
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ldsfld	float64 ble_un::zero
 	ble.un E
 	br FAIL
 
 E:
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ldsfld	float64 ble_un::one
 	ble.un F
 	br FAIL
 
 F:
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ldsfld	float64 ble_un::max
 	ble.un G
 	br FAIL
 
 G:
-	ldsfld	float64 ble_un::_inf
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::neg_inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un H
 	br FAIL
 
 H:
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ldsfld	float64 ble_un::NaN
 	ble.un K
 	br FAIL
 K:
-	ldsfld	float64 ble_un::_min
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::min
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_min
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
+	ldsfld	float64 ble_un::min
 	ble.un L
 	br FAIL
 
 L:
-	ldsfld	float64 ble_un::_min
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::min
+	ldsfld	float64 ble_un::minus_one
 	ble.un M
 	br FAIL
 
 M:
-	ldsfld	float64 ble_un::_min
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::min
+	ldsfld	float64 ble_un::minus_zero
 	ble.un N
 	br FAIL
 
 N:
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ldsfld	float64 ble_un::zero
 	ble.un O
 	br FAIL
 
 O:
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ldsfld	float64 ble_un::one
 	ble.un P
 	br FAIL
 
 P:
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ldsfld	float64 ble_un::max
 	ble.un Q
 	br FAIL
 
 Q:
-	ldsfld	float64 ble_un::_min
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::min
+	ldsfld	float64 ble_un::pos_inf
 	ble.un R
 	br FAIL
 
 R:
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ldsfld	float64 ble_un::NaN
 	ble.un S
 	br FAIL
 
 
 S:
-	ldsfld	float64 ble_un::_one
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::minus_one
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_one
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::minus_one
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_one
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
+	ldsfld	float64 ble_un::minus_one
 	ble.un T
 	br FAIL
 
 T:
-	ldsfld	float64 ble_un::_one
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_one
+	ldsfld	float64 ble_un::minus_zero
 	ble.un U
 	br FAIL
 
 U:
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ldsfld	float64 ble_un::zero
 	ble.un V
 	br FAIL
 
 V:
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ldsfld	float64 ble_un::one
 	ble.un W
 	br FAIL
 
 W:
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ldsfld	float64 ble_un::max
 	ble.un X
 	br FAIL
 
 X:
-	ldsfld	float64 ble_un::_one
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::minus_one
+	ldsfld	float64 ble_un::pos_inf
 	ble.un Y
 	br FAIL
 
 Y:
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ldsfld	float64 ble_un::NaN
 	ble.un Z
 	br FAIL
 Z:
-	ldsfld	float64 ble_un::_zero
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::minus_zero
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_zero
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::minus_zero
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_zero
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_zero
+	ldsfld	float64 ble_un::minus_one
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::_zero
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
+	ldsfld	float64 ble_un::minus_zero
 	ble.un AA
 	br FAIL
 
 AA:
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ldsfld	float64 ble_un::zero
 	ble.un BB
 	br FAIL
 
 BB:
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ldsfld	float64 ble_un::one
 	ble.un CC
 	br FAIL
 
 CC:
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ldsfld	float64 ble_un::max
 	ble.un DD
 	br FAIL
 
 DD:
-	ldsfld	float64 ble_un::_zero
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::minus_zero
+	ldsfld	float64 ble_un::pos_inf
 	ble.un EE
 	br FAIL
 
 EE:
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ldsfld	float64 ble_un::NaN
 	ble.un FF
 	br FAIL
 
 FF:
 	ldsfld	float64 ble_un::zero
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::zero
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::zero
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::zero
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ble.un GG
 	br FAIL
 
@@ -284,7 +293,7 @@ II:
 
 JJ:
 	ldsfld	float64 ble_un::zero
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un KK
 	br FAIL
 
@@ -296,19 +305,19 @@ KK:
 
 LL:
 	ldsfld	float64 ble_un::one
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::one
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::one
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::one
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::one
@@ -328,7 +337,7 @@ MM:
 
 NN:
 	ldsfld	float64 ble_un::one
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un OO
 	br FAIL
 
@@ -340,19 +349,19 @@ OO:
 
 PP:
 	ldsfld	float64 ble_un::max
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::max
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::max
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::max
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ble.un FAIL
 
 	ldsfld	float64 ble_un::max
@@ -370,7 +379,7 @@ PP:
 
 QQ:
 	ldsfld	float64 ble_un::max
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un RR
 	br FAIL
 
@@ -381,66 +390,66 @@ RR:
 	br FAIL
 
 SS:
-	ldsfld	float64 ble_un::inf
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::pos_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::pos_inf
+	ldsfld	float64 ble_un::min
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::pos_inf
+	ldsfld	float64 ble_un::minus_one
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::pos_inf
+	ldsfld	float64 ble_un::minus_zero
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ldsfld	float64 ble_un::zero
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ldsfld	float64 ble_un::one
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ldsfld	float64 ble_un::max
 	ble.un FAIL
 
-	ldsfld	float64 ble_un::inf
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un TT
 	br FAIL
 
 TT:
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ldsfld	float64 ble_un::NaN
 	ble.un UU
 	br FAIL
 
 UU:
 	ldsfld	float64 ble_un::NaN
-	ldsfld	float64 ble_un::_inf
+	ldsfld	float64 ble_un::neg_inf
 	ble.un VV
 	br FAIL
 
 VV:
 	ldsfld	float64 ble_un::NaN
-	ldsfld	float64 ble_un::_min
+	ldsfld	float64 ble_un::min
 	ble.un WW
 	br FAIL
 
 WW:
 	ldsfld	float64 ble_un::NaN
-	ldsfld	float64 ble_un::_one
+	ldsfld	float64 ble_un::minus_one
 	ble.un XX
 	br FAIL
 
 XX:
 	ldsfld	float64 ble_un::NaN
-	ldsfld	float64 ble_un::_zero
+	ldsfld	float64 ble_un::minus_zero
 	ble.un YY
 	br FAIL
 
@@ -464,14 +473,448 @@ AAA:
 
 BBB:
 	ldsfld	float64 ble_un::NaN
-	ldsfld	float64 ble_un::inf
+	ldsfld	float64 ble_un::pos_inf
 	ble.un CCC
 	br FAIL
 
 CCC:
 	ldsfld	float64 ble_un::NaN
 	ldsfld	float64 ble_un::NaN
-	ble.un  BACKCHECK
+	ble.un  L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	ble.un L1
+	br FAIL
+
+L1:
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	ble.un L2
+	br FAIL
+
+L2:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	ble.un L3
+	br FAIL
+
+L3:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	ble.un L4
+	br FAIL
+
+L4:
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	ble.un L5
+	br FAIL
+
+L5:
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	ble.un L6
+	br FAIL
+
+L6:
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	ble.un L7
+	br FAIL
+
+L7:
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	ble.un L8
+	br FAIL
+
+L8:
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	ble.un L9
+	br FAIL
+
+L9:
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MIN
+	ble.un L10
+	br FAIL
+
+L10:
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	ble.un L11
+	br FAIL
+
+L11:
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	ble.un L12
+	br FAIL
+
+L12:
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	ble.un L13
+	br FAIL
+
+L13:
+	ldc.r8		MIN
+	ldc.r8		ONE
+	ble.un L14
+	br FAIL
+
+L14:
+	ldc.r8		MIN
+	ldc.r8		MAX
+	ble.un L15
+	br FAIL
+
+L15:
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	ble.un L16
+	br FAIL
+
+L16:
+	ldc.r8		MIN
+	ldc.r8		NAN
+	ble.un L17
+	br FAIL
+
+L17:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	ble.un L18
+	br FAIL
+
+L18:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	ble.un L19
+	br FAIL
+
+L19:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	ble.un L20
+	br FAIL
+
+L20:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	ble.un L21
+	br FAIL
+
+L21:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	ble.un L22
+	br FAIL
+
+L22:
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	ble.un L23
+	br FAIL
+
+L23:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	ble.un L24
+	br FAIL
+
+L24:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	ble.un L25
+	br FAIL
+
+L25:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	ble.un L26
+	br FAIL
+
+L26:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	ble.un L27
+	br FAIL
+
+L27:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	ble.un L28
+	br FAIL
+
+L28:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	ble.un L29
+	br FAIL
+
+L29:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	ble.un L30
+	br FAIL
+
+L30:
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	ble.un L31
+	br FAIL
+
+L31:
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	ble.un L32
+	br FAIL
+
+L32:
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	ble.un L33
+	br FAIL
+
+L33:
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	ble.un L34
+	br FAIL
+
+L34:
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	ble.un L35
+	br FAIL
+
+L35:
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	ble.un L36
+	br FAIL
+
+L36:
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	ble.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ONE
+	ble.un L37
+	br FAIL
+
+L37:
+	ldc.r8		ONE
+	ldc.r8		MAX
+	ble.un L38
+	br FAIL
+
+L38:
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	ble.un L39
+	br FAIL
+
+L39:
+	ldc.r8		ONE
+	ldc.r8		NAN
+	ble.un L40
+	br FAIL
+
+L40:
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ONE
+	ble.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MAX
+	ble.un L41
+	br FAIL
+
+L41:
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	ble.un L42
+	br FAIL
+
+L42:
+	ldc.r8		MAX
+	ldc.r8		NAN
+	ble.un L43
+	br FAIL
+
+L43:
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	ble.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	ble.un L44
+	br FAIL
+
+L44:
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	ble.un L45
+	br FAIL
+
+L45:
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	ble.un L46
+	br FAIL
+
+L46:
+	ldc.r8		NAN
+	ldc.r8		MIN
+	ble.un L47
+	br FAIL
+
+L47:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	ble.un L48
+	br FAIL
+
+L48:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	ble.un L49
+	br FAIL
+
+L49:
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	ble.un L50
+	br FAIL
+
+L50:
+	ldc.r8		NAN
+	ldc.r8		ONE
+	ble.un L51
+	br FAIL
+
+L51:
+	ldc.r8		NAN
+	ldc.r8		MAX
+	ble.un L52
+	br FAIL
+
+L52:
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	ble.un L53
+	br FAIL
+
+L53:
+	ldc.r8		NAN
+	ldc.r8		NAN
+	ble.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r4.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
 
 .class public _blt_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 _blt_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 _blt_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 _blt_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 _blt_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 _blt_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 _blt_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 _blt_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 _blt_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 _blt_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 _blt_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 _blt_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 _blt_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 _blt_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 _blt_un::NaN
 	ret
 }
@@ -44,218 +53,218 @@
 .maxstack		10
 	call	void _blt_un::initialize()
 
-	ldsfld	float32 _blt_un::_inf
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
 A:
-	ldsfld	float32 _blt_un::_inf
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::neg_inf
+	ldsfld	float32 _blt_un::min
 	blt.un B
 	br FAIL
 
 B:
-	ldsfld	float32 _blt_un::_inf
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::neg_inf
+	ldsfld	float32 _blt_un::minus_one
 	blt.un C
 	br FAIL
 
 C:
-	ldsfld	float32 _blt_un::_inf
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::neg_inf
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un D
 	br FAIL
 
 D:
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	ldsfld	float32 _blt_un::zero
 	blt.un E
 	br FAIL
 
 E:
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	ldsfld	float32 _blt_un::one
 	blt.un F
 	br FAIL
 
 F:
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	ldsfld	float32 _blt_un::max
 	blt.un G
 	br FAIL
 
 G:
-	ldsfld	float32 _blt_un::_inf
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::neg_inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un H
 	br FAIL
 
 H:
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	ldsfld	float32 _blt_un::NaN
 	blt.un K
 	br FAIL
 K:
-	ldsfld	float32 _blt_un::_min
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::min
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_min
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
 L:
-	ldsfld	float32 _blt_un::_min
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::min
+	ldsfld	float32 _blt_un::minus_one
 	blt.un M
 	br FAIL
 
 M:
-	ldsfld	float32 _blt_un::_min
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::min
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un N
 	br FAIL
 
 N:
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	ldsfld	float32 _blt_un::zero
 	blt.un O
 	br FAIL
 
 O:
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	ldsfld	float32 _blt_un::one
 	blt.un P
 	br FAIL
 
 P:
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	ldsfld	float32 _blt_un::max
 	blt.un Q
 	br FAIL
 
 Q:
-	ldsfld	float32 _blt_un::_min
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::min
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un R
 	br FAIL
 
 R:
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	ldsfld	float32 _blt_un::NaN
 	blt.un S
 	br FAIL
 
 
 S:
-	ldsfld	float32 _blt_un::_one
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::minus_one
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_one
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::minus_one
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_one
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
 T:
-	ldsfld	float32 _blt_un::_one
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_one
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un U
 	br FAIL
 
 U:
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	ldsfld	float32 _blt_un::zero
 	blt.un V
 	br FAIL
 
 V:
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	ldsfld	float32 _blt_un::one
 	blt.un W
 	br FAIL
 
 W:
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	ldsfld	float32 _blt_un::max
 	blt.un X
 	br FAIL
 
 X:
-	ldsfld	float32 _blt_un::_one
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::minus_one
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un Y
 	br FAIL
 
 Y:
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	ldsfld	float32 _blt_un::NaN
 	blt.un Z
 	br FAIL
 Z:
-	ldsfld	float32 _blt_un::_zero
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::minus_zero
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_zero
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::minus_zero
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_zero
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_zero
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::_zero
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un FAIL
 
 AA:
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	ldsfld	float32 _blt_un::zero
 	blt.un FAIL
 
 BB:
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	ldsfld	float32 _blt_un::one
 	blt.un CC
 	br FAIL
 
 CC:
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	ldsfld	float32 _blt_un::max
 	blt.un DD
 	br FAIL
 
 DD:
-	ldsfld	float32 _blt_un::_zero
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::minus_zero
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un EE
 	br FAIL
 
 EE:
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	ldsfld	float32 _blt_un::NaN
 	blt.un FF
 	br FAIL
 
 FF:
 	ldsfld	float32 _blt_un::zero
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::zero
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::zero
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::zero
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un FAIL
 
 GG:
@@ -277,7 +286,7 @@ II:
 
 JJ:
 	ldsfld	float32 _blt_un::zero
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un KK
 	br FAIL
 
@@ -289,19 +298,19 @@ KK:
 
 LL:
 	ldsfld	float32 _blt_un::one
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::one
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::one
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::one
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::one
@@ -320,7 +329,7 @@ MM:
 
 NN:
 	ldsfld	float32 _blt_un::one
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un OO
 	br FAIL
 
@@ -332,19 +341,19 @@ OO:
 
 PP:
 	ldsfld	float32 _blt_un::max
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::max
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::max
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::max
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un FAIL
 
 	ldsfld	float32 _blt_un::max
@@ -361,7 +370,7 @@ PP:
 
 QQ:
 	ldsfld	float32 _blt_un::max
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un RR
 	br FAIL
 
@@ -372,65 +381,65 @@ RR:
 	br FAIL
 
 SS:
-	ldsfld	float32 _blt_un::inf
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::pos_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::pos_inf
+	ldsfld	float32 _blt_un::min
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::pos_inf
+	ldsfld	float32 _blt_un::minus_one
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::pos_inf
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	ldsfld	float32 _blt_un::zero
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	ldsfld	float32 _blt_un::one
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	ldsfld	float32 _blt_un::max
 	blt.un FAIL
 
-	ldsfld	float32 _blt_un::inf
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un FAIL
 
 TT:
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	ldsfld	float32 _blt_un::NaN
 	blt.un UU
 	br FAIL
 
 UU:
 	ldsfld	float32 _blt_un::NaN
-	ldsfld	float32 _blt_un::_inf
+	ldsfld	float32 _blt_un::neg_inf
 	blt.un VV
 	br FAIL
 
 VV:
 	ldsfld	float32 _blt_un::NaN
-	ldsfld	float32 _blt_un::_min
+	ldsfld	float32 _blt_un::min
 	blt.un WW
 	br FAIL
 
 WW:
 	ldsfld	float32 _blt_un::NaN
-	ldsfld	float32 _blt_un::_one
+	ldsfld	float32 _blt_un::minus_one
 	blt.un XX
 	br FAIL
 
 XX:
 	ldsfld	float32 _blt_un::NaN
-	ldsfld	float32 _blt_un::_zero
+	ldsfld	float32 _blt_un::minus_zero
 	blt.un YY
 	br FAIL
 
@@ -454,14 +463,428 @@ AAA:
 
 BBB:
 	ldsfld	float32 _blt_un::NaN
-	ldsfld	float32 _blt_un::inf
+	ldsfld	float32 _blt_un::pos_inf
 	blt.un CCC
 	br FAIL
 
 CCC:
 	ldsfld	float32 _blt_un::NaN
 	ldsfld	float32 _blt_un::NaN
-	blt.un  BACKCHECK
+	blt.un  L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	blt.un L1
+	br FAIL
+
+L1:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	blt.un L2
+	br FAIL
+
+L2:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	blt.un L3
+	br FAIL
+
+L3:
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	blt.un L4
+	br FAIL
+
+L4:
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	blt.un L5
+	br FAIL
+
+L5:
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	blt.un L6
+	br FAIL
+
+L6:
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	blt.un L7
+	br FAIL
+
+L7:
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	blt.un L8
+	br FAIL
+
+L8:
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	blt.un L9
+	br FAIL
+
+L9:
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	blt.un L10
+	br FAIL
+
+L10:
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	blt.un L11
+	br FAIL
+
+L11:
+	ldc.r4		MIN
+	ldc.r4		ONE
+	blt.un L12
+	br FAIL
+
+L12:
+	ldc.r4		MIN
+	ldc.r4		MAX
+	blt.un L13
+	br FAIL
+
+L13:
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	blt.un L14
+	br FAIL
+
+L14:
+	ldc.r4		MIN
+	ldc.r4		NAN
+	blt.un L15
+	br FAIL
+
+L15:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	blt.un L16
+	br FAIL
+
+L16:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	blt.un L17
+	br FAIL
+
+L17:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	blt.un L18
+	br FAIL
+
+L18:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	blt.un L19
+	br FAIL
+
+L19:
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	blt.un L20
+	br FAIL
+
+L20:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	blt.un L21
+	br FAIL
+
+L21:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	blt.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	blt.un L22
+	br FAIL
+
+L22:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	blt.un L23
+	br FAIL
+
+L23:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	blt.un L24
+	br FAIL
+
+L24:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	blt.un L25
+	br FAIL
+
+L25:
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	blt.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	blt.un L26
+	br FAIL
+
+L26:
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	blt.un L27
+	br FAIL
+
+L27:
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	blt.un L28
+	br FAIL
+
+L28:
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	blt.un L29
+	br FAIL
+
+L29:
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ONE
+	blt.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	blt.un L30
+	br FAIL
+
+L30:
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	blt.un L31
+	br FAIL
+
+L31:
+	ldc.r4		ONE
+	ldc.r4		NAN
+	blt.un L32
+	br FAIL
+
+L32:
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ONE
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MAX
+	blt.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	blt.un L33
+	br FAIL
+
+L33:
+	ldc.r4		MAX
+	ldc.r4		NAN
+	blt.un L34
+	br FAIL
+
+L34:
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	blt.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	blt.un L35
+	br FAIL
+
+L35:
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	blt.un L36
+	br FAIL
+
+L36:
+	ldc.r4		NAN
+	ldc.r4		MIN
+	blt.un L37
+	br FAIL
+
+L37:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	blt.un L38
+	br FAIL
+
+L38:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	blt.un L39
+	br FAIL
+
+L39:
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	blt.un L40
+	br FAIL
+
+L40:
+	ldc.r4		NAN
+	ldc.r4		ONE
+	blt.un L41
+	br FAIL
+
+L41:
+	ldc.r4		NAN
+	ldc.r4		MAX
+	blt.un L42
+	br FAIL
+
+L42:
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	blt.un L43
+	br FAIL
+
+L43:
+	ldc.r4		NAN
+	ldc.r4		NAN
+	blt.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r8.il
@@ -3,38 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
 
 .class public blt_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 blt_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 blt_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 blt_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 blt_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 blt_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 blt_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 blt_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 blt_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 blt_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 blt_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 blt_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 blt_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 blt_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 blt_un::NaN
 	ret
 }
@@ -44,218 +53,218 @@
 .maxstack		10
 	call	void blt_un::initialize()
 
-	ldsfld	float64 blt_un::_inf
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
 A:
-	ldsfld	float64 blt_un::_inf
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::neg_inf
+	ldsfld	float64 blt_un::min
 	blt.un B
 	br FAIL
 
 B:
-	ldsfld	float64 blt_un::_inf
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::neg_inf
+	ldsfld	float64 blt_un::minus_one
 	blt.un C
 	br FAIL
 
 C:
-	ldsfld	float64 blt_un::_inf
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::neg_inf
+	ldsfld	float64 blt_un::minus_zero
 	blt.un D
 	br FAIL
 
 D:
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	ldsfld	float64 blt_un::zero
 	blt.un E
 	br FAIL
 
 E:
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	ldsfld	float64 blt_un::one
 	blt.un F
 	br FAIL
 
 F:
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	ldsfld	float64 blt_un::max
 	blt.un G
 	br FAIL
 
 G:
-	ldsfld	float64 blt_un::_inf
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::neg_inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un H
 	br FAIL
 
 H:
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	ldsfld	float64 blt_un::NaN
 	blt.un K
 	br FAIL
 K:
-	ldsfld	float64 blt_un::_min
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::min
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_min
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
 L:
-	ldsfld	float64 blt_un::_min
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::min
+	ldsfld	float64 blt_un::minus_one
 	blt.un M
 	br FAIL
 
 M:
-	ldsfld	float64 blt_un::_min
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::min
+	ldsfld	float64 blt_un::minus_zero
 	blt.un N
 	br FAIL
 
 N:
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	ldsfld	float64 blt_un::zero
 	blt.un O
 	br FAIL
 
 O:
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	ldsfld	float64 blt_un::one
 	blt.un P
 	br FAIL
 
 P:
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	ldsfld	float64 blt_un::max
 	blt.un Q
 	br FAIL
 
 Q:
-	ldsfld	float64 blt_un::_min
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::min
+	ldsfld	float64 blt_un::pos_inf
 	blt.un R
 	br FAIL
 
 R:
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	ldsfld	float64 blt_un::NaN
 	blt.un S
 	br FAIL
 
 
 S:
-	ldsfld	float64 blt_un::_one
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::minus_one
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_one
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::minus_one
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_one
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
 T:
-	ldsfld	float64 blt_un::_one
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_one
+	ldsfld	float64 blt_un::minus_zero
 	blt.un U
 	br FAIL
 
 U:
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	ldsfld	float64 blt_un::zero
 	blt.un V
 	br FAIL
 
 V:
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	ldsfld	float64 blt_un::one
 	blt.un W
 	br FAIL
 
 W:
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	ldsfld	float64 blt_un::max
 	blt.un X
 	br FAIL
 
 X:
-	ldsfld	float64 blt_un::_one
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::minus_one
+	ldsfld	float64 blt_un::pos_inf
 	blt.un Y
 	br FAIL
 
 Y:
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	ldsfld	float64 blt_un::NaN
 	blt.un Z
 	br FAIL
 Z:
-	ldsfld	float64 blt_un::_zero
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::minus_zero
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_zero
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::minus_zero
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_zero
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_zero
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::_zero
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
+	ldsfld	float64 blt_un::minus_zero
 	blt.un FAIL
 
 AA:
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	ldsfld	float64 blt_un::zero
 	blt.un FAIL
 
 BB:
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	ldsfld	float64 blt_un::one
 	blt.un CC
 	br FAIL
 
 CC:
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	ldsfld	float64 blt_un::max
 	blt.un DD
 	br FAIL
 
 DD:
-	ldsfld	float64 blt_un::_zero
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::minus_zero
+	ldsfld	float64 blt_un::pos_inf
 	blt.un EE
 	br FAIL
 
 EE:
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	ldsfld	float64 blt_un::NaN
 	blt.un FF
 	br FAIL
 
 FF:
 	ldsfld	float64 blt_un::zero
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::zero
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::zero
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::zero
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	blt.un FAIL
 
 GG:
@@ -277,7 +286,7 @@ II:
 
 JJ:
 	ldsfld	float64 blt_un::zero
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un KK
 	br FAIL
 
@@ -289,19 +298,19 @@ KK:
 
 LL:
 	ldsfld	float64 blt_un::one
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::one
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::one
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::one
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::one
@@ -320,7 +329,7 @@ MM:
 
 NN:
 	ldsfld	float64 blt_un::one
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un OO
 	br FAIL
 
@@ -332,19 +341,19 @@ OO:
 
 PP:
 	ldsfld	float64 blt_un::max
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::max
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::max
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::max
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	blt.un FAIL
 
 	ldsfld	float64 blt_un::max
@@ -361,7 +370,7 @@ PP:
 
 QQ:
 	ldsfld	float64 blt_un::max
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un RR
 	br FAIL
 
@@ -372,65 +381,65 @@ RR:
 	br FAIL
 
 SS:
-	ldsfld	float64 blt_un::inf
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::pos_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::pos_inf
+	ldsfld	float64 blt_un::min
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::pos_inf
+	ldsfld	float64 blt_un::minus_one
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::pos_inf
+	ldsfld	float64 blt_un::minus_zero
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	ldsfld	float64 blt_un::zero
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	ldsfld	float64 blt_un::one
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	ldsfld	float64 blt_un::max
 	blt.un FAIL
 
-	ldsfld	float64 blt_un::inf
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un FAIL
 
 TT:
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	ldsfld	float64 blt_un::NaN
 	blt.un UU
 	br FAIL
 
 UU:
 	ldsfld	float64 blt_un::NaN
-	ldsfld	float64 blt_un::_inf
+	ldsfld	float64 blt_un::neg_inf
 	blt.un VV
 	br FAIL
 
 VV:
 	ldsfld	float64 blt_un::NaN
-	ldsfld	float64 blt_un::_min
+	ldsfld	float64 blt_un::min
 	blt.un WW
 	br FAIL
 
 WW:
 	ldsfld	float64 blt_un::NaN
-	ldsfld	float64 blt_un::_one
+	ldsfld	float64 blt_un::minus_one
 	blt.un XX
 	br FAIL
 
 XX:
 	ldsfld	float64 blt_un::NaN
-	ldsfld	float64 blt_un::_zero
+	ldsfld	float64 blt_un::minus_zero
 	blt.un YY
 	br FAIL
 
@@ -454,14 +463,428 @@ AAA:
 
 BBB:
 	ldsfld	float64 blt_un::NaN
-	ldsfld	float64 blt_un::inf
+	ldsfld	float64 blt_un::pos_inf
 	blt.un CCC
 	br FAIL
 
 CCC:
 	ldsfld	float64 blt_un::NaN
 	ldsfld	float64 blt_un::NaN
-	blt.un  BACKCHECK
+	blt.un  L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	blt.un L1
+	br FAIL
+
+L1:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	blt.un L2
+	br FAIL
+
+L2:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	blt.un L3
+	br FAIL
+
+L3:
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	blt.un L4
+	br FAIL
+
+L4:
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	blt.un L5
+	br FAIL
+
+L5:
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	blt.un L6
+	br FAIL
+
+L6:
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	blt.un L7
+	br FAIL
+
+L7:
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	blt.un L8
+	br FAIL
+
+L8:
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	blt.un L9
+	br FAIL
+
+L9:
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	blt.un L10
+	br FAIL
+
+L10:
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	blt.un L11
+	br FAIL
+
+L11:
+	ldc.r8		MIN
+	ldc.r8		ONE
+	blt.un L12
+	br FAIL
+
+L12:
+	ldc.r8		MIN
+	ldc.r8		MAX
+	blt.un L13
+	br FAIL
+
+L13:
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	blt.un L14
+	br FAIL
+
+L14:
+	ldc.r8		MIN
+	ldc.r8		NAN
+	blt.un L15
+	br FAIL
+
+L15:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	blt.un L16
+	br FAIL
+
+L16:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	blt.un L17
+	br FAIL
+
+L17:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	blt.un L18
+	br FAIL
+
+L18:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	blt.un L19
+	br FAIL
+
+L19:
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	blt.un L20
+	br FAIL
+
+L20:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	blt.un L21
+	br FAIL
+
+L21:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	blt.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	blt.un L22
+	br FAIL
+
+L22:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	blt.un L23
+	br FAIL
+
+L23:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	blt.un L24
+	br FAIL
+
+L24:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	blt.un L25
+	br FAIL
+
+L25:
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	blt.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	blt.un L26
+	br FAIL
+
+L26:
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	blt.un L27
+	br FAIL
+
+L27:
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	blt.un L28
+	br FAIL
+
+L28:
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	blt.un L29
+	br FAIL
+
+L29:
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ONE
+	blt.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	blt.un L30
+	br FAIL
+
+L30:
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	blt.un L31
+	br FAIL
+
+L31:
+	ldc.r8		ONE
+	ldc.r8		NAN
+	blt.un L32
+	br FAIL
+
+L32:
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ONE
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MAX
+	blt.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	blt.un L33
+	br FAIL
+
+L33:
+	ldc.r8		MAX
+	ldc.r8		NAN
+	blt.un L34
+	br FAIL
+
+L34:
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	blt.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	blt.un L35
+	br FAIL
+
+L35:
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	blt.un L36
+	br FAIL
+
+L36:
+	ldc.r8		NAN
+	ldc.r8		MIN
+	blt.un L37
+	br FAIL
+
+L37:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	blt.un L38
+	br FAIL
+
+L38:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	blt.un L39
+	br FAIL
+
+L39:
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	blt.un L40
+	br FAIL
+
+L40:
+	ldc.r8		NAN
+	ldc.r8		ONE
+	blt.un L41
+	br FAIL
+
+L41:
+	ldc.r8		NAN
+	ldc.r8		MAX
+	blt.un L42
+	br FAIL
+
+L42:
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	blt.un L43
+	br FAIL
+
+L43:
+	ldc.r8		NAN
+	ldc.r8		NAN
+	blt.un BACKCHECK
 	br FAIL
 
 TOPASS:

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.il
@@ -3,36 +3,46 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
+
 .class public bne_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 .method public static void initialize() {
 .maxstack		10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 bne_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 bne_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 bne_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 bne_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 bne_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 bne_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 bne_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 bne_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 bne_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 bne_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 bne_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 bne_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 bne_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 bne_un::NaN
 	ret
 }
@@ -41,230 +51,230 @@
 .entrypoint
 .maxstack		10
 	call	void bne_un::initialize()
-	ldsfld	float32 bne_un::_inf
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un FAIL
 
-	ldsfld	float32 bne_un::_inf
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::neg_inf
+	ldsfld	float32 bne_un::min
 	bne.un A
 	br FAIL
 
 A:
-	ldsfld	float32 bne_un::_inf
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::neg_inf
+	ldsfld	float32 bne_un::minus_one
 	bne.un B
 	br FAIL
 
 B:
-	ldsfld	float32 bne_un::_inf
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::neg_inf
+	ldsfld	float32 bne_un::minus_zero
 	bne.un C
 	br FAIL
 
 C:
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	ldsfld	float32 bne_un::zero
 	bne.un D
 	br FAIL
 
 D:
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	ldsfld	float32 bne_un::one
 	bne.un E
 	br FAIL
 
 E:
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	ldsfld	float32 bne_un::max
 	bne.un F
 	br FAIL
 
 F:
-	ldsfld	float32 bne_un::_inf
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::neg_inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un G
 	br FAIL
 
 G:
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	ldsfld	float32 bne_un::NaN
 	bne.un H
 	br FAIL
 
 H:
-	ldsfld	float32 bne_un::_min
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::min
+	ldsfld	float32 bne_un::neg_inf
 	bne.un I
 	br FAIL
 
 I:
-	ldsfld	float32 bne_un::_min
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
+	ldsfld	float32 bne_un::min
 	bne.un FAIL
 
-	ldsfld	float32 bne_un::_min
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::min
+	ldsfld	float32 bne_un::minus_one
 	bne.un J
 	br FAIL
 
 J:
-	ldsfld	float32 bne_un::_min
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::min
+	ldsfld	float32 bne_un::minus_zero
 	bne.un K
 	br FAIL
 
 K:
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	ldsfld	float32 bne_un::zero
 	bne.un L
 	br		FAIL
 
 L:
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	ldsfld	float32 bne_un::one
 	bne.un M
 	br		FAIL
 
 M:
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	ldsfld	float32 bne_un::max
 	bne.un N
 	br		FAIL
 
 N:
-	ldsfld	float32 bne_un::_min
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::min
+	ldsfld	float32 bne_un::pos_inf
 	bne.un O
 	br		FAIL
 
 O:
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	ldsfld	float32 bne_un::NaN
 	bne.un P
 	br		FAIL
 P:
-	ldsfld	float32 bne_un::_one
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::minus_one
+	ldsfld	float32 bne_un::neg_inf
 	bne.un Q
 	br		FAIL
 
 Q:
-	ldsfld	float32 bne_un::_one
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::minus_one
+	ldsfld	float32 bne_un::min
 	bne.un R
 	br		FAIL
 
 R:
-	ldsfld	float32 bne_un::_one
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
+	ldsfld	float32 bne_un::minus_one
 	bne.un FAIL
 
 S:
-	ldsfld	float32 bne_un::_one
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_one
+	ldsfld	float32 bne_un::minus_zero
 	bne.un T
 	br		FAIL
 
 T:
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	ldsfld	float32 bne_un::zero
 	bne.un U
 	br		FAIL
 
 U:
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	ldsfld	float32 bne_un::one
 	bne.un V
 	br		FAIL
 
 V:
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	ldsfld	float32 bne_un::max
 	bne.un W
 	br		FAIL
 
 W:
-	ldsfld	float32 bne_un::_one
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::minus_one
+	ldsfld	float32 bne_un::pos_inf
 	bne.un X
 	br		FAIL
 
 X:
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	ldsfld	float32 bne_un::NaN
 	bne.un Y
 	br		FAIL
 Y:
-	ldsfld	float32 bne_un::_zero
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::minus_zero
+	ldsfld	float32 bne_un::neg_inf
 	bne.un Z
 	br		FAIL
 
 Z:
-	ldsfld	float32 bne_un::_zero
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::minus_zero
+	ldsfld	float32 bne_un::min
 	bne.un AA
 	br		FAIL
 
 AA:
-	ldsfld	float32 bne_un::_zero
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_zero
+	ldsfld	float32 bne_un::minus_one
 	bne.un BB
 	br		FAIL
 
 BB:
-	ldsfld	float32 bne_un::_zero
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
+	ldsfld	float32 bne_un::minus_zero
 	bne.un FAIL
 
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	ldsfld	float32 bne_un::zero
 	bne.un FAIL
 
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	ldsfld	float32 bne_un::one
 	bne.un CC
 	br		FAIL
 
 CC:
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	ldsfld	float32 bne_un::max
 	bne.un DD
 	br		FAIL
 
 DD:
-	ldsfld	float32 bne_un::_zero
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::minus_zero
+	ldsfld	float32 bne_un::pos_inf
 	bne.un EE
 	br		FAIL
 
 EE:
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	ldsfld	float32 bne_un::NaN
 	bne.un FF
 	br		FAIL
 FF:
 	ldsfld	float32 bne_un::zero
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un GG
 	br		FAIL
 
 GG:
 	ldsfld	float32 bne_un::zero
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	bne.un HH
 	br		FAIL
 
 HH:
 	ldsfld	float32 bne_un::zero
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	bne.un II
 	br		FAIL
 
 II:
 	ldsfld	float32 bne_un::zero
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	bne.un FAIL
 
 	ldsfld	float32 bne_un::zero
@@ -284,7 +294,7 @@ JJ:
 
 KK:
 	ldsfld	float32 bne_un::zero
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un LL
 	br		FAIL
 
@@ -296,25 +306,25 @@ LL:
 
 MM:
 	ldsfld	float32 bne_un::one
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un NN
 	br		FAIL
 
 NN:
 	ldsfld	float32 bne_un::one
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	bne.un OO
 	br		FAIL
 
 OO:
 	ldsfld	float32 bne_un::one
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	bne.un PP
 	br		FAIL
 
 PP:
 	ldsfld	float32 bne_un::one
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	bne.un QQ
 	br		FAIL
 
@@ -337,7 +347,7 @@ SS:
 
 TT:
 	ldsfld	float32 bne_un::one
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un UU
 	br		FAIL
 
@@ -349,25 +359,25 @@ UU:
 
 VV:
 	ldsfld	float32 bne_un::max
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un WW
 	br		FAIL
 
 WW:
 	ldsfld	float32 bne_un::max
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	bne.un XX
 	br		FAIL
 
 XX:
 	ldsfld	float32 bne_un::max
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	bne.un YY
 	br		FAIL
 
 YY:
 	ldsfld	float32 bne_un::max
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	bne.un ZZ
 	br		FAIL
 
@@ -389,7 +399,7 @@ BBB:
 	bne.un FAIL
 
 	ldsfld	float32 bne_un::max
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un CCC
 	br		FAIL
 
@@ -400,78 +410,78 @@ CCC:
 	br	FAIL
 
 DDD:
-	ldsfld	float32 bne_un::inf
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::pos_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un EEE
 	br		FAIL
 
 EEE:
-	ldsfld	float32 bne_un::inf
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::pos_inf
+	ldsfld	float32 bne_un::min
 	bne.un FFF
 	br		FAIL
 
 FFF:
-	ldsfld	float32 bne_un::inf
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::pos_inf
+	ldsfld	float32 bne_un::minus_one
 	bne.un GGG
 	br		FAIL
 
 GGG:
-	ldsfld	float32 bne_un::inf
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::pos_inf
+	ldsfld	float32 bne_un::minus_zero
 	bne.un HHH
 	br		FAIL
 
 HHH:
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	ldsfld	float32 bne_un::zero
 	bne.un III
 	br		FAIL
 
 III:
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	ldsfld	float32 bne_un::one
 	bne.un JJJ
 	br		FAIL
 
 JJJ:
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	ldsfld	float32 bne_un::max
 	bne.un KK_
 	br		FAIL
 
 KK_:
-	ldsfld	float32 bne_un::inf
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un FAIL
 
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	ldsfld	float32 bne_un::NaN
 	bne.un LLL
 	br		FAIL
 
 LLL:
 	ldsfld	float32 bne_un::NaN
-	ldsfld	float32 bne_un::_inf
+	ldsfld	float32 bne_un::neg_inf
 	bne.un MMM
 	br		FAIL
 
 MMM:
 	ldsfld	float32 bne_un::NaN
-	ldsfld	float32 bne_un::_min
+	ldsfld	float32 bne_un::min
 	bne.un NNN
 	br		FAIL
 
 NNN:
 	ldsfld	float32 bne_un::NaN
-	ldsfld	float32 bne_un::_one
+	ldsfld	float32 bne_un::minus_one
 	bne.un OOO
 	br		FAIL
 
 OOO:
 	ldsfld	float32 bne_un::NaN
-	ldsfld	float32 bne_un::_zero
+	ldsfld	float32 bne_un::minus_zero
 	bne.un PPP
 	br		FAIL
 
@@ -495,13 +505,481 @@ RRR:
 
 SSS:
 	ldsfld	float32 bne_un::NaN
-	ldsfld	float32 bne_un::inf
+	ldsfld	float32 bne_un::pos_inf
 	bne.un TTT
 	br		FAIL
 
 TTT:
 	ldsfld	float32 bne_un::NaN
 	ldsfld	float32 bne_un::NaN
+	bne.un L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	bne.un FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	bne.un L1
+	br FAIL
+
+L1:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	bne.un L2
+	br FAIL
+
+L2:
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	bne.un L3
+	br FAIL
+
+L3:
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	bne.un L4
+	br FAIL
+
+L4:
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	bne.un L5
+	br FAIL
+
+L5:
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	bne.un L6
+	br FAIL
+
+L6:
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	bne.un L7
+	br FAIL
+
+L7:
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	bne.un L8
+	br FAIL
+
+L8:
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	bne.un L9
+	br FAIL
+
+L9:
+	ldc.r4		MIN
+	ldc.r4		MIN
+	bne.un FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	bne.un L10
+	br FAIL
+
+L10:
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	bne.un L11
+	br FAIL
+
+L11:
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	bne.un L12
+	br FAIL
+
+L12:
+	ldc.r4		MIN
+	ldc.r4		ONE
+	bne.un L13
+	br FAIL
+
+L13:
+	ldc.r4		MIN
+	ldc.r4		MAX
+	bne.un L14
+	br FAIL
+
+L14:
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	bne.un L15
+	br FAIL
+
+L15:
+	ldc.r4		MIN
+	ldc.r4		NAN
+	bne.un L16
+	br FAIL
+
+L16:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	bne.un L17
+	br FAIL
+
+L17:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	bne.un L18
+	br FAIL
+
+L18:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	bne.un FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	bne.un L19
+	br FAIL
+
+L19:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	bne.un L20
+	br FAIL
+
+L20:
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	bne.un L21
+	br FAIL
+
+L21:
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	bne.un L22
+	br FAIL
+
+L22:
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	bne.un L23
+	br FAIL
+
+L23:
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	bne.un L24
+	br FAIL
+
+L24:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	bne.un L25
+	br FAIL
+
+L25:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	bne.un L26
+	br FAIL
+
+L26:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	bne.un L27
+	br FAIL
+
+L27:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	bne.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	bne.un FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	bne.un L28
+	br FAIL
+
+L28:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	bne.un L29
+	br FAIL
+
+L29:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	bne.un L30
+	br FAIL
+
+L30:
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	bne.un L31
+	br FAIL
+
+L31:
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	bne.un L32
+	br FAIL
+
+L32:
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	bne.un L33
+	br FAIL
+
+L33:
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	bne.un L34
+	br FAIL
+
+L34:
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	bne.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	bne.un FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	bne.un L35
+	br FAIL
+
+L35:
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	bne.un L36
+	br FAIL
+
+L36:
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	bne.un L37
+	br FAIL
+
+L37:
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	bne.un L38
+	br FAIL
+
+L38:
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	bne.un L39
+	br FAIL
+
+L39:
+	ldc.r4		ONE
+	ldc.r4		MIN
+	bne.un L40
+	br FAIL
+
+L40:
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	bne.un L41
+	br FAIL
+
+L41:
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	bne.un L42
+	br FAIL
+
+L42:
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	bne.un L43
+	br FAIL
+
+L43:
+	ldc.r4		ONE
+	ldc.r4		ONE
+	bne.un FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	bne.un L44
+	br FAIL
+
+L44:
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	bne.un L45
+	br FAIL
+
+L45:
+	ldc.r4		ONE
+	ldc.r4		NAN
+	bne.un L46
+	br FAIL
+
+L46:
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	bne.un L47
+	br FAIL
+
+L47:
+	ldc.r4		MAX
+	ldc.r4		MIN
+	bne.un L48
+	br FAIL
+
+L48:
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	bne.un L49
+	br FAIL
+
+L49:
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	bne.un L50
+	br FAIL
+
+L50:
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	bne.un L51
+	br FAIL
+
+L51:
+	ldc.r4		MAX
+	ldc.r4		ONE
+	bne.un L52
+	br FAIL
+
+L52:
+	ldc.r4		MAX
+	ldc.r4		MAX
+	bne.un FAIL
+
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	bne.un L53
+	br FAIL
+
+L53:
+	ldc.r4		MAX
+	ldc.r4		NAN
+	bne.un L54
+	br FAIL
+
+L54:
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	bne.un L55
+	br FAIL
+
+L55:
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	bne.un L56
+	br FAIL
+
+L56:
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	bne.un L57
+	br FAIL
+
+L57:
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	bne.un L58
+	br FAIL
+
+L58:
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	bne.un L59
+	br FAIL
+
+L59:
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	bne.un L60
+	br FAIL
+
+L60:
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	bne.un L61
+	br FAIL
+
+L61:
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	bne.un FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	bne.un L62
+	br FAIL
+
+L62:
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	bne.un L63
+	br FAIL
+
+L63:
+	ldc.r4		NAN
+	ldc.r4		MIN
+	bne.un L64
+	br FAIL
+
+L64:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	bne.un L65
+	br FAIL
+
+L65:
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	bne.un L66
+	br FAIL
+
+L66:
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	bne.un L67
+	br FAIL
+
+L67:
+	ldc.r4		NAN
+	ldc.r4		ONE
+	bne.un L68
+	br FAIL
+
+L68:
+	ldc.r4		NAN
+	ldc.r4		MAX
+	bne.un L69
+	br FAIL
+
+L69:
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	bne.un L70
+	br FAIL
+
+L70:
+	ldc.r4		NAN
+	ldc.r4		NAN
 	bne.un BACKCHECK
 	br FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.il
@@ -3,36 +3,46 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
+
 .class public bne_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 .method public static void initialize() {
 .maxstack		10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 bne_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 bne_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 bne_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 bne_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 bne_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 bne_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 bne_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 bne_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 bne_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 bne_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 bne_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 bne_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 bne_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 bne_un::NaN
 	ret
 }
@@ -41,230 +51,230 @@
 .entrypoint
 .maxstack		10
 	call	void bne_un::initialize()
-	ldsfld	float64 bne_un::_inf
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un FAIL
 
-	ldsfld	float64 bne_un::_inf
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::neg_inf
+	ldsfld	float64 bne_un::min
 	bne.un A
 	br FAIL
 
 A:
-	ldsfld	float64 bne_un::_inf
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::neg_inf
+	ldsfld	float64 bne_un::minus_one
 	bne.un B
 	br FAIL
 
 B:
-	ldsfld	float64 bne_un::_inf
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::neg_inf
+	ldsfld	float64 bne_un::minus_zero
 	bne.un C
 	br FAIL
 
 C:
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	ldsfld	float64 bne_un::zero
 	bne.un D
 	br FAIL
 
 D:
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	ldsfld	float64 bne_un::one
 	bne.un E
 	br FAIL
 
 E:
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	ldsfld	float64 bne_un::max
 	bne.un F
 	br FAIL
 
 F:
-	ldsfld	float64 bne_un::_inf
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::neg_inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un G
 	br FAIL
 
 G:
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	ldsfld	float64 bne_un::NaN
 	bne.un H
 	br FAIL
 
 H:
-	ldsfld	float64 bne_un::_min
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::min
+	ldsfld	float64 bne_un::neg_inf
 	bne.un I
 	br FAIL
 
 I:
-	ldsfld	float64 bne_un::_min
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
+	ldsfld	float64 bne_un::min
 	bne.un FAIL
 
-	ldsfld	float64 bne_un::_min
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::min
+	ldsfld	float64 bne_un::minus_one
 	bne.un J
 	br FAIL
 
 J:
-	ldsfld	float64 bne_un::_min
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::min
+	ldsfld	float64 bne_un::minus_zero
 	bne.un K
 	br FAIL
 
 K:
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	ldsfld	float64 bne_un::zero
 	bne.un L
 	br		FAIL
 
 L:
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	ldsfld	float64 bne_un::one
 	bne.un M
 	br		FAIL
 
 M:
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	ldsfld	float64 bne_un::max
 	bne.un N
 	br		FAIL
 
 N:
-	ldsfld	float64 bne_un::_min
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::min
+	ldsfld	float64 bne_un::pos_inf
 	bne.un O
 	br		FAIL
 
 O:
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	ldsfld	float64 bne_un::NaN
 	bne.un P
 	br		FAIL
 P:
-	ldsfld	float64 bne_un::_one
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::minus_one
+	ldsfld	float64 bne_un::neg_inf
 	bne.un Q
 	br		FAIL
 
 Q:
-	ldsfld	float64 bne_un::_one
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::minus_one
+	ldsfld	float64 bne_un::min
 	bne.un R
 	br		FAIL
 
 R:
-	ldsfld	float64 bne_un::_one
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
+	ldsfld	float64 bne_un::minus_one
 	bne.un FAIL
 
 S:
-	ldsfld	float64 bne_un::_one
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_one
+	ldsfld	float64 bne_un::minus_zero
 	bne.un T
 	br		FAIL
 
 T:
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	ldsfld	float64 bne_un::zero
 	bne.un U
 	br		FAIL
 
 U:
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	ldsfld	float64 bne_un::one
 	bne.un V
 	br		FAIL
 
 V:
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	ldsfld	float64 bne_un::max
 	bne.un W
 	br		FAIL
 
 W:
-	ldsfld	float64 bne_un::_one
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::minus_one
+	ldsfld	float64 bne_un::pos_inf
 	bne.un X
 	br		FAIL
 
 X:
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	ldsfld	float64 bne_un::NaN
 	bne.un Y
 	br		FAIL
 Y:
-	ldsfld	float64 bne_un::_zero
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::minus_zero
+	ldsfld	float64 bne_un::neg_inf
 	bne.un Z
 	br		FAIL
 
 Z:
-	ldsfld	float64 bne_un::_zero
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::minus_zero
+	ldsfld	float64 bne_un::min
 	bne.un AA
 	br		FAIL
 
 AA:
-	ldsfld	float64 bne_un::_zero
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_zero
+	ldsfld	float64 bne_un::minus_one
 	bne.un BB
 	br		FAIL
 
 BB:
-	ldsfld	float64 bne_un::_zero
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
+	ldsfld	float64 bne_un::minus_zero
 	bne.un FAIL
 
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	ldsfld	float64 bne_un::zero
 	bne.un FAIL
 
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	ldsfld	float64 bne_un::one
 	bne.un CC
 	br		FAIL
 
 CC:
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	ldsfld	float64 bne_un::max
 	bne.un DD
 	br		FAIL
 
 DD:
-	ldsfld	float64 bne_un::_zero
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::minus_zero
+	ldsfld	float64 bne_un::pos_inf
 	bne.un EE
 	br		FAIL
 
 EE:
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	ldsfld	float64 bne_un::NaN
 	bne.un FF
 	br		FAIL
 FF:
 	ldsfld	float64 bne_un::zero
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un GG
 	br		FAIL
 
 GG:
 	ldsfld	float64 bne_un::zero
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	bne.un HH
 	br		FAIL
 
 HH:
 	ldsfld	float64 bne_un::zero
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	bne.un II
 	br		FAIL
 
 II:
 	ldsfld	float64 bne_un::zero
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	bne.un FAIL
 
 	ldsfld	float64 bne_un::zero
@@ -284,7 +294,7 @@ JJ:
 
 KK:
 	ldsfld	float64 bne_un::zero
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un LL
 	br		FAIL
 
@@ -296,25 +306,25 @@ LL:
 
 MM:
 	ldsfld	float64 bne_un::one
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un NN
 	br		FAIL
 
 NN:
 	ldsfld	float64 bne_un::one
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	bne.un OO
 	br		FAIL
 
 OO:
 	ldsfld	float64 bne_un::one
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	bne.un PP
 	br		FAIL
 
 PP:
 	ldsfld	float64 bne_un::one
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	bne.un QQ
 	br		FAIL
 
@@ -337,7 +347,7 @@ SS:
 
 TT:
 	ldsfld	float64 bne_un::one
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un UU
 	br		FAIL
 
@@ -349,25 +359,25 @@ UU:
 
 VV:
 	ldsfld	float64 bne_un::max
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un WW
 	br		FAIL
 
 WW:
 	ldsfld	float64 bne_un::max
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	bne.un XX
 	br		FAIL
 
 XX:
 	ldsfld	float64 bne_un::max
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	bne.un YY
 	br		FAIL
 
 YY:
 	ldsfld	float64 bne_un::max
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	bne.un ZZ
 	br		FAIL
 
@@ -389,7 +399,7 @@ BBB:
 	bne.un FAIL
 
 	ldsfld	float64 bne_un::max
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un CCC
 	br		FAIL
 
@@ -400,78 +410,78 @@ CCC:
 	br	FAIL
 
 DDD:
-	ldsfld	float64 bne_un::inf
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::pos_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un EEE
 	br		FAIL
 
 EEE:
-	ldsfld	float64 bne_un::inf
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::pos_inf
+	ldsfld	float64 bne_un::min
 	bne.un FFF
 	br		FAIL
 
 FFF:
-	ldsfld	float64 bne_un::inf
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::pos_inf
+	ldsfld	float64 bne_un::minus_one
 	bne.un GGG
 	br		FAIL
 
 GGG:
-	ldsfld	float64 bne_un::inf
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::pos_inf
+	ldsfld	float64 bne_un::minus_zero
 	bne.un HHH
 	br		FAIL
 
 HHH:
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	ldsfld	float64 bne_un::zero
 	bne.un III
 	br		FAIL
 
 III:
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	ldsfld	float64 bne_un::one
 	bne.un JJJ
 	br		FAIL
 
 JJJ:
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	ldsfld	float64 bne_un::max
 	bne.un KK_
 	br		FAIL
 
 KK_:
-	ldsfld	float64 bne_un::inf
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un FAIL
 
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	ldsfld	float64 bne_un::NaN
 	bne.un LLL
 	br		FAIL
 
 LLL:
 	ldsfld	float64 bne_un::NaN
-	ldsfld	float64 bne_un::_inf
+	ldsfld	float64 bne_un::neg_inf
 	bne.un MMM
 	br		FAIL
 
 MMM:
 	ldsfld	float64 bne_un::NaN
-	ldsfld	float64 bne_un::_min
+	ldsfld	float64 bne_un::min
 	bne.un NNN
 	br		FAIL
 
 NNN:
 	ldsfld	float64 bne_un::NaN
-	ldsfld	float64 bne_un::_one
+	ldsfld	float64 bne_un::minus_one
 	bne.un OOO
 	br		FAIL
 
 OOO:
 	ldsfld	float64 bne_un::NaN
-	ldsfld	float64 bne_un::_zero
+	ldsfld	float64 bne_un::minus_zero
 	bne.un PPP
 	br		FAIL
 
@@ -495,13 +505,481 @@ RRR:
 
 SSS:
 	ldsfld	float64 bne_un::NaN
-	ldsfld	float64 bne_un::inf
+	ldsfld	float64 bne_un::pos_inf
 	bne.un TTT
 	br		FAIL
 
 TTT:
 	ldsfld	float64 bne_un::NaN
 	ldsfld	float64 bne_un::NaN
+	bne.un L0
+	br FAIL
+
+	// Testing early folding logic
+
+L0:
+	ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	bne.un FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	bne.un L1
+	br FAIL
+
+L1:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	bne.un L2
+	br FAIL
+
+L2:
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	bne.un L3
+	br FAIL
+
+L3:
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	bne.un L4
+	br FAIL
+
+L4:
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	bne.un L5
+	br FAIL
+
+L5:
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	bne.un L6
+	br FAIL
+
+L6:
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	bne.un L7
+	br FAIL
+
+L7:
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	bne.un L8
+	br FAIL
+
+L8:
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	bne.un L9
+	br FAIL
+
+L9:
+	ldc.r8		MIN
+	ldc.r8		MIN
+	bne.un FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	bne.un L10
+	br FAIL
+
+L10:
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	bne.un L11
+	br FAIL
+
+L11:
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	bne.un L12
+	br FAIL
+
+L12:
+	ldc.r8		MIN
+	ldc.r8		ONE
+	bne.un L13
+	br FAIL
+
+L13:
+	ldc.r8		MIN
+	ldc.r8		MAX
+	bne.un L14
+	br FAIL
+
+L14:
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	bne.un L15
+	br FAIL
+
+L15:
+	ldc.r8		MIN
+	ldc.r8		NAN
+	bne.un L16
+	br FAIL
+
+L16:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	bne.un L17
+	br FAIL
+
+L17:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	bne.un L18
+	br FAIL
+
+L18:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	bne.un FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	bne.un L19
+	br FAIL
+
+L19:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	bne.un L20
+	br FAIL
+
+L20:
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	bne.un L21
+	br FAIL
+
+L21:
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	bne.un L22
+	br FAIL
+
+L22:
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	bne.un L23
+	br FAIL
+
+L23:
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	bne.un L24
+	br FAIL
+
+L24:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	bne.un L25
+	br FAIL
+
+L25:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	bne.un L26
+	br FAIL
+
+L26:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	bne.un L27
+	br FAIL
+
+L27:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	bne.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	bne.un FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	bne.un L28
+	br FAIL
+
+L28:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	bne.un L29
+	br FAIL
+
+L29:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	bne.un L30
+	br FAIL
+
+L30:
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	bne.un L31
+	br FAIL
+
+L31:
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	bne.un L32
+	br FAIL
+
+L32:
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	bne.un L33
+	br FAIL
+
+L33:
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	bne.un L34
+	br FAIL
+
+L34:
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	bne.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	bne.un FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	bne.un L35
+	br FAIL
+
+L35:
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	bne.un L36
+	br FAIL
+
+L36:
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	bne.un L37
+	br FAIL
+
+L37:
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	bne.un L38
+	br FAIL
+
+L38:
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	bne.un L39
+	br FAIL
+
+L39:
+	ldc.r8		ONE
+	ldc.r8		MIN
+	bne.un L40
+	br FAIL
+
+L40:
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	bne.un L41
+	br FAIL
+
+L41:
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	bne.un L42
+	br FAIL
+
+L42:
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	bne.un L43
+	br FAIL
+
+L43:
+	ldc.r8		ONE
+	ldc.r8		ONE
+	bne.un FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	bne.un L44
+	br FAIL
+
+L44:
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	bne.un L45
+	br FAIL
+
+L45:
+	ldc.r8		ONE
+	ldc.r8		NAN
+	bne.un L46
+	br FAIL
+
+L46:
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	bne.un L47
+	br FAIL
+
+L47:
+	ldc.r8		MAX
+	ldc.r8		MIN
+	bne.un L48
+	br FAIL
+
+L48:
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	bne.un L49
+	br FAIL
+
+L49:
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	bne.un L50
+	br FAIL
+
+L50:
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	bne.un L51
+	br FAIL
+
+L51:
+	ldc.r8		MAX
+	ldc.r8		ONE
+	bne.un L52
+	br FAIL
+
+L52:
+	ldc.r8		MAX
+	ldc.r8		MAX
+	bne.un FAIL
+
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	bne.un L53
+	br FAIL
+
+L53:
+	ldc.r8		MAX
+	ldc.r8		NAN
+	bne.un L54
+	br FAIL
+
+L54:
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	bne.un L55
+	br FAIL
+
+L55:
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	bne.un L56
+	br FAIL
+
+L56:
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	bne.un L57
+	br FAIL
+
+L57:
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	bne.un L58
+	br FAIL
+
+L58:
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	bne.un L59
+	br FAIL
+
+L59:
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	bne.un L60
+	br FAIL
+
+L60:
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	bne.un L61
+	br FAIL
+
+L61:
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	bne.un FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	bne.un L62
+	br FAIL
+
+L62:
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	bne.un L63
+	br FAIL
+
+L63:
+	ldc.r8		NAN
+	ldc.r8		MIN
+	bne.un L64
+	br FAIL
+
+L64:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	bne.un L65
+	br FAIL
+
+L65:
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	bne.un L66
+	br FAIL
+
+L66:
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	bne.un L67
+	br FAIL
+
+L67:
+	ldc.r8		NAN
+	ldc.r8		ONE
+	bne.un L68
+	br FAIL
+
+L68:
+	ldc.r8		NAN
+	ldc.r8		MAX
+	bne.un L69
+	br FAIL
+
+L69:
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	bne.un L70
+	br FAIL
+
+L70:
+	ldc.r8		NAN
+	ldc.r8		NAN
 	bne.un BACKCHECK
 	br FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.il
@@ -457,6 +457,7 @@
 	brfalse		FAIL
 
     // Testing early folding logic
+
     ldc.r4		NEG_INF
 	ldc.r4		NEG_INF
 	cgt.un

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.il
@@ -3,37 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
+
 .class public cgt_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 cgt_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 cgt_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 cgt_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 cgt_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 cgt_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 cgt_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 cgt_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 cgt_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 cgt_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 cgt_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 cgt_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 cgt_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 cgt_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 cgt_un::NaN
 	ret
 }
@@ -42,202 +52,202 @@
 .entrypoint
 .maxstack		10
 	call	void cgt_un::initialize()
-	ldsfld	float32 cgt_un::_inf
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::neg_inf
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::neg_inf
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::neg_inf
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	ldsfld	float32 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	ldsfld	float32 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	ldsfld	float32 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::neg_inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	ldsfld	float32 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
-	ldsfld	float32 cgt_un::_min
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::min
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_min
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::min
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::min
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	ldsfld	float32 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	ldsfld	float32 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	ldsfld	float32 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::min
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	ldsfld	float32 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 
-	ldsfld	float32 cgt_un::_one
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::minus_one
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_one
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::minus_one
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_one
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_one
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	ldsfld	float32 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	ldsfld	float32 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	ldsfld	float32 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::minus_one
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	ldsfld	float32 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
-	ldsfld	float32 cgt_un::_zero
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::minus_zero
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_zero
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::minus_zero
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_zero
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_zero
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::_zero
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	ldsfld	float32 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	ldsfld	float32 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	ldsfld	float32 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_zero
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::minus_zero
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	ldsfld	float32 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::zero
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::zero
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::zero
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::zero
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
@@ -257,7 +267,7 @@
 	brtrue		FAIL
 
 	ldsfld	float32 cgt_un::zero
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -267,22 +277,22 @@
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::one
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::one
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::one
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::one
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -302,7 +312,7 @@
 	brtrue		FAIL
 
 	ldsfld	float32 cgt_un::one
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -312,22 +322,22 @@
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::max
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::max
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::max
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::max
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -347,7 +357,7 @@
 	brtrue		FAIL
 
 	ldsfld	float32 cgt_un::max
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -356,68 +366,68 @@
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::pos_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::pos_inf
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::pos_inf
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::pos_inf
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	ldsfld	float32 cgt_un::zero
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	ldsfld	float32 cgt_un::one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	ldsfld	float32 cgt_un::max
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float32 cgt_un::inf
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	ldsfld	float32 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
-	ldsfld	float32 cgt_un::_inf
+	ldsfld	float32 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
-	ldsfld	float32 cgt_un::_min
+	ldsfld	float32 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
-	ldsfld	float32 cgt_un::_one
+	ldsfld	float32 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
-	ldsfld	float32 cgt_un::_zero
+	ldsfld	float32 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -437,12 +447,417 @@
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
-	ldsfld	float32 cgt_un::inf
+	ldsfld	float32 cgt_un::pos_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float32 cgt_un::NaN
 	ldsfld	float32 cgt_un::NaN
+	cgt.un
+	brfalse		FAIL
+
+    // Testing early folding logic
+    ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MIN
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MAX
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		NAN
 	cgt.un
 	brfalse		FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.il
@@ -3,37 +3,47 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
+
 .class public cgt_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 
 .method public static	void initialize() {
 .maxstack	10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 cgt_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 cgt_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 cgt_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 cgt_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 cgt_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 cgt_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 cgt_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 cgt_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 cgt_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 cgt_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 cgt_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 cgt_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 cgt_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 cgt_un::NaN
 	ret
 }
@@ -43,202 +53,202 @@
 .maxstack		10
 	call	void cgt_un::initialize()
 
-	ldsfld	float64 cgt_un::_inf
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::neg_inf
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::neg_inf
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::neg_inf
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	ldsfld	float64 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	ldsfld	float64 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	ldsfld	float64 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::neg_inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	ldsfld	float64 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
-	ldsfld	float64 cgt_un::_min
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::min
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_min
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::min
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::min
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	ldsfld	float64 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	ldsfld	float64 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	ldsfld	float64 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::min
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	ldsfld	float64 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 
-	ldsfld	float64 cgt_un::_one
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::minus_one
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_one
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::minus_one
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_one
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_one
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	ldsfld	float64 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	ldsfld	float64 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	ldsfld	float64 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::minus_one
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	ldsfld	float64 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
-	ldsfld	float64 cgt_un::_zero
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::minus_zero
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_zero
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::minus_zero
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_zero
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_zero
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::_zero
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	ldsfld	float64 cgt_un::zero
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	ldsfld	float64 cgt_un::one
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	ldsfld	float64 cgt_un::max
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_zero
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::minus_zero
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	ldsfld	float64 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::zero
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::zero
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::zero
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::zero
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brtrue		FAIL
 
@@ -258,7 +268,7 @@
 	brtrue		FAIL
 
 	ldsfld	float64 cgt_un::zero
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -268,22 +278,22 @@
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::one
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::one
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::one
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::one
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -303,7 +313,7 @@
 	brtrue		FAIL
 
 	ldsfld	float64 cgt_un::one
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -313,22 +323,22 @@
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::max
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::max
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::max
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::max
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -348,7 +358,7 @@
 	brtrue		FAIL
 
 	ldsfld	float64 cgt_un::max
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
@@ -357,68 +367,68 @@
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::pos_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::pos_inf
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::pos_inf
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::pos_inf
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	ldsfld	float64 cgt_un::zero
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	ldsfld	float64 cgt_un::one
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	ldsfld	float64 cgt_un::max
 	cgt.un
 	brfalse		FAIL
 
-	ldsfld	float64 cgt_un::inf
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brtrue		FAIL
 
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	ldsfld	float64 cgt_un::NaN
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
-	ldsfld	float64 cgt_un::_inf
+	ldsfld	float64 cgt_un::neg_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
-	ldsfld	float64 cgt_un::_min
+	ldsfld	float64 cgt_un::min
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
-	ldsfld	float64 cgt_un::_one
+	ldsfld	float64 cgt_un::minus_one
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
-	ldsfld	float64 cgt_un::_zero
+	ldsfld	float64 cgt_un::minus_zero
 	cgt.un
 	brfalse		FAIL
 
@@ -438,12 +448,417 @@
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
-	ldsfld	float64 cgt_un::inf
+	ldsfld	float64 cgt_un::pos_inf
 	cgt.un
 	brfalse		FAIL
 
 	ldsfld	float64 cgt_un::NaN
 	ldsfld	float64 cgt_un::NaN
+	cgt.un
+	brfalse		FAIL
+
+    // Testing early folding logic
+    ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MIN
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ONE
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MAX
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	cgt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MIN
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		ONE
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MAX
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	cgt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		NAN
 	cgt.un
 	brfalse		FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.il
@@ -458,6 +458,7 @@
 	brfalse		FAIL
 
     // Testing early folding logic
+
     ldc.r8		NEG_INF
 	ldc.r8		NEG_INF
 	cgt.un

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.il
@@ -456,6 +456,7 @@
 	brfalse		FAIL
 
     // Testing early folding logic
+
     ldc.r4		NEG_INF
 	ldc.r4		NEG_INF
 	clt.un

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.il
@@ -3,36 +3,46 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float32(0xFF800000)"
+#define MIN        "float32(0xFF7FFFFF)"
+#define MINUS_ONE  "float32(0xBF800000)"
+#define MINUS_ZERO "float32(0x80000000)"
+#define ZERO       "float32(0x00000000)"
+#define ONE        "float32(0x3F800000)"
+#define MAX        "float32(0x7F7FFFFF)"
+#define POS_INF    "float32(0x7F800000)"
+#define NAN        "float32(0x7FC00000)"
+
 .class public clt_un {
 
-.field public static	float32 _inf
-.field public static	float32 _min
-.field public static	float32 _one
-.field public static	float32 _zero
+.field public static	float32 neg_inf
+.field public static	float32 min
+.field public static	float32 minus_one
+.field public static	float32 minus_zero
 .field public static	float32 zero
 .field public static	float32 one
 .field public static	float32 max
-.field public static	float32 inf
+.field public static	float32 pos_inf
 .field public static	float32 NaN
 .method public static void initialize() {
 .maxstack		10
-	ldc.r4		float32(0xFF800000)
-	stsfld	float32 clt_un::_inf
-	ldc.r4		float32(0xFF7FFFFF)
-	stsfld	float32 clt_un::_min
-	ldc.r4		float32(0xBF800000)
-	stsfld	float32 clt_un::_one
-	ldc.r4		float32(0x80000000)
-	stsfld	float32 clt_un::_zero
-	ldc.r4		float32(0x00000000)
+	ldc.r4		NEG_INF
+	stsfld	float32 clt_un::neg_inf
+	ldc.r4		MIN
+	stsfld	float32 clt_un::min
+	ldc.r4		MINUS_ONE
+	stsfld	float32 clt_un::minus_one
+	ldc.r4		MINUS_ZERO
+	stsfld	float32 clt_un::minus_zero
+	ldc.r4		ZERO
 	stsfld	float32 clt_un::zero
-	ldc.r4		float32(0x3F800000)
+	ldc.r4		ONE
 	stsfld	float32 clt_un::one
-	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		MAX
 	stsfld	float32 clt_un::max
-	ldc.r4		float32(0x7F800000)
-	stsfld	float32 clt_un::inf
-	ldc.r4		float32(0x7FC00000)
+	ldc.r4		POS_INF
+	stsfld	float32 clt_un::pos_inf
+	ldc.r4		NAN
 	stsfld	float32 clt_un::NaN
 	ret
 }
@@ -41,202 +51,202 @@
 .entrypoint
 .maxstack		10
 	call	void clt_un::initialize()
-	ldsfld	float32 clt_un::_inf
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_inf
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::neg_inf
+	ldsfld	float32 clt_un::min
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::neg_inf
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::neg_inf
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	ldsfld	float32 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	ldsfld	float32 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	ldsfld	float32 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::neg_inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	ldsfld	float32 clt_un::NaN
 	clt.un
 	brfalse		FAIL
-	ldsfld	float32 clt_un::_min
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::min
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_min
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_min
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::min
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::min
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	ldsfld	float32 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	ldsfld	float32 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	ldsfld	float32 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::min
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	ldsfld	float32 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 
 
-	ldsfld	float32 clt_un::_one
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::minus_one
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_one
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::minus_one
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_one
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_one
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_one
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	ldsfld	float32 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	ldsfld	float32 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	ldsfld	float32 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_one
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::minus_one
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	ldsfld	float32 clt_un::NaN
 	clt.un
 	brfalse		FAIL
-	ldsfld	float32 clt_un::_zero
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::minus_zero
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_zero
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::minus_zero
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_zero
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_zero
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_zero
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	ldsfld	float32 clt_un::zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	ldsfld	float32 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	ldsfld	float32 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_zero
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::minus_zero
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	ldsfld	float32 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::zero
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::zero
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::zero
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::zero
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
@@ -256,7 +266,7 @@
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::zero
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
@@ -266,22 +276,22 @@
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::one
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::one
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::one
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::one
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
@@ -301,7 +311,7 @@
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::one
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
@@ -311,22 +321,22 @@
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::max
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::max
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::max
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::max
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
@@ -346,7 +356,7 @@
 	brtrue		FAIL
 
 	ldsfld	float32 clt_un::max
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
@@ -355,68 +365,68 @@
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float32 clt_un::inf
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::pos_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::pos_inf
+	ldsfld	float32 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::pos_inf
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::pos_inf
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	ldsfld	float32 clt_un::zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	ldsfld	float32 clt_un::one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	ldsfld	float32 clt_un::max
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	ldsfld	float32 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
-	ldsfld	float32 clt_un::_inf
+	ldsfld	float32 clt_un::neg_inf
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
-	ldsfld	float32 clt_un::_min
+	ldsfld	float32 clt_un::min
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
-	ldsfld	float32 clt_un::_one
+	ldsfld	float32 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
-	ldsfld	float32 clt_un::_zero
+	ldsfld	float32 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
@@ -436,12 +446,417 @@
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
-	ldsfld	float32 clt_un::inf
+	ldsfld	float32 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float32 clt_un::NaN
 	ldsfld	float32 clt_un::NaN
+	clt.un
+	brfalse		FAIL
+
+    // Testing early folding logic
+    ldc.r4		NEG_INF
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MIN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NEG_INF
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r4		MIN
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MIN
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ONE
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MINUS_ZERO
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ZERO
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		ONE
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		MAX
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		MAX
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		MAX
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		POS_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r4		POS_INF
+	ldc.r4		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		NEG_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MIN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r4		NAN
+	ldc.r4		NAN
 	clt.un
 	brfalse		FAIL
 

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.il
@@ -453,6 +453,7 @@
 	brfalse		FAIL
 
     // Testing early folding logic
+
     ldc.r8		NEG_INF
 	ldc.r8		NEG_INF
 	clt.un

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.il
@@ -3,36 +3,46 @@
 
 .assembly extern legacy library mscorlib {}
 
+#define NEG_INF    "float64(0xFFF0000000000000)"
+#define MIN        "float64(0xFF7FFFFFFFFFFFFF)"
+#define MINUS_ONE  "float64(0xBFF0000000000000)"
+#define MINUS_ZERO "float64(0x8000000000000000)"
+#define ZERO       "float64(0x0000000000000000)"
+#define ONE        "float64(0x3FF0000000000000)"
+#define MAX        "float64(0x7FEFFFFFFFFFFFFF)"
+#define POS_INF    "float64(0x7FF0000000000000)"
+#define NAN        "float64(0x7FF8000000000000)"
+
 .class public clt_un {
 
-.field public static	float64 _inf
-.field public static	float64 _min
-.field public static	float64 _one
-.field public static	float64 _zero
+.field public static	float64 neg_inf
+.field public static	float64 min
+.field public static	float64 minus_one
+.field public static	float64 minus_zero
 .field public static	float64 zero
 .field public static	float64 one
 .field public static	float64 max
-.field public static	float64 inf
+.field public static	float64 pos_inf
 .field public static	float64 NaN
 .method public static void initialize() {
 .maxstack		10
-	ldc.r8		float64(0xFFF0000000000000)
-	stsfld	float64 clt_un::_inf
-	ldc.r8		float64(0xFF7FFFFFFFFFFFFF)
-	stsfld	float64 clt_un::_min
-	ldc.r8		float64(0xBFF0000000000000)
-	stsfld	float64 clt_un::_one
-	ldc.r8		float64(0x8000000000000000)
-	stsfld	float64 clt_un::_zero
-	ldc.r8		float64(0x0000000000000000)
+	ldc.r8		NEG_INF
+	stsfld	float64 clt_un::neg_inf
+	ldc.r8		MIN
+	stsfld	float64 clt_un::min
+	ldc.r8		MINUS_ONE
+	stsfld	float64 clt_un::minus_one
+	ldc.r8		MINUS_ZERO
+	stsfld	float64 clt_un::minus_zero
+	ldc.r8		ZERO
 	stsfld	float64 clt_un::zero
-	ldc.r8		float64(0x3FF0000000000000)
+	ldc.r8		ONE
 	stsfld	float64 clt_un::one
-	ldc.r8		float64(0x7FEFFFFFFFFFFFFF)
+	ldc.r8		MAX
 	stsfld	float64 clt_un::max
-	ldc.r8		float64(0x7FF0000000000000)
-	stsfld	float64 clt_un::inf
-	ldc.r8		float64(0x7FF8000000000000)
+	ldc.r8		POS_INF
+	stsfld	float64 clt_un::pos_inf
+	ldc.r8		NAN
 	stsfld	float64 clt_un::NaN
 	ret
 }
@@ -41,199 +51,199 @@
 .entrypoint
 .maxstack		10
 	call	void clt_un::initialize()
-	ldsfld	float64 clt_un::_inf
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_inf
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::neg_inf
+	ldsfld	float64 clt_un::min
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::neg_inf
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::neg_inf
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	ldsfld	float64 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	ldsfld	float64 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	ldsfld	float64 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::neg_inf
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
-	ldsfld	float64 clt_un::_min
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::min
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_min
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_min
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::min
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::min
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	ldsfld	float64 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	ldsfld	float64 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	ldsfld	float64 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::min
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
-	ldsfld	float64 clt_un::_one
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::minus_one
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_one
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::minus_one
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_one
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_one
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_one
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	ldsfld	float64 clt_un::zero
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	ldsfld	float64 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	ldsfld	float64 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_one
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::minus_one
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
-	ldsfld	float64 clt_un::_zero
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::minus_zero
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_zero
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::minus_zero
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_zero
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_zero
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_zero
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	ldsfld	float64 clt_un::zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	ldsfld	float64 clt_un::one
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	ldsfld	float64 clt_un::max
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_zero
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::minus_zero
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
@@ -253,77 +263,77 @@
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::zero
-	ldsfld	float64 clt_un::NaN
-	clt.un
-	brfalse		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::_inf
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::_min
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::_one
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::_zero
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::zero
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::one
-	clt.un
-	brtrue		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::max
-	clt.un
-	brfalse		FAIL
-
-	ldsfld	float64 clt_un::one
-	ldsfld	float64 clt_un::inf
-	clt.un
-	brfalse		FAIL
-
-	ldsfld	float64 clt_un::one
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::neg_inf
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::min
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::minus_one
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::minus_zero
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::zero
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::one
+	clt.un
+	brtrue		FAIL
+
+	ldsfld	float64 clt_un::one
 	ldsfld	float64 clt_un::max
-	ldsfld	float64 clt_un::_inf
+	clt.un
+	brfalse		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::pos_inf
+	clt.un
+	brfalse		FAIL
+
+	ldsfld	float64 clt_un::one
+	ldsfld	float64 clt_un::NaN
+	clt.un
+	brfalse		FAIL
+
+	ldsfld	float64 clt_un::max
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::max
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::max
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::max
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
@@ -343,7 +353,7 @@
 	brtrue		FAIL
 
 	ldsfld	float64 clt_un::max
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
@@ -352,68 +362,68 @@
 	clt.un
 	brfalse	FAIL
 
-	ldsfld	float64 clt_un::inf
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::pos_inf
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::pos_inf
+	ldsfld	float64 clt_un::min
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::pos_inf
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::pos_inf
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	ldsfld	float64 clt_un::zero
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	ldsfld	float64 clt_un::one
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	ldsfld	float64 clt_un::max
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brtrue		FAIL
 
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	ldsfld	float64 clt_un::NaN
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
-	ldsfld	float64 clt_un::_inf
+	ldsfld	float64 clt_un::neg_inf
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
-	ldsfld	float64 clt_un::_min
+	ldsfld	float64 clt_un::min
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
-	ldsfld	float64 clt_un::_one
+	ldsfld	float64 clt_un::minus_one
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
-	ldsfld	float64 clt_un::_zero
+	ldsfld	float64 clt_un::minus_zero
 	clt.un
 	brfalse		FAIL
 
@@ -433,12 +443,414 @@
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
-	ldsfld	float64 clt_un::inf
+	ldsfld	float64 clt_un::pos_inf
 	clt.un
 	brfalse		FAIL
 
 	ldsfld	float64 clt_un::NaN
 	ldsfld	float64 clt_un::NaN
+	clt.un
+	brfalse		FAIL
+
+    // Testing early folding logic
+    ldc.r8		NEG_INF
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MIN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NEG_INF
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r8		MIN
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MIN
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r8		MINUS_ONE
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ONE
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MINUS_ZERO
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+	ldc.r8		ZERO
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ZERO
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		ONE
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		MAX
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		MAX
+	ldc.r8		NAN
+	clt.un
+	brfalse	FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NEG_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MIN
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ZERO
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		ONE
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		MAX
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		POS_INF
+	clt.un
+	brtrue		FAIL
+
+	ldc.r8		POS_INF
+	ldc.r8		NAN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		NEG_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MIN
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MINUS_ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MINUS_ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		ZERO
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		ONE
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		MAX
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		POS_INF
+	clt.un
+	brfalse		FAIL
+
+	ldc.r8		NAN
+	ldc.r8		NAN
 	clt.un
 	brfalse		FAIL
 


### PR DESCRIPTION
These were blocked and it was causing issues for unrolling as the unroller substitutes iterator variables with constants, but if the comparison is unsigned (in other words, the `(uint)index >= Length` trick was used), later phases do not clean it up. The code to actually handle the folding is already there:
https://github.com/dotnet/runtime/blob/a350bc6e0896d2869e4028fdafb94588e3fe0867/src/coreclr/jit/valuenum.cpp#L862
https://github.com/dotnet/runtime/blob/a350bc6e0896d2869e4028fdafb94588e3fe0867/src/coreclr/jit/valuenum.cpp#L889-L904

The diffs (with `--pmi`) are as expected:
<details>
<summary>Vector methods</summary>

```
PMI CodeSize Diffs for System.Private.CoreLib.dll for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 6504771
Total bytes of diff: 6504383
Total bytes of delta: -388 (-0.01% of base)
    diff is an improvement.


Top file improvements (bytes):
        -388 : System.Private.CoreLib.dasm (-0.01% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -70 (-26.92% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Int32]):bool
         -70 (-26.32% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Int64][System.Int64]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[Int64]):bool
         -58 (-22.31% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Int64][System.Int64]:GetHashCode():int:this
         -54 (-25.59% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:GetHashCode():int:this
         -38 (-16.10% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Double]):bool
         -34 (-12.01% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:GetHashCode():int:this
         -34 (-24.64% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Int64]):bool
         -30 (-19.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:GetHashCode():int:this

Top method improvements (percentages):
         -70 (-26.92% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Int32]):bool
         -70 (-26.32% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Int64][System.Int64]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[Int64]):bool
         -54 (-25.59% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:GetHashCode():int:this
         -34 (-24.64% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Int64]):bool
         -58 (-22.31% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Int64][System.Int64]:GetHashCode():int:this
         -30 (-19.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:GetHashCode():int:this
         -38 (-16.10% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Double]):bool
         -34 (-12.01% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:GetHashCode():int:this

8 total methods with Code Size differences (8 improved, 0 regressed), 36609 unchanged.
```
</details>

[An example](https://www.diffchecker.com/PwvG2QPW).

Draft for now to test this in CI.