### PR TITLE
Set CA1200 severity to info

### DIFF
--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -56,7 +56,7 @@
     <Rule Id="CA1068" Action="None" />          <!-- CancellationToken parameters must come last -->
     <Rule Id="CA1069" Action="None" />          <!-- Enums values should not be duplicated -->
     <Rule Id="CA1070" Action="Info" />          <!-- Do not declare event fields as virtual -->
-    <Rule Id="CA1200" Action="Warning" />       <!-- Avoid using cref tags with a prefix -->
+    <Rule Id="CA1200" Action="Info" />          <!-- Avoid using cref tags with a prefix -->
     <Rule Id="CA1303" Action="None" />          <!-- Do not pass literals as localized parameters -->
     <Rule Id="CA1304" Action="None" />          <!-- Specify CultureInfo -->
     <Rule Id="CA1305" Action="None" />          <!-- Specify IFormatProvider -->


### PR DESCRIPTION
We [are working](https://github.com/dotnet/runtime/issues/44969) on making triple slash comments the source of truth for documentation, instead of MS Docs. To achieve this, we are backporting MS Docs documentation to source code.

In MS Docs, we have the ability to have `<see cref="Namespace.MethodGroupName()"/>` items to point to groups of method overloads by either removing the parenthesis part, or adding the suffix `%2A`, or by preceding the API DocID with `O:`.

In triple slash, we don't yet have the ability to point to groups of method overloads. There's [a csharplang issue tracking this](https://github.com/dotnet/csharplang/issues/320#issuecomment-769473469).

The workaround is to prefix the DocID with `O:`, but to avoid a build failure, we need to change the severity of the [CA1200](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1200) Roslyn analyzers from `Warning` to `Info` ([default is Hidden](https://github.com/dotnet/roslyn-analyzers/blob/181a4b5f8c929be92504d7b807eec3a995e75f27/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif#L56)).

It should be `Info` because we still want people to tell people to avoid using prefixes, unless they are using `O:`.

Here is a docs backporting PR that has to deal with that problem: https://github.com/dotnet/runtime/pull/48137