### PR TITLE
Fix another doc comment typo in JsonSerializerOptions.cs

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -336,7 +336,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Determines whether fields are handled during serialization and deserialization.
+        /// Determines whether fields are handled on serialization and deserialization.
         /// The default value is false.
         /// </summary>
         /// <exception cref="InvalidOperationException">

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -336,7 +336,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Determines whether fields are handled serialization and deserialization.
+        /// Determines whether fields are handled during serialization and deserialization.
         /// The default value is false.
         /// </summary>
         /// <exception cref="InvalidOperationException">


### PR DESCRIPTION
The following sentence in the doc comments for the `IncludeFields` member:

> Determines whether fields are handled serialization and deserialization.

Should read:

> Determines whether fields are handled **during** serialization and deserialization.

This is consistent with the correct text on the [live docs](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions?view=net-5.0):

![image](https://user-images.githubusercontent.com/20465797/108705849-e36d6c80-751e-11eb-9eee-fbff7c8f6a58.png)

The typo shows up in Visual Studio Intellisense as follows:

![image](https://user-images.githubusercontent.com/20465797/108706060-22032700-751f-11eb-8c4d-584fb6be8a33.png)