### PR TITLE
Enable async-over-sync Task in Dns to be canceled

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -167,11 +167,11 @@ namespace System.Net
                 throw new ArgumentException(SR.net_invalid_ip_addr, nameof(address));
             }
 
-            return RunAsync(s => {
-                    IPHostEntry ipHostEntry = GetHostEntryCore((IPAddress)s, AddressFamily.Unspecified);
+            return RunAsync(static s => {
+                IPHostEntry ipHostEntry = GetHostEntryCore((IPAddress)s, AddressFamily.Unspecified);
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info((IPAddress)s, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
                 return ipHostEntry;
-            }, address);
+            }, address, CancellationToken.None);
         }
 
         public static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback? requestCallback, object? stateObject) =>
@@ -578,25 +578,25 @@ namespace System.Net
 
             if (justAddresses)
             {
-                return RunAsync(s => s switch
+                return RunAsync(static s => s switch
                 {
                     string h => GetHostAddressesCore(h, AddressFamily.Unspecified),
                     KeyValuePair<string, AddressFamily> t => GetHostAddressesCore(t.Key, t.Value),
                     IPAddress a => GetHostAddressesCore(a, AddressFamily.Unspecified),
                     KeyValuePair<IPAddress, AddressFamily> t => GetHostAddressesCore(t.Key, t.Value),
                     _ => null
-                }, asyncState);
+                }, asyncState, cancellationToken);
             }
             else
             {
-                return RunAsync(s => s switch
+                return RunAsync(static s => s switch
                 {
                     string h => GetHostEntryCore(h, AddressFamily.Unspecified),
                     KeyValuePair<string, AddressFamily> t => GetHostEntryCore(t.Key, t.Value),
                     IPAddress a => GetHostEntryCore(a, AddressFamily.Unspecified),
                     KeyValuePair<IPAddress, AddressFamily> t => GetHostEntryCore(t.Key, t.Value),
                     _ => null
-                }, asyncState);
+                }, asyncState, cancellationToken);
             }
         }
 
@@ -631,8 +631,8 @@ namespace System.Net
             }
         }
 
-        private static Task<TResult> RunAsync<TResult>(Func<object, TResult> func, object arg) =>
-            Task.Factory.StartNew(func!, arg, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        private static Task<TResult> RunAsync<TResult>(Func<object, TResult> func, object arg, CancellationToken cancellationToken) =>
+            Task.Factory.StartNew(func!, arg, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
         private static IPHostEntry CreateHostEntryForAddress(IPAddress address) =>
             new IPHostEntry


### PR DESCRIPTION
While we can't currently cancel the synchronous call, we can at least cancel the Task prior to its being executed.