### PR TITLE
fix proxy detection for websockets on Windows

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
@@ -117,13 +117,25 @@ namespace System.Net.Http
             //    fAutoLogonIfChallenged member set to TRUE.
             //
             // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
+
+            string destination = uri.AbsoluteUri;
+            // Underlying code does not understand WebSockets so we need to convert it to http or https.
+            if (uri.Scheme == UriScheme.Wss)
+            {
+                destination = "https" + destination.Substring(3);
+            }
+            else if (uri.Scheme == UriScheme.Ws)
+            {
+                destination = "http" + destination.Substring(2);
+            }
+
             var repeat = false;
             do
             {
                 _autoDetectionFailed = false;
                 if (Interop.WinHttp.WinHttpGetProxyForUrl(
                     sessionHandle!,
-                    uri.AbsoluteUri,
+                    destination,
                     ref autoProxyOptions,
                     out proxyInfo))
                 {

--- a/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
@@ -122,11 +122,11 @@ namespace System.Net.Http
             // Underlying code does not understand WebSockets so we need to convert it to http or https.
             if (uri.Scheme == UriScheme.Wss)
             {
-                destination = "https" + destination.Substring(3);
+                destination = UriScheme.Https + destination.Substring(UriScheme.Wss.Length);
             }
             else if (uri.Scheme == UriScheme.Ws)
             {
-                destination = "http" + destination.Substring(2);
+                destination = UriScheme.Http + destination.Substring(UriScheme.Ws.Length);
             }
 
             var repeat = false;


### PR DESCRIPTION
Using WebSockets & proxies works on Unix as well as in case of manual configuration on Windows as we use IsSecureUri() wrapper.  However passing 'ws://..' or 'wss://` URI to WinHttp helper may not work. 
This is small fix-up to match Framework behavior.

It seems like on Framework this works because we override the WebSocket uri early on:
https://referencesource.microsoft.com/#System/net/System/Net/HttpWebRequest.cs,5755

I did not figure out how to write good test as this really depends on internal pac processing. 

fixes #43656