### PR TITLE
Compile native AppleCryptoNative_SecCopyErrorMessageString for ios/tvos

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_sec.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_sec.c
@@ -3,9 +3,11 @@
 
 #include "pal_sec.h"
 
-#if !defined(TARGET_MACCATALYST) && !defined(TARGET_IOS) && !defined(TARGET_TVOS)
 CFStringRef AppleCryptoNative_SecCopyErrorMessageString(int32_t osStatus)
 {
+#if (defined(TARGET_IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_11_3) || (defined(TARGET_TVOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < __TVOS_11_3)
+    return CFStringCreateWithCString(NULL, "", kCFStringEncodingUTF8);
+#else
     return SecCopyErrorMessageString(osStatus, NULL);
-}
 #endif
+}


### PR DESCRIPTION
It's referenced from a lot of managed placed