### PR TITLE
BufferedStream performance improvements

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -539,7 +539,7 @@ namespace System.IO
 
             // Ok. We can fill the buffer:
             EnsureBufferAllocated();
-            _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
+            _readLen = _stream.Read(_buffer!, 0, _bufferSize);
 
             bytesFromBuffer = ReadFromBuffer(buffer, offset, count);
 
@@ -594,7 +594,7 @@ namespace System.IO
             {
                 // Otherwise, fill the buffer, then read from that.
                 EnsureBufferAllocated();
-                _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
+                _readLen = _stream.Read(_buffer!, 0, _bufferSize);
                 return ReadFromBuffer(destination) + bytesFromBuffer;
             }
         }
@@ -785,7 +785,7 @@ namespace System.IO
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
-                _readLen = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer!.Length), cancellationToken).ConfigureAwait(false);
+                _readLen = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
 
                 bytesFromBuffer = ReadFromBuffer(buffer.Span);
                 return bytesAlreadySatisfied + bytesFromBuffer;
@@ -826,7 +826,7 @@ namespace System.IO
                 FlushWrite();
 
             EnsureBufferAllocated();
-            _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
+            _readLen = _stream.Read(_buffer!, 0, _bufferSize);
             _readPos = 0;
 
             if (_readLen == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -85,7 +85,11 @@ namespace System.IO
         private void EnsureNotClosed()
         {
             if (_stream == null)
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            {
+                Throw();
+            }
+
+            static void Throw() => throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
         }
 
         private void EnsureCanSeek()
@@ -93,7 +97,11 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanSeek)
-                throw new NotSupportedException(SR.NotSupported_UnseekableStream);
+            {
+                Throw();
+            }
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
         }
 
         private void EnsureCanRead()
@@ -101,7 +109,11 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanRead)
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+            {
+                Throw();
+            }
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnreadableStream);
         }
 
         private void EnsureCanWrite()
@@ -109,7 +121,11 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             if (!_stream.CanWrite)
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+            {
+                Throw();
+            }
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
         }
 
         private void EnsureShadowBufferAllocated()
@@ -403,9 +419,13 @@ namespace System.IO
             // However, since the user did not call a method that is intuitively expected to seek, a better message is in order.
             // Ideally, we would throw an InvalidOperation here, but for backward compat we have to stick with NotSupported.
             if (!_stream.CanSeek)
-                throw new NotSupportedException(SR.NotSupported_CannotWriteToBufferedStreamIfReadBufferCannotBeFlushed);
+            {
+                Throw();
+            }
 
             FlushRead();
+
+            static void Throw() => throw new NotSupportedException(SR.NotSupported_CannotWriteToBufferedStreamIfReadBufferCannotBeFlushed);
         }
 
         private void FlushWrite()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -539,7 +539,7 @@ namespace System.IO
 
             // Ok. We can fill the buffer:
             EnsureBufferAllocated();
-            _readLen = _stream.Read(_buffer!, 0, _bufferSize);
+            _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
 
             bytesFromBuffer = ReadFromBuffer(buffer, offset, count);
 
@@ -594,7 +594,7 @@ namespace System.IO
             {
                 // Otherwise, fill the buffer, then read from that.
                 EnsureBufferAllocated();
-                _readLen = _stream.Read(_buffer!, 0, _bufferSize);
+                _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
                 return ReadFromBuffer(destination) + bytesFromBuffer;
             }
         }
@@ -755,7 +755,7 @@ namespace System.IO
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
-                _readLen = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
+                _readLen = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer!.Length), cancellationToken).ConfigureAwait(false);
 
                 bytesFromBuffer = ReadFromBuffer(buffer.Span);
                 return bytesAlreadySatisfied + bytesFromBuffer;
@@ -796,7 +796,7 @@ namespace System.IO
                 FlushWrite();
 
             EnsureBufferAllocated();
-            _readLen = _stream.Read(_buffer!, 0, _bufferSize);
+            _readLen = _stream.Read(_buffer!, 0, _buffer!.Length);
             _readPos = 0;
 
             if (_readLen == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -740,14 +740,11 @@ namespace System.IO
 
             // Employ async waiting based on the same synchronization used in BeginRead of the abstract Stream.
             await semaphoreLockTask.ConfigureAwait(false);
-
             try
             {
-                int bytesFromBuffer = 0;
-
                 // The buffer might have been changed by another async task while we were waiting on the semaphore.
                 // Check it now again.
-                bytesFromBuffer = ReadFromBuffer(buffer.Span);
+                int bytesFromBuffer = ReadFromBuffer(buffer.Span);
                 if (bytesFromBuffer == buffer.Length)
                 {
                     return bytesAlreadySatisfied + bytesFromBuffer;
@@ -1083,7 +1080,7 @@ namespace System.IO
                 {
                     if (_writePos == 0)
                     {
-                        ClearReadBufferBeforeWrite(); // Seeks, but does not perform sync IO
+                        ClearReadBufferBeforeWrite();
                     }
 
                     Debug.Assert(_writePos < _bufferSize);
@@ -1141,9 +1138,7 @@ namespace System.IO
                 // However, note that if we recalculate the sync completion condition to TRUE, then useBuffer will also be TRUE.
 
                 if (_writePos == 0)
-                {
                     ClearReadBufferBeforeWrite();
-                }
 
                 int totalUserBytes;
                 bool useBuffer;
@@ -1158,7 +1153,7 @@ namespace System.IO
                 {
                     buffer = buffer.Slice(WriteToBuffer(buffer.Span));
 
-                    if (_writePos < _buffer!.Length)
+                    if (_writePos < _bufferSize)
                     {
                         Debug.Assert(buffer.Length == 0);
                         return;
@@ -1218,7 +1213,7 @@ namespace System.IO
 
         public override void WriteByte(byte value)
         {
-            if (_writePos > 0 && _writePos < _buffer!.Length - 1)
+            if (_writePos > 0 && _writePos < _bufferSize - 1)
             {
                 _buffer![_writePos++] = value;
             }
@@ -1245,7 +1240,7 @@ namespace System.IO
 
             _buffer![_writePos++] = value;
 
-            Debug.Assert(_writePos < _buffer!.Length);
+            Debug.Assert(_writePos < _bufferSize);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -1185,6 +1185,18 @@ namespace System.IO
 
         public override void WriteByte(byte value)
         {
+            if (_writePos > 0 && _writePos < _buffer!.Length - 1)
+            {
+                _buffer![_writePos++] = value;
+            }
+            else
+            {
+                WriteByteSlow(value);
+            }
+        }
+
+        private void WriteByteSlow(byte value)
+        {
             EnsureNotClosed();
 
             if (_writePos == 0)
@@ -1200,7 +1212,7 @@ namespace System.IO
 
             _buffer![_writePos++] = value;
 
-            Debug.Assert(_writePos < _bufferSize);
+            Debug.Assert(_writePos < _buffer!.Length);
         }
 
         public override long Seek(long offset, SeekOrigin origin)


### PR DESCRIPTION
The following changes improve `BufferedStream` perf a bit and in the near future might allow for the implementation of `BufferedFileStreamStrategy`, where `BufferedStream` is going to be used for all the buffering logic on top of actual `FileStreamStrategy` (which derives from `Stream`).

Changes:

1. Move throws to local functions to allow for the inlining of small guard methods.
2. ~~Use `_buffer.Length` instead of `_bufferLength` as `BufferedStream` might resize `_buffer` when it decides it's a good idea ([source code](https://github.com/dotnet/runtime/blob/d5ab93c4a8e45da2dab8924c2165000bf78f84e6/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs#L115)).~~
3. ~~Don't try to acquire the lock if it already has been acquired~~
4. Add common code path for `ReadAsync` and `WriteAsync` when there is nothing to Flush and buffering is not beneficial (user buffer size => internal buffer size). 
5. Optimize common `WriteByte` code path (at least one byte has already been written to buffer and we don't need to perform all expensive checks). [ReadByte](https://github.com/dotnet/runtime/blob/d5ab93c4a8e45da2dab8924c2165000bf78f84e6/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs#L755-L760) already has such an optimization