### PR TITLE
Remove old macOS work arounds in Apple native shims

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -4,12 +4,9 @@
 #include "pal_ssl.h"
 #include <dlfcn.h>
 
-// TLS 1.3 is only defined with 10.13 headers, but we build on 10.12
-#define kTLSProtocol13_ForwardDef 10
-
 // 10.13.4 introduced public API but linking would fail on all prior versions.
 // For that reason we use function pointers instead of direct call.
-// This can be revisited after we drop support for 10.12.
+// This can be revisited after we drop support for 10.12 and iOS 10
 
 static OSStatus (*SSLSetALPNProtocolsPtr)(SSLContextRef context, CFArrayRef protocols) = NULL;
 static OSStatus (*SSLCopyALPNProtocolsPtr)(SSLContextRef context, CFArrayRef* protocols) = NULL;
@@ -39,11 +36,11 @@ static SSLProtocol PalSslProtocolToSslProtocol(PAL_SslProtocol palProtocolId)
 {
     switch (palProtocolId)
     {
-        case PAL_SslProtocol_Tls13:
-            return kTLSProtocol13_ForwardDef;
-        case PAL_SslProtocol_Tls12:
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"       
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        case PAL_SslProtocol_Tls13:
+            return kTLSProtocol13;
+        case PAL_SslProtocol_Tls12: 
             return kTLSProtocol12;
         case PAL_SslProtocol_Tls11:
             return kTLSProtocol11;
@@ -546,7 +543,7 @@ int32_t AppleCryptoNative_SslGetProtocolVersion(SSLContextRef sslContext, PAL_Ss
     {
         PAL_SslProtocol matchedProtocol = PAL_SslProtocol_None;
 
-        if (protocol == kTLSProtocol13_ForwardDef)
+        if (protocol == kTLSProtocol13)
             matchedProtocol = PAL_SslProtocol_Tls13;
         else if (protocol == kTLSProtocol12)
             matchedProtocol = PAL_SslProtocol_Tls12;


### PR DESCRIPTION
We don't support 10.12 or 10.13 any more, so we can remove a few work arounds we had in place for those platforms.