### PR TITLE
[RyuJIT] Fix optRemoveRedundantZeroInits for loops

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9562,35 +9562,38 @@ void Compiler::optRemoveRedundantZeroInits()
                             bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
                             bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
 
-                            if (BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclNum) ||
-                                (lclDsc->lvIsStructField &&
-                                 BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||
-                                (!lclDsc->lvTracked && !fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn)))
+                            if (!bbInALoop || bbIsReturn)
                             {
-                                // We are guaranteed to have a zero initialization in the prolog or a
-                                // dominating explicit zero initialization and the local hasn't been redefined
-                                // between the prolog and this explicit zero initialization so the assignment
-                                // can be safely removed.
-                                if (tree == stmt->GetRootNode())
+                                if (BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclNum) ||
+                                    (lclDsc->lvIsStructField &&
+                                        BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||
+                                    (!lclDsc->lvTracked && !fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn)))
                                 {
-                                    fgRemoveStmt(block, stmt);
-                                    removedExplicitZeroInit      = true;
-                                    lclDsc->lvSuppressedZeroInit = 1;
-
-                                    if (lclDsc->lvTracked)
+                                    // We are guaranteed to have a zero initialization in the prolog or a
+                                    // dominating explicit zero initialization and the local hasn't been redefined
+                                    // between the prolog and this explicit zero initialization so the assignment
+                                    // can be safely removed.
+                                    if (tree == stmt->GetRootNode())
                                     {
-                                        removedTrackedDefs   = true;
-                                        unsigned* pDefsCount = defsInBlock.LookupPointer(lclNum);
-                                        *pDefsCount          = (*pDefsCount) - 1;
+                                        fgRemoveStmt(block, stmt);
+                                        removedExplicitZeroInit = true;
+                                        lclDsc->lvSuppressedZeroInit = 1;
+
+                                        if (lclDsc->lvTracked)
+                                        {
+                                            removedTrackedDefs = true;
+                                            unsigned* pDefsCount = defsInBlock.LookupPointer(lclNum);
+                                            *pDefsCount = (*pDefsCount) - 1;
+                                        }
                                     }
                                 }
-                            }
 
-                            if (treeOp->gtOp1->OperIs(GT_LCL_VAR))
-                            {
-                                BitVecOps::AddElemD(&bitVecTraits, zeroInitLocals, lclNum);
+                                if (treeOp->gtOp1->OperIs(GT_LCL_VAR))
+                                {
+                                    BitVecOps::AddElemD(&bitVecTraits, zeroInitLocals, lclNum);
+                                }
+                                *pRefCount = 0;
                             }
-                            *pRefCount = 0;
                         }
 
                         if (!removedExplicitZeroInit && treeOp->gtOp1->OperIs(GT_LCL_VAR) &&

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9583,7 +9583,7 @@ void Compiler::optRemoveRedundantZeroInits()
                                         {
                                             removedTrackedDefs   = true;
                                             unsigned* pDefsCount = defsInBlock.LookupPointer(lclNum);
-                                            *pDefsCount = (*pDefsCount) - 1;
+                                            *pDefsCount          = (*pDefsCount) - 1;
                                         }
                                     }
                                 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9566,7 +9566,7 @@ void Compiler::optRemoveRedundantZeroInits()
                             {
                                 if (BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclNum) ||
                                     (lclDsc->lvIsStructField &&
-                                        BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||
+                                     BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||
                                     (!lclDsc->lvTracked && !fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn)))
                                 {
                                     // We are guaranteed to have a zero initialization in the prolog or a
@@ -9576,12 +9576,12 @@ void Compiler::optRemoveRedundantZeroInits()
                                     if (tree == stmt->GetRootNode())
                                     {
                                         fgRemoveStmt(block, stmt);
-                                        removedExplicitZeroInit = true;
+                                        removedExplicitZeroInit      = true;
                                         lclDsc->lvSuppressedZeroInit = 1;
 
                                         if (lclDsc->lvTracked)
                                         {
-                                            removedTrackedDefs = true;
+                                            removedTrackedDefs   = true;
                                             unsigned* pDefsCount = defsInBlock.LookupPointer(lclNum);
                                             *pDefsCount = (*pDefsCount) - 1;
                                         }

--- a/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.cs
+++ b/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class NotRedundantInitsAreRemoved_Github_48394
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue(ref object obj)
+    {
+        if (obj != null)
+            throw new Exception("array was expected to be null here");
+
+        obj = new object();
+    }
+
+    public static int Main()
+    {
+        object obj = null;
+        int i = 0;
+        do
+        {
+            obj = null; // JIT shouldn't remove this store.
+            ValidateAndAssignValue(ref obj);
+        }
+        while (i++ < 2);
+        return 100;
+    }
+}

--- a/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.cs
+++ b/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.cs
@@ -4,27 +4,154 @@
 using System;
 using System.Runtime.CompilerServices;
 
+public struct Struct1
+{
+    public long a;
+    public long b;
+}
+
 public class NotRedundantInitsAreRemoved_Github_48394
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ValidateAndAssignValue(ref object obj)
+    private static void ValidateAndAssignValue<T>(ref T obj) where T : new()
     {
         if (obj != null)
-            throw new Exception("array was expected to be null here");
+            throw new Exception("obj was expected to be null");
 
-        obj = new object();
+        obj = new T();
     }
 
-    public static int Main()
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue(ref int val) 
+    {
+        if (val != 0)
+            throw new Exception("val was expected to be zero");
+
+        val = 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue(ref Struct1 val)
+    {
+        if (val.a != 0 || val.b != 0)
+            throw new Exception("val was expected to be zero");
+
+        val.a = 42;
+        val.b = 43;
+    }
+
+    public static void TestRefs()
     {
         object obj = null;
         int i = 0;
         do
         {
-            obj = null; // JIT shouldn't remove this store.
+            obj = null;
             ValidateAndAssignValue(ref obj);
         }
         while (i++ < 2);
+    }
+
+    public static void TestInt()
+    {
+        int val = 0;
+        int i = 0;
+        do
+        {
+            val = 0;
+            ValidateAndAssignValue(ref val);
+        }
+        while (i++ < 2);
+    }
+
+    public static void TestStruct()
+    {
+        Struct1 val = default;
+        int i = 0;
+        do
+        {
+            val.a = 0;
+            val.b = 0; 
+            ValidateAndAssignValue(ref val);
+        }
+        while (i++ < 2);
+    }
+
+    public static unsafe void TestTakeAddress()
+    {
+        int a = 0;
+        int* pa = &a;
+        *pa = 42;
+        a = 0;
+        if (a != 0)
+            throw new Exception("a was expected to be zero");
+    }
+
+    public static unsafe void TestTakeAddress(bool cond)
+    {
+        int a = 0;
+        if (cond)
+        {
+            int* pa = &a;
+            *pa = 42;
+        }
+        a = 0;
+        if (a != 0)
+            throw new Exception("a was expected to be zero");
+    }
+
+    public static void ReproFrom_GitHub_48394()
+    {
+        bool x = false;
+        int c = 0;
+        try
+        {
+            while (true)
+            {
+                c = 0;
+                if (!x)
+                {
+                    c = c + 100;
+                    x = true;
+                }
+                else
+                {
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            if (c != 0)
+                throw new Exception("c was expected to be 100");
+        }
+    }
+
+    public static int Zero => 0;
+
+    public static void TestInt2()
+    {
+        int val = Zero;
+        int i = 0;
+
+    label:
+        val = Zero;
+        ValidateAndAssignValue(ref val);
+        i++;
+        if (i < 10)
+            goto label;
+    }
+
+    public static int Main()
+    {
+        ReproFrom_GitHub_48394();
+        TestTakeAddress();
+        TestTakeAddress(true);
+        TestTakeAddress(false);
+        TestInt();
+        TestInt2();
+        TestRefs();
+        TestStruct();
         return 100;
     }
 }

--- a/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.csproj
+++ b/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NotRedundantInitsAreRemoved_Github_48394.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.csproj
+++ b/src/tests/JIT/opt/DSE/Regressions/NotRedundantInitsAreRemoved_Github_48394.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NotRedundantInitsAreRemoved_Github_48394.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48394 (Eugene's fix + tests)

jit-diff:
```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 53773460
Total bytes of diff: 53773466
Total bytes of delta: 6 (0.00% of base)
    diff is a regression.


Top file regressions (bytes):
           6 : System.Net.Security.dasm (0.00% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 270 unchanged.

Top method regressions (bytes):
           6 ( 0.96% of base) : System.Net.Security.dasm - SecureChannel:GenerateToken(ReadOnlySpan`1,byref):SecurityStatusPal:this

Top method regressions (percentages):
           6 ( 0.96% of base) : System.Net.Security.dasm - SecureChannel:GenerateToken(ReadOnlySpan`1,byref):SecurityStatusPal:this

1 total methods with Code Size differences (0 improved, 1 regressed), 267896 unchanged.
```
https://github.com/dotnet/runtime/blob/d5ab93c4a8e45da2dab8924c2165000bf78f84e6/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs#L776 this line was preserved basically.


