### PR TITLE
Set nuspec packaging properties correctly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -217,9 +217,11 @@
   <!-- Packaging -->
   <PropertyGroup>
     <GitHubRepositoryName>runtime</GitHubRepositoryName>
-    <RepositoryUrl>git://github.com/dotnet/$(GitHubRepositoryName)</RepositoryUrl>
-    <ProjectUrl>https://github.com/dotnet/$(GitHubRepositoryName)</ProjectUrl>
-    <LicenseUrl>https://github.com/dotnet/$(GitHubRepositoryName)/blob/master/LICENSE.TXT</LicenseUrl>
+    <RepositoryUrl>https://github.com/dotnet/$(GitHubRepositoryName)</RepositoryUrl>
+    <PackageProjectUrl>https://dot.net</PackageProjectUrl>
+    <!-- Remove ProjectUrl after https://github.com/dotnet/arcade/pull/6995 is merged and consumed. -->
+    <ProjectUrl>$(PackageProjectUrl)</ProjectUrl>
+    <Owners>microsoft,dotnetframework</Owners>
     <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'pkg', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Define PackageProjectUrl which is the public facing property to specify
a project url in a nuspec. Arcade defaults PackageProjectUrl to
RepositoryUrl if it isn't set. RepositoryUrl was incorrectly set to
git://github.com/dotnet/runtime instead of
https://github.com/dotnet/runtime which caused PackageProjectUrl to use
that incorrect value as well which ultimately resulted in nuget.org
failing package validation and refusing to add the package.

Also changing the project url to the previous https://dot.net value which is
the expected url. In addition to that, specifying owners which aren't set
anymore in 6.0.

Keeping the ProjectUrl property as well as the
Microsoft.DotNet.Build.Tasks.Packaging package depends on it. That line
can be removed after the fix to not override its value unconditionally
is merged and consumed.

Fixes https://github.com/dotnet/runtime/issues/48421