### PR TITLE
Add new APIs for abstracting the system clock and local time zone.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -258,12 +258,16 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerTypeProxyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerVisualizerAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\ActualSystemClock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackFrame.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackFrameExtensions.cs" Condition="'$(TargetsCoreRT)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackTrace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackTraceHiddenAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Stopwatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\SymbolStore\ISymbolDocumentWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\TimeClock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\TimeContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\VirtualClock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DivideByZeroException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DllNotFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Double.cs" />
@@ -1621,6 +1625,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\DateTime.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\ActualSystemClock.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Stopwatch.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\RuntimeEventSourceHelper.Windows.cs" Condition="'$(FeaturePerfTracing)' == 'true'" />
@@ -1823,6 +1828,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DateTime.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\ActualSystemClock.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Stopwatch.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\RuntimeEventSourceHelper.Unix.cs" Condition="'$(FeaturePerfTracing)' == 'true'" />

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.Unix.cs
@@ -7,14 +7,6 @@ namespace System
     {
         internal const bool s_systemSupportsLeapSeconds = false;
 
-        public static DateTime UtcNow
-        {
-            get
-            {
-                return new DateTime(((ulong)(Interop.Sys.GetSystemTimeAsTicks() + UnixEpochTicks)) | KindUtc);
-            }
-        }
-
         private static DateTime FromFileTimeLeapSecondsAware(ulong fileTime) => default;
         private static ulong ToFileTimeLeapSecondsAware(long ticks) => default;
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -81,7 +81,7 @@ namespace System
         private const long MaxMillis = (long)DaysTo10000 * MillisPerDay;
 
         internal const long UnixEpochTicks = DaysTo1970 * TicksPerDay;
-        private const long FileTimeOffset = DaysTo1601 * TicksPerDay;
+        internal const long FileTimeOffset = DaysTo1601 * TicksPerDay;
         private const long DoubleDateOffset = DaysTo1899 * TicksPerDay;
         // The minimum OA date is 0100/01/01 (Note it's year 100).
         // The maximum OA date is 9999/12/31
@@ -112,7 +112,7 @@ namespace System
         private const ulong FlagsMask = 0xC000000000000000;
         private const long TicksCeiling = 0x4000000000000000;
         private const ulong KindUnspecified = 0x0000000000000000;
-        private const ulong KindUtc = 0x4000000000000000;
+        internal const ulong KindUtc = 0x4000000000000000;
         private const ulong KindLocal = 0x8000000000000000;
         private const ulong KindLocalAmbiguousDst = 0xC000000000000000;
         private const int KindShift = 62;
@@ -140,7 +140,7 @@ namespace System
             _dateData = (ulong)ticks;
         }
 
-        private DateTime(ulong dateData)
+        internal DateTime(ulong dateData)
         {
             this._dateData = dateData;
         }
@@ -743,7 +743,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(fileTime), SR.ArgumentOutOfRange_FileTimeInvalid);
             }
 
-#pragma warning disable 162 // Unrechable code on Unix
+#pragma warning disable 162 // Unreachable code on Unix
             if (s_systemSupportsLeapSeconds)
             {
                 return FromFileTimeLeapSecondsAware((ulong)fileTime);
@@ -1057,6 +1057,8 @@ namespace System
         //
         public static DateTime Today => Now.Date;
 
+        public static DateTime UtcNow => TimeContext.Current.Clock.GetCurrentUtcDateTime();
+
         // Returns the year part of this DateTime. The returned value is an
         // integer between 1 and 9999.
         //
@@ -1203,7 +1205,7 @@ namespace System
             // Treats the input as universal if it is not specified
             long ticks = ((_dateData & KindLocal) != 0) ? ToUniversalTime().Ticks : Ticks;
 
-#pragma warning disable 162 // Unrechable code on Unix
+#pragma warning disable 162 // Unreachable code on Unix
             if (s_systemSupportsLeapSeconds)
             {
                 return (long)ToFileTimeLeapSecondsAware(ticks);

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -54,7 +54,7 @@ namespace System
 
         // Constructors
 
-        private DateTimeOffset(short validOffsetMinutes, DateTime validDateTime)
+        internal DateTimeOffset(short validOffsetMinutes, DateTime validDateTime)
         {
             _dateTime = validDateTime;
             _offsetMinutes = validOffsetMinutes;
@@ -176,18 +176,7 @@ namespace System
         // resolution of the returned value depends on the system timer.
         public static DateTimeOffset Now => ToLocalTime(DateTime.UtcNow, true);
 
-        public static DateTimeOffset UtcNow
-        {
-            get
-            {
-                DateTime utcNow = DateTime.UtcNow;
-                var result = new DateTimeOffset(0, utcNow);
-
-                Debug.Assert(new DateTimeOffset(utcNow) == result); // ensure lack of verification does not break anything
-
-                return result;
-            }
-        }
+        public static DateTimeOffset UtcNow => TimeContext.Current.Clock.GetCurrentUtcDateTimeOffset();
 
         public DateTime DateTime => ClockDateTime;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.Unix.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics
+{
+    public partial class ActualSystemClock
+    {
+        private static unsafe ulong GetTicks() => (ulong)(Interop.Sys.GetSystemTimeAsTicks() + DateTime.UnixEpochTicks);
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.Windows.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System.Diagnostics
+{
+    public partial class ActualSystemClock
+    {
+        private static unsafe ulong GetTicks()
+        {
+            ulong fileTime;
+            s_pfnGetSystemTimeAsFileTime(&fileTime);
+
+            if (!DateTime.s_systemSupportsLeapSeconds)
+            {
+                return fileTime + DateTime.FileTimeOffset;
+            }
+
+            Interop.Kernel32.SYSTEMTIME time;
+            ulong hundredNanoSecond;
+
+            if (Interop.Kernel32.FileTimeToSystemTime(&fileTime, &time) != Interop.BOOL.FALSE)
+            {
+                // to keep the time precision
+                ulong tmp = fileTime; // temp. variable avoids double read from memory
+                hundredNanoSecond = tmp % TimeSpan.TicksPerMillisecond;
+            }
+            else
+            {
+                Interop.Kernel32.GetSystemTime(&time);
+                hundredNanoSecond = 0;
+            }
+
+            return DateTime.GetTicksFromSystemTime(in time, hundredNanoSecond);
+        }
+
+        private static readonly unsafe delegate* unmanaged[SuppressGCTransition]<ulong*, void> s_pfnGetSystemTimeAsFileTime = GetGetSystemTimeAsFileTimeFnPtr();
+
+        private static unsafe delegate* unmanaged[SuppressGCTransition]<ulong*, void> GetGetSystemTimeAsFileTimeFnPtr()
+        {
+            IntPtr kernel32Lib = Interop.Kernel32.LoadLibraryEx(Interop.Libraries.Kernel32, IntPtr.Zero, Interop.Kernel32.LOAD_LIBRARY_SEARCH_SYSTEM32);
+            Debug.Assert(kernel32Lib != IntPtr.Zero);
+
+            IntPtr pfnGetSystemTime = NativeLibrary.GetExport(kernel32Lib, "GetSystemTimeAsFileTime");
+
+            if (NativeLibrary.TryGetExport(kernel32Lib, "GetSystemTimePreciseAsFileTime", out IntPtr pfnGetSystemTimePrecise))
+            {
+                // GetSystemTimePreciseAsFileTime exists and we'd like to use it.  However, on
+                // misconfigured systems, it's possible for the "precise" time to be inaccurate:
+                //     https://github.com/dotnet/runtime/issues/9014
+                // If it's inaccurate, though, we expect it to be wildly inaccurate, so as a
+                // workaround/heuristic, we get both the "normal" and "precise" times, and as
+                // long as they're close, we use the precise one. This workaround can be removed
+                // when we better understand what's causing the drift and the issue is no longer
+                // a problem or can be better worked around on all targeted OSes.
+
+                // Retry this check several times to reduce chance of false negatives due to thread being rescheduled
+                // at wrong time.
+                for (int i = 0; i < 10; i++)
+                {
+                    long systemTimeResult, preciseSystemTimeResult;
+                    ((delegate* unmanaged[SuppressGCTransition]<long*, void>)pfnGetSystemTime)(&systemTimeResult);
+                    ((delegate* unmanaged[SuppressGCTransition]<long*, void>)pfnGetSystemTimePrecise)(&preciseSystemTimeResult);
+
+                    if (Math.Abs(preciseSystemTimeResult - systemTimeResult) <= 100 * TimeSpan.TicksPerMillisecond)
+                    {
+                        pfnGetSystemTime = pfnGetSystemTimePrecise; // use the precise version
+                        break;
+                    }
+                }
+            }
+
+            return (delegate* unmanaged[SuppressGCTransition]<ulong*, void>)pfnGetSystemTime;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/ActualSystemClock.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Implements a <see cref="TimeClock"/> that retrieves the current time from
+    /// the actual system clock, as provided by the underlying operating system.
+    /// </summary>
+    public sealed partial class ActualSystemClock : TimeClock
+    {
+        private ActualSystemClock()
+        {
+        }
+
+        /// <summary>
+        /// Gets a singleton instance of the <see cref="ActualSystemClock"/>.
+        /// </summary>
+        public static ActualSystemClock Instance { get; } = new();
+
+        protected override DateTimeOffset GetCurrentUtcDateTimeOffsetImpl()
+        {
+            ulong ticks = GetTicks();
+            return new DateTimeOffset(0, new DateTime(ticks));
+        }
+
+        internal override DateTime GetCurrentUtcDateTimeImpl()
+        {
+            ulong ticks = GetTicks();
+            return new DateTime(ticks | DateTime.KindUtc);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/TimeClock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/TimeClock.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Provides an abstraction for a clock which is used to retrieve the current time.
+    /// </summary>
+    public abstract class TimeClock
+    {
+        /// <summary>
+        /// Gets the current time from the clock instance, as a <see cref="DateTimeOffset"/>,
+        /// in terms of Coordinated Universal Time (UTC).
+        /// </summary>
+        /// <returns>
+        /// A <see cref="DateTimeOffset"/> value representing the current UTC time.
+        /// The value will always have a zero offset.
+        /// </returns>
+        public DateTimeOffset GetCurrentUtcDateTimeOffset()
+        {
+            DateTimeOffset value = GetCurrentUtcDateTimeOffsetImpl();
+            return value.Offset == TimeSpan.Zero ? value : value.ToUniversalTime();
+        }
+
+        /// <summary>
+        /// Gets the current time from the clock instance, as a <see cref="DateTime"/>,
+        /// in terms of Coordinated Universal Time (UTC).
+        /// </summary>
+        /// <returns>
+        /// A <see cref="DateTime"/> value representing the current UTC time.
+        /// The value will always have a kind of <see cref="DateTimeKind.Utc"/>.
+        /// </returns>
+        public DateTime GetCurrentUtcDateTime() => GetCurrentUtcDateTimeImpl();
+
+        /// <summary>
+        /// Provides the implementation logic for the clock instance to return the current time.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="DateTimeOffset"/> value representing the current time from the clock instance.
+        /// </returns>
+        protected abstract DateTimeOffset GetCurrentUtcDateTimeOffsetImpl();
+
+        /// <summary>
+        /// Provides the implementation logic for the clock instance to return the current time.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="DateTime"/> value representing the current time from the clock instance.
+        /// </returns>
+        /// <remarks>
+        /// This method is overriden internally by the <see cref="ActualSystemClock"/> only, for performance benefits.
+        /// All other clocks will implement only the <see cref="GetCurrentUtcDateTimeOffsetImpl"/> method.
+        /// </remarks>
+        internal virtual DateTime GetCurrentUtcDateTimeImpl() => GetCurrentUtcDateTimeOffsetImpl().UtcDateTime;
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/TimeContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/TimeContext.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Represents an ambient context that can be used to run an operation using a specific <see cref="TimeClock"/>,
+    /// a specific <see cref="TimeZoneInfo"/>, or both.
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///     Providing a <see cref="TimeClock"/> to any of the <c>Run</c> or <c>RunAsync</c> static methods, for the
+    ///     scope of the provided operation, will use that clock to control the values of properties that give the
+    ///     current time, including <see cref="DateTimeOffset.UtcNow"/>, <see cref="DateTime.UtcNow"/>,
+    ///     <see cref="DateTimeOffset.Now"/>, <see cref="DateTime.Now"/>, and <see cref="DateTime.Today"/>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Providing a <see cref="TimeZoneInfo"/> to any of the <c>Run</c> or <c>RunAsync</c> static methods, for the
+    ///     scope of the provided operation, will use that time zone to control the values of properties that give or use
+    ///     the local time zone, including <see cref="TimeZoneInfo.Local"/>, <see cref="DateTimeOffset.Now"/>,
+    ///     <see cref="DateTime.Now"/>, and <see cref="DateTime.Today"/>, and becomes the local time zone used by all
+    ///     platform features that convert to or from local time, such as <see cref="DateTime.ToLocalTime"/>
+    ///     <see cref="DateTime.ToUniversalTime"/>,
+    ///     and many others.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </summary>
+    public sealed class TimeContext
+    {
+        private readonly TimeClock _clock;
+        private readonly Func<TimeZoneInfo> _localTimeZoneAccessor;
+
+        // The default time context will use the actual system clock and local system time zone.
+        private static readonly TimeContext s_defaultTimeContext = new TimeContext(ActualSystemClock.Instance, TimeZoneInfo.GetActualSystemLocal);
+
+        // This is the ambient storage for the time context.
+        private static readonly AsyncLocal<TimeContext> s_context = new();
+
+        // Private constructor only.  No public construction allowed.
+        private TimeContext(TimeClock clock, Func<TimeZoneInfo> localTimeZoneAccessor)
+        {
+            _clock = clock;
+            _localTimeZoneAccessor = localTimeZoneAccessor;
+        }
+
+        /// <summary>
+        /// Gets the currently active ambient time context.
+        /// </summary>
+        public static TimeContext Current
+        {
+            get => s_context.Value ?? s_defaultTimeContext;
+            private set => s_context.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the actual system clock, regardless of whether it is the current clock or not.
+        /// </summary>
+        public static ActualSystemClock ActualSystemClock => ActualSystemClock.Instance;
+
+        /// <summary>
+        /// Gets a value that indicates whether the current clock is the actual system clock.
+        /// </summary>
+        public static bool ActualSystemClockIsActive => Current._clock is ActualSystemClock;
+
+        /// <summary>
+        /// Gets the actual system time zone, regardless of whether it is the current local time zone or not.
+        /// </summary>
+        public static TimeZoneInfo ActualSystemLocalTimeZone => TimeZoneInfo.GetActualSystemLocal();
+
+        /// <summary>
+        /// Gets a value that indicates whether the current local time zone is the actual system local time zone.
+        /// </summary>
+        public static bool ActualSystemLocalTimeZoneIsActive => Current._localTimeZoneAccessor == TimeZoneInfo.GetActualSystemLocal;
+
+        /// <summary>
+        /// Gets the clock used by this time context.
+        /// </summary>
+        public TimeClock Clock => _clock;
+
+        /// <summary>
+        /// Gets the local time zone used by this time context.
+        /// </summary>
+        public TimeZoneInfo LocalTimeZone => _localTimeZoneAccessor();
+
+        /// <summary>
+        /// Runs a synchronous action under a <see cref="TimeContext"/> with the specified clock.
+        /// </summary>
+        /// <param name="clock">The clock that will be in effect during the action.</param>
+        /// <param name="action">The action to run.</param>
+        public static void Run(TimeClock clock, Action action)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, original._localTimeZoneAccessor);
+            action.Invoke();
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs a synchronous action under a <see cref="TimeContext"/> with the specified local time zone.
+        /// </summary>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the action.</param>
+        /// <param name="action">The action to run.</param>
+        public static void Run(TimeZoneInfo localTimeZone, Action action)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(original._clock, () => localTimeZone);
+            action.Invoke();
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs a synchronous action under a <see cref="TimeContext"/> with the specified clock and local time zone.
+        /// </summary>
+        /// <param name="clock">The clock that will be in effect during the action.</param>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the action.</param>
+        /// <param name="action">The action to run.</param>
+        public static void Run(TimeClock clock, TimeZoneInfo localTimeZone, Action action)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, () => localTimeZone);
+            action.Invoke();
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs a synchronous function under a <see cref="TimeContext"/> with the specified clock.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>The result from running the function.</returns>
+        public static TResult Run<TResult>(TimeClock clock, Func<TResult> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, original._localTimeZoneAccessor);
+            TResult result = function.Invoke();
+            Current = original;
+            return result;
+        }
+
+        /// <summary>
+        /// Runs a synchronous function under a <see cref="TimeContext"/> with the specified local time zone.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>The result from running the function.</returns>
+        public static TResult Run<TResult>(TimeZoneInfo localTimeZone, Func<TResult> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(original._clock, () => localTimeZone);
+            TResult result = function.Invoke();
+            Current = original;
+            return result;
+        }
+
+        /// <summary>
+        /// Runs a synchronous function under a <see cref="TimeContext"/> with the specified clock and local time zone.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>The result from running the function.</returns>
+        public static TResult Run<TResult>(TimeClock clock, TimeZoneInfo localTimeZone, Func<TResult> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, () => localTimeZone);
+            TResult result = function.Invoke();
+            Current = original;
+            return result;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified clock.
+        /// </summary>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task"/> from the asynchronous function call.</returns>
+        public static async Task RunAsync(TimeClock clock, Func<Task> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, original._localTimeZoneAccessor);
+            await function.Invoke().ConfigureAwait(false);
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified local time zone.
+        /// </summary>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task"/> from the asynchronous function call.</returns>
+        public static async Task RunAsync(TimeZoneInfo localTimeZone, Func<Task> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(original._clock, () => localTimeZone);
+            await function.Invoke().ConfigureAwait(false);
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified clock and local time zone.
+        /// </summary>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task"/> from the asynchronous function call.</returns>
+        public static async Task RunAsync(TimeClock clock, TimeZoneInfo localTimeZone, Func<Task> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, () => localTimeZone);
+            await function.Invoke().ConfigureAwait(false);
+            Current = original;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified clock.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task{TResult}"/> from the asynchronous function call.</returns>
+        public static async Task<TResult> RunAsync<TResult>(TimeClock clock, Func<Task<TResult>> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, original._localTimeZoneAccessor);
+            TResult result = await function.Invoke().ConfigureAwait(false);
+            Current = original;
+            return result;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified local time zone.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task{TResult}"/> from the asynchronous function call.</returns>
+        public static async Task<TResult> RunAsync<TResult>(TimeZoneInfo localTimeZone, Func<Task<TResult>> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(original._clock, () => localTimeZone);
+            TResult result = await function.Invoke().ConfigureAwait(false);
+            Current = original;
+            return result;
+        }
+
+        /// <summary>
+        /// Runs an asynchronous function under a <see cref="TimeContext"/> with the specified clock and local time zone.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the function.</typeparam>
+        /// <param name="clock">The clock that will be in effect during the function.</param>
+        /// <param name="localTimeZone">The local time zone that will be in effect during the function.</param>
+        /// <param name="function">The function to run.</param>
+        /// <returns>A <see cref="Task{TResult}"/> from the asynchronous function call.</returns>
+        public static async Task<TResult> RunAsync<TResult>(TimeClock clock, TimeZoneInfo localTimeZone, Func<Task<TResult>> function)
+        {
+            TimeContext original = Current;
+            Current = new TimeContext(clock, () => localTimeZone);
+            TResult result = await function.Invoke().ConfigureAwait(false);
+            Current = original;
+            return result;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/VirtualClock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/VirtualClock.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Implements a <see cref="TimeClock"/> that tracks time in its internal state.
+    /// This is primarily intended for use in unit tests, so that an artificial time can be provided
+    /// to the code being tested rather than the actual system time.
+    /// </summary>
+    public sealed class VirtualClock : TimeClock
+    {
+        // This is the internal time value of the virtual clock.
+        private DateTimeOffset? _value;
+
+        // This is only used when constructing the virtual clock using a DateTime instead of a DateTimeOffset.
+        // It is later converted to a DateTimeOffset when used in the GetCurrentUtcDateTimeOffsetImpl method.
+        private readonly DateTime _initialDateTimeValue;
+
+        // When set, this function controls how the internal time value advances after each value is retrieved.
+        // Otherwise, the internal time value is fixed and does not advance.
+        private readonly Func<DateTimeOffset, DateTimeOffset>? _advancementFunction;
+
+        /// <summary>
+        /// Constructs a virtual clock that always provides a fixed time value.
+        /// </summary>
+        /// <param name="timeValue">The time that the clock is set to.</param>
+        /// <remarks>
+        /// The <paramref name="timeValue"/> parameter will internally be converted to UTC using its <see cref="DateTimeOffset.Offset"/>.
+        /// </remarks>
+        public VirtualClock(DateTimeOffset timeValue)
+        {
+            _value = timeValue.ToUniversalTime();
+        }
+
+        /// <summary>
+        /// Constructs a virtual clock that always provides a fixed time value.
+        /// </summary>
+        /// <param name="timeValue">The time that the clock is set to.</param>
+        /// <remarks>
+        /// The <paramref name="timeValue"/> parameter will internally be converted to UTC using its <see cref="DateTime.Kind"/>.
+        /// Values with <see cref="DateTimeKind.Local"/> or <see cref="DateTimeKind.Unspecified"/> will be treated as local time,
+        /// using the local time zone as given by <see cref="TimeZoneInfo.Local"/> or the current <see cref="TimeContext.LocalTimeZone"/>.
+        /// </remarks>
+        public VirtualClock(DateTime timeValue)
+        {
+            _initialDateTimeValue = timeValue;
+        }
+
+        /// <summary>
+        /// Constructs a virtual clock that is initialized to a given value, and advances after each retrieval by a given amount.
+        /// </summary>
+        /// <param name="initialTimeValue">The time that the clock is initially set to.</param>
+        /// <param name="advancementAmount">The amount of time that the clock will advance after the current time is retrieved.</param>
+        /// <remarks>
+        /// The <paramref name="initialTimeValue"/> parameter will internally be converted to UTC using its <see cref="DateTimeOffset.Offset"/>.
+        /// </remarks>
+        public VirtualClock(DateTimeOffset initialTimeValue, TimeSpan advancementAmount)
+        {
+            _value = initialTimeValue.ToUniversalTime();
+            _advancementFunction = value => value.Add(advancementAmount);
+        }
+
+        /// <summary>
+        /// Constructs a virtual clock that is initialized to a given value, and advances after each retrieval by a given amount.
+        /// </summary>
+        /// <param name="initialTimeValue">The time that the clock is initially set to.</param>
+        /// <param name="advancementAmount">The amount of time that the clock will advance after the current time is retrieved.</param>
+        /// <remarks>
+        /// The <paramref name="initialTimeValue"/> parameter will internally be converted to UTC using its <see cref="DateTime.Kind"/>.
+        /// Values with <see cref="DateTimeKind.Local"/> or <see cref="DateTimeKind.Unspecified"/> will be treated as local time,
+        /// using the local time zone as given by <see cref="TimeZoneInfo.Local"/> or the current <see cref="TimeContext.LocalTimeZone"/>.
+        /// </remarks>
+        public VirtualClock(DateTime initialTimeValue, TimeSpan advancementAmount)
+        {
+            _initialDateTimeValue = initialTimeValue;
+            _advancementFunction = value => value.Add(advancementAmount);
+        }
+
+        /// <summary>
+        /// Constructs a virtual clock that is initialized to a given value, and advances after each retrieval according
+        /// to a given function.
+        /// </summary>
+        /// <param name="initialTimeValue">The time that the clock is initially set to.</param>
+        /// <param name="advancementFunction">
+        /// A function that advances the clock after the current time is retrieved.
+        /// The function's input parameter is the clock's current value, and the function should return the clock's new value.
+        /// </param>
+        /// <remarks>
+        /// The <paramref name="initialTimeValue"/> parameter will internally be converted to UTC using its <see cref="DateTimeOffset.Offset"/>.
+        /// </remarks>
+        public VirtualClock(DateTimeOffset initialTimeValue, Func<DateTimeOffset, DateTimeOffset> advancementFunction)
+        {
+            _value = initialTimeValue.ToUniversalTime();
+            _advancementFunction = advancementFunction;
+        }
+
+        /// <summary>
+        /// Constructs a virtual clock that is initialized to a given value, and advances after each retrieval according
+        /// to a given function.
+        /// </summary>
+        /// <param name="initialTimeValue">The time that the clock is initially set to.</param>
+        /// <param name="advancementFunction">
+        /// A function that advances the clock after the current time is retrieved.
+        /// The function's input parameter is the clock's current value, and the function should return the clock's new value.
+        /// </param>
+        /// <remarks>
+        /// The <paramref name="initialTimeValue"/> parameter will internally be converted to UTC using its <see cref="DateTime.Kind"/>.
+        /// Values with <see cref="DateTimeKind.Local"/> or <see cref="DateTimeKind.Unspecified"/> will be treated as local time,
+        /// using the local time zone as given by <see cref="TimeZoneInfo.Local"/> or the current <see cref="TimeContext.LocalTimeZone"/>.
+        /// </remarks>
+        public VirtualClock(DateTime initialTimeValue, Func<DateTimeOffset, DateTimeOffset> advancementFunction)
+        {
+            _initialDateTimeValue = initialTimeValue;
+            _advancementFunction = advancementFunction;
+        }
+
+        protected override DateTimeOffset GetCurrentUtcDateTimeOffsetImpl()
+        {
+            // Note: When the clock is initialized using a DateTime, the conversion to DateTimeOffset is done here
+            //       rather than in the constructor.  This allows for the local time zone to be changed (if desired)
+            //       when using this clock within an ambient TimeContext, thus affecting the conversion behavior
+            //       in the following line of code when the DateTime value has a Kind of Local or Unspecified.
+            DateTimeOffset value = _value ?? new DateTimeOffset(_initialDateTimeValue);
+
+            if (_advancementFunction != null)
+            {
+                DateTimeOffset newValue = _advancementFunction.Invoke(value);
+                _value = newValue.ToUniversalTime();
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -364,6 +364,13 @@ namespace System
         // DateTime.Now fast path that avoids allocating an historically accurate TimeZoneInfo.Local and just creates a 1-year (current year) accurate time zone
         internal static TimeSpan GetDateTimeNowUtcOffsetFromUtc(DateTime time, out bool isAmbiguousLocalDst)
         {
+            if (!TimeContext.ActualSystemLocalTimeZoneIsActive)
+            {
+                // Use the standard code path when we're in a time context that has changed the system local time zone.
+                bool isDaylightSavings;
+                return GetUtcOffsetFromUtc(time, Local, out isDaylightSavings, out isAmbiguousLocalDst);
+            }
+
             isAmbiguousLocalDst = false;
             int timeYear = time.Year;
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5691,6 +5691,12 @@ namespace System.Configuration.Assemblies
 }
 namespace System.Diagnostics
 {
+    public sealed partial class ActualSystemClock : System.Diagnostics.TimeClock
+    {
+        internal ActualSystemClock() { }
+        public static System.Diagnostics.ActualSystemClock Instance { get { throw null; } }
+        protected override System.DateTimeOffset GetCurrentUtcDateTimeOffsetImpl() { throw null; }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
     public sealed partial class ConditionalAttribute : System.Attribute
     {
@@ -5878,6 +5884,46 @@ namespace System.Diagnostics
         public void Start() { }
         public static System.Diagnostics.Stopwatch StartNew() { throw null; }
         public void Stop() { }
+    }
+    public abstract partial class TimeClock
+    {
+        protected TimeClock() { }
+        public System.DateTime GetCurrentUtcDateTime() { throw null; }
+        public System.DateTimeOffset GetCurrentUtcDateTimeOffset() { throw null; }
+        protected abstract System.DateTimeOffset GetCurrentUtcDateTimeOffsetImpl();
+    }
+    public sealed partial class TimeContext
+    {
+        internal TimeContext() { }
+        public static System.TimeZoneInfo ActualSystemLocalTimeZone { get { throw null; } }
+        public static bool ActualSystemLocalTimeZoneIsActive { get { throw null; } }
+        public System.Diagnostics.TimeClock Clock { get { throw null; } }
+        public static System.Diagnostics.TimeContext Current { get { throw null; } }
+        public System.TimeZoneInfo LocalTimeZone { get { throw null; } }
+        public static System.Diagnostics.ActualSystemClock ActualSystemClock { get { throw null; } }
+        public static bool ActualSystemClockIsActive { get { throw null; } }
+        public static void Run(System.Diagnostics.TimeClock clock, System.Action action) { }
+        public static void Run(System.Diagnostics.TimeClock clock, System.TimeZoneInfo localTimeZone, System.Action action) { }
+        public static void Run(System.TimeZoneInfo localTimeZone, System.Action action) { }
+        public static System.Threading.Tasks.Task RunAsync(System.Diagnostics.TimeClock clock, System.Func<System.Threading.Tasks.Task> function) { throw null; }
+        public static System.Threading.Tasks.Task RunAsync(System.Diagnostics.TimeClock clock, System.TimeZoneInfo localTimeZone, System.Func<System.Threading.Tasks.Task> function) { throw null; }
+        public static System.Threading.Tasks.Task RunAsync(System.TimeZoneInfo localTimeZone, System.Func<System.Threading.Tasks.Task> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> RunAsync<TResult>(System.Diagnostics.TimeClock clock, System.Func<System.Threading.Tasks.Task<TResult>> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> RunAsync<TResult>(System.Diagnostics.TimeClock clock, System.TimeZoneInfo localTimeZone, System.Func<System.Threading.Tasks.Task<TResult>> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> RunAsync<TResult>(System.TimeZoneInfo localTimeZone, System.Func<System.Threading.Tasks.Task<TResult>> function) { throw null; }
+        public static TResult Run<TResult>(System.Diagnostics.TimeClock clock, System.Func<TResult> function) { throw null; }
+        public static TResult Run<TResult>(System.Diagnostics.TimeClock clock, System.TimeZoneInfo localTimeZone, System.Func<TResult> function) { throw null; }
+        public static TResult Run<TResult>(System.TimeZoneInfo localTimeZone, System.Func<TResult> function) { throw null; }
+    }
+    public sealed partial class VirtualClock : System.Diagnostics.TimeClock
+    {
+        public VirtualClock(System.DateTime timeValue) { }
+        public VirtualClock(System.DateTime initialTimeValue, System.Func<System.DateTimeOffset, System.DateTimeOffset> advancementFunction) { }
+        public VirtualClock(System.DateTime initialTimeValue, System.TimeSpan advancementAmount) { }
+        public VirtualClock(System.DateTimeOffset timeValue) { }
+        public VirtualClock(System.DateTimeOffset initialTimeValue, System.Func<System.DateTimeOffset, System.DateTimeOffset> advancementFunction) { }
+        public VirtualClock(System.DateTimeOffset initialTimeValue, System.TimeSpan advancementAmount) { }
+        protected override System.DateTimeOffset GetCurrentUtcDateTimeOffsetImpl() { throw null; }
     }
 }
 namespace System.Diagnostics.CodeAnalysis

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -64,7 +64,6 @@
     <Compile Include="System\DBNullTests.cs" />
     <Compile Include="System\DecimalTests.cs" />
     <Compile Include="System\DelegateTests.cs" />
-    <Compile Include="System\Diagnostics\CodeAnalysis\DynamicDependencyAttributeTests.cs" />
     <Compile Include="System\DivideByZeroExceptionTests.cs" />
     <Compile Include="System\DoubleTests.cs" />
     <Compile Include="System\DuplicateWaitObjectExceptionTests.cs" />
@@ -157,7 +156,12 @@
     <Compile Include="System\Collections\ObjectModel\ReadOnlyCollectionTests.cs" />
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.cs" />
     <Compile Include="System\ComponentModel\EditorBrowsableAttributeTests.cs" />
+    <Compile Include="System\Diagnostics\ActualSystemClockTests.cs" />
     <Compile Include="System\Diagnostics\ConditionalAttributeTests.cs" />
+    <Compile Include="System\Diagnostics\TimeClockTests.cs" />
+    <Compile Include="System\Diagnostics\TimeContextTests.cs" />
+    <Compile Include="System\Diagnostics\VirtualClockTests.cs" />
+    <Compile Include="System\Diagnostics\CodeAnalysis\DynamicDependencyAttributeTests.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttributeTests.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttributeTests.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttributeTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/ActualSystemClockTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/ActualSystemClockTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
+
+using TestClock = System.Tests.TimeClockTests.TestClock;
+
+namespace System.Tests
+{
+    public class ActualSystemClockTests
+    {
+        [Fact]
+        public void CurrentUtcDateTimeOffset_Advances()
+        {
+            DateTimeOffset start = ActualSystemClock.Instance.GetCurrentUtcDateTimeOffset();
+            Assert.True(
+                SpinWait.SpinUntil(() => ActualSystemClock.Instance.GetCurrentUtcDateTimeOffset() > start, TimeSpan.FromSeconds(30)),
+                "Expected GetCurrentUtcDateTimeOffset result to change");
+        }
+
+        [Fact]
+        public void CurrentUtcDateTime_Advances()
+        {
+            DateTime start = ActualSystemClock.Instance.GetCurrentUtcDateTime();
+            Assert.True(
+                SpinWait.SpinUntil(() => ActualSystemClock.Instance.GetCurrentUtcDateTime() > start, TimeSpan.FromSeconds(30)),
+                "Expected GetCurrentUtcDateTime result to change");
+        }
+
+        [Fact]
+        public void CurrentUtcDateTimeOffset_AdvancesEvenWhenAnotherFixedClockIsActive()
+        {
+            // The test clock has a fixed value that never changes.
+            var testClock = new TestClock();
+
+            TimeContext.Run(testClock, () =>
+            {
+                // Make sure the test clock is active, not the actual system clock.
+                Assert.Same(testClock, TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+
+                // Despite the test clock being active, the actual system clock should still advance.
+                DateTimeOffset start = ActualSystemClock.Instance.GetCurrentUtcDateTimeOffset();
+                Assert.True(
+                    SpinWait.SpinUntil(() => ActualSystemClock.Instance.GetCurrentUtcDateTimeOffset() > start, TimeSpan.FromSeconds(30)),
+                    "Expected GetCurrentUtcDateTimeOffset result to change");
+            });
+        }
+
+        [Fact]
+        public void CurrentUtcDateTime_AdvancesEvenWhenAnotherFixedClockIsActive()
+        {
+            // The test clock has a fixed value that never changes.
+            var testClock = new TestClock();
+
+            TimeContext.Run(testClock, () =>
+            {
+                // Make sure the test clock is active, not the actual system clock.
+                Assert.Same(testClock, TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+
+                // Despite the test clock being active, the actual system clock should still advance.
+                DateTime start = ActualSystemClock.Instance.GetCurrentUtcDateTime();
+                Assert.True(
+                    SpinWait.SpinUntil(() => ActualSystemClock.Instance.GetCurrentUtcDateTime() > start, TimeSpan.FromSeconds(30)),
+                    "Expected GetCurrentUtcDateTime result to change");
+            });
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/TimeClockTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/TimeClockTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace System.Tests
+{
+    public class TimeClockTests
+    {
+        public class TestClock : TimeClock
+        {
+            public static readonly DateTimeOffset Value = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.FromHours(-8));
+            protected override DateTimeOffset GetCurrentUtcDateTimeOffsetImpl() => Value;
+        }
+
+        [Fact]
+        public void CurrentDateTimeOffset_AdjustsToUniversalTime()
+        {
+            TimeClock clock = new TestClock();
+            DateTimeOffset actual = clock.GetCurrentUtcDateTimeOffset();
+
+            DateTimeOffset expected = TestClock.Value.ToUniversalTime();
+            Assert.Equal(expected.DateTime, actual.DateTime);
+            Assert.Equal(expected.Offset, actual.Offset);
+        }
+
+        [Fact]
+        public void CurrentDateTime_AdjustsToUniversalTime()
+        {
+            TimeClock clock = new TestClock();
+            DateTime actual = clock.GetCurrentUtcDateTime();
+
+            DateTime expected = TestClock.Value.UtcDateTime;
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.Kind, actual.Kind);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/TimeContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/TimeContextTests.cs
@@ -1,0 +1,1029 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+using TestClock = System.Tests.TimeClockTests.TestClock;
+
+namespace System.Tests
+{
+    public class TimeContextTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly TimeClock _testClock = new TestClock();
+        private static readonly TimeZoneInfo s_testTimeZone = GetTestTimeZone();
+
+        public TimeContextTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        #region Examples
+
+        [Fact]
+        public void LeapYearBusinessLogicTest1()
+        {
+            // This test demonstrates testing code that is sensitive to leap years.
+            // Testing actual application code like this might expose leap day bugs before they become an issue.
+
+            DateTime GetOneYearFromToday_Incorrect()
+            {
+                // This shows an incorrect way to get a date that is one year from today.
+                // It will throw an exception when "today" is a leap day (Februrary 29th).
+                return new DateTime(DateTime.Today.Year + 1, DateTime.Today.Month, DateTime.Today.Day);
+            }
+
+            DateTime GetOneYearFromToday_Correct()
+            {
+                // This shows the correct way to get a date that is one year from today.
+                // When run on a leap day (Februrary 29th), it will return February 28th of the following year.
+                return DateTime.Today.AddYears(1);
+            }
+
+            // When the current year is not a leap year, either method will pass the test on the last day of February.
+            var clock1 = new VirtualClock(new DateTime(2021, 2, DateTime.DaysInMonth(2021, 2)));
+            TimeContext.Run(clock1, () =>
+            {
+                var result1a = GetOneYearFromToday_Correct();
+                Assert.Equal(new DateTime(2022, 2, 28), result1a);
+
+                var result1b = GetOneYearFromToday_Incorrect();
+                Assert.Equal(new DateTime(2022, 2, 28), result1b);
+            });
+
+            // When the current year is a leap year, only the correct method will pass the test on the last day of February.
+            var clock2 = new VirtualClock(new DateTime(2024, 2, DateTime.DaysInMonth(2024, 2)));
+            TimeContext.Run(clock2, () =>
+            {
+                var result2a = GetOneYearFromToday_Correct();
+                Assert.Equal(new DateTime(2025, 2, 28), result2a);
+
+                // In an application's unit testing, we'd expect the bad code to fail the test.
+                // However here we're expecting it to throw, highlighting the value of testing such code.
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    var result2b = GetOneYearFromToday_Incorrect();
+                });
+            });
+        }
+
+        [Fact]
+        public void LeapYearBusinessLogicTest2()
+        {
+            // This test demonstrates testing code that is sensitive to leap years.
+            // Testing actual application code like this might expose leap day bugs before they become an issue.
+
+            DateTime GetBirthdayThisYear_Incorrect(DateTime dateOfBirth)
+            {
+                // This shows an incorrect way to get a birthday for the current year.
+                // It will throw an exception for February 29th birthdays when the current year is not a leap year.
+                return new DateTime(DateTime.Now.Year, dateOfBirth.Month, dateOfBirth.Day);
+            }
+
+            DateTime GetBirthdayThisYear_Correct(DateTime dateOfBirth)
+            {
+                // This is the correct way to get a birthday for the current year.
+                // It will treat February 29th birthdays as February 28th when the current year is not a leap year.
+                return dateOfBirth.AddYears(DateTime.Now.Year - dateOfBirth.Year);
+            }
+
+            var dateOfBirth = new DateTime(2000, 2, 29);
+
+            // When the current year is a leap year, either method will pass the test.
+            var clock1 = new VirtualClock(new DateTime(2020, 1, 1));
+            TimeContext.Run(clock1, () =>
+            {
+                var result1a = GetBirthdayThisYear_Correct(dateOfBirth);
+                Assert.Equal(new DateTime(2020, 2, 29), result1a);
+
+                var result1b = GetBirthdayThisYear_Incorrect(dateOfBirth);
+                Assert.Equal(new DateTime(2020, 2, 29), result1b);
+            });
+
+            // When the current year is not a leap year, only the correct method will pass the test.
+            var clock2 = new VirtualClock(new DateTime(2021, 1, 1));
+            TimeContext.Run(clock2, () =>
+            {
+                var result2a = GetBirthdayThisYear_Correct(dateOfBirth);
+                Assert.Equal(new DateTime(2021, 2, 28), result2a);
+
+                // In an application's unit testing, we'd expect the bad code to fail the test.
+                // However here we're expecting it to throw, highlighting the value of testing such code.
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    var result2b = GetBirthdayThisYear_Incorrect(dateOfBirth);
+                });
+            });
+        }
+
+        // The following two test classes are used in the LeapYearBusinessLogicTest3 below it.
+
+        private class TestClassWithIncorrectInternalArray
+        {
+            // This shows an incorrect way to define an array with values for each day of the current year.
+            private int[] _values = new int[365];
+
+            public void AssignTodaysValue(int value)
+            {
+                // This will work correctly on most days, but it will throw an exeception when used
+                // on the last day of a leap year (Day 366).
+                _values[DateTime.Today.DayOfYear - 1] = value;
+            }
+        }
+
+        private class TestClassWithCorrectInternalArray
+        {
+            // This shows one way to correctly define an array with values for each day of the current year.
+            private int[] _values = new int[DateTime.IsLeapYear(DateTime.Today.Year) ? 366 : 365];
+
+            public void AssignTodaysValue(int value)
+            {
+                // This will work correctly for every day, including Day 366.
+                _values[DateTime.Today.DayOfYear - 1] = value;
+            }
+        }
+
+        [Fact]
+        public void LeapYearBusinessLogicTest3()
+        {
+            // This test demonstrates testing code that is sensitive to leap years.
+            // Testing actual application code like this might expose leap day bugs before they become an issue.
+
+            // When the current year is not a leap year, either method will pass the test.
+            var clock1 = new VirtualClock(new DateTime(2021, 12, 31));
+            TimeContext.Run(clock1, () =>
+            {
+                var test1 = new TestClassWithCorrectInternalArray();
+                test1.AssignTodaysValue(12345);
+
+                var test2 = new TestClassWithIncorrectInternalArray();
+                test2.AssignTodaysValue(12345);
+            });
+
+            // When the current year is a leap year, only the correct method will pass the test.
+            var clock2 = new VirtualClock(new DateTime(2024, 12, 31));
+            TimeContext.Run(clock2, () =>
+            {
+                var test1 = new TestClassWithCorrectInternalArray();
+                test1.AssignTodaysValue(12345);
+
+                // In an application's unit testing, we'd expect the bad code to fail the test.
+                // However here we're expecting it to throw, highlighting the value of testing such code.
+                Assert.Throws<IndexOutOfRangeException>(() =>
+                {
+                    var test2 = new TestClassWithIncorrectInternalArray();
+                    test2.AssignTodaysValue(12345);
+                });
+            });
+        }
+
+        [Fact]
+        public void DaylightSavingTime_SpringForwardTest()
+        {
+            // This test demonstrates advancing the clock by whole hours on the day of a DST "spring-forward" transition.
+            // The time context ensures that the values returned from DateTime.Now are controled by the provided VirtualClock.
+            // Testing actual application code like this might expose any bugs related to the start of daylight saving time.
+
+            var dt = new DateTime(2020, 3, 8, 0, 0, 0);
+            var advancement = TimeSpan.FromHours(1);
+            var clock = new VirtualClock(dt, advancement);
+
+            var stdOffset = s_testTimeZone.GetUtcOffset(new DateTime(2020, 1, 1));
+            var dstOffset = s_testTimeZone.GetUtcOffset(new DateTime(2020, 7, 1));
+
+            TimeContext.Run(clock, s_testTimeZone, () =>
+            {
+                var firstValue = DateTimeOffset.Now;
+                var secondValue = DateTimeOffset.Now;
+                var thirdValue = DateTimeOffset.Now;
+
+                // In the test time zone, DST started on 2020-03-08, when the local time advanced from 1:59:59 to 3:00:00.
+                // Thus, the 2:00 hour is skipped.  Since we are advancing by whole hours, we should not see it in
+                // consecutive calls to DateTime.Now.
+                Assert.Equal(new DateTimeOffset(2020, 3, 8, 0, 0, 0, stdOffset), firstValue);
+                Assert.Equal(new DateTimeOffset(2020, 3, 8, 1, 0, 0, stdOffset), secondValue);
+                Assert.Equal(new DateTimeOffset(2020, 3, 8, 3, 0, 0, dstOffset), thirdValue);
+
+                // Test the offsets separately also.
+                Assert.Equal(stdOffset, firstValue.Offset);
+                Assert.Equal(stdOffset, secondValue.Offset);
+                Assert.Equal(dstOffset, thirdValue.Offset);
+            });
+        }
+
+        [Fact]
+        public void DaylightSavingTime_FallBackTest()
+        {
+            // This test demonstrates advancing the clock by whole hours on the day of a DST "fall-back" transition.
+            // The time context ensures that the values returned from DateTime.Now are controled by the provided VirtualClock.
+            // Testing actual application code like this might expose any bugs related to the end of daylight saving time.
+
+            var dt = new DateTime(2020, 11, 1, 0, 0, 0);
+            var advancement = TimeSpan.FromHours(1);
+            var clock = new VirtualClock(dt, advancement);
+
+            var stdOffset = s_testTimeZone.GetUtcOffset(new DateTime(2020, 1, 1));
+            var dstOffset = s_testTimeZone.GetUtcOffset(new DateTime(2020, 7, 1));
+
+            TimeContext.Run(clock, s_testTimeZone, () =>
+            {
+                var firstValue = DateTimeOffset.Now;
+                var secondValue = DateTimeOffset.Now;
+                var thirdValue = DateTimeOffset.Now;
+                var fourthValue = DateTimeOffset.Now;
+
+                // In the test time zone, DST ended on 2020-11-01, when the local time advanced from 1:59:59 to 1:00:00.
+                // The 1:00 hour is repeated.  Since we are advancing by whole hours, we should see it twice in
+                // consecutive calls to DateTime.Now.
+                Assert.Equal(new DateTimeOffset(2020, 11, 1, 0, 0, 0, dstOffset), firstValue);
+                Assert.Equal(new DateTimeOffset(2020, 11, 1, 1, 0, 0, dstOffset), secondValue);
+                Assert.Equal(new DateTimeOffset(2020, 11, 1, 1, 0, 0, stdOffset), thirdValue);
+                Assert.Equal(new DateTimeOffset(2020, 11, 1, 2, 0, 0, stdOffset), fourthValue);
+
+                // Test the offsets separately also.
+                Assert.Equal(dstOffset, firstValue.Offset);
+                Assert.Equal(dstOffset, secondValue.Offset);
+                Assert.Equal(stdOffset, thirdValue.Offset);
+                Assert.Equal(stdOffset, fourthValue.Offset);
+            });
+        }
+
+        #endregion
+
+        #region Default Values Tests
+
+        [Fact]
+        public void CurrentClock_IsActualSystemClockByDefault()
+        {
+            Assert.True(TimeContext.ActualSystemClockIsActive);
+            Assert.IsType<ActualSystemClock>(TimeContext.Current.Clock);
+        }
+
+        [Fact]
+        public void CurrentLocalTimeZone_IsActualSystemLocalTimeZoneByDefault()
+        {
+            // Unlike the clock test, we cannot tell if the value from ActualSystemLocalTimeZone
+            // is indeed the actual system local time zone by testing the value or its type.
+            // We'll just emit it to the test output for easy inspection if needed.
+            TimeZoneInfo tz = TimeContext.ActualSystemLocalTimeZone;
+            _output.WriteLine($"The local system time zone is: [{ tz.Id }] { tz.DisplayName }.");
+
+            // However, we can test if the ActualSystemLocalTimeZoneIsActive property is working.
+            // Internally this property compares the accessor function rather than the time zone value itself.
+            Assert.True(TimeContext.ActualSystemLocalTimeZoneIsActive);
+        }
+
+        #endregion
+
+        #region Multi-threading/task Tests
+
+        [Fact]
+        public void CanUseTwoDifferentClockInTwoDifferentThreads()
+        {
+            var dt1 = new DateTime(2000, 1, 1);
+            var dt2 = new DateTime(2020, 12, 31);
+
+            var clock1 = new VirtualClock(dt1);
+            var clock2 = new VirtualClock(dt2);
+
+            var t1 = new Thread(() =>
+            {
+                TimeContext.Run(clock1, () =>
+                {
+                    var now = DateTime.Now;
+                    Assert.Equal(dt1, now);
+                });
+            });
+
+            var t2 = new Thread(() =>
+            {
+                TimeContext.Run(clock2, () =>
+                {
+                    var now = DateTime.Now;
+                    Assert.Equal(dt2, now);
+                });
+            });
+
+            t1.Start();
+            t2.Start();
+
+            t1.Join();
+            t2.Join();
+        }
+
+        [Fact]
+        public async Task CanUseTwoDifferentClockInTwoDifferentTasks()
+        {
+            var dt1 = new DateTime(2000, 1, 1);
+            var dt2 = new DateTime(2020, 12, 31);
+
+            var clock1 = new VirtualClock(dt1);
+            var clock2 = new VirtualClock(dt2);
+
+            var t1 = new Task(async () =>
+            {
+                await TimeContext.RunAsync(clock1, async () =>
+                {
+                    await Task.Yield();
+
+                    var now = DateTime.Now;
+                    Assert.Equal(dt1, now);
+                });
+            });
+
+            var t2 = new Task(async () =>
+            {
+                await TimeContext.RunAsync(clock2, async () =>
+                {
+                    await Task.Yield();
+
+                    var now = DateTime.Now;
+                    Assert.Equal(dt2, now);
+                });
+            });
+
+            t1.Start();
+            t2.Start();
+
+            await Task.WhenAll(t1, t2);
+        }
+        #endregion
+
+        #region Clock Changing Tests
+
+        [Fact]
+        public void CurrentClock_CanBeChangedForAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                Assert.IsType<TestClock>(TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+            });
+        }
+
+        [Fact]
+        public void CurrentClock_IsRestoredAfterAnOperation()
+        {
+            TimeContext.Run(_testClock, () => { });
+
+            Assert.IsType<ActualSystemClock>(TimeContext.Current.Clock);
+            Assert.True(TimeContext.ActualSystemClockIsActive);
+        }
+
+        [Fact]
+        public void CurrentClock_CanBeChangedForAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                Assert.IsType<TestClock>(TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void CurrentClock_IsRestoredAfterAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () => 1);
+
+            Assert.IsType<ActualSystemClock>(TimeContext.Current.Clock);
+            Assert.True(TimeContext.ActualSystemClockIsActive);
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task CurrentClock_CanBeChangedForAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                Assert.IsType<TestClock>(TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+            });
+        }
+
+        [Fact]
+        public async Task CurrentClock_IsRestoredAfterAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+            });
+
+            Assert.IsType<ActualSystemClock>(TimeContext.Current.Clock);
+            Assert.True(TimeContext.ActualSystemClockIsActive);
+        }
+
+        [Fact]
+        public async Task CurrentClock_CanBeChangedForAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                Assert.IsType<TestClock>(TimeContext.Current.Clock);
+                Assert.False(TimeContext.ActualSystemClockIsActive);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task CurrentClock_IsRestoredAfterAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                return 1;
+            });
+
+            Assert.IsType<ActualSystemClock>(TimeContext.Current.Clock);
+            Assert.True(TimeContext.ActualSystemClockIsActive);
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTimeOffset_UtcNow_UsesTestClockDuringAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.UtcNow;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTimeOffset_Now_UsesTestClockDuringAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTime_UtcNow_UsesTestClockDuringAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.UtcNow;
+                DateTime expected = TestClock.Value.UtcDateTime;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTime_Now_UsesTestClockDuringAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.Now;
+                DateTime expected = TestClock.Value.LocalDateTime;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTime_Today_UsesTestClockDuringAnOperation()
+        {
+            TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.Today;
+                DateTime expected = TestClock.Value.LocalDateTime.Date;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTimeOffset_UtcNow_UsesTestClockDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.UtcNow;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTimeOffset_Now_UsesTestClockDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTime_UtcNow_UsesTestClockDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.UtcNow;
+                DateTime expected = TestClock.Value.UtcDateTime;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTime_Now_UsesTestClockDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.Now;
+                DateTime expected = TestClock.Value.LocalDateTime;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTime_Today_UsesTestClockDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(_testClock, () =>
+            {
+                DateTime actual = DateTime.Today;
+                DateTime expected = TestClock.Value.LocalDateTime.Date;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_UtcNow_UsesTestClockDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.UtcNow;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_Now_UsesTestClockDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTime_UtcNow_UsesTestClockDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.UtcNow;
+                DateTime expected = TestClock.Value.UtcDateTime;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTime_Now_UsesTestClockDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Now;
+                DateTime expected = TestClock.Value.LocalDateTime;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTime_Today_UsesTestClockDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Today;
+                DateTime expected = TestClock.Value.LocalDateTime.Date;
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_UtcNow_UsesTestClockDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.UtcNow;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_Now_UsesTestClockDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TestClock.Value;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTime_UtcNow_UsesTestClockDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.UtcNow;
+                DateTime expected = TestClock.Value.UtcDateTime;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTime_Now_UsesTestClockDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Now;
+                DateTime expected = TestClock.Value.LocalDateTime;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTime_Today_UsesTestClockDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(_testClock, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Today;
+                DateTime expected = TestClock.Value.LocalDateTime.Date;
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        #endregion
+
+        #region Local Time Zone Changing Tests
+
+        [Fact]
+        public void CurrentLocalTimeZone_CanBeChangedForAnOperation()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            TimeContext.Run(s_testTimeZone, () =>
+            {
+                var localTimeZone = TimeContext.Current.LocalTimeZone;
+                Assert.Equal(s_testTimeZone, localTimeZone);
+                Assert.NotEqual(originalTimeZone, localTimeZone);
+            });
+        }
+
+        [Fact]
+        public void CurrentLocalTimeZone_IsRestoredAfterAnOperation()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            TimeContext.Run(s_testTimeZone, () => { });
+
+            var localTimeZone = TimeContext.Current.LocalTimeZone;
+            Assert.Equal(originalTimeZone, localTimeZone);
+            Assert.NotEqual(s_testTimeZone, localTimeZone);
+        }
+
+        [Fact]
+        public void CurrentLocalTimeZone_CanBeChangedForAnOperationWithResult()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            int result = TimeContext.Run(s_testTimeZone, () =>
+            {
+                var localTimeZone = TimeContext.Current.LocalTimeZone;
+                Assert.Equal(s_testTimeZone, localTimeZone);
+                Assert.NotEqual(originalTimeZone, localTimeZone);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void CurrentLocalTimeZone_IsRestoredAfterAnOperationWithResult()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            int result = TimeContext.Run(s_testTimeZone, () => 1);
+
+            var localTimeZone = TimeContext.Current.LocalTimeZone;
+            Assert.Equal(originalTimeZone, localTimeZone);
+            Assert.NotEqual(s_testTimeZone, localTimeZone);
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task CurrentLocalTimeZone_CanBeChangedForAnAsyncOperation()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                var localTimeZone = TimeContext.Current.LocalTimeZone;
+                Assert.Equal(s_testTimeZone, localTimeZone);
+                Assert.NotEqual(originalTimeZone, localTimeZone);
+            });
+        }
+
+        [Fact]
+        public async Task CurrentLocalTimeZone_IsRestoredAfterAnAsyncOperation()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+            });
+
+            var localTimeZone = TimeContext.Current.LocalTimeZone;
+            Assert.Equal(originalTimeZone, localTimeZone);
+            Assert.NotEqual(s_testTimeZone, localTimeZone);
+        }
+
+        [Fact]
+        public async Task CurrentLocalTimeZone_CanBeChangedForAnAsyncOperationWithResult()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            int result = await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                var localTimeZone = TimeContext.Current.LocalTimeZone;
+                Assert.Equal(s_testTimeZone, localTimeZone);
+                Assert.NotEqual(originalTimeZone, localTimeZone);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task CurrentLocalTimeZone_IsRestoredAfterAnAsyncOperationWithResult()
+        {
+            var originalTimeZone = TimeContext.Current.LocalTimeZone;
+
+            int result = await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                return 1;
+            });
+
+            var localTimeZone = TimeContext.Current.LocalTimeZone;
+            Assert.Equal(originalTimeZone, localTimeZone);
+            Assert.NotEqual(s_testTimeZone, localTimeZone);
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTimeOffset_Now_UsesTestTimeZoneDuringAnOperation()
+        {
+            TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected.Offset, actual.Offset);
+            });
+        }
+
+        [Fact]
+        public void DateTime_Now_UsesTestTimeZoneDuringAnOperation()
+        {
+            TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTime actual = DateTime.Now;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTime_Today_UsesTestTimeZoneDuringAnOperation()
+        {
+            TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTime actual = DateTime.Today;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public void DateTimeOffset_Now_UsesTestTimeZoneDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected.Offset, actual.Offset);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTime_Now_UsesTestTimeZoneDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTime actual = DateTime.Now;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void DateTime_Today_UsesTestTimeZoneDuringAnOperationWithResult()
+        {
+            int result = TimeContext.Run(s_testTimeZone, () =>
+            {
+                DateTime actual = DateTime.Today;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_Now_UsesTestTimeZoneDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected.Offset, actual.Offset);
+            });
+        }
+
+        [Fact]
+        public async Task DateTime_Now_UsesTestTimeZoneDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Now;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTime_Today_UsesTestTimeZoneDuringAnAsyncOperation()
+        {
+            await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Today;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        [Fact]
+        public async Task DateTimeOffset_Now_UsesTestTimeZoneDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTimeOffset actual = DateTimeOffset.Now;
+                DateTimeOffset expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected.Offset, actual.Offset);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTime_Now_UsesTestTimeZoneDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Now;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task DateTime_Today_UsesTestTimeZoneDuringAnAsyncOperationWithResult()
+        {
+            int result = await TimeContext.RunAsync(s_testTimeZone, async () =>
+            {
+                await Task.Yield();
+
+                DateTime actual = DateTime.Today;
+                DateTime expected = TimeZoneInfo.ConvertTime(actual, s_testTimeZone);
+                Assert.Equal(expected, actual);
+                return 1;
+            });
+
+            Assert.Equal(1, result);
+        }
+
+        #endregion
+
+        #region Helper functions
+
+        private static TimeZoneInfo GetTestTimeZone()
+        {
+            // Choose a test time zone that is not the actual system time zone.
+            // We'll use USA time zones that have the same DST rules so we can test some transitions.
+            bool windows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string id1 = windows ? "Eastern Standard Time" : "America/New_York";
+            string id2 = windows ? "Central Standard Time" : "America/Chicago";
+            string tzid = TimeContext.ActualSystemLocalTimeZone.Id.Equals(id1, StringComparison.OrdinalIgnoreCase) ? id2 : id1;
+            return TimeZoneInfo.FindSystemTimeZoneById(tzid);
+        }
+
+        #endregion
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/VirtualClockTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/VirtualClockTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace System.Tests
+{
+    public class VirtualClockTests
+    {
+        [Fact]
+        public void CanUseFixedDateTimeOffsetValue()
+        {
+            var value = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            TimeClock clock = new VirtualClock(value);
+
+            DateTimeOffset firstResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(value, firstResult);
+
+            DateTimeOffset secondResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(value, secondResult);
+
+            DateTimeOffset thirdResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(value, thirdResult);
+        }
+
+        [Fact]
+        public void CanUseFixedDateTimeValue()
+        {
+            var value = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            TimeClock clock = new VirtualClock(value);
+
+            DateTime firstResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(value, firstResult);
+
+            DateTime secondResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(value, secondResult);
+
+            DateTime thirdResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(value, thirdResult);
+        }
+
+        [Fact]
+        public void CanUseInitialDateTimeOffsetValueAndTimespanIncrement()
+        {
+            var initialValue = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var increment = TimeSpan.FromHours(1);
+            TimeClock clock = new VirtualClock(initialValue, increment);
+
+            DateTimeOffset firstResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue, firstResult);
+
+            DateTimeOffset secondResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue.Add(increment), secondResult);
+
+            DateTimeOffset thirdResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue.Add(increment * 2), thirdResult);
+        }
+
+        [Fact]
+        public void CanUseInitialDateTimeValueAndTimespanIncrement()
+        {
+            var initialValue = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var increment = TimeSpan.FromHours(1);
+            TimeClock clock = new VirtualClock(initialValue, increment);
+
+            DateTime firstResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue, firstResult);
+
+            DateTime secondResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue.Add(increment), secondResult);
+
+            DateTime thirdResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue.Add(increment * 2), thirdResult);
+        }
+
+        [Fact]
+        public void CanUseInitialDateTimeOffsetValueAndFunctionIncrement()
+        {
+            var initialValue = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var increment = TimeSpan.FromHours(1);
+            TimeClock clock = new VirtualClock(initialValue, x => x.Add(increment));
+
+            DateTimeOffset firstResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue, firstResult);
+
+            DateTimeOffset secondResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue.Add(increment), secondResult);
+
+            DateTimeOffset thirdResult = clock.GetCurrentUtcDateTimeOffset();
+            Assert.Equal(initialValue.Add(increment * 2), thirdResult);
+        }
+
+        [Fact]
+        public void CanUseInitialDateTimeValueAndFunctionIncrement()
+        {
+            var initialValue = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var increment = TimeSpan.FromHours(1);
+            TimeClock clock = new VirtualClock(initialValue, x => x.Add(increment));
+
+            DateTime firstResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue, firstResult);
+
+            DateTime secondResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue.Add(increment), secondResult);
+
+            DateTime thirdResult = clock.GetCurrentUtcDateTime();
+            Assert.Equal(initialValue.Add(increment * 2), thirdResult);
+        }
+    }
+}


### PR DESCRIPTION
This PR is a proposed implementation of the [revised API proposal I submitted](https://github.com/dotnet/runtime/issues/36617#issuecomment-784734677) for #36617.  **I do not expect this PR to be merged at this time.** Please see the issue thread for details.

One open question I have with specific regards to the implementation (not the public API)

- In `TimeContext.cs`, I implement the internal storage for the ambient context simply as:

    ```csharp
    private static readonly AsyncLocal<TimeContext> s_context = new();
    ```

  This seems to work fine, and all tests pass.  However, looking at [the implementation](https://github.com/dotnet/runtime/blob/ecfcdfd776da13f12f521e3b5b9a13483a0a5038/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs#L116-L132) for a similar concept, I see that `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture` each use *both* an `AsyncLocal<T>` field and a `[ThreadStatic]` field, with some logic synchronizing them.  Is that necessary here also? Why or why not?

Thanks.

# Benchmarks

I ran the existing microbenchmarks [from here](https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/libraries/System.Runtime), that test `DateTime.UtcNow`, `DateTimeOffset.UtcNow`, `DateTime.Now`, and `DateTimeOffset.Now`, both before and after my changes, and both with and without leap seconds enabled (via registry flag [as described here](https://github.com/dotnet/runtime/issues/13091#issuecomment-511937942)).  The benchmark results show roughly a 8-20ns cost for the `UtcNow` properties, and a 19-92ns cost for the `Now` properties, both of which I believe are reasonable and negligible.

Full benchmark results follow.

## ResultsComparer difference, with leap seconds enabled

| Slower                                     | diff/base | Base Median (ns) | Diff Median (ns) | Modality |
| ------------------------------------------ | ---------:| ----------------:| ----------------:| -------- |
| System.Tests.Perf_DateTime.GetUtcNow       |      1.23 |            84.10 |           103.49 | bimodal  |
| System.Tests.Perf_DateTimeOffset.GetUtcNow |      1.14 |            87.15 |            99.20 |          |
| System.Tests.Perf_DateTime.GetNow          |      1.41 |           225.26 |           317.44 | bimodal  |
| System.Tests.Perf_DateTimeOffset.GetNow    |      1.09 |           266.76 |           291.16 |          |

## ResultsComparer difference, with leap seconds disabled

| Slower                                     | diff/base | Base Median (ns) | Diff Median (ns) | Modality |
| ------------------------------------------ | ---------:| ----------------:| ----------------:| -------- |
| System.Tests.Perf_DateTime.GetUtcNow       |      1.29 |            29.12 |            37.46 |          |
| System.Tests.Perf_DateTimeOffset.GetUtcNow |      1.44 |            33.19 |            47.91 |          |
| System.Tests.Perf_DateTime.GetNow          |      1.37 |           172.73 |           236.09 | several? |
| System.Tests.Perf_DateTimeOffset.GetNow    |      1.09 |           214.23 |           232.70 |          |

## Test Setup

``` ini
BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.19042
Intel Core i7-6600U CPU 2.60GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET SDK=6.0.100-preview.2.21120.3
  [Host]     : .NET 6.0.0 (6.0.21.11806), X64 RyuJIT
  Job-YNAJFG : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  Toolchain=CoreRun  
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15  
WarmupCount=1  
```

## Before changes, leap seconds enabled

**Benchmark Test Class: `System.Tests.Perf_DateTime`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|---------:|------:|------:|------:|----------:|
|    GetNow | 224.61 ns | 9.719 ns | 10.80 ns | 225.26 ns | 200.93 ns | 248.0 ns |     - |     - |     - |         - |
| GetUtcNow |  88.22 ns | 9.425 ns | 10.85 ns |  84.10 ns |  75.37 ns | 108.9 ns |     - |     - |     - |         - |

**Benchmark Test Class: `System.Tests.Perf_DateTimeOffset`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |       Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|    GetNow | 264.16 ns | 7.296 ns | 8.403 ns | 266.76 ns | 248.45 ns | 276.40 ns |     - |     - |     - |         - |
| GetUtcNow |  87.16 ns | 0.460 ns | 0.384 ns |  87.15 ns |  86.67 ns |  88.07 ns |     - |     - |     - |         - |

## After changes, leap seconds enabled

**Benchmark Test Class: `System.Tests.Perf_DateTime`**

|    Method |     Mean |    Error |   StdDev |   Median |       Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |---------:|---------:|---------:|---------:|----------:|---------:|-------:|------:|------:|----------:|
|    GetNow | 318.6 ns | 17.70 ns | 19.67 ns | 317.4 ns | 295.43 ns | 371.8 ns | 0.0300 |     - |     - |      64 B |
| GetUtcNow | 102.3 ns | 12.35 ns | 14.22 ns | 103.5 ns |  81.61 ns | 126.0 ns |      - |     - |     - |         - |

**Benchmark Test Class: `System.Tests.Perf_DateTimeOffset`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|---------:|------:|------:|------:|----------:|
|    GetNow | 290.33 ns | 7.544 ns | 8.072 ns | 291.16 ns | 274.91 ns | 309.7 ns |     - |     - |     - |         - |
| GetUtcNow |  98.69 ns | 2.394 ns | 2.757 ns |  99.20 ns |  93.35 ns | 102.8 ns |     - |     - |     - |         - |

## Before changes, leap seconds disabled

**Benchmark Test Class: `System.Tests.Perf_DateTime`**

|    Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|    GetNow | 181.71 ns | 18.316 ns | 21.093 ns | 172.73 ns | 155.07 ns | 228.21 ns |     - |     - |     - |         - |
| GetUtcNow |  28.67 ns |  0.906 ns |  0.930 ns |  29.12 ns |  26.47 ns |  29.91 ns |     - |     - |     - |         - |

**Benchmark Test Class: `System.Tests.Perf_DateTimeOffset`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |       Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|    GetNow | 215.47 ns | 3.810 ns | 4.235 ns | 214.23 ns | 208.70 ns | 224.72 ns |     - |     - |     - |         - |
| GetUtcNow |  32.98 ns | 1.020 ns | 1.092 ns |  33.19 ns |  30.72 ns |  34.82 ns |     - |     - |     - |         - |

## After changes, leap seconds disabled

**Benchmark Test Class: System.Tests.`Perf_DateTime`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |       Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|------:|------:|----------:|
|    GetNow | 235.03 ns | 8.502 ns | 8.731 ns | 236.09 ns | 218.86 ns | 255.13 ns | 0.0302 |     - |     - |      64 B |
| GetUtcNow |  37.37 ns | 1.473 ns | 1.696 ns |  37.46 ns |  34.88 ns |  40.53 ns |      - |     - |     - |         - |

**Benchmark Test Class: `System.Tests.Perf_DateTimeOffset`**

|    Method |      Mean |    Error |   StdDev |    Median |       Min |       Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|    GetNow | 231.58 ns | 8.161 ns | 8.380 ns | 232.70 ns | 214.52 ns | 247.20 ns |     - |     - |     - |         - |
| GetUtcNow |  47.59 ns | 1.233 ns | 1.319 ns |  47.91 ns |  43.86 ns |  49.18 ns |     - |     - |     - |         - |

