### PR TITLE
Rework request retry logic to be based on retry count limit

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -91,6 +91,14 @@ namespace System.Net.Test.Common
 
             if (Text.Encoding.ASCII.GetString(_prefix).Contains("HTTP/1.1"))
             {
+                // Tests that use HttpAgnosticLoopbackServer will attempt to send an HTTP/1.1 request to an HTTP/2 server.
+                // This is invalid and we should terminate the connection.
+                // However, if we simply terminate the connection without sending anything, then this could be interpreted
+                // as a server failure that should be retried by SocketsHttpHandler.
+                // Since those tests are not set up to handle multiple retries, we instead just send back an invalid response here
+                // so that SocketsHttpHandler will not induce retry.
+                // The contents of what we send don't really matter, as long as it is interpreted by SocketsHttpHandler as an invalid response.
+                await _connectionStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/2.0 400 Bad Request\r\n\r\n"));
                 throw new Exception("HTTP 1.1 request received.");
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -94,17 +94,12 @@ namespace System.Net.Test.Common
                 // Tests that use HttpAgnosticLoopbackServer will attempt to send an HTTP/1.1 request to an HTTP/2 server.
                 // This is invalid and we should terminate the connection.
                 // However, if we simply terminate the connection without sending anything, then this could be interpreted
-                // as a server failure that should be retried by SocketsHttpHandler.
+                // as a server disconnect that should be retried by SocketsHttpHandler.
                 // Since those tests are not set up to handle multiple retries, we instead just send back an invalid response here
                 // so that SocketsHttpHandler will not induce retry.
                 // The contents of what we send don't really matter, as long as it is interpreted by SocketsHttpHandler as an invalid response.
                 await _connectionStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/2.0 400 Bad Request\r\n\r\n"));
                 _connectionSocket.Shutdown(SocketShutdown.Send);
-
-                // Wait for client close to avoid RST which could lead to retry.
-                byte[] buffer = new byte[1024];
-                while ((await _connectionStream.ReadAsync(buffer)) != 0) { }
-                throw new Exception("HTTP 1.1 request received.");
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -99,6 +99,11 @@ namespace System.Net.Test.Common
                 // so that SocketsHttpHandler will not induce retry.
                 // The contents of what we send don't really matter, as long as it is interpreted by SocketsHttpHandler as an invalid response.
                 await _connectionStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/2.0 400 Bad Request\r\n\r\n"));
+                _connectionSocket.Shutdown(SocketShutdown.Send);
+
+                // Wait for client close to avoid RST which could lead to retry.
+                byte[] buffer = new byte[1024];
+                while ((await _connectionStream.ReadAsync(buffer)) != 0) { }
                 throw new Exception("HTTP 1.1 request received.");
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpAgnosticLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpAgnosticLoopbackServer.cs
@@ -5,13 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Xunit;
 
 namespace System.Net.Test.Common
 {
@@ -105,43 +101,18 @@ namespace System.Net.Test.Common
                     }
                 }
 
-                if (_options.ClearTextVersion is null)
+                if (_options.ClearTextVersion == HttpVersion.Version11)
                 {
-                    throw new Exception($"HTTP server does not accept clear text connections, either set '{nameof(HttpAgnosticOptions.UseSsl)}' or set up '{nameof(HttpAgnosticOptions.ClearTextVersion)}' in server options.");
+                    return connection = await Http11LoopbackServerFactory.Singleton.CreateConnectionAsync(socket, stream, options).ConfigureAwait(false);
                 }
-
-                var buffer = new byte[24];
-                var position = 0;
-                while (position < buffer.Length)
+                else if (_options.ClearTextVersion == HttpVersion.Version20)
                 {
-                    var readBytes = await stream.ReadAsync(buffer, position, buffer.Length - position).ConfigureAwait(false);
-                    if (readBytes == 0)
-                    {
-                        break;
-                    }
-                    position += readBytes;
+                    return connection = await Http2LoopbackServerFactory.Singleton.CreateConnectionAsync(socket, stream, options).ConfigureAwait(false);
                 }
-                
-                var memory = new Memory<byte>(buffer, 0, position);
-                stream = new ReturnBufferStream(stream, memory);
-
-                var prefix = Text.Encoding.ASCII.GetString(memory.Span);
-                if (prefix == Http2LoopbackConnection.Http2Prefix)
+                else 
                 {
-                    if (_options.ClearTextVersion == HttpVersion.Version20 || _options.ClearTextVersion == HttpVersion.Unknown)
-                    {
-                        return connection = await Http2LoopbackServerFactory.Singleton.CreateConnectionAsync(socket, stream, options).ConfigureAwait(false);
-                    }
+                    throw new Exception($"Invalid ClearTextVersion={_options.ClearTextVersion} specified");
                 }
-                else
-                {
-                    if (_options.ClearTextVersion == HttpVersion.Version11 || _options.ClearTextVersion == HttpVersion.Unknown)
-                    {
-                        return connection = await Http11LoopbackServerFactory.Singleton.CreateConnectionAsync(socket, stream, options).ConfigureAwait(false);
-                    }
-                }
-
-                throw new Exception($"HTTP/{_options.ClearTextVersion} server cannot establish connection due to unexpected data: '{prefix}'");
             }
             catch
             {            
@@ -194,8 +165,7 @@ namespace System.Net.Test.Common
 
     public class HttpAgnosticOptions : GenericLoopbackOptions
     {
-        // Default null will raise an exception for any clear text protocol version
-        // Use HttpVersion.Unknown to use protocol version detection for clear text.
+        // Must specify either HttpVersion.Version11 or HttpVersion.Version20.
         public Version ClearTextVersion { get; set; }
         public List<SslApplicationProtocol> SslApplicationProtocols { get; set; }
     }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -161,11 +161,6 @@ namespace System.Net.Http.Functional.Tests
         protected override bool SupportsIdna => !PlatformDetection.IsWindows7;
     }
 
-    public sealed class PlatformHandler_HttpRetryProtocolTests : HttpRetryProtocolTests
-    {
-        public PlatformHandler_HttpRetryProtocolTests(ITestOutputHelper output) : base(output) { }
-    }
-
     public sealed class PlatformHandlerTest_Cookies : HttpClientHandlerTest_Cookies
     {
         public PlatformHandlerTest_Cookies(ITestOutputHelper output) : base(output) { }
@@ -338,13 +333,6 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_IdnaProtocol_Http2_Tests(ITestOutputHelper output) : base(output) { }
         // WinHttp on Win7 does not support IDNA
         protected override bool SupportsIdna => !PlatformDetection.IsWindows7;
-    }
-
-    public sealed class PlatformHandler_HttpRetryProtocol_Http2_Tests : HttpRetryProtocolTests
-    {
-        protected override Version UseVersion => HttpVersion20.Value;
-
-        public PlatformHandler_HttpRetryProtocol_Http2_Tests(ITestOutputHelper output) : base(output) { }
     }
 
     public sealed class PlatformHandlerTest_Cookies_Http11_Http2 : HttpClientHandlerTest_Cookies_Http11

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -109,8 +109,6 @@
              Link="Common\System\Net\Http\HttpClient.SelectedSitesTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientEKUTest.cs"
              Link="Common\System\Net\Http\HttpClientEKUTest.cs" />
-    <Compile Include="$(CommonTestPath)System\Net\Http\HttpRetryProtocolTests.cs"
-             Link="Common\System\Net\Http\HttpRetryProtocolTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\IdnaProtocolTests.cs"
              Link="Common\System\Net\Http\IdnaProtocolTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackProxyServer.cs"

--- a/src/libraries/System.Net.Http/src/System/Net/Http/RequestRetryType.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/RequestRetryType.cs
@@ -14,22 +14,24 @@ namespace System.Net.Http
         NoRetry,
 
         /// <summary>
+        /// The request failed due to e.g. server shutting down (GOAWAY) and should be retried on a new connection.
+        /// </summary>
+        RetryOnConnectionFailure,
+
+        /// <summary>
         /// The request failed on the current HTTP version, and the server requested it be retried on a lower version.
         /// </summary>
         RetryOnLowerHttpVersion,
-
-        /// <summary>
-        /// The request failed due to e.g. server shutting down (GOAWAY) and should be retried on a new connection.
-        /// </summary>
-        RetryOnSameOrNextProxy,
 
         /// <summary>
         /// The proxy failed, so the request should be retried on the next proxy.
         /// </summary>
         RetryOnNextProxy,
 
+        /// <summary>
         /// The HTTP/2 connection reached the maximum number of streams and
         /// another HTTP/2 connection must be created or found to serve the request.
-        RetryOnNextConnection
+        /// </summary>
+        RetryOnStreamLimitReached
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1271,16 +1271,15 @@ namespace System.Net.Http
         {
             Debug.Assert(Monitor.IsEntered(SyncObject));
 
-            // Throw a retryable exception that will allow this unprocessed request to be processed on a new connection.
-            // In rare cases, such as receiving GOAWAY immediately after connection establishment, we will not
-            // actually retry the request, so we must give a useful exception here for these cases.
-
-            Exception innerException;
             if (_abortException != null)
             {
-                innerException = _abortException;
+                // We had an IO failure on the connection. Don't retry in this case.
+                throw new HttpRequestException(SR.net_http_client_execution_error, _abortException);
             }
-            else if (_lastStreamId != -1)
+
+            // Connection is being gracefully shutdown. Allow the request to be retried.
+            Exception innerException;
+            if (_lastStreamId != -1)
             {
                 // We must have received a GOAWAY.
                 innerException = new IOException(SR.net_http_server_shutdown);
@@ -1288,7 +1287,6 @@ namespace System.Net.Http
             else
             {
                 // We must either be disposed or out of stream IDs.
-                // Note that in this case, the exception should never be visible to the user (it should be retried).
                 Debug.Assert(_disposed || _nextStream == MaxStreamId);
 
                 innerException = new ObjectDisposedException(nameof(Http2Connection));

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1307,7 +1307,7 @@ namespace System.Net.Http
                 {
                     if (_pool.EnableMultipleHttp2Connections)
                     {
-                        throw new HttpRequestException(null, null, RequestRetryType.RetryOnNextConnection);
+                        throw new HttpRequestException(null, null, RequestRetryType.RetryOnStreamLimitReached);
                     }
 
                     if (HttpTelemetry.Log.IsEnabled())
@@ -2014,7 +2014,7 @@ namespace System.Net.Http
 
         [DoesNotReturn]
         private static void ThrowRetry(string message, Exception innerException) =>
-            throw new HttpRequestException(message, innerException, allowRetry: RequestRetryType.RetryOnSameOrNextProxy);
+            throw new HttpRequestException(message, innerException, allowRetry: RequestRetryType.RetryOnConnectionFailure);
 
         private static Exception GetRequestAbortedException(Exception? innerException = null) =>
             new IOException(SR.net_http_request_aborted, innerException);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -209,7 +209,7 @@ namespace System.Net.Http
 
                 if (quicStream == null)
                 {
-                    throw new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnSameOrNextProxy);
+                    throw new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure);
                 }
 
                 // 0-byte write to force QUIC to allocate a stream ID.
@@ -224,7 +224,7 @@ namespace System.Net.Http
 
                 if (goAway)
                 {
-                    throw new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnSameOrNextProxy);
+                    throw new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure);
                 }
 
                 Task<HttpResponseMessage> responseTask = requestStream.SendAsync(cancellationToken);
@@ -238,7 +238,7 @@ namespace System.Net.Http
             {
                 // This will happen if we aborted _connection somewhere.
                 Abort(ex);
-                throw new HttpRequestException(SR.Format(SR.net_http_http3_connection_error, ex.ErrorCode), ex, RequestRetryType.RetryOnSameOrNextProxy);
+                throw new HttpRequestException(SR.Format(SR.net_http_http3_connection_error, ex.ErrorCode), ex, RequestRetryType.RetryOnConnectionFailure);
             }
             finally
             {
@@ -281,7 +281,7 @@ namespace System.Net.Http
 
             while (_waitingRequests.TryDequeue(out TaskCompletionSourceWithCancellation<bool>? tcs))
             {
-                tcs.TrySetException(new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnSameOrNextProxy));
+                tcs.TrySetException(new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure));
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -269,7 +269,7 @@ namespace System.Net.Http
                 else
                 {
                     Debug.Assert(_goawayCancellationToken.IsCancellationRequested == true);
-                    throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnSameOrNextProxy);
+                    throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnConnectionFailure);
                 }
             }
             catch (Http3ConnectionException ex)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -63,6 +63,7 @@ namespace System.Net.Http
 
         private bool _inUse;
         private bool _canRetry;
+        private bool _startedSendingRequestBody;
         private bool _connectionClose; // Connection: close was seen on last response
 
         private const int Status_Disposed = 1;
@@ -385,8 +386,8 @@ namespace System.Net.Http
             _currentRequest = request;
             HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
 
-            Debug.Assert(!_canRetry);
-            _canRetry = true;
+            _canRetry = false;
+            _startedSendingRequestBody = false;
 
             // Send the request.
             if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");
@@ -561,22 +562,28 @@ namespace System.Net.Http
 
                     if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
 
-                    if (bytesRead == 0)
-                    {
-                        throw new IOException(SR.net_http_invalid_response_premature_eof);
-                    }
-
                     _readOffset = 0;
                     _readLength = bytesRead;
                 }
                 else
                 {
-                    await FillAsync(async).ConfigureAwait(false);
+                    // No read-ahead, so issue a read ourselves. We will check below for EOF.
+                    await InitialFillAsync(async).ConfigureAwait(false);
                 }
 
-                // We have received data from the server, so the request is no longer retryable.
-                // (We may have already set this above if we sent request content.)
-                _canRetry = false;
+                if (_readLength == 0)
+                {
+                    // The server shutdown the connection on their end, likely because of an idle timeout.
+                    // If we haven't started sending the request body yet (or there is no request body),
+                    // then we allow the request to be retried.
+                    if (!_startedSendingRequestBody)
+                    {
+                        _canRetry = true;
+                    }
+
+                    throw new IOException(SR.net_http_invalid_response_premature_eof);
+                }
+
 
                 // Parse the response status line.
                 var response = new HttpResponseMessage() { RequestMessage = request, Content = new HttpConnectionResponseContent() };
@@ -866,8 +873,8 @@ namespace System.Net.Http
 
         private async ValueTask SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, bool async, CancellationToken cancellationToken)
         {
-            // Now that we're sending content, prohibit retries on this connection.
-            _canRetry = false;
+            // Now that we're sending content, prohibit retries of this request by setting this flag.
+            _startedSendingRequestBody = true;
 
             Debug.Assert(stream.BytesWritten == 0);
             if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestContentStart();
@@ -1551,6 +1558,19 @@ namespace System.Net.Http
             ValueTask fillTask = FillAsync(async: false);
             Debug.Assert(fillTask.IsCompleted);
             fillTask.GetAwaiter().GetResult();
+        }
+
+        // Does not throw on EOF. Also assumes there is no buffered data.
+        private async ValueTask InitialFillAsync(bool async)
+        {
+            Debug.Assert(_readAheadTask == null);
+
+            _readOffset = 0;
+            _readLength = async ?
+                await _stream.ReadAsync(_readBuffer).ConfigureAwait(false) :
+                _stream.Read(_readBuffer);
+
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {_readLength} bytes.");
         }
 
         // Throws IOException on EOF.  This is only called when we expect more data.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -569,10 +569,13 @@ namespace System.Net.Http
                     _readOffset = 0;
                     _readLength = bytesRead;
                 }
+                else
+                {
+                    await FillAsync(async).ConfigureAwait(false);
+                }
 
-                // The request is no longer retryable; either we received data from the _readAheadTask,
-                // or there was no _readAheadTask because this is the first request on the connection.
-                // (We may have already set this as well if we sent request content.)
+                // We have received data from the server, so the request is no longer retryable.
+                // (We may have already set this above if we sent request content.)
                 _canRetry = false;
 
                 // Parse the response status line.
@@ -821,7 +824,7 @@ namespace System.Net.Http
             {
                 // For consistency with other handlers we wrap the exception in an HttpRequestException.
                 // If the request is retryable, indicate that on the exception.
-                mappedException = new HttpRequestException(SR.net_http_client_execution_error, ioe, _canRetry ? RequestRetryType.RetryOnSameOrNextProxy : RequestRetryType.NoRetry);
+                mappedException = new HttpRequestException(SR.net_http_client_execution_error, ioe, _canRetry ? RequestRetryType.RetryOnConnectionFailure : RequestRetryType.NoRetry);
                 return true;
             }
             // Otherwise, just allow the original exception to propagate.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -746,16 +746,11 @@ namespace System.Net.Http
             }
         }
 
-<<<<<<< HEAD
         // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        private async ValueTask<(HttpConnectionBase connection, bool isNewConnection)>
-            GetHttp3ConnectionAsync(HttpRequestMessage request, HttpAuthority authority, CancellationToken cancellationToken)
-=======
         private async ValueTask<HttpConnectionBase> GetHttp3ConnectionAsync(HttpRequestMessage request, HttpAuthority authority, CancellationToken cancellationToken)
->>>>>>> 6b367ba633a... rework request retry logic to be based off a fixed retry limit (MaxConnectionFailureRetries) instead of isNewConnection logic
         {
             Debug.Assert(_kind == HttpConnectionKind.Https);
             Debug.Assert(_http3Enabled == true);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -52,6 +52,9 @@ namespace System.Net.Http
         private CancellationTokenSource? _altSvcBlocklistTimerCancellation;
         private volatile bool _altSvcEnabled = true;
 
+        /// <summary>The maximum number of times to retry a request after a failure on an established connection.</summary>
+        private const int MaxConnectionFailureRetries = 5;
+
         /// <summary>
         /// If <see cref="_altSvcBlocklist"/> exceeds this size, Alt-Svc will be disabled entirely for <see cref="AltSvcBlocklistTimeoutInMilliseconds"/> milliseconds.
         /// This is to prevent a failing server from bloating the dictionary beyond a reasonable value.
@@ -358,20 +361,19 @@ namespace System.Net.Http
         /// <summary>Object used to synchronize access to state in the pool.</summary>
         private object SyncObj => _idleConnections;
 
-        private ValueTask<(HttpConnectionBase connection, bool isNewConnection)>
-            GetConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        private ValueTask<HttpConnectionBase> GetConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             // Do not even attempt at getting/creating a connection if it's already obvious we cannot provided the one requested.
             if (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
             {
                 if (request.Version.Major == 3 && !_http3Enabled)
                 {
-                    return ValueTask.FromException<(HttpConnectionBase connection, bool isNewConnection)>(
+                    return ValueTask.FromException<HttpConnectionBase>(
                         new HttpRequestException(SR.Format(SR.net_http_requested_version_not_enabled, request.Version, request.VersionPolicy, 3)));
                 }
                 if (request.Version.Major == 2 && !_http2Enabled)
                 {
-                    return ValueTask.FromException<(HttpConnectionBase connection, bool isNewConnection)>(
+                    return ValueTask.FromException<HttpConnectionBase>(
                         new HttpRequestException(SR.Format(SR.net_http_requested_version_not_enabled, request.Version, request.VersionPolicy, 2)));
                 }
             }
@@ -392,7 +394,7 @@ namespace System.Net.Http
                     {
                         if (IsAltSvcBlocked(authority))
                         {
-                            return ValueTask.FromException<(HttpConnectionBase connection, bool isNewConnection)>(
+                            return ValueTask.FromException<HttpConnectionBase>(
                                 new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, 3)));
                         }
 
@@ -404,7 +406,7 @@ namespace System.Net.Http
             // If we got here, we cannot provide HTTP/3 connection. Do not continue if downgrade is not allowed.
             if (request.Version.Major >= 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
             {
-                return ValueTask.FromException<(HttpConnectionBase connection, bool isNewConnection)>(
+                return ValueTask.FromException<HttpConnectionBase>(
                     new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, 3)));
             }
 
@@ -417,7 +419,7 @@ namespace System.Net.Http
             // If we got here, we cannot provide HTTP/2 connection. Do not continue if downgrade is not allowed.
             if (request.Version.Major >= 2 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
             {
-                return ValueTask.FromException<(HttpConnectionBase connection, bool isNewConnection)>(
+                return ValueTask.FromException<HttpConnectionBase>(
                     new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, 2)));
             }
 
@@ -522,21 +524,19 @@ namespace System.Net.Http
             }
         }
 
-        private async ValueTask<(HttpConnectionBase connection, bool isNewConnection)>
-            GetHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        private async ValueTask<HttpConnectionBase> GetHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             HttpConnection? connection = await GetOrReserveHttp11ConnectionAsync(async, cancellationToken).ConfigureAwait(false);
-            if (connection != null)
+            if (connection is not null)
             {
-                return (connection, false);
+                return connection;
             }
 
-            if (NetEventSource.Log.IsEnabled()) Trace("Creating new connection for pool.");
+            if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/1.1 connection for pool.");
 
             try
             {
-                connection = await CreateHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
-                return (connection, true);
+                return await CreateHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -545,8 +545,7 @@ namespace System.Net.Http
             }
         }
 
-        private async ValueTask<(HttpConnectionBase connection, bool isNewConnection)>
-            GetHttp2ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        private async ValueTask<HttpConnectionBase> GetHttp2ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(_kind == HttpConnectionKind.Https || _kind == HttpConnectionKind.SslProxyTunnel || _kind == HttpConnectionKind.Http);
 
@@ -558,7 +557,7 @@ namespace System.Net.Http
                 // Connection exists and it is still good to use.
                 if (NetEventSource.Log.IsEnabled()) Trace("Using existing HTTP2 connection.");
                 _usedSinceLastCleanup = true;
-                return (http2Connection, false);
+                return http2Connection;
             }
 
             // Ensure that the connection creation semaphore is created
@@ -586,7 +585,7 @@ namespace System.Net.Http
                 http2Connection = GetExistingHttp2Connection();
                 if (http2Connection != null)
                 {
-                    return (http2Connection, false);
+                    return http2Connection;
                 }
 
                 // Recheck if HTTP2 has been disabled by a previous attempt.
@@ -613,7 +612,7 @@ namespace System.Net.Http
                             Trace("New unencrypted HTTP2 connection established.");
                         }
 
-                        return (http2Connection, true);
+                        return http2Connection;
                     }
 
                     Debug.Assert(sslStream != null);
@@ -635,7 +634,7 @@ namespace System.Net.Http
                             Trace("New HTTP2 connection established.");
                         }
 
-                        return (http2Connection, true);
+                        return http2Connection;
                     }
                 }
             }
@@ -682,8 +681,8 @@ namespace System.Net.Http
 
                 if (canUse)
                 {
-                    return (await ConstructHttp11ConnectionAsync(async, socket, stream!, transportContext, request, cancellationToken).ConfigureAwait(false), true);
-                }
+                    return await ConstructHttp11ConnectionAsync(async, socket, stream!, transportContext, request, cancellationToken).ConfigureAwait(false);
+               }
                 else
                 {
                     if (NetEventSource.Log.IsEnabled())
@@ -747,12 +746,16 @@ namespace System.Net.Http
             }
         }
 
+<<<<<<< HEAD
         // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
         private async ValueTask<(HttpConnectionBase connection, bool isNewConnection)>
             GetHttp3ConnectionAsync(HttpRequestMessage request, HttpAuthority authority, CancellationToken cancellationToken)
+=======
+        private async ValueTask<HttpConnectionBase> GetHttp3ConnectionAsync(HttpRequestMessage request, HttpAuthority authority, CancellationToken cancellationToken)
+>>>>>>> 6b367ba633a... rework request retry logic to be based off a fixed retry limit (MaxConnectionFailureRetries) instead of isNewConnection logic
         {
             Debug.Assert(_kind == HttpConnectionKind.Https);
             Debug.Assert(_http3Enabled == true);
@@ -774,7 +777,7 @@ namespace System.Net.Http
                     // Connection exists and it is still good to use.
                     if (NetEventSource.Log.IsEnabled()) Trace("Using existing HTTP3 connection.");
                     _usedSinceLastCleanup = true;
-                    return (http3Connection, false);
+                    return http3Connection;
                 }
             }
 
@@ -802,7 +805,7 @@ namespace System.Net.Http
                         Trace("Using existing HTTP3 connection.");
                     }
 
-                    return (_http3Connection, false);
+                    return _http3Connection;
                 }
 
                 if (NetEventSource.Log.IsEnabled())
@@ -839,7 +842,7 @@ namespace System.Net.Http
                     Trace("New HTTP3 connection established.");
                 }
 
-                return (http3Connection, true);
+                return http3Connection;
             }
             finally
             {
@@ -849,11 +852,13 @@ namespace System.Net.Http
 
         public async ValueTask<HttpResponseMessage> SendWithRetryAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
+            int retryCount = 0;
+
             while (true)
             {
-                // Loop on connection failures and retry if possible.
+                // Loop on connection failures (or other problems like version downgrade) and retry if possible.
 
-                (HttpConnectionBase connection, bool isNewConnection) = await GetConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
+                HttpConnectionBase connection = await GetConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
 
                 HttpResponseMessage response;
 
@@ -878,26 +883,19 @@ namespace System.Net.Http
                         response = await connection!.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
                     }
                 }
-                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnLowerHttpVersion)
+                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnConnectionFailure)
                 {
-                    // Throw since fallback is not allowed by the version policy.
-                    if (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
+                    retryCount++;
+                    if (retryCount == MaxConnectionFailureRetries)
                     {
-                        throw new HttpRequestException(SR.Format(SR.net_http_requested_version_server_refused, request.Version, request.VersionPolicy), e);
+                        if (NetEventSource.Log.IsEnabled())
+                        {
+                            Trace($"MaxConnectionFailureRetries limit hit. Retryable request will not be retried. Exception: {e}");
+                        }
+
+                        throw;
                     }
 
-                    if (NetEventSource.Log.IsEnabled())
-                    {
-                        Trace($"Retrying request after exception on existing connection: {e}");
-                    }
-
-                    // Eat exception and try again on a lower protocol version.
-                    Debug.Assert(connection is HttpConnection == false, $"{nameof(RequestRetryType.RetryOnLowerHttpVersion)} should not be thrown by HTTP/1 connections.");
-                    request.Version = HttpVersion.Version11;
-                    continue;
-                }
-                catch (HttpRequestException e) when (!isNewConnection && e.AllowRetry == RequestRetryType.RetryOnSameOrNextProxy)
-                {
                     if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Retrying request after exception on existing connection: {e}");
@@ -906,7 +904,25 @@ namespace System.Net.Http
                     // Eat exception and try again.
                     continue;
                 }
-                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnNextConnection)
+                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnLowerHttpVersion)
+                {
+                    // Throw if fallback is not allowed by the version policy.
+                    if (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
+                    {
+                        throw new HttpRequestException(SR.Format(SR.net_http_requested_version_server_refused, request.Version, request.VersionPolicy), e);
+                    }
+
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        Trace($"Retrying request because server requested version fallback: {e}");
+                    }
+
+                    // Eat exception and try again on a lower protocol version.
+                    Debug.Assert(connection is HttpConnection == false, $"{nameof(RequestRetryType.RetryOnLowerHttpVersion)} should not be thrown by HTTP/1 connections.");
+                    request.Version = HttpVersion.Version11;
+                    continue;
+                }
+                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnStreamLimitReached)
                 {
                     if (NetEventSource.Log.IsEnabled())
                     {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -254,9 +254,11 @@ namespace System.Net.Http.Functional.Tests
                 Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
 
                 // Send invalid initial SETTINGS value
-                await server.EstablishConnectionAsync(new SettingsEntry { SettingId = settingId, Value = value });
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = settingId, Value = value });
 
                 await AssertProtocolErrorAsync(sendTask, expectedError);
+
+                connection.Dispose();
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.RequestRetry.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.RequestRetry.cs
@@ -84,7 +84,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_RetryUntilLimitExceeded_ThrowsHttpRequestException()
         {
-            const int MaxRetries = 5;
+            const int MaxRetries = 3;
 
             await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
@@ -97,7 +97,8 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                for (int i = 0; i < MaxRetries; i++)
+                // Note, total attempts will be MaxRetries + 1 for the original attempt.
+                for (int i = 0; i <= MaxRetries; i++)
                 {
                     // Establish connection and then close it before sending a response
                     await server.AcceptConnectionAsync(async connection =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1006,9 +1006,9 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-    public sealed class SocketsHttpHandler_HttpRetryProtocolTests : HttpRetryProtocolTests
+    public sealed class SocketsHttpHandlerTest_RequestRetry : HttpClientHandlerTest_RequestRetry
     {
-        public SocketsHttpHandler_HttpRetryProtocolTests(ITestOutputHelper output) : base(output) { }
+        public SocketsHttpHandlerTest_RequestRetry(ITestOutputHelper output) : base(output) { }
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SyncHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SyncHttpHandlerTest.cs
@@ -61,9 +61,9 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-    public sealed class SyncHttpHandler_HttpRetryProtocolTests : HttpRetryProtocolTests
+    public sealed class SyncHttpHandlerTest_RequestRetry : HttpClientHandlerTest_RequestRetry
     {
-        public SyncHttpHandler_HttpRetryProtocolTests(ITestOutputHelper output) : base(output) { }
+        public SyncHttpHandlerTest_RequestRetry(ITestOutputHelper output) : base(output) { }
         protected override bool TestAsync => false;
     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="HttpClientHandlerTest.Http3.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.RemoteServer.cs"
              Link="Common\System\Net\Http\HttpClientHandlerTest.RemoteServer.cs" />
+    <Compile Include="HttpClientHandlerTest.RequestRetry.cs" />
     <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.ServerCertificates.cs"
              Link="Common\System\Net\Http\HttpClientHandlerTest.ServerCertificates.cs" />
@@ -136,8 +137,6 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
-    <Compile Include="$(CommonTestPath)System\Net\Http\HttpRetryProtocolTests.cs"
-             Link="Common\System\Net\Http\HttpRetryProtocolTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\IdnaProtocolTests.cs"
              Link="Common\System\Net\Http\IdnaProtocolTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpProtocolTests.cs"

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1555,10 +1555,6 @@ namespace System.Net
                     try
                     {
                         socket.NoDelay = true;
-                        if (parameters.ReadWriteTimeout > 0) // default is 5 minutes, so this is generally going to be true
-                        {
-                            socket.SendTimeout = socket.ReceiveTimeout = parameters.ReadWriteTimeout;
-                        }
 
                         if (parameters.Async)
                         {
@@ -1573,6 +1569,11 @@ namespace System.Net
 
                             // Throw in case cancellation caused the socket to be disposed after the Connect completed
                             cancellationToken.ThrowIfCancellationRequested();
+                        }
+
+                        if (parameters.ReadWriteTimeout > 0) // default is 5 minutes, so this is generally going to be true
+                        {
+                            socket.SendTimeout = socket.ReceiveTimeout = parameters.ReadWriteTimeout;
                         }
                     }
                     catch

--- a/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
@@ -84,9 +84,12 @@ namespace System.Net
             }
             else if (exception is TaskCanceledException)
             {
+
+                // temp hack to try to diagnose what's going on in CI.
                 return new WebException(
                     SR.net_webstatus_Timeout,
-                    null,
+                    //null,
+                    exception,
                     WebExceptionStatus.Timeout,
                     null);
             }

--- a/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
@@ -84,12 +84,9 @@ namespace System.Net
             }
             else if (exception is TaskCanceledException)
             {
-
-                // temp hack to try to diagnose what's going on in CI.
                 return new WebException(
                     SR.net_webstatus_Timeout,
-                    //null,
-                    exception,
+                    null,
                     WebExceptionStatus.Timeout,
                     null);
             }

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1117,10 +1117,10 @@ namespace System.Net.Tests
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         await connection.ReadRequestHeaderAsync();
-                        if (!forceTimeoutDuringHeaders)
-                        {
-                            await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nHello Wor");
-                        }
+
+                        // Make sure to send at least one byte, or the request retry logic in SocketsHttpHandler
+                        // will consider this a retryable request, since we never received any response.
+                        await connection.WriteStringAsync(forceTimeoutDuringHeaders ? "H" : "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nHello Wor");
                         await tcs.Task;
                     });
                 }

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1066,6 +1066,7 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => { request.ReadWriteTimeout = -10; });
         }
 
+        [OuterLoop("Uses timeout")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -1085,7 +1086,7 @@ namespace System.Net.Tests
                 try
                 {
                     HttpWebRequest request = WebRequest.CreateHttp(uri);
-                    request.ReadWriteTimeout = 20;
+                    request.ReadWriteTimeout = 100;
                     Exception e = await Assert.ThrowsAnyAsync<Exception>(async () =>
                     {
                         using WebResponse response = await GetResponseAsync(request);

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1085,7 +1085,7 @@ namespace System.Net.Tests
                 try
                 {
                     HttpWebRequest request = WebRequest.CreateHttp(uri);
-                    request.ReadWriteTimeout = 10;
+                    request.ReadWriteTimeout = 20;
                     Exception e = await Assert.ThrowsAnyAsync<Exception>(async () =>
                     {
                         using WebResponse response = await GetResponseAsync(request);

--- a/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -234,12 +234,17 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ConditionalTheory(nameof(WebSocketsSupported))]
+        [ConditionalFact(nameof(WebSocketsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+<<<<<<< HEAD
         [InlineData("ws://")]
         [InlineData("wss://")]
         [SkipOnPlatform(TestPlatforms.Browser, "Credentials not supported on browser")]
         public async Task NonSecureConnect_ConnectThruProxy_CONNECTisUsed(string connectionType)
+=======
+        [PlatformSpecific(~TestPlatforms.Browser)] // Credentials not supported on browser
+        public async Task NonSecureConnect_ConnectThruProxy_CONNECTisUsed()
+>>>>>>> 4a979d820a8... fix bogus websocket test
         {
             if (PlatformDetection.IsWindows7)
             {
@@ -253,7 +258,7 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cws = new ClientWebSocket())
                 {
                     cws.Options.Proxy = new WebProxy(proxyUri);
-                    try { await cws.ConnectAsync(new Uri(connectionType + Guid.NewGuid().ToString("N")), default); } catch { }
+                    try { await cws.ConnectAsync(new Uri("ws://doesntmatter.invalid"), default); } catch { }
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {

--- a/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -262,7 +262,8 @@ namespace System.Net.WebSockets.Client.Tests
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
-                Assert.Contains("CONNECT", await connection.ReadLineAsync());
+                var lines = await connection.ReadRequestHeaderAsync();
+                Assert.Contains("CONNECT", lines[0]);
                 connectionAccepted = true;
 
                 // Send non-success error code so that SocketsHttpHandler won't retry.


### PR DESCRIPTION
We currently disallow request retries on connection failure when the failure occurs on a "new" connection (one that hasn't been used for previous requests). We do this mainly to ensure that the retry logic doesn't end up in an infinite loop -- as connections fail, sooner or later the request will be retried on a "new" connection, and we will break out of the retry loop.

This logic is suboptimal for a couple reasons:
(1) There's nothing particularly unique about the first request on a connection. Servers can die or choose to close connections at any time.
(2) We currently do a bad job of deciding which request is the first request for an HTTP2 connection. It is timing dependent. This means that in certain scenarios, when the server sends valid REFUSED_STREAM errors, we end up not retrying requests that should be retried.
(3) We can in theory end up retrying a request many, many times until we actually use a new connection and break out of the retry loop. This is particularly problematic for HTTP2, for several reasons: (a) a single connection can handle many requests, yet connection failure only causes one to stop retrying; (b) we treat REFUSED_STREAM errors as retryable in all cases except for the initial request, even though the connection is still valid, which means that we may never actually choose a new connection for the request; (c) we handle GOAWAY to determine which requests are allowed to be retried, but these same requests could just end up being subject to REFUSED_STREAM or GOAWAY on a different connection, etc.

This PR changes the request retry logic to be based on a fixed retry count limit. The limit is 5 retries; we could adjust this as appropriate or make it configurable if desired.

Note that failure to successfully establish a connection will still cause a request to fail immediately. Requests are only retryable when an established connection causes a failure.

Also:
- Add relevant tests
- Rename some of the RequestRetryType enum values for clarity
- Rename HttpRetryProtocolTests file/class to HttpClientHandlerTest.RequestRetry, and move from common code to System.Net.Http since none of these tests were actually running for WinHttpHandler
- Fix/simplify some test code around HttpAgnosticLoopbackServer that caused failures with these changes

 Fixes #44669 

UPDATE:

From exploring certain test failures that were caused by this PR, it's clear to me that we are too lenient about allowing retries in many cases. For example, we are retrying on IO timeouts in one of the HttpWebRequest tests, even though the user is explicitly setting this timeout and presumably wants to fail (not retry) when the timeout is exceeded.

I believe many of these weird cases of lenient retry policy were masked by the way the old retry logic worked, which was that it never allowed retry on the first request on a connection. This means most unit tests never induced retry, even in failure cases that would have caused retry if the request were not the first on the connection -- which is extremely common in practice, but not common in our tests, unfortunately.

So it's actually good that this new retry policy has exposed these issues -- they already existed but were largely hidden.

To address these issues, I am changing the retry logic to be more conservative. We no longer will retry on arbitrary IO errors. We will only retry in cases where we believe that the server is attempting to gracefully tear down a connection -- that is, receiving EOF before any other response data for HTTP/1.1, or receiving GOAWAY for HTTP2.

Please take a look and comment. @stephentoub @scalablecory 