### PR TITLE
Use a single approach to detect presence of pseudo handle support

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptAlgPseudoHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptAlgPseudoHandle.cs
@@ -19,5 +19,7 @@ internal partial class Interop
             BCRYPT_SHA512_ALG_HANDLE = 0x00000061,
             BCRYPT_PBKDF2_ALG_HANDLE = 0x00000331,
         }
+
+        internal static bool PseudoHandlesSupported { get; } = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 0);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Pbkdf2Implementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Pbkdf2Implementation.Windows.cs
@@ -16,8 +16,6 @@ namespace Internal.Cryptography
 {
     internal partial class Pbkdf2Implementation
     {
-        private static readonly bool s_usePseudoHandles = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 0);
-
         // For Windows 7 we will use BCryptDeriveKeyPBKDF2. For Windows 8+ we will use BCryptKeyDerivation
         // since it has better performance.
         private static readonly bool s_useKeyDerivation = OperatingSystem.IsWindowsVersionAtLeast(8, 0, 0);
@@ -115,7 +113,7 @@ namespace Internal.Cryptography
 
             NTSTATUS generateKeyStatus;
 
-            if (s_usePseudoHandles)
+            if (Interop.BCrypt.PseudoHandlesSupported)
             {
                 fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
                 {


### PR DESCRIPTION
This also makes the one-shot hash pseudo handle path more assertive about unexpected inputs instead of falling back to the slower path. Realistically, if the pseudo handle approach is going to fail now, then it isn't going to succeed in the slow path either.