### PR TITLE
Baggage and Tags for activity tracking options (#46571)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -109,11 +109,11 @@ namespace Microsoft.Extensions.Logging.Console
                 writer.WriteStartArray("Scopes");
                 scopeProvider.ForEachScope((scope, state) =>
                 {
-                    if (scope is IEnumerable<KeyValuePair<string, object>> scopes)
+                    if (scope is IEnumerable<KeyValuePair<string, object>> scopeItems)
                     {
                         state.WriteStartObject();
                         state.WriteString("Message", scope.ToString());
-                        foreach (KeyValuePair<string, object> item in scopes)
+                        foreach (KeyValuePair<string, object> item in scopeItems)
                         {
                             WriteItem(state, item);
                         }

--- a/src/libraries/Microsoft.Extensions.Logging/ref/Microsoft.Extensions.Logging.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/ref/Microsoft.Extensions.Logging.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Extensions.Logging
         ParentId = 4,
         TraceState = 8,
         TraceFlags = 16,
+        Tags = 32,
+        Baggage = 64
     }
     public static partial class FilterLoggingBuilderExtensions
     {

--- a/src/libraries/Microsoft.Extensions.Logging/src/ActivityTrackingOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/ActivityTrackingOptions.cs
@@ -16,28 +16,38 @@ namespace Microsoft.Extensions.Logging
         None        = 0x0000,
 
         /// <summary>
-        /// Span Id wil be included in the logging.
+        /// Span Id will be included in the logging.
         /// </summary>
         SpanId      = 0x0001,
 
         /// <summary>
-        /// Trace Id wil be included in the logging.
+        /// Trace Id will be included in the logging.
         /// </summary>
         TraceId     = 0x0002,
 
         /// <summary>
-        /// Parent Id wil be included in the logging.
+        /// Parent Id will be included in the logging.
         /// </summary>
         ParentId    = 0x0004,
 
         /// <summary>
-        /// Trace State wil be included in the logging.
+        /// Trace State will be included in the logging.
         /// </summary>
         TraceState  = 0x0008,
 
         /// <summary>
-        /// Trace flags wil be included in the logging.
+        /// Trace flags will be included in the logging.
         /// </summary>
-        TraceFlags  = 0x0010
+        TraceFlags  = 0x0010,
+
+        /// <summary>
+        /// Tags will be included in the logging.
+        /// </summary>
+        Tags        = 0x0020,
+
+        /// <summary>
+        /// Items of baggage will be included in the logging.
+        /// </summary>
+        Baggage     = 0x0040
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -66,7 +66,9 @@ namespace Microsoft.Extensions.Logging
             _factoryOptions = options == null || options.Value == null ? new LoggerFactoryOptions() : options.Value;
 
             const ActivityTrackingOptions ActivityTrackingOptionsMask = ~(ActivityTrackingOptions.SpanId | ActivityTrackingOptions.TraceId | ActivityTrackingOptions.ParentId |
-                                                                          ActivityTrackingOptions.TraceFlags | ActivityTrackingOptions.TraceState);
+                                                                          ActivityTrackingOptions.TraceFlags | ActivityTrackingOptions.TraceState | ActivityTrackingOptions.Tags
+                                                                          | ActivityTrackingOptions.Baggage);
+
 
             if ((_factoryOptions.ActivityTrackingOptions & ActivityTrackingOptionsMask) != 0)
             {

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryScopeProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryScopeProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text;
-using System.Globalization;
 using System.Threading;
 using System.Collections;
 using System.Diagnostics;
@@ -48,10 +47,45 @@ namespace Microsoft.Extensions.Logging
                     }
 
                     callback(activityLogScope, state);
+
+                    // Tags and baggage are opt-in and thus we assume that most of the time it will not be used.
+                    if ((_activityTrackingOption & ActivityTrackingOptions.Tags) != 0
+                        && activity.TagObjects.GetEnumerator().MoveNext())
+                    {
+                        // As TagObjects is a IEnumerable<KeyValuePair<string, object?>> this can be used directly as a scope.
+                        // We do this to safe the allocation of a wrapper object.
+                         callback(activity.TagObjects, state);
+                    }
+
+                    if ((_activityTrackingOption & ActivityTrackingOptions.Baggage) != 0)
+                    {
+                        // Only access activity.Baggage as every call leads to an allocation
+                        IEnumerable<KeyValuePair<string, string?>> baggage = activity.Baggage;
+                        if (baggage.GetEnumerator().MoveNext())
+                        {
+                            // For the baggage a wrapper object is necessary because we need to be able to overwrite ToString().
+                            // In contrast to the TagsObject, Baggage doesn't have one underlining type where we can do this overwrite.
+                            ActivityBaggageLogScopeWrapper scope = GetOrCreateActivityBaggageLogScopeWrapper(activity, baggage);
+                            callback(scope, state);
+                        }
+                    }
                 }
             }
 
             Report(_currentScope.Value);
+        }
+
+        private static ActivityBaggageLogScopeWrapper GetOrCreateActivityBaggageLogScopeWrapper(Activity activity, IEnumerable<KeyValuePair<string, string?>> items)
+        {
+            const string additionalItemsBaggagePropertyKey = "__ActivityBaggageItemsLogScope__";
+            var activityBaggageLogScopeWrapper = activity.GetCustomProperty(additionalItemsBaggagePropertyKey) as ActivityBaggageLogScopeWrapper;
+            if (activityBaggageLogScopeWrapper == null)
+            {
+                activityBaggageLogScopeWrapper = new ActivityBaggageLogScopeWrapper(items);
+                activity.SetCustomProperty(additionalItemsBaggagePropertyKey, activityBaggageLogScopeWrapper);
+            }
+
+            return activityBaggageLogScopeWrapper;
         }
 
         public IDisposable Push(object state)
@@ -185,7 +219,59 @@ namespace Microsoft.Extensions.Logging
                 return GetEnumerator();
             }
         }
+
+        private class ActivityBaggageLogScopeWrapper : IEnumerable<KeyValuePair<string, string?>>
+        {
+            private readonly IEnumerable<KeyValuePair<string, string?>> _items;
+
+            private StringBuilder? _stringBuilder;
+
+            public ActivityBaggageLogScopeWrapper (IEnumerable<KeyValuePair<string, string?>> items)
+            {
+                _items = items;
+            }
+
+            public IEnumerator<KeyValuePair<string, string?>> GetEnumerator()
+            {
+                return _items.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _items.GetEnumerator();
+            }
+
+            public override string ToString()
+            {
+                lock (this)
+                {
+                    IEnumerator<KeyValuePair<string, string?>> enumerator = _items.GetEnumerator();
+                    if (!enumerator.MoveNext())
+                    {
+                        return string.Empty;
+                    }
+
+                    _stringBuilder ??= new StringBuilder();
+                    _stringBuilder.Append(enumerator.Current.Key);
+                    _stringBuilder.Append(':');
+                    _stringBuilder.Append(enumerator.Current.Value);
+
+                    while (enumerator.MoveNext())
+                    {
+                        _stringBuilder.Append(", ");
+                        _stringBuilder.Append(enumerator.Current.Key);
+                        _stringBuilder.Append(':');
+                        _stringBuilder.Append(enumerator.Current.Value);
+                    }
+
+                    string result = _stringBuilder.ToString();
+                    _stringBuilder.Clear();
+                    return result;
+                }
+            }
+        }
     }
+
     internal static class ActivityExtensions
     {
         public static string GetSpanId(this Activity activity)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1458,6 +1458,8 @@ namespace System.Diagnostics
             private LinkedListNode<KeyValuePair<string, object?>>? _first;
             private LinkedListNode<KeyValuePair<string, object?>>? _last;
 
+            private StringBuilder? _stringBuilder;
+
             public TagsLinkedList(KeyValuePair<string, object?> firstValue, bool set = false) => _last = _first = ((set && firstValue.Value == null) ? null : new LinkedListNode<KeyValuePair<string, object?>>(firstValue));
 
             public TagsLinkedList(IEnumerator<KeyValuePair<string, object?>> e)
@@ -1618,6 +1620,37 @@ namespace System.Diagnostics
 
                     current = current.Next;
                 };
+            }
+
+            public override string ToString()
+            {
+                lock (this)
+                {
+                    if (_first == null)
+                    {
+                        return string.Empty;
+                    }
+
+                    _stringBuilder ??= new StringBuilder();
+                    _stringBuilder.Append(_first.Value.Key);
+                    _stringBuilder.Append(':');
+                    _stringBuilder.Append(_first.Value.Value);
+
+                    LinkedListNode<KeyValuePair<string, object?>>? current = _first.Next;
+                    while (current != null)
+                    {
+                        _stringBuilder.Append(", ");
+                        _stringBuilder.Append(current.Value.Key);
+                        _stringBuilder.Append(':');
+                        _stringBuilder.Append(current.Value.Value);
+
+                        current = current.Next;
+                    }
+
+                    string result = _stringBuilder.ToString();
+                    _stringBuilder.Clear();
+                    return result;
+                }
             }
         }
 


### PR DESCRIPTION
@tarekgh here we go. It's the simplest implementation I can think of.
As stated in #47315 a logging scope is expected to be `IEnumerable<KeyValuePair<string, object>>` *
Tags and baggage are already `IEnumerable<KeyValuePair<string, object>>` and can be used.
It makes no sense to cache them like it's done for the ActivityLogScope, as they change from one log line to the other.

Tests will follow.

\* Is there a reason the `ActivityLogScope` implements `IReadOnlyList<T>`?

