### PR TITLE
Use managed AsnFormatter on Android

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/PlatformSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/PlatformSupport.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Test.Cryptography
+{
+    internal static class PlatformSupport
+    {
+        // Platforms that support OpenSSL - all Unix except OSX and Android
+        internal const TestPlatforms OpenSSL = TestPlatforms.AnyUnix & ~(TestPlatforms.OSX | TestPlatforms.Android);
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/AsnFormatter.Managed.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/AsnFormatter.Managed.cs
@@ -11,10 +11,10 @@ namespace Internal.Cryptography
 {
     internal abstract partial class AsnFormatter
     {
-        private static readonly AsnFormatter s_instance = new AppleAsnFormatter();
+        private static readonly AsnFormatter s_instance = new ManagedAsnFormatter();
     }
 
-    internal class AppleAsnFormatter : AsnFormatter
+    internal class ManagedAsnFormatter : AsnFormatter
     {
         protected override string? FormatNative(Oid? oid, byte[] rawData, bool multiLine)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -13,8 +13,8 @@
     <UseAndroidCrypto Condition="'$(TargetsAndroid)' == 'true' and '$(ANDROID_OPENSSL_AAR)' == ''">true</UseAndroidCrypto>
     <UseAppleCrypto Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</UseAppleCrypto>
   </PropertyGroup>
-  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(UseAppleCrypto)' == 'true'" />
-  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(UseAppleCrypto)' == 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'" />
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="Internal\Cryptography\AsnFormatter.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.cs" />
@@ -58,9 +58,10 @@
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
              Link="Common\Interop\Windows\Interop.Libraries.cs" />
   </ItemGroup>
-  <!-- Used in Unix except Apple -->
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(UseAppleCrypto)' != 'true'">
+  <!-- Used in Unix except Android (native crypto) and Apple -->
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(UseAndroidCrypto)' != 'true' and '$(UseAppleCrypto)' != 'true'">
     <Compile Include="Internal\Cryptography\AsnFormatter.Unix.cs" />
+    <Compile Include="Internal\Cryptography\OidLookup.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslAsnFormatter.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
@@ -85,15 +86,8 @@
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs"
              Link="Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs" />
   </ItemGroup>
-    <!-- Used in Unix except Android (native crypto) and Apple -->
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(UseAndroidCrypto)' != 'true' and '$(UseAppleCrypto)' != 'true'">
-    <Compile Include="Internal\Cryptography\OidLookup.Unix.cs" />
-  </ItemGroup>
-   <!-- Used in Android (native crypto) -->
-  <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true'">
-    <Compile Include="Internal\Cryptography\OidLookup.NoFallback.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(UseAppleCrypto)' == 'true'">
+   <!-- Used in Android (native crypto) and Apple -->
+  <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'">
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs"
              Link="Common\System\Memory\PointerMemoryManager.cs" />
     <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
@@ -124,7 +118,7 @@
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="Internal\Cryptography\AsnFormatter.OSX.cs" />
+    <Compile Include="Internal\Cryptography\AsnFormatter.Managed.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.NoFallback.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -137,7 +131,7 @@
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
-  <ItemGroup Condition="'$(UseAppleCrypto)' == 'true'">
+  <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'">
     <Reference Include="System.Formats.Asn1" />
     <Reference Include="System.Runtime.Numerics" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Encoding.Tests
@@ -299,12 +300,12 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~(TestPlatforms.OSX | TestPlatforms.Android))] // Uses P/Invokes to search Oid in the lookup table
-        public static void LookupOidByValue_Method_UnixExceptOSXAndAndroid()
+        [PlatformSpecific(PlatformSupport.OpenSSL)] // Uses P/Invokes to search Oid in the lookup table
+        public static void LookupOidByValue_Method_OpenSSL()
         {
             // This needs to be an OID not in the static lookup table.  The purpose is to verify the
-            // NativeOidToFriendlyName fallback for Unix.  For Windows this is accomplished by
-            // using FromOidValue with an OidGroup other than OidGroup.All.
+            // NativeOidToFriendlyName fallback for platforms using OpenSSL.  For Windows this is
+            // accomplished by using FromOidValue with an OidGroup other than OidGroup.All.
             Oid oid = Oid.FromOidValue(ObsoleteSmime3desWrap_Oid, OidGroup.All);
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);
@@ -312,12 +313,12 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~(TestPlatforms.OSX | TestPlatforms.Android))]  // Uses P/Invokes to search Oid in the lookup table
-        public static void LookupOidByFriendlyName_Method_UnixExceptOSXAndAndroid()
+        [PlatformSpecific(PlatformSupport.OpenSSL)]  // Uses P/Invokes to search Oid in the lookup table
+        public static void LookupOidByFriendlyName_Method_OpenSSL()
         {
             // This needs to be a name not in the static lookup table.  The purpose is to verify the
-            // NativeFriendlyNameToOid fallback for Unix.  For Windows this is accomplished by
-            // using FromOidValue with an OidGroup other than OidGroup.All.
+            // NativeFriendlyNameToOid fallback for platforms using OpenSSL.  For Windows this is
+            // accomplished by using FromOidValue with an OidGroup other than OidGroup.All.
             Oid oid = Oid.FromFriendlyName(ObsoleteSmime3desWrap_Name, OidGroup.All);
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -189,9 +189,9 @@ namespace System.Security.Cryptography.Encoding.Tests
         {
             Oid oid = new Oid(SHA1_Oid, SHA256_Name);
             Assert.Equal(SHA1_Oid, oid.Value);
-            
+
             oid.FriendlyName = SHA256_Name;
-            
+
             Assert.Equal(SHA256_Name, oid.FriendlyName);
             Assert.Equal(SHA1_Oid, oid.Value);
         }
@@ -299,67 +299,26 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to search Oid in the lookup table
-        public static void LookupOidByValue_Method_UnixOnly()
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~(TestPlatforms.OSX | TestPlatforms.Android))] // Uses P/Invokes to search Oid in the lookup table
+        public static void LookupOidByValue_Method_UnixExceptOSXAndAndroid()
         {
             // This needs to be an OID not in the static lookup table.  The purpose is to verify the
             // NativeOidToFriendlyName fallback for Unix.  For Windows this is accomplished by
             // using FromOidValue with an OidGroup other than OidGroup.All.
-
-            Oid oid;
-
-            try
-            {
-                oid = Oid.FromOidValue(ObsoleteSmime3desWrap_Oid, OidGroup.All);
-            }
-            catch (CryptographicException)
-            {
-                bool isMac = OperatingSystem.IsMacOS();
-
-                Assert.True(isMac, "Exception is only raised on macOS");
-
-                if (isMac)
-                {
-                    return;
-                }
-                else
-                {
-                    throw;
-                }
-            }
+            Oid oid = Oid.FromOidValue(ObsoleteSmime3desWrap_Oid, OidGroup.All);
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);
             Assert.Equal(ObsoleteSmime3desWrap_Name, oid.FriendlyName);
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes to search Oid in the lookup table
-        public static void LookupOidByFriendlyName_Method_UnixOnly()
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~(TestPlatforms.OSX | TestPlatforms.Android))]  // Uses P/Invokes to search Oid in the lookup table
+        public static void LookupOidByFriendlyName_Method_UnixExceptOSXAndAndroid()
         {
             // This needs to be a name not in the static lookup table.  The purpose is to verify the
             // NativeFriendlyNameToOid fallback for Unix.  For Windows this is accomplished by
             // using FromOidValue with an OidGroup other than OidGroup.All.
-            Oid oid;
-
-            try
-            {
-                oid = Oid.FromFriendlyName(ObsoleteSmime3desWrap_Name, OidGroup.All);
-            }
-            catch (CryptographicException)
-            {
-                bool isMac = OperatingSystem.IsMacOS();
-
-                Assert.True(isMac, "Exception is only raised on macOS");
-
-                if (isMac)
-                {
-                    return;
-                }
-                else
-                {
-                    throw;
-                }
-            }
+            Oid oid = Oid.FromFriendlyName(ObsoleteSmime3desWrap_Name, OidGroup.All);
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);
             Assert.Equal(ObsoleteSmime3desWrap_Name, oid.FriendlyName);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="PemEncodingFindTests.cs" />
     <Compile Include="PemEncodingTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs" Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs" Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs" Link="Common\System\Memory\PointerMemoryManager.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This functionality isn't exposed in Android platform APIs - use the managed formatting that OSX is already using.

This makes the `System.Security.Crptography.Encoding` tests pass using AndroidCrypto.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs