### PR TITLE
Disable GetHostName and GetHost Entry tests on Unix

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -101,7 +101,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(IPAddress.IPv6Loopback, entry.AddressList[0]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.Unix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
@@ -111,7 +111,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(Dns.GetHostName(), entry.HostName, StringComparison.OrdinalIgnoreCase);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.Unix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,7 +20,7 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.Unix)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
@@ -69,7 +69,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.Unix)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]


### PR DESCRIPTION
Related Issue https://github.com/dotnet/runtime/issues/1488