### PR TITLE
Support SPMI collection of tiered compilation runs, fix utf8 issues

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -251,6 +251,7 @@ collect_parser.add_argument("-output_mch_path", help="Location to place the fina
 collect_parser.add_argument("--merge_mch_files", action="store_true", help="Merge multiple MCH files. Use the -mch_files flag to pass a list of MCH files to merge.")
 collect_parser.add_argument("-mch_files", metavar="MCH_FILE", nargs='+', help="Pass a sequence of MCH files which will be merged. Required by --merge_mch_files.")
 collect_parser.add_argument("--use_zapdisable", action="store_true", help="Sets COMPlus_ZapDisable=1 and COMPlus_ReadyToRun=0 when doing collection to cause NGEN/ReadyToRun images to not be used, and thus causes JIT compilation and SuperPMI collection of these methods.")
+collect_parser.add_argument("--tiered_compilation", action="store_true", help="Sets COMPlus_TieredCompilation=1 when doing collections.")
 
 # Allow for continuing a collection in progress
 collect_parser.add_argument("-temp_dir", help="Specify an existing temporary directory to use. Useful if continuing an ongoing collection process, or forcing a temporary directory to a particular hard drive. Optional; default is to create a temporary directory in the usual TEMP location.")
@@ -487,7 +488,7 @@ def run_and_log(command, log_level=logging.DEBUG):
     logging.debug("Invoking: %s", " ".join(command))
     proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     stdout_output, _ = proc.communicate()
-    for line in stdout_output.decode('utf-8').splitlines():  # There won't be any stderr output since it was piped to stdout
+    for line in stdout_output.decode('utf-8', errors='replace').splitlines():  # There won't be any stderr output since it was piped to stdout
         logging.log(log_level, line)
     return proc.returncode
 
@@ -829,7 +830,9 @@ class SuperPMICollect:
 
             complus_env = {}
             complus_env["EnableExtraSuperPmiQueries"] = "1"
-            complus_env["TieredCompilation"] = "0"
+
+            if not self.coreclr_args.tiered_compilation:
+                complus_env["TieredCompilation"] = "0"
 
             if self.coreclr_args.use_zapdisable:
                 complus_env["ZapDisable"] = "1"
@@ -880,7 +883,7 @@ class SuperPMICollect:
                 command = [self.collection_command, ] + self.collection_args
                 proc = subprocess.Popen(command, env=collection_command_env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 stdout_output, _ = proc.communicate()
-                for line in stdout_output.decode('utf-8').splitlines():  # There won't be any stderr output since it was piped to stdout
+                for line in stdout_output.decode('utf-8', errors='replace').splitlines():  # There won't be any stderr output since it was piped to stdout
                     logging.debug(line)
             ################################################################################################ end of "self.collection_command is not None"
 
@@ -1536,8 +1539,7 @@ class SuperPMIReplayAsmDiffs:
             "COMPlus_JitEnableNoWayAssert": "1",
             "COMPlus_JitNoForceFallback": "1",
             "COMPlus_JitRequired": "1",
-            "COMPlus_JitDisasmWithGC": "1",
-            "COMPlus_TieredCompilation": "0" }
+            "COMPlus_JitDisasmWithGC": "1" }
 
         if self.coreclr_args.gcinfo:
             asm_complus_vars.update({
@@ -2849,7 +2851,7 @@ def setup_args(args):
         if os.path.isfile(log_file):
             logging.critical("Warning: deleting existing log file %s", log_file)
             os.remove(log_file)
-        file_handler = logging.FileHandler(log_file)
+        file_handler = logging.FileHandler(log_file, encoding='utf8')
         file_handler.setLevel(logging.DEBUG)
         logger.addHandler(file_handler)
         logging.critical("================ Logging to %s", log_file)
@@ -3057,6 +3059,11 @@ def setup_args(args):
                             "use_zapdisable",
                             lambda unused: True,
                             "Unable to set use_zapdisable")
+
+        coreclr_args.verify(args,
+                            "tiered_compilation",
+                            lambda unused: True,
+                            "Unable to set tiered_compilation")
 
         if (args.collection_command is None) and (args.pmi is False) and (args.crossgen is False) and (args.crossgen2 is False):
             print("Either a collection command or `--pmi` or `--crossgen` or `--crossgen2` must be specified")
@@ -3350,11 +3357,6 @@ def main(args):
         print("Please install python 3.7 or greater")
 
         return 1
-
-    # Force tiered compilation off. It will affect both collection and replay.
-    # REVIEW: Is this true for replay? We specifically set this when doing collections. Can we remove this line?
-    #         Or move it more close to the location that requires it, and output to the console that we're setting this?
-    os.environ["COMPlus_TieredCompilation"] = "0"
 
     # Parse the arguments.
 


### PR DESCRIPTION
Add new flag `--tiered_compilation` to enable collection of runs with tiered
compilation enabled (by not setting `COMPlus_TieredCompilation=0`).

Note `COMPlus_TieredCompilation` has no impact on prejitting or on replay.

Also be more tolerant of utf-8 encoding issues, in case we see asserts in
methods or classes with funny names.