### PR TITLE
JIT: remove JitGuardedDevirtualizationGuessBestClass

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -445,7 +445,6 @@ CONFIG_INTEGER(JitEnableGuardedDevirtualization, W("JitEnableGuardedDevirtualiza
 #if defined(DEBUG)
 // Various policies for GuardedDevirtualization
 CONFIG_STRING(JitGuardedDevirtualizationRange, W("JitGuardedDevirtualizationRange"))
-CONFIG_INTEGER(JitGuardedDevirtualizationGuessBestClass, W("JitGuardedDevirtualizationGuessBestClass"), 1)
 #endif // DEBUG
 
 // Enable insertion of patchpoints into Tier0 methods with loops.


### PR DESCRIPTION
And slightly rearrange the two bits of code that consider guarded
devirualization with the goal of eventually unifying them.

Fixes #48564.