### PR TITLE
Preserve the System.RuntimeType constructor in mono ILLink

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -309,6 +309,7 @@
 
 		<!-- domain.c: mono_defaults.runtimetype_class -->
 		<!-- under mono, this has no runtime visible fields -->
+		<!-- RuntimeType is a fundamental type and the constructor is called by the runtime to implement reflection primitives like Object.GetType() and typeof(C) -->
 		<type fullname="System.RuntimeType">
 			<method signature="System.Void .ctor()" />
 		</type>

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -308,7 +308,7 @@
 		<type fullname="System.RuntimeMethodHandle" preserve="fields" />
 
 		<!-- domain.c: mono_defaults.runtimetype_class -->
-		<!-- under mono, this has no runtime visible fields -->
+		<!-- under mono, this has no runtime visible fields but the constructor can be called from unmanaged code in mono_type_get_object_checked -->
 		<!-- RuntimeType is a fundamental type and the constructor is called by the runtime to implement reflection primitives like Object.GetType() and typeof(C) -->
 		<type fullname="System.RuntimeType">
 			<method signature="System.Void .ctor()" />

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -309,7 +309,9 @@
 
 		<!-- domain.c: mono_defaults.runtimetype_class -->
 		<!-- under mono, this has no runtime visible fields -->
-		<type fullname="System.RuntimeType" preserve="nothing" />
+		<type fullname="System.RuntimeType">
+			<method signature="System.Void .ctor()" />
+		</type>
 
 		<!-- domain.c: mono_defaults.typehandle_class -->
 		<type fullname="System.RuntimeTypeHandle" preserve="fields" />


### PR DESCRIPTION
Fixes #48522

Without this, the linker will think that `RuntimeType` is never instantiated and can generate code such as (the red without this fix vs the green with this fix):
```diff
-      Type underlyingSystemType = type.UnderlyingSystemType;
-      RuntimeType runtimeType = (RuntimeType) null;
-      if ((object) runtimeType != null)
-        return runtimeType.CreateInstanceImpl(bindingAttr, binder, args, culture);
+      RuntimeType underlyingSystemType = type.UnderlyingSystemType as RuntimeType;
+      if ((object) underlyingSystemType != null)
+        return underlyingSystemType.CreateInstanceImpl(bindingAttr, binder, args, culture);
```

Additionally, under this scenario the runtime will end up failing to load S.P.Corelib with an error similar to:
```
WASM-ERR: [ERROR] FATAL UNHANDLED EXCEPTION: Nested exception detected.
WASM-ERR: Original Exception: at System.Collections.Generic.Dictionary`2<string, object>..ctor (int,System.Collections.Generic.IEqualityComparer`1<string>) <0x00060>
WASM-ERR: at System.Collections.Generic.Dictionary`2<string, object>..ctor (int) <0x00014>
WASM-ERR: at System.AppContext.Setup (char**,char**,int) <0x00016>
WASM-ERR:
WASM-ERR: Nested exception:at System.RuntimeType.get_BaseType () <0x00056>
WASM-ERR: at System.Type.IsSubclassOf (System.Type) <0x00044>
WASM-ERR: at System.Reflection.CustomAttribute.IsDefined (System.Reflection.ICustomAttributeProvider,System.Type,bool) <0x00040>
WASM-ERR: at System.Reflection.RuntimeMethodInfo.IsDefined (System.Type,bool) <0x00016>
WASM-ERR: at System.Diagnostics.StackTrace.ShowInStackTrace (System.Reflection.MethodBase) <0x00048>
WASM-ERR: at System.Diagnostics.StackTrace.ToString (System.Diagnostics.StackTrace/TraceFormat,System.Text.StringBuilder) <0x000c8>
WASM-ERR: at System.Diagnostics.StackTrace.ToString (System.Diagnostics.StackTrace/TraceFormat) <0x00036>
WASM-ERR: at System.Exception.GetStackTrace (bool) <0x0006a>
WASM-ERR: at System.Exception.get_StackTrace () <0x0000e>
WASM-ERR: at System.Exception.ToString () <0x000ae>
WASM-ERR: at System.Exception.ToString () <0x00054>
WASM-ERR:
WASM-ERR:
```
