### PR TITLE
Remove unnecessary msbuild-sdk from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,7 +16,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21105.12",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21105.12",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21105.12",
-    "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "6.0.0-preview.2.21115.2",
     "Microsoft.Build.NoTargets": "2.0.17",
     "Microsoft.Build.Traversal": "2.1.1"

--- a/global.json
+++ b/global.json
@@ -16,8 +16,8 @@
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21105.12",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21105.12",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21105.12",
-    "Microsoft.NET.Sdk.IL": "6.0.0-preview.2.21115.2",
     "Microsoft.Build.NoTargets": "2.0.17",
-    "Microsoft.Build.Traversal": "2.1.1"
+    "Microsoft.Build.Traversal": "2.1.1",
+    "Microsoft.NET.Sdk.IL": "6.0.0-preview.2.21115.2"
   }
 }


### PR DESCRIPTION
This line was meant to delineate between sdks that were auto-updated by different PRs. But we can use the hard-coded SDKs to be in-between the auto-updated lines.