### PR TITLE
Fixup richnav triggers

### DIFF
--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -1,8 +1,25 @@
 trigger:
+  batch: true
   branches:
     include:
       - master
       - release/*.*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - eng/Version.Details.xml
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
+
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/48659

I also added `batched: true` as this was running for every single commit. 

Also, added `pr: none` as at the moment we don't want to run them on PRs because of time constraints. @jepetty is doing some more work to enable native richnav, once we get that we will work to enable this on PRs so that people can use richnav to do PR reviews.