### PR TITLE
Remove hardcoded PackageVersion in Platforms pkg

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <PropertyGroup>
-    <PackageVersion>$(ProductVersion)</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>


### PR DESCRIPTION
Mapping the package to `$(ProductVersion)` would be wrong in servicing cases. Hence just removing the hardcoded value entirely.