### PR TITLE
Apply optimizations and fixes to Enumerable.Take(Range)

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -121,36 +121,9 @@ namespace System.Linq
 
             return count <= 0 ?
                 source.Skip(0) :
-                SkipLastIterator(source, count);
-        }
-
-        private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(count > 0);
-
-            var queue = new Queue<TSource>();
-
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                while (e.MoveNext())
-                {
-                    if (queue.Count == count)
-                    {
-                        do
-                        {
-                            yield return queue.Dequeue();
-                            queue.Enqueue(e.Current);
-                        }
-                        while (e.MoveNext());
-                        break;
-                    }
-                    else
-                    {
-                        queue.Enqueue(e.Current);
-                    }
-                }
-            }
+                TakeRangeFromEndIterator(source,
+                    isStartIndexFromEnd: false, startIndex: 0,
+                    isEndIndexFromEnd: true, endIndex: count);
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -117,6 +117,7 @@ namespace System.Linq
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                SkipLastIterator(source, count);
             }
 
             return count <= 0 ?
@@ -124,6 +125,11 @@ namespace System.Linq
                 TakeRangeFromEndIterator(source,
                     isStartIndexFromEnd: false, startIndex: 0,
                     isEndIndexFromEnd: true, endIndex: count);
+        }
+
+        private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)
+        {
+            yield break;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -117,7 +117,6 @@ namespace System.Linq
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-                SkipLastIterator(source, count);
             }
 
             return count <= 0 ?
@@ -125,11 +124,6 @@ namespace System.Linq
                 TakeRangeFromEndIterator(source,
                     isStartIndexFromEnd: false, startIndex: 0,
                     isEndIndexFromEnd: true, endIndex: count);
-        }
-
-        private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)
-        {
-            yield break;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
@@ -40,7 +40,7 @@ namespace System.Linq
             while (index < endIndex && e.MoveNext())
             {
                 yield return e.Current;
-                checked { ++index; }
+                ++index;
             }
         }
     }

--- a/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
@@ -18,5 +18,30 @@ namespace System.Linq
                 if (--count == 0) break;
             }
         }
+
+        private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(startIndex >= 0 && startIndex < endIndex);
+
+            using IEnumerator<TSource> e = source.GetEnumerator();
+
+            int index = 0;
+            while (index < startIndex && e.MoveNext())
+            {
+                ++index;
+            }
+
+            if (index < startIndex)
+            {
+                yield break;
+            }
+
+            while (index < endIndex && e.MoveNext())
+            {
+                yield return e.Current;
+                checked { ++index; }
+            }
+        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -2,14 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count) =>
-            source is IPartition<TSource> partition ? partition.Take(count) :
-            source is IList<TSource> sourceList ? (IEnumerable<TSource>)new ListPartition<TSource>(sourceList, 0, count - 1) :
-            new EnumerablePartition<TSource>(source, 0, count - 1);
+        private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(count > 0);
+
+            return
+                source is IPartition<TSource> partition ? partition.Take(count) :
+                source is IList<TSource> sourceList ? new ListPartition<TSource>(sourceList, 0, count - 1) :
+                new EnumerablePartition<TSource>(source, 0, count - 1);
+        }
+
+        private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(startIndex >= 0 && startIndex < endIndex);
+
+            return
+                source is IPartition<TSource> partition ? TakePartitionRange(partition, startIndex, endIndex) :
+                source is IList<TSource> sourceList ? new ListPartition<TSource>(sourceList, startIndex, endIndex - 1) :
+                new EnumerablePartition<TSource>(source, startIndex, endIndex - 1);
+
+            static IPartition<TSource> TakePartitionRange(IPartition<TSource> partition, int startIndex, int endIndex)
+            {
+                partition = endIndex == 0 ? EmptyPartition<TSource>.Instance : partition.Take(endIndex);
+                return startIndex == 0 ? partition : partition.Skip(startIndex);
+            }
+        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -255,50 +255,9 @@ namespace System.Linq
 
             return count <= 0 ?
                 Empty<TSource>() :
-                TakeLastIterator(source, count);
-        }
-
-        private static IEnumerable<TSource> TakeLastIterator<TSource>(IEnumerable<TSource> source, int count)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(count > 0);
-
-            Queue<TSource> queue;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                if (!e.MoveNext())
-                {
-                    yield break;
-                }
-
-                queue = new Queue<TSource>();
-                queue.Enqueue(e.Current);
-
-                while (e.MoveNext())
-                {
-                    if (queue.Count < count)
-                    {
-                        queue.Enqueue(e.Current);
-                    }
-                    else
-                    {
-                        do
-                        {
-                            queue.Dequeue();
-                            queue.Enqueue(e.Current);
-                        }
-                        while (e.MoveNext());
-                        break;
-                    }
-                }
-            }
-
-            Debug.Assert(queue.Count <= count);
-            do
-            {
-                yield return queue.Dequeue();
-            }
-            while (queue.Count > 0);
+                TakeRangeFromEndIterator(source,
+                    isStartIndexFromEnd: true, startIndex: count,
+                    isEndIndexFromEnd: true, endIndex: 0);
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -73,7 +73,7 @@ namespace System.Linq
             // in order to convert fromEnd indices to regular indices.
             // Enumerable counts can change over time, so it is very
             // important that this check happens at enumeration time;
-            // do not move outside of the iterator method.
+            // do not move it outside of the iterator method.
             if (source.TryGetNonEnumeratedCount(out int count))
             {
                 startIndex = CalculateStartIndex(isStartIndexFromEnd, startIndex, count);

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -125,7 +125,7 @@ namespace System.Linq
                             } while (e.MoveNext());
                             break;
                         }
-                    } while (e.MoveNext());
+                    }
 
                     Debug.Assert(queue.Count == Math.Min(count, startIndex));
                 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -55,67 +55,85 @@ namespace System.Linq
             {
                 return startIndex >= endIndex
                     ? Empty<TSource>()
-                    : source.Skip(startIndex).Take(endIndex - startIndex);
+                    : TakeRangeIterator(source, startIndex, endIndex);
             }
 
-            return TakeIterator(source, isStartIndexFromEnd, startIndex, isEndIndexFromEnd, endIndex);
+            return TakeRangeFromEndIterator(source, isStartIndexFromEnd, startIndex, isEndIndexFromEnd, endIndex);
         }
 
-        private static IEnumerable<TSource> TakeIterator<TSource>(
-            IEnumerable<TSource> source, bool isStartIndexFromEnd, int startIndex, bool isEndIndexFromEnd, int endIndex)
+        private static IEnumerable<TSource> TakeRangeFromEndIterator<TSource>(IEnumerable<TSource> source, bool isStartIndexFromEnd, int startIndex, bool isEndIndexFromEnd, int endIndex)
         {
             Debug.Assert(source != null);
+            Debug.Assert(isStartIndexFromEnd || isEndIndexFromEnd);
             Debug.Assert(isStartIndexFromEnd
                 ? startIndex > 0 && (!isEndIndexFromEnd || startIndex > endIndex)
                 : startIndex >= 0 && (isEndIndexFromEnd || startIndex < endIndex));
-            Debug.Assert(endIndex >= 0);
 
-            using IEnumerator<TSource> e = source.GetEnumerator();
-            if (isStartIndexFromEnd)
+            // Attempt to extract the count of the source enumerator,
+            // in order to convert fromEnd indices to regular indices.
+            // Enumerable counts can change over time, so it is very
+            // important that this check happens at enumeration time;
+            // do not move outside of the iterator method.
+            if (source.TryGetNonEnumeratedCount(out int count))
             {
-                if (!e.MoveNext())
+                startIndex = CalculateStartIndex(isStartIndexFromEnd, startIndex, count);
+                endIndex = CalculateEndIndex(isEndIndexFromEnd, endIndex, count);
+
+                if (startIndex >= endIndex)
                 {
                     yield break;
                 }
 
-                int index = 0;
-                Queue<TSource> queue = new();
-                queue.Enqueue(e.Current);
-
-                while (e.MoveNext())
+                foreach (TSource element in TakeRangeIterator(source, startIndex, endIndex))
                 {
-                    checked
+                    yield return element;
+                }
+
+                yield break;
+            }
+
+            Queue<TSource> queue;
+
+            if (isStartIndexFromEnd)
+            {
+                // TakeLast compat: enumerator should be disposed before yielding the first element.
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
                     {
-                        index++;
+                        yield break;
                     }
 
-                    if (queue.Count == startIndex)
-                    {
-                        queue.Dequeue();
-                    }
-
+                    queue = new Queue<TSource>();
                     queue.Enqueue(e.Current);
+                    count = 1;
+
+                    while (e.MoveNext())
+                    {
+                        if (count < startIndex)
+                        {
+                            queue.Enqueue(e.Current);
+                            ++count;
+                        }
+                        else
+                        {
+                            do
+                            {
+                                queue.Dequeue();
+                                queue.Enqueue(e.Current);
+                                checked { ++count; }
+                            } while (e.MoveNext());
+                            break;
+                        }
+                    } while (e.MoveNext());
+
+                    Debug.Assert(queue.Count == Math.Min(count, startIndex));
                 }
 
-                int count = checked(index + 1);
-                Debug.Assert(queue.Count == Math.Min(count, startIndex));
-
-                startIndex = count - startIndex;
-                if (startIndex < 0)
-                {
-                    startIndex = 0;
-                }
-
-                if (isEndIndexFromEnd)
-                {
-                    endIndex = count - endIndex;
-                }
-                else if (endIndex > count)
-                {
-                    endIndex = count;
-                }
-
+                startIndex = CalculateStartIndex(isStartIndexFromEnd: true, startIndex, count);
+                endIndex = CalculateEndIndex(isEndIndexFromEnd, endIndex, count);
                 Debug.Assert(endIndex - startIndex <= queue.Count);
+
                 for (int rangeIndex = startIndex; rangeIndex < endIndex; rangeIndex++)
                 {
                     yield return queue.Dequeue();
@@ -123,53 +141,47 @@ namespace System.Linq
             }
             else
             {
-                int index = 0;
-                while (index <= startIndex)
-                {
-                    if (!e.MoveNext())
-                    {
-                        yield break;
-                    }
+                Debug.Assert(!isStartIndexFromEnd && isEndIndexFromEnd);
 
-                    checked
-                    {
-                        index++;
-                    }
+                // SkipLast compat: the enumerator should be disposed at the end of the enumeration.
+                using IEnumerator<TSource> e = source.GetEnumerator();
+
+                count = 0;
+                while (count < startIndex && e.MoveNext())
+                {
+                    ++count;
                 }
 
-                if (isEndIndexFromEnd)
+                if (count < startIndex)
                 {
-                    if (endIndex > 0)
+                    yield break;
+                }
+
+                queue = new Queue<TSource>();
+                while (e.MoveNext())
+                {
+                    if (queue.Count == endIndex)
                     {
-                        Queue<TSource> queue = new();
                         do
                         {
-                            if (queue.Count == endIndex)
-                            {
-                                yield return queue.Dequeue();
-                            }
-
                             queue.Enqueue(e.Current);
+                            yield return queue.Dequeue();
                         } while (e.MoveNext());
+
+                        break;
                     }
                     else
                     {
-                        do
-                        {
-                            yield return e.Current;
-                        } while (e.MoveNext());
-                    }
-                }
-                else
-                {
-                    Debug.Assert(index < endIndex);
-                    yield return e.Current;
-                    while (checked(++index) < endIndex && e.MoveNext())
-                    {
-                        yield return e.Current;
+                        queue.Enqueue(e.Current);
                     }
                 }
             }
+
+            static int CalculateStartIndex(bool isStartIndexFromEnd, int startIndex, int count) =>
+                Math.Max(0, isStartIndexFromEnd ? count - startIndex : startIndex);
+
+            static int CalculateEndIndex(bool isEndIndexFromEnd, int endIndex, int count) =>
+                Math.Min(count, isEndIndexFromEnd ? count - endIndex : endIndex);
         }
 
         public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -128,29 +128,29 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NonEnumeratingCount_NullSource_ThrowsArgumentNullException()
+        public void NonEnumeratedCount_NullSource_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).TryGetNonEnumeratedCount(out _));
         }
 
         [Theory]
-        [MemberData(nameof(NonEnumeratingCount_SupportedEnumerables))]
-        public void NonEnumeratingCount_SupportedEnumerables_ShouldReturnExpectedCount<T>(int expectedCount, IEnumerable<T> source)
+        [MemberData(nameof(NonEnumeratedCount_SupportedEnumerables))]
+        public void NonEnumeratedCount_SupportedEnumerables_ShouldReturnExpectedCount<T>(int expectedCount, IEnumerable<T> source)
         {
             Assert.True(source.TryGetNonEnumeratedCount(out int actualCount));
             Assert.Equal(expectedCount, actualCount);
         }
 
         [Theory]
-        [MemberData(nameof(NonEnumeratingCount_UnsupportedEnumerables))]
-        public void NonEnumeratingCount_UnsupportedEnumerables_ShouldReturnFalse<T>(IEnumerable<T> source)
+        [MemberData(nameof(NonEnumeratedCount_UnsupportedEnumerables))]
+        public void NonEnumeratedCount_UnsupportedEnumerables_ShouldReturnFalse<T>(IEnumerable<T> source)
         {
             Assert.False(source.TryGetNonEnumeratedCount(out int actualCount));
             Assert.Equal(0, actualCount);
         }
 
         [Fact]
-        public void NonEnumeratingCount_ShouldNotEnumerateSource()
+        public void NonEnumeratedCount_ShouldNotEnumerateSource()
         {
             bool isEnumerated = false;
             Assert.False(Source().TryGetNonEnumeratedCount(out int count));
@@ -164,7 +164,7 @@ namespace System.Linq.Tests
             }
         }
 
-        public static IEnumerable<object[]> NonEnumeratingCount_SupportedEnumerables()
+        public static IEnumerable<object[]> NonEnumeratedCount_SupportedEnumerables()
         {
             yield return WrapArgs(4, new int[]{ 1, 2, 3, 4 });
             yield return WrapArgs(4, new List<int>(new int[] { 1, 2, 3, 4 }));
@@ -188,7 +188,7 @@ namespace System.Linq.Tests
             static object[] WrapArgs<T>(int expectedCount, IEnumerable<T> source) => new object[] { expectedCount, source };
         }
 
-        public static IEnumerable<object[]> NonEnumeratingCount_UnsupportedEnumerables()
+        public static IEnumerable<object[]> NonEnumeratedCount_UnsupportedEnumerables()
         {
             yield return WrapArgs(Enumerable.Range(1, 100).Where(x => x % 2 == 0));
             yield return WrapArgs(Enumerable.Range(1, 100).GroupBy(x => x % 2 == 0));

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -179,7 +179,6 @@ namespace System.Linq.Tests
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(4, new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
-                yield return WrapArgs(7, Enumerable.Range(1, 20).ToLookup(x => x % 7));
                 yield return WrapArgs(20, Enumerable.Range(1, 20).Reverse());
                 yield return WrapArgs(20, Enumerable.Range(1, 20).OrderBy(x => -x));
                 yield return WrapArgs(20, Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));
@@ -202,7 +201,6 @@ namespace System.Linq.Tests
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));            
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
-                yield return WrapArgs(Enumerable.Range(1, 20).ToLookup(x => x % 7));
                 yield return WrapArgs(Enumerable.Range(1, 20).Reverse());
                 yield return WrapArgs(Enumerable.Range(1, 20).OrderBy(x => -x));
                 yield return WrapArgs(Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -179,6 +179,7 @@ namespace System.Linq.Tests
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(4, new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
+                yield return WrapArgs(7, Enumerable.Range(1, 20).ToLookup(x => x % 7));
                 yield return WrapArgs(20, Enumerable.Range(1, 20).Reverse());
                 yield return WrapArgs(20, Enumerable.Range(1, 20).OrderBy(x => -x));
                 yield return WrapArgs(20, Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));
@@ -201,6 +202,7 @@ namespace System.Linq.Tests
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));            
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
+                yield return WrapArgs(Enumerable.Range(1, 20).ToLookup(x => x % 7));
                 yield return WrapArgs(Enumerable.Range(1, 20).Reverse());
                 yield return WrapArgs(Enumerable.Range(1, 20).OrderBy(x => -x));
                 yield return WrapArgs(Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));


### PR DESCRIPTION
Makes the following changes to the new `Enumerable.Take(Range)` implementation:

* Separate `SizeOpt` and `SpeedOpt` implementations for non-`fromEnd` ranges.
* Optimize `fromEnd` ranges using `Enumerable.TryGetNonEnumeratedCount` to obtain the source count.
* Change enumerator disposal semantics to more closely follow the `TakeLast` and `SkipLast` implementations.
* Finally, expresses the `TakeLast` and `SkipLast` in terms of the `Take(Range)` implementation.

Fix #48631.