### PR TITLE
Use unknown placeholder for collectible class typehandle

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -56,6 +56,7 @@
 #include "castcache.h"
 #include "onstackreplacement.h"
 #include "pgo.h"
+#include "pgo_formatprocessing.h"
 
 #ifndef FEATURE_EH_FUNCLETS
 #include "excep.h"
@@ -5260,12 +5261,13 @@ HCIMPL2(void, JIT_ClassProfile, Object *obj, void* tableAddress)
 
     MethodTable* pMT = objRef->GetMethodTable();
 
-    // If the object class is collectible, record NULL
-    // for the class handle.
+    // If the object class is collectible, record an unknown typehandle.
+    // We do this instead of recording NULL so that we won't over-estimate
+    // the likelihood of known type handles.
     //
     if (pMT->GetLoaderAllocator()->IsCollectible())
     {
-        pMT = NULL;
+        pMT = (MethodTable*)DEFAULT_UNKNOWN_TYPEHANDLE;
     }
 
 #ifdef _DEBUG


### PR DESCRIPTION
instead of null, so that we won't over-estimate likelihood of other types at a
call site where we see both collectible and non-collectible types.

Addresses part of #48549.