### PR TITLE
Fix an old test source.

### DIFF
--- a/src/tests/JIT/Directed/coverage/oldtests/subbyref.il
+++ b/src/tests/JIT/Directed/coverage/oldtests/subbyref.il
@@ -43,7 +43,8 @@
 	ldloca V_2
 	ldc.i4 1
 	sub
-	call       void [System.Console]System.Console::WriteLine(int32)
+	conv.i8
+	call       void [System.Console]System.Console::WriteLine(int64)
 
 ldc.i4 100
   IL_0038:  ret


### PR DESCRIPTION
The test was calling `System.Console::WriteLine(int32)` with `byref` on the stack, ECMA says it should be an invalid program exception and we started to generate it in https://github.com/dotnet/runtime/pull/43386, however, in this test it was hidden by another incorrect retyping in the Jit.
I am deleting the retyping and see this failing after that.