### PR TITLE
Upgrade minimum required SDK to 6.0 Preview 1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100-preview.1.21103.13",
     "allowPrerelease": true,
     "rollForward": "major"
   },


### PR DESCRIPTION
**Part of March's batched infrastructure rollout: https://github.com/dotnet/runtime/issues/48168**

We want to update the minimum required version of the SDK to 6.0 Preview 1 which is already publicly available. The target version of the SDK is already a latter one (Preview 2 build) and the goal is to again consolidate these when Preview 2 shipped.