### PR TITLE
Use MemoryExtensions.LastIndexOf in ReThrowWithPath

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -292,7 +292,11 @@ namespace System.Text.Json
             string message = ex.Message;
 
             // Insert the "Path" portion before "LineNumber" and "BytePositionInLine".
+#if BUILDING_INBOX_LIBRARY
+            int iPos = message.AsSpan().LastIndexOf(" LineNumber: ");
+#else
             int iPos = message.LastIndexOf(" LineNumber: ", StringComparison.InvariantCulture);
+#endif
             if (iPos >= 0)
             {
                 message = $"{message.Substring(0, iPos)} Path: {path} |{message.Substring(iPos)}";


### PR DESCRIPTION
Enable string.LastIndexOf (and some of the other StringComparison paths) to be trimmed in a default Blazor wasm app, and don't require an ICU fallback.

@steveharter, is there any reason InvariantCulture is actually needed here, as opposed to ordinal?