### PR TITLE
[browser][crypto] Fix Quota Exceeded error

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_random.js
+++ b/src/libraries/Native/Unix/System.Native/pal_random.js
@@ -3,14 +3,28 @@
 
 var DotNetEntropyLib = {
     $DOTNETENTROPY: {
+        // batchedQuotaMax is the max number of bytes as specified by the api spec.
+        // If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
+        // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
+        batchedQuotaMax: 65536,
+        getBatchedRandomValues: function (buffer, bufferLength) {
+            // for modern web browsers
+            // map the work array to the memory buffer passed with the length
+            var wrkArray = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
+            while (bufferLength > 0) {
+                var sliceEm = bufferLength % this.batchedQuotaMax;
+                sliceEm = sliceEm > 0 ? sliceEm : this.batchedQuotaMax;
+                var diceEmSegment = new Uint8Array(sliceEm);
+                crypto.getRandomValues(diceEmSegment);
+                bufferLength -= sliceEm;
+                wrkArray.set(diceEmSegment, bufferLength);
+            }
+        }
     },
     dotnet_browser_entropy : function (buffer, bufferLength) {
         // check that we have crypto available
         if (typeof crypto === 'object' && typeof crypto['getRandomValues'] === 'function') {
-            // for modern web browsers
-            // map the work array to the memory buffer passed with the length
-            var wrkArray = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
-            crypto.getRandomValues(wrkArray);
+            DOTNETENTROPY.getBatchedRandomValues(buffer, bufferLength)
             return 0;
         } else {
             // we couldn't find a proper implementation, as Math.random() is not suitable

--- a/src/libraries/Native/Unix/System.Native/pal_random.js
+++ b/src/libraries/Native/Unix/System.Native/pal_random.js
@@ -10,14 +10,9 @@ var DotNetEntropyLib = {
         getBatchedRandomValues: function (buffer, bufferLength) {
             // for modern web browsers
             // map the work array to the memory buffer passed with the length
-            var wrkArray = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
-            while (bufferLength > 0) {
-                var sliceEm = bufferLength % this.batchedQuotaMax;
-                sliceEm = sliceEm > 0 ? sliceEm : this.batchedQuotaMax;
-                var diceEmSegment = new Uint8Array(sliceEm);
-                crypto.getRandomValues(diceEmSegment);
-                bufferLength -= sliceEm;
-                wrkArray.set(diceEmSegment, bufferLength);
+            for (var i = 0; i < bufferLength; i += this.batchedQuotaMax) {
+                var view = new Uint8Array(Module.HEAPU8.buffer, buffer + i, Math.min(bufferLength - i, this.batchedQuotaMax));
+                crypto.getRandomValues(view)
             }
         }
     },

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -12,10 +12,13 @@ namespace System.Security.Cryptography.RNG.Tests
 {
     public class RandomNumberGeneratorTests
     {
-        [Fact]
-        public static void RandomDistribution()
+        [Theory]
+        [InlineData(2048)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void RandomDistribution(int arraySize)
         {
-            byte[] random = new byte[2048];
+            byte[] random = new byte[arraySize];
 
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -99,26 +99,33 @@ namespace System.Security.Cryptography.RNG.Tests
             }
         }
 
-        [Fact]
-        public static void GetNonZeroBytes_Array()
+        [Theory]
+        [InlineData(10)]
+        [InlineData(256)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void GetNonZeroBytes_Array(int arraySize)
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
                 AssertExtensions.Throws<ArgumentNullException>("data", () => rng.GetNonZeroBytes(null));
 
                 // Array should not have any zeros
-                byte[] rand = new byte[65536];
+                byte[] rand = new byte[arraySize];
                 rng.GetNonZeroBytes(rand);
                 Assert.Equal(-1, Array.IndexOf<byte>(rand, 0));
             }
         }
 
-        [Fact]
-        public static void GetBytes_Offset()
+        [Theory]
+        [InlineData(400)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void GetBytes_Offset(int arraySize)
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
-                byte[] rand = new byte[400];
+                byte[] rand = new byte[arraySize];
 
                 // Set canary bytes
                 rand[99] = 77;
@@ -160,6 +167,7 @@ namespace System.Security.Cryptography.RNG.Tests
         [InlineData(10)]
         [InlineData(256)]
         [InlineData(65536)]
+        [InlineData(1048576)]
         public static void DifferentSequential_Array(int arraySize)
         {
             // Ensure that the RNG doesn't produce a stable set of data.
@@ -186,6 +194,7 @@ namespace System.Security.Cryptography.RNG.Tests
         [InlineData(10)]
         [InlineData(256)]
         [InlineData(65536)]
+        [InlineData(1048576)]
         public static void DifferentParallel(int arraySize)
         {
             // Ensure that two RNGs don't produce the same data series (such as being implemented via new Random(1)).
@@ -243,18 +252,24 @@ namespace System.Security.Cryptography.RNG.Tests
             Assert.Empty(result);
         }
 
-        [Fact]
-        public static void GetBytes_Int_RandomDistribution()
+        [Theory]
+        [InlineData(2048)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void GetBytes_Int_RandomDistribution(int arraySize)
         {
-            byte[] result = RandomNumberGenerator.GetBytes(2048);
+            byte[] result = RandomNumberGenerator.GetBytes(arraySize);
             RandomDataGenerator.VerifyRandomDistribution(result);
         }
 
-        [Fact]
-        public static void GetBytes_Int_NotSame()
+        [Theory]
+        [InlineData(2048)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void GetBytes_Int_NotSame(int arraySize)
         {
-            byte[] result1 = RandomNumberGenerator.GetBytes(2048);
-            byte[] result2 = RandomNumberGenerator.GetBytes(2048);
+            byte[] result1 = RandomNumberGenerator.GetBytes(arraySize);
+            byte[] result2 = RandomNumberGenerator.GetBytes(arraySize);
             Assert.NotEqual(result1, result2);
         }
 
@@ -262,6 +277,7 @@ namespace System.Security.Cryptography.RNG.Tests
         [InlineData(10)]
         [InlineData(256)]
         [InlineData(65536)]
+        [InlineData(1048576)]
         public static void DifferentSequential_Span(int arraySize)
         {
             // Ensure that the RNG doesn't produce a stable set of data.
@@ -295,12 +311,16 @@ namespace System.Security.Cryptography.RNG.Tests
             }
         }
 
-        [Fact]
-        public static void GetNonZeroBytes_Span()
+        [Theory]
+        [InlineData(10)]
+        [InlineData(256)]
+        [InlineData(65536)]
+        [InlineData(1048576)]
+        public static void GetNonZeroBytes_Span(int arraySize)
         {
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
-                var rand = new byte[65536];
+                var rand = new byte[arraySize];
                 rng.GetNonZeroBytes(new Span<byte>(rand));
                 Assert.Equal(-1, Array.IndexOf<byte>(rand, 0));
             }


### PR DESCRIPTION
Add batched implementation to fix error with quota exceeded limit.
- If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
- https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues

Add and/or update tests for exceeding the quota limit of browser set at 65536.

The tests only went up to `65536` so this error was never caught.

A small repo from issue:
```c#
Span<byte> data = new byte[ 1024 * 1024 ];
RandomNumberGenerator.Fill( data );
```

1024 * 1024 = 1048576

Fix https://github.com/dotnet/runtime/issues/48584