### PR TITLE
Replace non-generic WeakReference usage in several libraries

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Switch.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Switch.cs
@@ -27,7 +27,7 @@ namespace System.Diagnostics
         private readonly string? _defaultValue;
         private object? _initializedLock;
 
-        private static readonly List<WeakReference> s_switches = new List<WeakReference>();
+        private static readonly List<WeakReference<Switch>> s_switches = new List<WeakReference<Switch>>();
         private static int s_LastCollectionCount;
         private StringDictionary? _attributes;
 
@@ -66,7 +66,7 @@ namespace System.Diagnostics
             lock (s_switches)
             {
                 _pruneCachedSwitches();
-                s_switches.Add(new WeakReference(this));
+                s_switches.Add(new WeakReference<Switch>(this));
             }
 
             _defaultValue = defaultSwitchValue;
@@ -78,11 +78,10 @@ namespace System.Diagnostics
             {
                 if (s_LastCollectionCount != GC.CollectionCount(2))
                 {
-                    List<WeakReference> buffer = new List<WeakReference>(s_switches.Count);
+                    List<WeakReference<Switch>> buffer = new List<WeakReference<Switch>>(s_switches.Count);
                     for (int i = 0; i < s_switches.Count; i++)
                     {
-                        Switch? s = ((Switch?)s_switches[i].Target);
-                        if (s != null)
+                        if (s_switches[i].TryGetTarget(out _))
                         {
                             buffer.Add(s_switches[i]);
                         }
@@ -236,8 +235,7 @@ namespace System.Diagnostics
                 _pruneCachedSwitches();
                 for (int i = 0; i < s_switches.Count; i++)
                 {
-                    Switch? swtch = ((Switch?)s_switches[i].Target);
-                    if (swtch != null)
+                    if (s_switches[i].TryGetTarget(out Switch? swtch))
                     {
                         swtch.Refresh();
                     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElementList.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElementList.cs
@@ -22,7 +22,7 @@ namespace System.Xml
         private bool _atomized;     //whether the localname and namespaceuri are atomized
         private int _matchCount;   // cached list count. -1 means it needs reconstruction
 
-        private WeakReference? _listener;   // XmlElementListListener
+        private WeakReference<XmlElementListListener>? _listener;   // XmlElementListListener
 
         private XmlElementList(XmlNode parent)
         {
@@ -37,7 +37,7 @@ namespace System.Xml
             _atomized = true;
             _matchCount = -1;
             // This can be a regular reference, but it would cause some kind of loop inside the GC
-            _listener = new WeakReference(new XmlElementListListener(parent.Document, this));
+            _listener = new WeakReference<XmlElementListListener>(new XmlElementListListener(parent.Document, this));
         }
 
         ~XmlElementList()
@@ -284,8 +284,7 @@ namespace System.Xml
         {
             if (_listener != null)
             {
-                XmlElementListListener? listener = (XmlElementListListener?)_listener.Target;
-                if (listener != null)
+                if (_listener.TryGetTarget(out XmlElementListListener? listener))
                 {
                     listener.Unregister();
                 }
@@ -358,14 +357,14 @@ namespace System.Xml
 
     internal class XmlElementListListener
     {
-        private WeakReference? _elemList;
+        private WeakReference<XmlElementList>? _elemList;
         private readonly XmlDocument _doc;
         private readonly XmlNodeChangedEventHandler _nodeChangeHandler;
 
         internal XmlElementListListener(XmlDocument doc, XmlElementList elemList)
         {
             _doc = doc;
-            _elemList = new WeakReference(elemList);
+            _elemList = new WeakReference<XmlElementList>(elemList);
             _nodeChangeHandler = new XmlNodeChangedEventHandler(this.OnListChanged);
             doc.NodeInserted += _nodeChangeHandler;
             doc.NodeRemoved += _nodeChangeHandler;
@@ -377,8 +376,7 @@ namespace System.Xml
             {
                 if (_elemList != null)
                 {
-                    XmlElementList? el = (XmlElementList?)_elemList.Target;
-                    if (null != el)
+                    if (_elemList.TryGetTarget(out XmlElementList? el))
                     {
                         el.ConcurrencyCheck(args);
                     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElementList.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElementList.cs
@@ -22,7 +22,7 @@ namespace System.Xml
         private bool _atomized;     //whether the localname and namespaceuri are atomized
         private int _matchCount;   // cached list count. -1 means it needs reconstruction
 
-        private WeakReference<XmlElementListListener>? _listener;   // XmlElementListListener
+        private WeakReference<XmlElementListListener>? _listener;
 
         private XmlElementList(XmlNode parent)
         {


### PR DESCRIPTION
The System.Private.Runtime.InteropServices.JavaScript changes are sufficient to let WeakReference be trimmed out of a default Blazor wasm app.