### PR TITLE
Fix ThreadPool events validation test

### DIFF
--- a/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
@@ -48,7 +48,7 @@ namespace Tracing.Tests.GCFinalizers
                     return total;
                 });
             }
-	    Task.WaitAll(tasks);
+            Task.WaitAll(tasks);
         };
 
         private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainEvents = (source) => 

--- a/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
@@ -48,6 +48,7 @@ namespace Tracing.Tests.GCFinalizers
                     return total;
                 });
             }
+	    Task.WaitAll(tasks);
         };
 
         private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainEvents = (source) => 


### PR DESCRIPTION
This test was failing sometimes because there were no ThreadPool events recorded. Turns out it wasn't waiting for the tasks to be complete... This should fix #48543. 