### PR TITLE
Tweak package build for dotnet-pgo so that it builds in our official builds

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -202,7 +202,7 @@
 
   <ItemGroup Condition="$(_subset.Contains('+clr.packages+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot).nuget\coreclr-packages.proj" Pack="true" Category="clr" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\dotnet-pgo\dotnet-pgo.csproj" Pack="true" BuildInParallel="false" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\dotnet-pgo\dotnet-pgo-pack.proj" Pack="true" BuildInParallel="false" Category="clr" />
   </ItemGroup>
 
   <!-- Mono sets -->

--- a/src/coreclr/tools/dotnet-pgo/dotnet-pgo-pack.proj
+++ b/src/coreclr/tools/dotnet-pgo/dotnet-pgo-pack.proj
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="Build">
+    <Msbuild Targets="Pack" Projects="dotnet-pgo.csproj" />
+  </Target>
+</Project>


### PR DESCRIPTION
My previous attempt foundered as our build scripts don't specify the pack target for clr based packages.