### PR TITLE
fix assertion merge for degenerate flow

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4658,8 +4658,16 @@ public:
 
             if (dupCount > 1)
             {
+                // Scenario where next block and conditional block, both point to the same block.
+                // In such case, intersect the assertions present on both the out edges of predBlock.
                 assert(predBlock->bbNext == block);
                 BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
+
+                JITDUMP("AssertionPropCallback::Merge     : Duplicate flow, " FMT_BB " in -> %s, predBlock " FMT_BB
+                        " out1 -> %s, out2 -> %s\n",
+                        block->bbNum, BitVecOps::ToString(apTraits, block->bbAssertionIn), predBlock->bbNum,
+                        BitVecOps::ToString(apTraits, mJumpDestOut[predBlock->bbNum]),
+                        BitVecOps::ToString(apTraits, predBlock->bbAssertionOut));
             }
         }
         else

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4651,20 +4651,19 @@ public:
     void Merge(BasicBlock* block, BasicBlock* predBlock, unsigned dupCount)
     {
         ASSERT_TP pAssertionOut;
-        if (dupCount == 2)
-        {
-            assert((predBlock->bbJumpKind == BBJ_COND) && (predBlock->bbJumpDest == block) &&
-                   (predBlock->bbNext == block));
-            pAssertionOut = mJumpDestOut[predBlock->bbNum];
-            BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
-        }
-        else if ((predBlock->bbJumpKind == BBJ_COND) && (predBlock->bbJumpDest == block))
+
+        if (predBlock->bbJumpKind == BBJ_COND && (predBlock->bbJumpDest == block))
         {
             pAssertionOut = mJumpDestOut[predBlock->bbNum];
+
+            if (dupCount > 1)
+            {
+                assert(predBlock->bbNext == block);
+                BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
+            }
         }
         else
         {
-            assert(dupCount == 1);
             pAssertionOut = predBlock->bbAssertionOut;
         }
 

--- a/src/coreclr/jit/dataflow.h
+++ b/src/coreclr/jit/dataflow.h
@@ -16,7 +16,7 @@
 //  {
 //  public:
 //      void StartMerge(BasicBlock* block);
-//      void Merge(BasicBlock* block, BasicBlock* pred, flowList* preds);
+//      void Merge(BasicBlock* block, BasicBlock* pred, unsigned dupCount);
 //      bool EndMerge(BasicBlock* block);
 //  };
 #pragma once
@@ -61,7 +61,7 @@ void DataFlow::ForwardAnalysis(TCallback& callback)
             flowList* preds = m_pCompiler->BlockPredsWithEH(block);
             for (flowList* pred = preds; pred; pred = pred->flNext)
             {
-                callback.Merge(block, pred->getBlock(), preds);
+                callback.Merge(block, pred->getBlock(), pred->flDupCount);
             }
         }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16245,9 +16245,9 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
                 // no side effects, remove the jump entirely
                 fgRemoveStmt(block, lastStmt);
             }
-            // block is a BBJ_COND that we are folding the conditional for
-            // bTaken is the path that will always be taken from block
-            // bNotTaken is the path that will never be taken from block
+            // block is a BBJ_COND that we are folding the conditional for.
+            // bTaken is the path that will always be taken from block.
+            // bNotTaken is the path that will never be taken from block.
             //
             BasicBlock* bTaken;
             BasicBlock* bNotTaken;

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1188,7 +1188,7 @@ public:
     }
 
     // Merge: perform the merging of each of the predecessor's liveness values (since this is a forward analysis)
-    void Merge(BasicBlock* block, BasicBlock* predBlock, flowList* preds)
+    void Merge(BasicBlock* block, BasicBlock* predBlock, unsigned dupCount)
     {
 #ifdef DEBUG
         if (m_comp->verbose)


### PR DESCRIPTION
Sometimes, we have degenerate flow involving 2 blocks A and B such that `A->jumpDst == B` as well as `A->bbNext == B`. In such case we should merge the assertions of out edges from both flows into the B's in edge. Eventually we want to avoid generating such flows in redundant branch optimization. See https://github.com/dotnet/runtime/issues/48609.

Thanks Andy for help identify the root cause.

Fixes:  #47101