### PR TITLE
Fix doc comment typo in JsonSerializerOptions.cs

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -313,7 +313,7 @@ namespace System.Text.Json
 
         /// <summary>
         /// Determines whether read-only fields are ignored during serialization.
-        /// A property is read-only if it isn't marked with the <c>readonly</c> keyword.
+        /// A field is read-only if it is marked with the <c>readonly</c> keyword.
         /// The default value is false.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
The following sentence in the doc comments for the `IgnoreReadOnlyFields` member:

> A property is read-only if it isn't marked with the `readonly` keyword.

Should read:

> A field is read-only if it is marked with the `readonly` keyword.

This is consistent with the correct text on the [live docs](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions?view=net-5.0):

![image](https://user-images.githubusercontent.com/20465797/108704109-96889680-751c-11eb-8fbb-53959549cc6c.png)
