### PR TITLE
[SuperPMI] Support spmi-asmdiffs on Arm64

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/callutils.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/callutils.cpp
@@ -215,25 +215,6 @@ CallType CallUtils::GetDirectCallSiteInfo(MethodContext*            mc,
 // SuperPMI's method context replaying instead of directly making calls into the JIT/EE interface.
 //-------------------------------------------------------------------------------------------------
 
-// Stolen from Compiler::impMethodInfo_hasRetBuffArg (in the importer)
-bool CallUtils::HasRetBuffArg(MethodContext* mc, CORINFO_SIG_INFO args)
-{
-    if (args.retType != CORINFO_TYPE_VALUECLASS && args.retType != CORINFO_TYPE_REFANY)
-    {
-        return false;
-    }
-
-#if defined(TARGET_AMD64)
-    // We don't need a return buffer if:
-    //   i) TYP_STRUCT argument that can fit into a single register and
-    //  ii) Power of two sized TYP_STRUCT on AMD64.
-    unsigned size = mc->repGetClassSize(args.retTypeClass);
-    return (size > sizeof(void*)) || ((size & (size - 1)) != 0);
-#else
-    return true;
-#endif
-}
-
 // Originally from src/jit/ee_il_dll.cpp
 const char* CallUtils::GetMethodName(MethodContext* mc, CORINFO_METHOD_HANDLE method, const char** classNamePtr)
 {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/callutils.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/callutils.h
@@ -28,7 +28,6 @@ public:
                                           void*                     callTarget,
                                           /*out*/ CORINFO_SIG_INFO* outSigInfo,
                                           /*out*/ char**            outCallTargetSymbol);
-    static bool HasRetBuffArg(MethodContext* mc, CORINFO_SIG_INFO args);
     static CorInfoHelpFunc GetHelperNum(CORINFO_METHOD_HANDLE method);
     static bool IsNativeMethod(CORINFO_METHOD_HANDLE method);
     static CORINFO_METHOD_HANDLE GetMethodHandleForNative(CORINFO_METHOD_HANDLE method);

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -745,7 +745,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
         const SPMI_TARGET_ARCHITECTURE targetArch = GetSpmiTargetArchitecture();
 
         const DWORD relocType = tmp.fRelocType;
-        bool relocWasHandled  = false;
+        bool wasRelocHandled  = false;
 
         // Do platform specific relocations first.
 
@@ -763,7 +763,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                     *(DWORD*)address = (DWORD)tmp.target;
                 }
 
-                relocWasHandled = true;
+                wasRelocHandled = true;
             }
         }
 
@@ -778,14 +778,14 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                     DWORDLONG endOfTheBlock = (DWORDLONG)originalAddr + (DWORDLONG)blocksize1;
                     INT64 delta = (INT64)(endOfTheBlock - fixupLocation);
                     PutArm64Rel28((UINT32*)branchInstr, (INT32)delta);
-                    relocWasHandled = true;
+                    wasRelocHandled = true;
                 }
                 break;
 
                 case IMAGE_REL_ARM64_PAGEBASE_REL21:
                 case IMAGE_REL_ARM64_PAGEOFFSET_12A:
                     LogError("Unimplemented reloc type %u", tmp.fRelocType);
-                    relocWasHandled = true;
+                    wasRelocHandled = true;
                     break;
 
                 default:
@@ -793,7 +793,8 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
             }
         }
 
-        if (relocWasHandled)
+
+        if (wasRelocHandled)
             continue;
 
         switch (tmp.fRelocType)

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -861,9 +861,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
             }
         }
 
-        const bool is64BitTarget = (targetArch == SPMI_TARGET_ARCHITECTURE_AMD64) || (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64);
-
-        if (is64BitTarget)
+        if (IsSpmiTarget64Bit())
         {
             if (relocType == IMAGE_REL_BASED_DIR64)
             {
@@ -896,7 +894,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                 DWORDLONG baseAddr      = fixupLocation + sizeof(INT32);
                 INT64     delta         = (INT64)(target - baseAddr);
 
-                if (is64BitTarget)
+                if (IsSpmiTarget64Bit())
                 {
                     if (delta != (INT64)(int)delta)
                     {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -902,7 +902,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                         // since we assume that original compilation fit fine. This is only an issue for
                         // 32-bit offsets on 64-bit targets.
                         target         = (DWORDLONG)originalAddr + (DWORDLONG)blocksize1;
-                        INT64 newdelta = (INT64)((BYTE*)target - baseAddr);
+                        INT64 newdelta = (INT64)(target - baseAddr);
 
                         LogDebug("  REL32 overflow. Mapping target to %016llX. Mapping delta: %016llX => %016llX", target,
                                  delta, newdelta);

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -885,6 +885,8 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
         if (wasRelocHandled)
             continue;
 
+        // Now do all-platform relocations.
+
         switch (tmp.fRelocType)
         {
             case IMAGE_REL_BASED_REL32:

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -913,14 +913,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
 
                 if (delta != (INT64)(int)delta)
                 {
-                    if (is64BitTarget)
-                    {
-                        LogError("REL32 relocation overflows field! delta=0x%016llX", delta);
-                    }
-                    else
-                    {
-                        LogError("REL32 relocation overflows field! delta=0x%08X", delta);
-                    }
+                    LogError("REL32 relocation overflows field! delta=0x%016llX", delta);
                 }
 
                 // Write 32-bits into location

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -894,7 +894,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                 DWORDLONG target        = tmp.target + tmp.addlDelta;
                 DWORDLONG fixupLocation = tmp.location + tmp.slotNum;
                 DWORDLONG baseAddr      = fixupLocation + sizeof(INT32);
-                INT64     delta         = (INT64)((BYTE*)target - baseAddr);
+                INT64     delta         = (INT64)(target - baseAddr);
 
                 if (is64BitTarget)
                 {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -834,6 +834,15 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
 
 #ifdef TARGET_ARM64
             case IMAGE_REL_ARM64_BRANCH26: // 26 bit offset << 2 & sign ext, for B and BL
+            {
+                DWORDLONG fixupLocation = tmp.location;
+                DWORDLONG branchInstr   = section_begin + fixupLocation - (DWORDLONG)originalAddr;
+                DWORDLONG endOfTheBlock = (DWORDLONG)originalAddr + (DWORDLONG)blocksize1;
+                INT64 delta             = (INT64)(endOfTheBlock - fixupLocation);
+                PutArm64Rel28((UINT32*)branchInstr, (INT32)delta);
+            }
+            break;
+
             case IMAGE_REL_ARM64_PAGEBASE_REL21:
             case IMAGE_REL_ARM64_PAGEOFFSET_12A:
                 LogError("Unimplemented reloc type %u", tmp.fRelocType);

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -749,7 +749,7 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
 
         // Do platform specific relocations first.
 
-        if (targetArch == SPMI_TARGET_ARCHITECTURE_X86)
+        if ((targetArch == SPMI_TARGET_ARCHITECTURE_X86) || (targetArch == SPMI_TARGET_ARCHITECTURE_ARM))
         {
             if (relocType == IMAGE_REL_BASED_HIGHLOW)
             {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -632,7 +632,7 @@ unsigned int toCorInfoSize(CorInfoType cit)
         case CORINFO_TYPE_PTR:
         case CORINFO_TYPE_BYREF:
         case CORINFO_TYPE_CLASS:
-            return sizeof(void*);
+            return SpmiTargetPointerSize();
 
         case CORINFO_TYPE_STRING:
         case CORINFO_TYPE_VALUECLASS:

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -632,7 +632,7 @@ unsigned int toCorInfoSize(CorInfoType cit)
         case CORINFO_TYPE_PTR:
         case CORINFO_TYPE_BYREF:
         case CORINFO_TYPE_CLASS:
-            return SpmiTargetPointerSize();
+            return (int)SpmiTargetPointerSize();
 
         case CORINFO_TYPE_STRING:
         case CORINFO_TYPE_VALUECLASS:

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -257,3 +257,21 @@ void PutArm64Rel28(UINT32* pCode, INT32 imm28)
     branchInstr |= ((imm28 >> 2) & 0x03FFFFFF);
     *pCode = branchInstr;
 }
+
+void PutArm64Rel21(UINT32* pCode, INT32 imm21)
+{
+    UINT32 adrpInstr = *pCode;
+    adrpInstr &= 0x9F00001F;
+    INT32 immlo = imm21 & 0x03;
+    INT32 immhi = (imm21 & 0x1FFFFC) >> 2;
+    adrpInstr |= ((immlo << 29) | (immhi << 5));
+    *pCode = adrpInstr;
+}
+
+void PutArm64Rel12(UINT32* pCode, INT32 imm12)
+{
+    UINT32 addInstr = *pCode;
+    addInstr &= 0xFFC003FF;
+    addInstr |= (imm12 << 10);
+    *pCode = addInstr;
+}

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -250,6 +250,11 @@ void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture)
     SpmiTargetArchitecture = spmiTargetArchitecture;
 }
 
+// The following functions are used for arm64/arm32 relocation processing.
+// They are copies of the code in src\coreclr\utilcode\util.cpp.
+// We decided to copy them instead of linking with utilcode library
+// to avoid introducing additional runtime dependencies.
+
 void PutArm64Rel28(UINT32* pCode, INT32 imm28)
 {
     UINT32 branchInstr = *pCode;

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -275,3 +275,41 @@ void PutArm64Rel12(UINT32* pCode, INT32 imm12)
     addInstr |= (imm12 << 10);
     *pCode = addInstr;
 }
+
+void PutThumb2Imm16(UINT16* p, UINT16 imm16)
+{
+    USHORT Opcode0 = p[0];
+    USHORT Opcode1 = p[1];
+    Opcode0 &= ~((0xf000 >> 12) | (0x0800 >> 1));
+    Opcode1 &= ~((0x0700 << 4) | (0x00ff << 0));
+    Opcode0 |= (imm16 & 0xf000) >> 12;
+    Opcode0 |= (imm16 & 0x0800) >> 1;
+    Opcode1 |= (imm16 & 0x0700) << 4;
+    Opcode1 |= (imm16 & 0x00ff) << 0;
+    p[0] = Opcode0;
+    p[1] = Opcode1;
+}
+
+void PutThumb2Mov32(UINT16* p, UINT32 imm32)
+{
+    PutThumb2Imm16(p, (UINT16)imm32);
+    PutThumb2Imm16(p + 2, (UINT16)(imm32 >> 16));
+}
+
+void PutThumb2BlRel24(UINT16* p, INT32 imm24)
+{
+    USHORT Opcode0 = p[0];
+    USHORT Opcode1 = p[1];
+    Opcode0 &= 0xF800;
+    Opcode1 &= 0xD000;
+
+    UINT32 S = (imm24 & 0x1000000) >> 24;
+    UINT32 J1 = ((imm24 & 0x0800000) >> 23) ^ S ^ 1;
+    UINT32 J2 = ((imm24 & 0x0400000) >> 22) ^ S ^ 1;
+
+    Opcode0 |= ((imm24 & 0x03FF000) >> 12) | (S << 10);
+    Opcode1 |= ((imm24 & 0x0000FFE) >> 1) | (J1 << 13) | (J2 << 11);
+
+    p[0] = Opcode0;
+    p[1] = Opcode1;
+}

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -227,3 +227,25 @@ WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const W
 
     return fullPath;
 }
+
+#ifdef TARGET_AMD64
+static SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_AMD64;
+#elif defined(TARGET_X86)
+static SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_X86;
+#elif defined(TARGET_ARM)
+static SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM;
+#elif defined(TARGET_ARM64)
+static SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM64;
+#else
+#error Unsupported architecture
+#endif
+
+SPMI_TARGET_ARCHITECTURE GetSpmiTargetArchitecture()
+{
+    return SpmiTargetArchitecture;
+}
+
+void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture)
+{
+    SpmiTargetArchitecture = spmiTargetArchitecture;
+}

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -249,3 +249,11 @@ void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture)
 {
     SpmiTargetArchitecture = spmiTargetArchitecture;
 }
+
+void PutArm64Rel28(UINT32* pCode, INT32 imm28)
+{
+    UINT32 branchInstr = *pCode;
+    branchInstr &= 0xFC000000;
+    branchInstr |= ((imm28 >> 2) & 0x03FFFFFF);
+    *pCode = branchInstr;
+}

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -45,4 +45,15 @@ inline DWORDLONG CastPointer(T* p)
     return (DWORDLONG)(uintptr_t)p;
 }
 
+enum SPMI_TARGET_ARCHITECTURE
+{
+    SPMI_TARGET_ARCHITECTURE_X86,
+    SPMI_TARGET_ARCHITECTURE_AMD64,
+    SPMI_TARGET_ARCHITECTURE_ARM64,
+    SPMI_TARGET_ARCHITECTURE_ARM
+};
+
+SPMI_TARGET_ARCHITECTURE GetSpmiTargetArchitecture();
+void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture);
+
 #endif // !_SPMIUtil

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -60,4 +60,7 @@ void PutArm64Rel28(UINT32* pCode, INT32 imm28);
 void PutArm64Rel21(UINT32* pCode, INT32 imm21);
 void PutArm64Rel12(UINT32* pCode, INT32 imm12);
 
+void PutThumb2Mov32(UINT16* p, UINT32 imm32);
+void PutThumb2BlRel24(UINT16* p, INT32 imm24);
+
 #endif // !_SPMIUtil

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -56,4 +56,6 @@ enum SPMI_TARGET_ARCHITECTURE
 SPMI_TARGET_ARCHITECTURE GetSpmiTargetArchitecture();
 void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture);
 
+void PutArm64Rel28(UINT32* pCode, INT32 imm28);
+
 #endif // !_SPMIUtil

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -57,5 +57,7 @@ SPMI_TARGET_ARCHITECTURE GetSpmiTargetArchitecture();
 void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture);
 
 void PutArm64Rel28(UINT32* pCode, INT32 imm28);
+void PutArm64Rel21(UINT32* pCode, INT32 imm21);
+void PutArm64Rel12(UINT32* pCode, INT32 imm12);
 
 #endif // !_SPMIUtil

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -56,6 +56,16 @@ enum SPMI_TARGET_ARCHITECTURE
 SPMI_TARGET_ARCHITECTURE GetSpmiTargetArchitecture();
 void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture);
 
+inline bool IsSpmiTarget64Bit()
+{
+    return (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_AMD64) || (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64);
+}
+
+inline size_t SpmiTargetPointerSize()
+{
+    return IsSpmiTarget64Bit() ? sizeof(INT64) : sizeof(INT32);
+}
+
 void PutArm64Rel28(UINT32* pCode, INT32 imm28);
 void PutArm64Rel21(UINT32* pCode, INT32 imm21);
 void PutArm64Rel12(UINT32* pCode, INT32 imm12);

--- a/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -320,18 +320,40 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
         }
         if (jitResult == CORJIT_SKIPPED)
         {
-            // For altjit, treat SKIPPED as OK
-#ifdef TARGET_AMD64
-            if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64)
+            SPMI_TARGET_ARCHITECTURE targetArch = GetSpmiTargetArchitecture();
+            bool matchesTargetArch              = false;
+
+            switch (pParam->pThis->mc->repGetExpectedTargetArchitecture())
+            {
+                case IMAGE_FILE_MACHINE_AMD64:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_AMD64);
+                    break;
+
+                case IMAGE_FILE_MACHINE_I386:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_X86);
+                    break;
+
+                case IMAGE_FILE_MACHINE_ARMNT:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_ARM);
+                    break;
+
+                case IMAGE_FILE_MACHINE_ARM64:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64);
+                    break;
+
+                default:
+                    LogError("Unknown target architecture");
+                break;
+            }
+
+            // If the target architecture doesn't match the expected target architecture
+            // then we have an altjit, so treat SKIPPED as OK to avoid counting the compilation as failed.
+
+            if (!matchesTargetArch)
             {
                 jitResult = CORJIT_OK;
             }
-#elif defined(TARGET_X86)
-            if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM)
-            {
-                jitResult = CORJIT_OK;
-            }
-#endif
+
         }
         if (jitResult == CORJIT_OK)
         {

--- a/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -322,12 +322,12 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
         {
             // For altjit, treat SKIPPED as OK
 #ifdef TARGET_AMD64
-            if (SpmiTargetArchitecture == SPMI_TARGET_ARCHITECTURE_ARM64)
+            if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64)
             {
                 jitResult = CORJIT_OK;
             }
 #elif defined(TARGET_X86)
-            if (SpmiTargetArchitecture == SPMI_TARGET_ARCHITECTURE_ARM)
+            if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM)
             {
                 jitResult = CORJIT_OK;
             }

--- a/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -1104,6 +1104,8 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
                      &coldCodeBlock_2, &roDataBlock_2, &orig_hotCodeBlock_2, &orig_coldCodeBlock_2,
                      &orig_roDataBlock_2);
 
+    // On Arm64 the constant pool is appended at the end of the method code section, hence hotCodeSize_{1,2}
+    // is a sum of their sizes. The following is to adjust theor sizes and the roDataBlock_{1,2} pointers.
     if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64)
     {
         BYTE*        nativeEntry_1;
@@ -1116,6 +1118,15 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
 
         cr1->repCompileMethod(&nativeEntry_1, &nativeSizeOfCode_1, &jitResult_1);
         cr2->repCompileMethod(&nativeEntry_2, &nativeSizeOfCode_2, &jitResult_2);
+
+        roDataSize_1 = hotCodeSize_1 - nativeSizeOfCode_1;
+        roDataSize_2 = hotCodeSize_2 - nativeSizeOfCode_2;
+
+        roDataBlock_1 = hotCodeBlock_1 + nativeSizeOfCode_1;
+        roDataBlock_2 = hotCodeBlock_2 + nativeSizeOfCode_2;
+
+        orig_roDataBlock_1 = (void*)((size_t)orig_hotCodeBlock_1 + nativeSizeOfCode_1);
+        orig_roDataBlock_2 = (void*)((size_t)orig_hotCodeBlock_2 + nativeSizeOfCode_2);
 
         hotCodeSize_1 = nativeSizeOfCode_1;
         hotCodeSize_2 = nativeSizeOfCode_2;

--- a/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -1105,7 +1105,7 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
                      &orig_roDataBlock_2);
 
     // On Arm64 the constant pool is appended at the end of the method code section, hence hotCodeSize_{1,2}
-    // is a sum of their sizes. The following is to adjust theor sizes and the roDataBlock_{1,2} pointers.
+    // is a sum of their sizes. The following is to adjust their sizes and the roDataBlock_{1,2} pointers.
     if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64)
     {
         BYTE*        nativeEntry_1;

--- a/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -13,6 +13,7 @@
 
 #include "logging.h"
 #include "neardiffer.h"
+#include "spmiutil.h"
 
 #ifdef USE_COREDISTOOLS
 
@@ -1102,6 +1103,23 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
     cr2->repAllocMem(&hotCodeSize_2, &coldCodeSize_2, &roDataSize_2, &xcptnsCount_2, &flag_2, &hotCodeBlock_2,
                      &coldCodeBlock_2, &roDataBlock_2, &orig_hotCodeBlock_2, &orig_coldCodeBlock_2,
                      &orig_roDataBlock_2);
+
+    if (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64)
+    {
+        BYTE*        nativeEntry_1;
+        ULONG        nativeSizeOfCode_1;
+        CorJitResult jitResult_1;
+
+        BYTE*        nativeEntry_2;
+        ULONG        nativeSizeOfCode_2;
+        CorJitResult jitResult_2;
+
+        cr1->repCompileMethod(&nativeEntry_1, &nativeSizeOfCode_1, &jitResult_1);
+        cr2->repCompileMethod(&nativeEntry_2, &nativeSizeOfCode_2, &jitResult_2);
+
+        hotCodeSize_1 = nativeSizeOfCode_1;
+        hotCodeSize_2 = nativeSizeOfCode_2;
+    }
 
     LogDebug("HCS1 %d CCS1 %d RDS1 %d xcpnt1 %d flag1 %08X, HCB %p CCB %p RDB %p ohcb %p occb %p odb %p", hotCodeSize_1,
              coldCodeSize_1, roDataSize_1, xcptnsCount_1, flag_1, hotCodeBlock_1, coldCodeBlock_1, roDataBlock_1,

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -17,6 +17,7 @@
 #include "methodcontextreader.h"
 #include "mclist.h"
 #include "methodstatsemitter.h"
+#include "spmiutil.h"
 
 extern int doParallelSuperPMI(CommandLine::Options& o);
 
@@ -29,43 +30,27 @@ const char* const g_AsmDiffsSummaryFormatString = "Loaded %d  Jitted %d  FailedC
 
 //#define SuperPMI_ChewMemory 0x7FFFFFFF //Amount of address space to consume on startup
 
-SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture;
-
 void SetSuperPmiTargetArchitecture(const char* targetArchitecture)
 {
-    // Set the default
-
-#ifdef TARGET_AMD64
-    SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_AMD64;
-#elif defined(TARGET_X86)
-    SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_X86;
-#elif defined(TARGET_ARM)
-    SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM;
-#elif defined(TARGET_ARM64)
-    SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM64;
-#else
-#error Unsupported architecture
-#endif
-
     // Allow overriding the default.
 
     if (targetArchitecture != nullptr)
     {
         if ((0 == _stricmp(targetArchitecture, "x64")) || (0 == _stricmp(targetArchitecture, "amd64")))
         {
-            SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_AMD64;
+            SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_AMD64);
         }
         else if (0 == _stricmp(targetArchitecture, "x86"))
         {
-            SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_X86;
+            SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_X86);
         }
         else if ((0 == _stricmp(targetArchitecture, "arm")) || (0 == _stricmp(targetArchitecture, "arm32")))
         {
-            SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM;
+            SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_ARM);
         }
         else if (0 == _stricmp(targetArchitecture, "arm64"))
         {
-            SpmiTargetArchitecture = SPMI_TARGET_ARCHITECTURE_ARM64;
+            SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_ARM64);
         }
         else
         {

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.h
@@ -6,17 +6,6 @@
 
 #include "errorhandling.h"
 
-enum SPMI_TARGET_ARCHITECTURE
-{
-    SPMI_TARGET_ARCHITECTURE_X86,
-    SPMI_TARGET_ARCHITECTURE_AMD64,
-    SPMI_TARGET_ARCHITECTURE_ARM64,
-    SPMI_TARGET_ARCHITECTURE_ARM
-};
-
-extern SPMI_TARGET_ARCHITECTURE SpmiTargetArchitecture;
-extern void SetSuperPmiTargetArchitecture(const char* targetArchitecture);
-
 extern const char* const g_SuperPMIUsageFirstLine;
 
 extern const char* const g_AllFormatStringFixedPrefix;


### PR DESCRIPTION
1. Convert `#ifdef TARGET_*` in `CompileResult::applyRelocs` in compileresult.cpp to runtime checks and allow SuperPMI to work with cross-architecture jits during asmdiffs (e.g. clrjit_win_arm64_x64.dll)
2. Refactor `CompileResult::applyRelocs` and separate platform specific relocations (x86, arm64, 64-bit targets) from platform agnostic relocations
3. Support `IMAGE_REL_ARM64_BRANCH26`, `IMAGE_REL_ARM64_PAGEBASE_REL21` and `IMAGE_REL_ARM64_PAGEOFFSET_12A` in `CompileResult::applyRelocs`. 
4. Support `IMAGE_REL_BASED_THUMB_MOV32`, `IMAGE_REL_BASED_REL_THUMB_MOV32_PCREL` and  `IMAGE_REL_BASED_THUMB_BRANCH24` in `CompileResult::applyRelocs`. 
5. Adjust code section size that SuperPMI gets by calling `repAllocMem` in `NearDiffer::compare` in neardiffer.cpp. On Arm64 methods that have literal (constant) pools will fail decoding since the pools are appended to the methods code section and the size of code section reported by `repAllocMem` will include the constant pool. In order to avoid decoding of the constant pools and adjust code section to only contain executable portion - use `repCompileMethod` in `NearDiffer::compare`.