### PR TITLE
Disable failing DNS tests on SLES

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -27,6 +27,7 @@ namespace System
         public static bool IsUbuntu1710OrHigher => IsDistroAndVersionOrHigher("ubuntu", 17, 10);
         public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 04);
         public static bool IsUbuntu1810OrHigher => IsDistroAndVersionOrHigher("ubuntu", 18, 10);
+        public static bool IsSLES => IsDistroAndVersion("sles");
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsFedora => IsDistroAndVersion("fedora");
 

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -102,6 +102,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
@@ -112,6 +113,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -102,10 +102,15 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             IPHostEntry entry = Dns.GetHostByName("");
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.
@@ -113,10 +118,15 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -21,6 +21,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
@@ -70,6 +71,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -21,12 +21,18 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
+        
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntry_HostString_Ok(string hostName)
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             try
             {
                 await TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
@@ -75,8 +81,16 @@ namespace System.Net.NameResolution.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
-        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName) =>
+        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName)
+        {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
+        }
 
         [Fact]
         public async Task Dns_GetHostEntryAsync_IPString_Ok() =>


### PR DESCRIPTION
As there's currently no infrastructure to disable just for SLES,
disabling for its parent, which is Linux.

https://github.com/dotnet/runtime/issues/48751

cc @dotnet/ncl 