### PR TITLE
Fix race condition in ReleaseOnDetach test

### DIFF
--- a/src/tests/profiler/native/profiler.def
+++ b/src/tests/profiler/native/profiler.def
@@ -3,6 +3,6 @@ LIBRARY     Profiler.dll
 EXPORTS
             DllGetClassObject       PRIVATE
             DllCanUnloadNow         PRIVATE
-            PassBoolToProfiler      PRIVATE
+            PassCallbackToProfiler  PRIVATE
             DoPInvoke               PRIVATE
 

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <chrono>
+#include <thread>
 
 using std::string;
 using std::ifstream;
@@ -50,6 +52,17 @@ ReleaseOnDetach::~ReleaseOnDetach()
     }
 
     fflush(stdout);
+
+
+    for (int i = 0; i < 50000; ++i)
+    {
+        if  (_doneFlag != NULL)
+        {
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 
     if (_doneFlag != NULL)
     {
@@ -113,7 +126,7 @@ HRESULT ReleaseOnDetach::ProfilerAttachComplete()
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE ReleaseOnDetach::ProfilerDetachSucceeded()
+HRESULT ReleaseOnDetach::ProfilerDetachSucceeded()
 {
     SHUTDOWNGUARD();
 
@@ -122,7 +135,13 @@ HRESULT STDMETHODCALLTYPE ReleaseOnDetach::ProfilerDetachSucceeded()
     return S_OK;
 }
 
-extern "C" EXPORT void STDMETHODCALLTYPE PassBoolToProfiler(void *boolPtr)
+void ReleaseOnDetach::SetBoolPtr(bool *done)
 {
-    ReleaseOnDetach::Instance->SetBoolPtr(boolPtr);
+    assert(done != NULL);
+    _doneFlag = reinterpret_cast<bool *>(done);
+}
+
+extern "C" EXPORT void STDMETHODCALLTYPE PassBoolToProfiler(bool *done)
+{
+    ReleaseOnDetach::Instance->SetBoolPtr(done);
 }

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
@@ -3,24 +3,7 @@
 
 #include "releaseondetach.h"
 
-#ifdef WIN32
-#include <Windows.h>
-#else // WIN32
-#include <dlfcn.h>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <chrono>
 #include <thread>
-
-using std::string;
-using std::ifstream;
-using std::getline;
-
-#ifdef __APPLE__
-#include <mach-o/dyld.h>
-#endif // __APPLE__
-#endif // WIN32
 
 using std::thread;
 

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.h
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.h
@@ -5,7 +5,6 @@
 
 #include "../profiler.h"
 
-#include <string>
 #include <atomic>
 
 typedef void (*ProfilerCallback) (void);

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.h
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <atomic>
 
-typedef HRESULT (*GetDispenserFunc) (const CLSID &pClsid, const IID &pIid, void **ppv);
+typedef void (*ProfilerCallback) (void);
 
 // This test class is very small and doesn't do much. A repeated problem we had was that 
 // if an ICorProfilerCallback* interface was added the developer would forget to add
@@ -33,7 +33,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE ProfilerAttachComplete();
     virtual HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded();
 
-    void SetBoolPtr(bool *done);
+    void SetCallback(ProfilerCallback callback);
 
 private:
 
@@ -42,5 +42,6 @@ private:
     IMetaDataDispenserEx* _dispenser;
     std::atomic<int> _failures;
     bool _detachSucceeded;
-    std::atomic<bool *> _doneFlag;
+    ProfilerCallback _callback;
+    ManualEvent _callbackSet;
 };

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.h
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.h
@@ -6,6 +6,7 @@
 #include "../profiler.h"
 
 #include <string>
+#include <atomic>
 
 typedef HRESULT (*GetDispenserFunc) (const CLSID &pClsid, const IID &pIid, void **ppv);
 
@@ -32,11 +33,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE ProfilerAttachComplete();
     virtual HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded();
 
-    void SetBoolPtr(void *ptr)
-    {
-        assert(ptr != NULL);
-        _doneFlag = reinterpret_cast<bool *>(ptr);
-    }
+    void SetBoolPtr(bool *done);
 
 private:
 
@@ -45,5 +42,5 @@ private:
     IMetaDataDispenserEx* _dispenser;
     std::atomic<int> _failures;
     bool _detachSucceeded;
-    volatile bool *_doneFlag;
+    std::atomic<bool *> _doneFlag;
 };

--- a/src/tests/profiler/unittest/releaseondetach.cs
+++ b/src/tests/profiler/unittest/releaseondetach.cs
@@ -46,7 +46,7 @@ namespace Profiler.Tests
             PassCallbackToProfiler(() => _profilerDone.Set());
             if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(5)))
             {
-                Console.WriteLine("Profiler did net set the callback, test will fail.");
+                Console.WriteLine("Profiler did not set the callback, test will fail.");
             }
 
             return 100;

--- a/src/tests/profiler/unittest/releaseondetach.cs
+++ b/src/tests/profiler/unittest/releaseondetach.cs
@@ -44,7 +44,10 @@ namespace Profiler.Tests
             ProfilerControlHelpers.AttachProfilerToSelf(ReleaseOnShutdownGuid, profilerPath);
 
             PassCallbackToProfiler(() => _profilerDone.Set());
-            _profilerDone.WaitOne();
+            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(5)))
+            {
+                Console.WriteLine("Profiler did net set the callback, test will fail.");
+            }
 
             return 100;
         }


### PR DESCRIPTION
Fixes #47098

There was a race condition in the ReleaseOnDetachTest. The call from the managed testcase to request a profiler attach to itself will block until the profiler succeeds in attaching, then the profiler requests a detach instantly. The vast majority of the time it takes a bit for the detach to actually happen, but sometimes the detach could happen before the call to SetBoolPtr happens. Then SetBoolPtr would call in to the profiler after detach and potentially AV.

The fix here is to add synchronization by polling for _doneFlag.