### PR TITLE
Dont throw exception in SerialStream constructor if dtr or rts is not available

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -568,11 +568,12 @@ namespace System.IO.Ports
                 {
                     DtrEnable = dtrEnable;
                 }
-                catch (IOException)
+                catch (IOException) when (dtrEnable == false)
                 {
                     // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
                     // the required termios command for setting DtrEnable, but it still works without setting the value
-                    // so we ignore this error in the constructor but still throw when setting the property manually
+                    // so we ignore this error in the constructor only if being set to false (which is the default).
+                    // When the property is set manually the exception is still thrown.
                 }
 
                 BaudRate = baudRate;
@@ -589,11 +590,12 @@ namespace System.IO.Ports
                         _rtsEnable = RtsEnabledNative();
                         RtsEnable = rtsEnable;
                     }
-                    catch (IOException)
+                    catch (IOException) when (rtsEnable == false)
                     {
                         // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
                         // the required termios command for setting RtsEnable, but it still works without setting the value
-                        // so we ignore this error in the constructor but still throw when setting the property manually
+                        // so we ignore this error in the constructor only if being set to false (which is the default).
+                        // When the property is set manually the exception is still thrown.
                     }
                 }
             }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -568,7 +568,7 @@ namespace System.IO.Ports
                 {
                     DtrEnable = dtrEnable;
                 }
-                catch (IOException ex)
+                catch (IOException)
                 {
                     // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
                     // the required termios command for setting DtrEnable, but it still works without setting the value
@@ -589,7 +589,7 @@ namespace System.IO.Ports
                         _rtsEnable = RtsEnabledNative();
                         RtsEnable = rtsEnable;
                     }
-                    catch (IOException ex)
+                    catch (IOException)
                     {
                         // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
                         // the required termios command for setting RtsEnable, but it still works without setting the value

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -564,7 +564,17 @@ namespace System.IO.Ports
                     throw new ArgumentException();
                 }
 
-                DtrEnable = dtrEnable;
+                try
+                {
+                    DtrEnable = dtrEnable;
+                }
+                catch (IOException ex)
+                {
+                    // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
+                    // the required termios command for setting DtrEnable, but it still works without setting the value
+                    // so we ignore this error in the constructor but still throw when setting the property manually
+                }
+
                 BaudRate = baudRate;
 
                 // now set this.RtsEnable to the specified value.
@@ -572,10 +582,19 @@ namespace System.IO.Ports
                 // handshake is either RequestToSend or RequestToSendXOnXOff
                 if ((handshake != Handshake.RequestToSend && handshake != Handshake.RequestToSendXOnXOff))
                 {
-                    // query and cache the initial RtsEnable value
-                    // so that set_RtsEnable can do the (value != rtsEnable) optimization
-                    _rtsEnable = RtsEnabledNative();
-                    RtsEnable = rtsEnable;
+                    try
+                    {
+                        // query and cache the initial RtsEnable value
+                        // so that set_RtsEnable can do the (value != rtsEnable) optimization
+                        _rtsEnable = RtsEnabledNative();
+                        RtsEnable = rtsEnable;
+                    }
+                    catch (IOException ex)
+                    {
+                        // An IOException can be thrown when using a virtual port from eg. socat, which doesn't implement
+                        // the required termios command for setting RtsEnable, but it still works without setting the value
+                        // so we ignore this error in the constructor but still throw when setting the property manually
+                    }
                 }
             }
             catch


### PR DESCRIPTION
Dont throw IOException in SerialStream constructor when setting dtr and/or rts is not possible (for example virtual ports on Linux cannot set this and currently crash in the constructor of SerialStream making it impossible to use on those ports)

This fixes #31523 using the suggestion in [#37841](https://github.com/dotnet/runtime/issues/37841#issuecomment-706956865). This only fixes the Linux version, not the windows one, so I don't think it completely fixes #37841 (I could probably add the try/catch in the windows implementation as well if you want me to). 