### PR TITLE
Better windows only guard which can be removed by linker

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Utilities/AbstractMemoryBlockTests.cs
@@ -120,21 +120,6 @@ namespace System.Reflection.Internal.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34493", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        public void FileStreamUnix()
-        {
-            try
-            {
-                FileStreamReadLightUp.readFileNotAvailable = true;
-                FileStream();
-            }
-            finally
-            {
-                FileStreamReadLightUp.readFileNotAvailable = false;
-            }
-        }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34493", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void FileStream()
         {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());


### PR DESCRIPTION
Also, remove superfluous tests poking into an internal state to mimic
non-Windows test environment

Contributes to #47533