### PR TITLE
Add "points to stack" tree flag for GT_ADDR.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2745,6 +2745,8 @@ public:
                                        FieldSeqNode* fieldSeq,
                                        var_types     type = TYP_I_IMPL);
 
+    GenTree* gtNewAddrNode(GenTree* tree);
+
 #ifdef FEATURE_SIMD
     GenTreeSIMD* gtNewSIMDNode(
         var_types type, GenTree* op1, SIMDIntrinsicID simdIntrinsicID, var_types baseType, unsigned size);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -989,7 +989,7 @@ inline GenTree* Compiler::gtNewOperNode(genTreeOps oper, var_types type, GenTree
                 // ldind.i2         - dereference ulong as short
                 // ret              - return short
                 // optimize the cast away.
-                GenTreeCast* cast  = op1->AsCast();
+                GenTreeCast* cast = op1->AsCast();
                 assert(genTypeSize(cast->gtCastType) == TARGET_POINTER_SIZE);
                 op1 = cast->gtGetOp1();
             }

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2264,8 +2264,12 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 }
                 break;
             case GT_ADDR:
+            {
+                const bool stackAddr = tree->DefinesLocalAddr(this);
+                //assert((!stackAddr && tree->TypeIs(TYP_BYREF)) || (stackAddr && tree->TypeIs(TYP_I_IMPL)));
                 assert(!op1->CanCSE());
-                break;
+            }
+            break;
 
             case GT_IND:
                 // Do we have a constant integer address as op1?

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2265,8 +2265,9 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 break;
             case GT_ADDR:
             {
-                const bool stackAddr = tree->DefinesLocalAddr(this);
-                //assert((!stackAddr && tree->TypeIs(TYP_BYREF)) || (stackAddr && tree->TypeIs(TYP_I_IMPL)));
+                const bool stackAddrCheck = tree->DefinesLocalAddr(this);
+                const bool stackAddrFlag  = ((tree->gtFlags & GTF_ADDR_STACK) != 0);
+                assert(stackAddrCheck == stackAddrFlag);
                 assert(!op1->CanCSE());
             }
             break;

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -341,7 +341,7 @@ GenTree* Compiler::fgGetStructAsStructPtr(GenTree* tree)
             return tree;
 
         default:
-            return gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
+            return gtNewAddrNode(tree);
     }
 }
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1652,7 +1652,7 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                    subsequent uses of the arg would have worked with the bashed value */
                 if (argInfo.argIsInvariant)
                 {
-                    assert(argNode->OperIsConst() || argNode->gtOper == GT_ADDR);
+                    assert(argNode->IsInvariant());
                 }
                 noway_assert((argInfo.argIsLclVar == 0) ==
                              (argNode->gtOper != GT_LCL_VAR || (argNode->gtFlags & GTF_GLOB_REF)));

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1887,7 +1887,7 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
 
     var_types typeMonAcquired = TYP_UBYTE;
     GenTree*  varNode         = gtNewLclvNode(lvaMonAcquired, typeMonAcquired);
-    GenTree*  varAddrNode     = gtNewOperNode(GT_ADDR, TYP_BYREF, varNode);
+    GenTree*  varAddrNode     = gtNewAddrNode(varNode);
     GenTree*  tree;
 
     if (info.compIsStatic)
@@ -2023,7 +2023,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add enter pinvoke exit callout at the start of prolog
 
-    GenTree* pInvokeFrameVar = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
+    GenTree* pInvokeFrameVar = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
 
     GenTree* tree;
 
@@ -2074,7 +2074,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     // Add reverse pinvoke exit callout at the end of epilog
 
-    tree = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
+    tree = gtNewAddrNode(gtNewLclvNode(lvaReversePInvokeFrameVar, TYP_BLK));
 
     CorInfoHelpFunc reversePInvokeExitHelper = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TRACK_TRANSITIONS)
                                                    ? CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT_TRACK_TRANSITIONS

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -639,6 +639,16 @@ void GCInfo::gcRegPtrSetInit()
 GCInfo::WriteBarrierForm GCInfo::gcWriteBarrierFormFromTargetAddress(GenTree* tgtAddr)
 {
     assert(tgtAddr->TypeIs(TYP_BYREF, TYP_I_IMPL));
+
+    if (tgtAddr->OperIs(GT_ADDR))
+    {
+        const bool stackAddrFlag = ((tgtAddr->gtFlags & GTF_ADDR_STACK) != 0);
+        if (stackAddrFlag)
+        {
+            return GCInfo::WBF_NoBarrier;
+        }
+    }
+
     bool simplifiedExpr = true;
     while (simplifiedExpr)
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16623,6 +16623,14 @@ bool GenTree::DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarComm
     return false;
 }
 
+bool GenTree::DefinesLocalAddr(Compiler* comp)
+{
+    const unsigned       dummyWidth      = 0;
+    GenTreeLclVarCommon* dummyLclVarTree = nullptr;
+    bool                 dummyIsEntire   = false;
+    return DefinesLocalAddr(comp, dummyWidth, &dummyLclVarTree, &dummyIsEntire);
+}
+
 //------------------------------------------------------------------------
 // IsLocalExpr: Determine if this is a LclVarCommon node and return some
 //              additional info about it in the two out parameters.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16599,6 +16599,10 @@ bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bo
 // Returns true if this GenTree defines a result which is based on the address of a local.
 bool GenTree::DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire)
 {
+    if (OperGet() == GT_CAST)
+    {
+        return AsCast()->gtGetOp1()->DefinesLocalAddr(comp, width, pLclVarTree, pIsEntire);
+    }
     if (OperGet() == GT_ADDR || OperGet() == GT_LCL_VAR_ADDR)
     {
         GenTree* addrArg = this;
@@ -16737,6 +16741,10 @@ bool GenTree::IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, Fie
 
 GenTreeLclVarCommon* GenTree::IsLocalAddrExpr()
 {
+    if (OperGet() == GT_CAST)
+    {
+        return AsCast()->gtGetOp1()->IsLocalAddrExpr();
+    }
     if (OperGet() == GT_ADDR)
     {
         return AsOp()->gtOp1->IsLocal() ? AsOp()->gtOp1->AsLclVarCommon() : nullptr;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6419,6 +6419,36 @@ GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned
     return node;
 }
 
+GenTree* Compiler::gtNewAddrNode(GenTree* tree)
+{
+    var_types addrType;
+    if (tree->IsLocal())
+    {
+        // When the address points to the stack
+        // we use TYP_I_IMPL, so if we create a LCL_VAR from it
+        // it does not need to be zero-init.
+        addrType = TYP_I_IMPL;
+    }
+    else if (tree->OperIs(GT_FIELD))
+    {
+        const GenTree* fldObj = tree->AsField()->gtFldObj;
+        assert((fldObj == nullptr) || fldObj->TypeIs(TYP_REF, TYP_BYREF, TYP_I_IMPL, TYP_STRUCT));
+        if ((fldObj != nullptr) && fldObj->TypeIs(TYP_REF, TYP_BYREF))
+        {
+            addrType = TYP_BYREF;
+        }
+        else
+        {
+            addrType = TYP_I_IMPL;
+        }
+    }
+    else
+    {
+        addrType = TYP_BYREF;
+    }
+    return gtNewOperNode(GT_ADDR, addrType, tree);
+}
+
 GenTree* Compiler::gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_types type, unsigned __int64 bbFlags)
 {
     assert(GenTree::s_gtNodeSizes[GT_RET_EXPR] == TREE_NODE_SZ_LARGE);
@@ -7438,7 +7468,7 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
                 {
                     return nullptr;
                 }
-                copy = gtNewOperNode(GT_ADDR, tree->TypeGet(), op1);
+                copy = gtNewAddrNode(op1);
             }
             else
             {
@@ -13728,11 +13758,11 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
         asg->gtBashToNOP();
 
         // Update the copy from the value to be boxed to the box temp
-        GenTree* newDst        = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, boxTempType));
+        GenTree* newDst        = gtNewAddrNode(gtNewLclvNode(boxTempLcl, boxTempType));
         copyDst->AsOp()->gtOp1 = newDst;
 
         // Return the address of the now-struct typed box temp
-        GenTree* retValue = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, boxTempType));
+        GenTree* retValue = gtNewAddrNode(gtNewLclvNode(boxTempLcl, boxTempType));
 
         return retValue;
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6717,7 +6717,7 @@ GenTreeObj* Compiler::gtNewObjNode(CORINFO_CLASS_HANDLE structHnd, GenTree* addr
 
     if (addr->OperIs(GT_ADDR))
     {
-        GenTree*     indir = addr->gtGetOp1();
+        GenTree* indir = addr->gtGetOp1();
         if (indir->OperIsIndir() && ((indir->gtFlags & GTF_IND_ARR_INDEX) == 0))
         {
             addr = indir->AsIndir()->Addr();

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -879,6 +879,8 @@ public:
 #define GTF_ADDRMODE_NO_CSE         0x80000000 // GT_ADD/GT_MUL/GT_LSH -- Do not CSE this node only, forms complex
                                                //                         addressing mode
 
+#define GTF_ADDR_STACK              0x8000000 // GT_ARRD - the address point to stack.
+
 #define GTF_MUL_64RSLT              0x40000000 // GT_MUL     -- produce 64-bit result
 
 #define GTF_RELOP_NAN_UN            0x80000000 // GT_<relop> -- Is branch taken if ops are NaN?

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1984,6 +1984,8 @@ public:
     // sets "*pIsEntire" to true if this assignment writes the full width of the local.
     bool DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire);
 
+    bool DefinesLocalAddr(Compiler* comp);
+
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily
     // modified to check this.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3158,15 +3158,15 @@ CORINFO_CLASS_HANDLE Compiler::impGetObjectClass()
 /* static */
 void Compiler::impBashVarAddrsToI(GenTree* tree1, GenTree* tree2)
 {
-    if (tree1->IsLocalAddrExpr() != nullptr)
-    {
-        tree1->gtType = TYP_I_IMPL;
-    }
+    // if (tree1->IsLocalAddrExpr() != nullptr)
+    //{
+    //    tree1->gtType = TYP_I_IMPL;
+    //}
 
-    if (tree2 && (tree2->IsLocalAddrExpr() != nullptr))
-    {
-        tree2->gtType = TYP_I_IMPL;
-    }
+    // if (tree2 && (tree2->IsLocalAddrExpr() != nullptr))
+    //{
+    //    tree2->gtType = TYP_I_IMPL;
+    //}
 }
 
 /*****************************************************************************
@@ -14395,8 +14395,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         }
 
                         // Obtain the address of the temp
-                        newObjThisPtr =
-                            gtNewAddrNode(gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet()));
+                        newObjThisPtr = gtNewAddrNode(gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet()));
                     }
                     else
                     {
@@ -20064,7 +20063,7 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
         // have been caught in impInlineInitVars.
         if (!op1->TypeIs(lclTyp))
         {
-            //if (lclTyp != TYP_BYREF) // We could have oprimized TYP_BYREF to TYP_I_IMPL.
+            // if (lclTyp != TYP_BYREF) // We could have oprimized TYP_BYREF to TYP_I_IMPL.
             {
                 op1->gtType = genActualType(lclTyp);
             }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19776,8 +19776,8 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
                     }
                     else if (inlArgNode->IsLocal())
                     {
-                        const GenTreeLclVarCommon* lcl = inlArgNode->AsLclVarCommon();
-                        const LclVarDsc* varDsc = lvaGetDesc(lcl);
+                        const GenTreeLclVarCommon* lcl    = inlArgNode->AsLclVarCommon();
+                        const LclVarDsc*           varDsc = lvaGetDesc(lcl);
                         if (varDsc->lvStackByref)
                         {
                             stackByref = true;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -647,11 +647,11 @@ private:
         }
 #endif // TARGET_64BIT
 
-        // TODO-ADDR: For now use LCL_VAR_ADDR and LCL_FLD_ADDR only as call arguments and assignment sources.
+        // TODO-ADDR: For now use LCL_VAR_ADDR and LCL_FLD_ADDR only as call arguments, assignment and cast sources.
         // Other usages require more changes. For example, a tree like OBJ(ADD(ADDR(LCL_VAR), 4))
         // could be changed to OBJ(LCL_FLD_ADDR) but then DefinesLocalAddr does not recognize
         // LCL_FLD_ADDR (even though it does recognize LCL_VAR_ADDR).
-        if (user->OperIs(GT_CALL, GT_ASG))
+        if (user->OperIs(GT_CALL, GT_ASG, GT_CAST))
         {
             MorphLocalAddress(val);
         }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -263,18 +263,19 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             // Otherwise, we treat it as a use here.
             if ((tree->gtFlags & GTF_IND_ASG_LHS) == 0)
             {
-                GenTreeLclVarCommon* dummyLclVarTree = nullptr;
+                GenTreeLclVarCommon* lclVarTree = nullptr;
+                const unsigned dummyWidth = 0;
                 bool                 dummyIsEntire   = false;
                 GenTree*             addrArg         = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
-                if (!addrArg->DefinesLocalAddr(this, /*width doesn't matter*/ 0, &dummyLclVarTree, &dummyIsEntire))
+                if (!addrArg->DefinesLocalAddr(this, dummyWidth, &lclVarTree, &dummyIsEntire))
                 {
                     fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);
                 }
                 else
                 {
                     // Defines a local addr
-                    assert(dummyLclVarTree != nullptr);
-                    fgMarkUseDef(dummyLclVarTree->AsLclVarCommon());
+                    assert(lclVarTree != nullptr);
+                    fgMarkUseDef(lclVarTree->AsLclVarCommon());
                 }
             }
             break;

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -263,10 +263,10 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             // Otherwise, we treat it as a use here.
             if ((tree->gtFlags & GTF_IND_ASG_LHS) == 0)
             {
-                GenTreeLclVarCommon* lclVarTree = nullptr;
-                const unsigned dummyWidth = 0;
-                bool                 dummyIsEntire   = false;
-                GenTree*             addrArg         = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
+                GenTreeLclVarCommon* lclVarTree    = nullptr;
+                const unsigned       dummyWidth    = 0;
+                bool                 dummyIsEntire = false;
+                GenTree*             addrArg       = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
                 if (!addrArg->DefinesLocalAddr(this, dummyWidth, &lclVarTree, &dummyIsEntire))
                 {
                     fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -356,7 +356,7 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
         return fgMorphCastIntoHelper(tree, CORINFO_HELP_LNG2DBL, oper);
     }
 #endif // TARGET_X86
-    else if (varTypeIsGC(srcType) != varTypeIsGC(dstType))
+    else if (varTypeIsGC(srcType) != varTypeIsGC(dstType) && !oper->IsLocalAddrExpr())
     {
         // We are casting away GC information.  we would like to just
         // change the type to int, however this gives the emitter fits because

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -373,7 +373,8 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
         oper->gtType    = srcType;
 
         // do the real cast
-        GenTree* cast = gtNewCastNode(tree->TypeGet(), gtNewLclvNode(lclNum, TYP_I_IMPL), false, dstType);
+        GenTree* lclVar = gtNewLclvNode(lclNum, TYP_I_IMPL);
+        GenTree* cast   = gtNewCastNode(tree->TypeGet(), lclVar, false, dstType);
 
         // Generate the comma tree
         oper = gtNewOperNode(GT_COMMA, tree->TypeGet(), asg, cast);
@@ -2963,12 +2964,9 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 
         fgArgTabEntry* argEntry = nullptr;
 
-        // Change the node to TYP_I_IMPL so we don't report GC info
-        // NOTE: We deferred this from the importer because of the inliner.
-
-        if (argx->IsLocalAddrExpr() != nullptr)
+        if (argx->OperIs(GT_ADDR) && (argx->IsLocalAddrExpr() != nullptr))
         {
-            argx->gtType = TYP_I_IMPL;
+            argx->gtFlags |= GTF_ADDR_STACK;
         }
 
         // We should never have any ArgPlaceHolder nodes at this point.
@@ -8204,9 +8202,8 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
 
         lvaSetVarAddrExposed(newRetLcl);
 
-        retValArg =
-            gtNewAddrNode(gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType)));
-        retVal = gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType));
+        retValArg = gtNewAddrNode(gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType)));
+        retVal    = gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType));
 
         if (varTypeIsStruct(origCall->gtType))
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14568,7 +14568,7 @@ DONE_MORPHING_CHILDREN:
                 break;
             }
 
-            if (op1->OperGet() == GT_IND)
+            if (op1->OperIsIndir())
             {
                 if ((op1->gtFlags & GTF_IND_ARR_INDEX) == 0)
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2000,7 +2000,7 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
         else
         {
             var_types addrType = TYP_BYREF;
-            arg                = gtNewOperNode(GT_ADDR, addrType, arg);
+            arg                = gtNewAddrNode(arg);
             addrNode           = arg;
 
 #if FEATURE_MULTIREG_ARGS
@@ -2027,7 +2027,7 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
         // other targets, we pass the struct by value
         assert(varTypeIsStruct(type));
 
-        addrNode = gtNewOperNode(GT_ADDR, TYP_BYREF, arg);
+        addrNode = gtNewAddrNode(arg);
 
         // Get a new Obj node temp to use it as a call argument.
         // gtNewObjNode will set the GTF_EXCEPT flag if this is not a local stack object.
@@ -4422,7 +4422,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
                 if (!actualArg->OperIs(GT_OBJ))
                 {
                     // Create an Obj of the temp to use it as a call argument.
-                    arg = gtNewOperNode(GT_ADDR, TYP_I_IMPL, arg);
+                    arg = gtNewAddrNode(arg);
                     arg = gtNewObjNode(lvaGetStruct(lcl->GetLclNum()), arg);
                 }
                 // Its fields will need to be accessed by address.
@@ -8168,7 +8168,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
 
             var_types tmpRetBufType = lvaGetDesc(tmpRetBufNum)->TypeGet();
 
-            retValArg = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(tmpRetBufNum, tmpRetBufType));
+            retValArg = gtNewAddrNode(gtNewLclvNode(tmpRetBufNum, tmpRetBufType));
 
             var_types callerRetBufType = lvaGetDesc(info.compRetBuffArg)->TypeGet();
 
@@ -8205,7 +8205,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
         lvaSetVarAddrExposed(newRetLcl);
 
         retValArg =
-            gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType)));
+            gtNewAddrNode(gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType)));
         retVal = gtNewLclvNode(newRetLcl, genActualType(lvaTable[newRetLcl].lvType));
 
         if (varTypeIsStruct(origCall->gtType))
@@ -8234,7 +8234,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
         lvaSetVarAddrExposed(lvaRetAddrVar);
     }
 
-    GenTree* retAddrSlot           = gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaRetAddrVar, TYP_I_IMPL));
+    GenTree* retAddrSlot           = gtNewAddrNode(gtNewLclvNode(lvaRetAddrVar, TYP_I_IMPL));
     callDispatcherNode->gtCallArgs = gtPrependNewCallArg(retAddrSlot, callDispatcherNode->gtCallArgs);
 
     GenTree* finalTree = callDispatcherNode;
@@ -9168,7 +9168,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
                     retValTmpNum = lvaGrabTemp(true DEBUGARG("substitute local for ret buff arg"));
                     lvaSetStruct(retValTmpNum, structHnd, true);
-                    dest = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(retValTmpNum, TYP_STRUCT));
+                    dest = gtNewAddrNode(gtNewLclvNode(retValTmpNum, TYP_STRUCT));
                 }
             }
         }
@@ -9274,7 +9274,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
     if (origDest != nullptr)
     {
-        GenTree* retValVarAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(retValTmpNum, TYP_STRUCT));
+        GenTree* retValVarAddr = gtNewAddrNode(gtNewLclvNode(retValTmpNum, TYP_STRUCT));
         // If the origDest expression was an assignment to a variable, it might be to an otherwise-unused
         // var, which would allow the whole assignment to be optimized away to a NOP.  So in that case, make the
         // origDest into a comma that uses the var.  Note that the var doesn't have to be a temp for this to
@@ -9934,7 +9934,7 @@ GenTree* Compiler::fgMorphOneAsgBlockOp(GenTree* tree)
 
                 if (dest == destLclVarTree)
                 {
-                    GenTree* addr = gtNewOperNode(GT_ADDR, TYP_BYREF, dest);
+                    GenTree* addr = gtNewAddrNode(dest);
                     dest          = gtNewIndir(asgType, addr);
                 }
             }
@@ -9999,7 +9999,7 @@ GenTree* Compiler::fgMorphOneAsgBlockOp(GenTree* tree)
                     GenTree* srcAddr;
                     if (src == srcLclVarTree)
                     {
-                        srcAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, src);
+                        srcAddr = gtNewAddrNode(src);
                         src     = gtNewOperNode(GT_IND, asgType, srcAddr);
                     }
                     else
@@ -10433,7 +10433,7 @@ GenTree* Compiler::fgMorphGetStructAddr(GenTree** pTree, CORINFO_CLASS_HANDLE cl
             {
                 tree->ChangeOper(GT_IND);
             }
-            addr = gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
+            addr = gtNewAddrNode(tree);
         }
     }
     else if (tree->gtOper == GT_COMMA)
@@ -10452,7 +10452,7 @@ GenTree* Compiler::fgMorphGetStructAddr(GenTree** pTree, CORINFO_CLASS_HANDLE cl
             case GT_INDEX:
             case GT_FIELD:
             case GT_ARR_ELEM:
-                addr = gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
+                addr = gtNewAddrNode(tree);
                 break;
             case GT_INDEX_ADDR:
                 addr = tree;
@@ -10513,7 +10513,7 @@ GenTree* Compiler::fgMorphBlkNode(GenTree* tree, bool isDest)
 
         GenTree* lastComma = commas.Top();
         noway_assert(lastComma->gtGetOp2() == effectiveVal);
-        GenTree* effectiveValAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);
+        GenTree* effectiveValAddr = gtNewAddrNode(effectiveVal);
 #ifdef DEBUG
         effectiveValAddr->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
@@ -10664,7 +10664,7 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
             }
             else
             {
-                GenTree* addr = gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);
+                GenTree* addr = gtNewAddrNode(effectiveVal);
                 effectiveVal  = gtNewIndir(asgType, addr);
             }
         }
@@ -10734,7 +10734,7 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
             else
             {
                 GenTree* newTree;
-                GenTree* addr = gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);
+                GenTree* addr = gtNewAddrNode(effectiveVal);
                 if (isBlkReqd)
                 {
                     CORINFO_CLASS_HANDLE clsHnd = gtGetStructHandleIfPresent(effectiveVal);
@@ -10910,7 +10910,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                 assert(dest->TypeGet() != TYP_STRUCT);
                 assert(dest->gtOper == GT_LCL_FLD);
                 blockWidth = genTypeSize(dest->TypeGet());
-                destAddr   = gtNewOperNode(GT_ADDR, TYP_BYREF, dest);
+                destAddr   = gtNewAddrNode(dest);
                 destFldSeq = dest->AsLclFld()->GetFieldSeq();
             }
         }
@@ -11312,7 +11312,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                 dest->SetOper(GT_IND);
                 dest->gtType = TYP_STRUCT;
             }
-            destAddr = gtNewOperNode(GT_ADDR, TYP_BYREF, dest);
+            destAddr = gtNewAddrNode(dest);
         }
 
         if (destDoFldAsg)
@@ -14661,7 +14661,7 @@ DONE_MORPHING_CHILDREN:
                     commaOp2->gtFlags |= (commaOp2->AsOp()->gtOp1->gtFlags & GTF_EXCEPT);
                 }
 
-                op1 = gtNewOperNode(GT_ADDR, TYP_BYREF, commaOp2);
+                op1 = gtNewAddrNode(commaOp2);
 
                 if (isZeroOffset)
                 {

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -558,7 +558,7 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
     GenTree* tree = comp->gtNewLclvNode(lclNum, TYP_STRUCT);
 
     // Add a pseudo-field for the method table pointer and initialize it
-    tree = comp->gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
+    tree = comp->gtNewAddrNode(tree);
     tree = comp->gtNewFieldRef(TYP_I_IMPL, FieldSeqStore::FirstElemPseudoField, tree, 0);
     tree = comp->gtNewAssignNode(tree, allocObj->gtGetOp1());
 
@@ -892,7 +892,7 @@ void ObjectAllocator::RewriteUses()
                 {
                     newType = TYP_I_IMPL;
                     tree =
-                        m_compiler->gtNewOperNode(GT_ADDR, newType, m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT));
+                        m_compiler->gtNewAddrNode(m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT));
                     *use = tree;
                 }
                 else

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -891,9 +891,8 @@ void ObjectAllocator::RewriteUses()
                 if (m_allocator->m_HeapLocalToStackLocalMap.TryGetValue(lclNum, &newLclNum))
                 {
                     newType = TYP_I_IMPL;
-                    tree =
-                        m_compiler->gtNewAddrNode(m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT));
-                    *use = tree;
+                    tree    = m_compiler->gtNewAddrNode(m_compiler->gtNewLclvNode(newLclNum, TYP_STRUCT));
+                    *use    = tree;
                 }
                 else
                 {

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -164,7 +164,7 @@ private:
         // call PPHelper(&ppCounter, ilOffset)
         GenTree*          ilOffsetNode  = compiler->gtNewIconNode(ilOffset, TYP_INT);
         GenTree*          ppCounterRef  = compiler->gtNewLclvNode(ppCounterLclNum, TYP_INT);
-        GenTree*          ppCounterAddr = compiler->gtNewOperNode(GT_ADDR, TYP_I_IMPL, ppCounterRef);
+        GenTree*          ppCounterAddr = compiler->gtNewAddrNode(ppCounterRef);
         GenTreeCall::Use* helperArgs    = compiler->gtNewCallArgs(ppCounterAddr, ilOffsetNode);
         GenTreeCall*      helperCall    = compiler->gtNewHelperCallNode(CORINFO_HELP_PATCHPOINT, TYP_VOID, helperArgs);
 

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -533,7 +533,8 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
 #endif // DEBUG
 
         location->SetOper(addrForm(locationOp));
-        location->gtType = address->TypeGet();
+        location->gtType = TYP_I_IMPL;
+        //assert(address->TypeIs(TYP_I_IMPL));
         copyFlags(location, address, GTF_ALL_EFFECT);
 
         use.ReplaceWith(comp, location);

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -533,8 +533,7 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
 #endif // DEBUG
 
         location->SetOper(addrForm(locationOp));
-        location->gtType = TYP_I_IMPL;
-        //assert(address->TypeIs(TYP_I_IMPL));
+        location->ChangeType(address->TypeGet());
         copyFlags(location, address, GTF_ALL_EFFECT);
 
         use.ReplaceWith(comp, location);

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -533,7 +533,7 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
 #endif // DEBUG
 
         location->SetOper(addrForm(locationOp));
-        location->gtType = TYP_BYREF;
+        location->gtType = address->TypeGet();
         copyFlags(location, address, GTF_ALL_EFFECT);
 
         use.ReplaceWith(comp, location);

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -1117,7 +1117,7 @@ GenTree* Compiler::impSIMDPopStack(var_types type, bool expectAddr, CORINFO_CLAS
     // SIMD type struct that it points to.
     if (expectAddr)
     {
-        assert(tree->TypeGet() == TYP_BYREF);
+        assert(tree->TypeIs(TYP_BYREF, TYP_I_IMPL));
         if (tree->OperGet() == GT_ADDR)
         {
             tree = tree->gtGetOp1();
@@ -1420,7 +1420,6 @@ GenTree* Compiler::getOp1ForConstructor(OPCODE opcode, GenTree* newobjThis, CORI
     {
         op1 = impSIMDPopStack(TYP_BYREF);
     }
-    assert(op1->TypeGet() == TYP_BYREF);
     return op1;
 }
 
@@ -1944,7 +1943,6 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
 
             op1 = getOp1ForConstructor(opcode, newobjThis, clsHnd);
 
-            assert(op1->TypeGet() == TYP_BYREF);
             assert(genActualType(op2->TypeGet()) == genActualType(baseType) || initFromFirstArgIndir);
 
             // For integral base types of size less than TYP_INT, expand the initializer
@@ -2322,7 +2320,7 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
             assert(src != nullptr);
             simdTree = gtNewSIMDNode(simdType, src, op2, simdIntrinsicID, baseType, size);
 
-            copyBlkDst = gtNewOperNode(GT_ADDR, TYP_BYREF, op1);
+            copyBlkDst = gtNewAddrNode(op1);
             doCopyBlk  = true;
         }
         break;


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/48308#issuecomment-781131248 we noticed that we are not consistent about our ADDR optimizations, long story short we don't need to emit a full write barrier when we change a byref that points to the stack, the current Jit does it by retyping `TYP_BYREF` to `TYP_I_IMPL` in some cases, however, other places are not aware of it and can generate worse code, asserts or bad code because of that.

I was trying to make it consistent and convert all such addresses to `I_IMPL` and then assert during check and rationalize, however, it did not work well, because:
1. asserts in `addrMode` that can't use `op2` with `LCL_VAR_ADDR` but it detects them by `byref` type, if it is `IMPL` we don't correctly update the liveness for it;
2. asserts in codegen because we lose GC pointers, morph is trying to solve it by `lvaGrabTemp(true DEBUGARG("Cast away GC"))` but does not catch all necessary cases.
3. CQ regressions because assertion and copy prop does not work when they see `LclVar V01 byref = LclVar V02 long`;
4. CQ regressions with inlining when it expected a byref but got LONG and rejected it.

These changes are in the first 5 commits.

so mostly because of the asserts I've decided to try to keep them as `BYREF` and use a tree flag on such addresses:
0771c2e7664: use a flag instead of IMPL type.
it passed stress tests (revealed one with incorrect IL, was fixed), gave some improvements but overall regression.

cbc2de76bd5: Fix regressions1.
Fix regressions when we had something like `IND short(cast short(ADDR byref ())`.

c8b8a4d8913: Fix regressions2.
Teach `DefinesLocal`, `impIsAddressInLocal` and `IsLocalExpr` to skip cast nodes.

Even with these fixes, the overall score is still a regression, mostly because of the new `DEBUGARG("Cast away GC"))` temps.

However, at least this change https://github.com/dotnet/runtime/commit/c723b6e91b3a32239250b21faf55ab8a03caf10c#diff-d593fa9f647288fed0e0a54655a5d55586fab17368fe5212df2604a48d5a064dL644 looks like a correctness fix. This code is working because in most cases `I_IMPL` is used for stack addresses but it could be used for anything via a cast, it this case we will get a hole.


I want to gather @dotnet/jit-contrib optinions:
1. What is the best representation for such addresses? I tend to `Byref` with a flag because of the existing logic that is checking `Type == BYREF` and assertion/copy prop;
2. Is anybody aware of any existing opened issues that could be associated with this inconsistent logic/wrong memory barrier?
3. Does anybody know how expensive would it be to get rid of `lvaGrabTemp(true DEBUGARG("Cast away GC"))` temps and support such implicit casts in emitter? How do we want to represent `CAST I_IMPL<-byref` in different phases?
4. Do we remember why we have 3 similar functions with different logic:  `DefinesLocal`, `impIsAddressInLocal` and `IsLocalExpr`? Is something preventing us from merging them?
5. do we want to take this change with the regressions as a correctness fix or leave the existing state?


Diffs (spmi x64):
```
benchmarks.run.windows.x64.checked.mch: 
  Total bytes of delta: 259 (0.05% of base)
  25 total methods with Code Size differences (3 improved, 22 regressed), 355 unchanged.
libraries.crossgen.windows.x64.checked.mch: 
  96 total methods with Code Size differences (14 improved, 82 regressed), 2639 unchanged.
  Total bytes of delta: 187 (0.01% of base)
libraries.pmi.windows.x64.checked.mch: 
  96 total methods with Code Size differences (20 improved, 76 regressed), 2478 unchanged.
  Total bytes of delta: 36 (0.00% of base)
tests.pmi.windows.x64.checked.mch: 
  Total bytes of delta: 3895 (0.09% of base)
  924 total methods with Code Size differences (126 improved, 798 regressed), 695 unchanged.
```
