### PR TITLE
Fix C# warning in Comparer_get_Default

### DIFF
--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
@@ -237,7 +237,7 @@ public struct Struct1 : IComparable
 {
     public long a;
     public long b;
-    public int CompareTo(object? obj)
+    public int CompareTo(object obj)
     {
         return b.CompareTo(((Struct1) obj).b);
     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/48160#issuecomment-784167999

cc @akoeplinger 