### PR TITLE
JIT: profile updates for return merges and tail calls

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -45,7 +45,7 @@ typedef BitVec_ValRet_T ASSERT_VALRET_TP;
 #define FMT_BB "BB%02u"
 
 // And this format for profile weights
-#define FMT_WT "%.7f"
+#define FMT_WT "%.7g"
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -44,6 +44,9 @@ typedef BitVec_ValRet_T ASSERT_VALRET_TP;
 // This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
 #define FMT_BB "BB%02u"
 
+// And this format for profile weights
+#define FMT_WT "%.7f"
+
 /*****************************************************************************
  *
  *  Each basic block ends with a jump which is described as a value
@@ -1291,8 +1294,14 @@ public:
     // They return false if the newWeight is not between the current [min..max]
     // when slop is non-zero we allow for the case where our weights might be off by 'slop'
     //
-    bool setEdgeWeightMinChecked(BasicBlock::weight_t newWeight, BasicBlock::weight_t slop, bool* wbUsedSlop);
-    bool setEdgeWeightMaxChecked(BasicBlock::weight_t newWeight, BasicBlock::weight_t slop, bool* wbUsedSlop);
+    bool setEdgeWeightMinChecked(BasicBlock::weight_t newWeight,
+                                 BasicBlock*          bDst,
+                                 BasicBlock::weight_t slop,
+                                 bool*                wbUsedSlop);
+    bool setEdgeWeightMaxChecked(BasicBlock::weight_t newWeight,
+                                 BasicBlock*          bDst,
+                                 BasicBlock::weight_t slop,
+                                 bool*                wbUsedSlop);
     void setEdgeWeights(BasicBlock::weight_t newMinWeight, BasicBlock::weight_t newMaxWeight);
 
     flowList(BasicBlock* block, flowList* rest)

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1302,7 +1302,7 @@ public:
                                  BasicBlock*          bDst,
                                  BasicBlock::weight_t slop,
                                  bool*                wbUsedSlop);
-    void setEdgeWeights(BasicBlock::weight_t newMinWeight, BasicBlock::weight_t newMaxWeight);
+    void setEdgeWeights(BasicBlock::weight_t newMinWeight, BasicBlock::weight_t newMaxWeight, BasicBlock* bDst);
 
     flowList(BasicBlock* block, flowList* rest)
         : flNext(rest), m_block(block), flEdgeWeightMin(0), flEdgeWeightMax(0), flDupCount(0)

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -557,10 +557,20 @@ struct BasicBlock : private LIR::Range
     }
 
     // setBBProfileWeight -- Set the profile-derived weight for a basic block
+    // and update the run rarely flag as appropriate.
     void setBBProfileWeight(weight_t weight)
     {
         this->bbFlags |= BBF_PROF_WEIGHT;
         this->bbWeight = weight;
+
+        if (weight == BB_ZERO_WEIGHT)
+        {
+            this->bbFlags |= BBF_RUN_RARELY;
+        }
+        else
+        {
+            this->bbFlags &= ~BBF_RUN_RARELY;
+        }
     }
 
     // modifyBBWeight -- same as setBBWeight, but also make sure that if the block is rarely run, it stays that

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -272,7 +272,7 @@ flowList* Compiler::fgAddRefPred(BasicBlock* block,
                 // If our caller has given us the old edge weights
                 // then we will use them.
                 //
-                flow->setEdgeWeights(oldEdge->edgeWeightMin(), oldEdge->edgeWeightMax());
+                flow->setEdgeWeights(oldEdge->edgeWeightMin(), oldEdge->edgeWeightMax(), block);
             }
             else
             {
@@ -284,17 +284,17 @@ flowList* Compiler::fgAddRefPred(BasicBlock* block,
                 // otherwise it is the same as the edge's max weight.
                 if (blockPred->NumSucc() > 1)
                 {
-                    flow->setEdgeWeights(BB_ZERO_WEIGHT, newWeightMax);
+                    flow->setEdgeWeights(BB_ZERO_WEIGHT, newWeightMax, block);
                 }
                 else
                 {
-                    flow->setEdgeWeights(flow->edgeWeightMax(), newWeightMax);
+                    flow->setEdgeWeights(flow->edgeWeightMax(), newWeightMax, block);
                 }
             }
         }
         else
         {
-            flow->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT);
+            flow->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT, block);
         }
     }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2323,7 +2323,7 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
                 {
                     newEdge2Max = BB_ZERO_WEIGHT;
                 }
-                edge2->setEdgeWeights(newEdge2Min, newEdge2Max);
+                edge2->setEdgeWeights(newEdge2Min, newEdge2Max, bDest);
             }
         }
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1752,15 +1752,6 @@ void Compiler::fgSetProfileWeight(BasicBlock* block, BasicBlock::weight_t profil
 
     block->setBBProfileWeight(profileWeight);
 
-    if (profileWeight == BB_ZERO_WEIGHT)
-    {
-        block->bbSetRunRarely();
-    }
-    else
-    {
-        block->bbFlags &= ~BBF_RUN_RARELY;
-    }
-
 #if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
     // Handle a special case -- some handler entries can't have zero profile count.
     //
@@ -2898,14 +2889,6 @@ void Compiler::fgComputeCalledCount(BasicBlock::weight_t returnWeight)
     if (fgFirstBBisScratch())
     {
         fgFirstBB->setBBProfileWeight(fgCalledCount);
-        if (fgFirstBB->bbWeight == BB_ZERO_WEIGHT)
-        {
-            fgFirstBB->bbFlags |= BBF_RUN_RARELY;
-        }
-        else
-        {
-            fgFirstBB->bbFlags &= ~BBF_RUN_RARELY;
-        }
     }
 
 #if DEBUG

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2671,7 +2671,7 @@ void flowList::setEdgeWeights(BasicBlock::weight_t theMinWeight, BasicBlock::wei
 {
     assert(theMinWeight <= theMaxWeight);
 
-    JITDUMP("\nSetting edge weights for BB?? -> " FMT_BB " to [" FMT_WT " .. " FMT_WT "]\n", getBlock()->bbNum,
+    JITDUMP("Setting edge weights for BB?? -> " FMT_BB " to [" FMT_WT " .. " FMT_WT "]\n", getBlock()->bbNum,
             theMinWeight, theMaxWeight);
 
     flEdgeWeightMin = theMinWeight;

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2666,13 +2666,14 @@ bool flowList::setEdgeWeightMaxChecked(BasicBlock::weight_t newWeight,
 // Arguments:
 //    theMinWeight - the new minimum lower (flEdgeWeightMin)
 //    theMaxWeight - the new maximum upper (flEdgeWeightMin)
+//    bDst         - the destination block for the edge
 //
-void flowList::setEdgeWeights(BasicBlock::weight_t theMinWeight, BasicBlock::weight_t theMaxWeight)
+void flowList::setEdgeWeights(BasicBlock::weight_t theMinWeight, BasicBlock::weight_t theMaxWeight, BasicBlock* bDst)
 {
     assert(theMinWeight <= theMaxWeight);
 
-    JITDUMP("Setting edge weights for BB?? -> " FMT_BB " to [" FMT_WT " .. " FMT_WT "]\n", getBlock()->bbNum,
-            theMinWeight, theMaxWeight);
+    JITDUMP("Setting edge weights for " FMT_BB " -> " FMT_BB " to [" FMT_WT " .. " FMT_WT "]\n", getBlock()->bbNum,
+            bDst->bbNum, theMinWeight, theMaxWeight);
 
     flEdgeWeightMin = theMinWeight;
     flEdgeWeightMax = theMaxWeight;
@@ -2970,7 +2971,7 @@ void Compiler::fgComputeEdgeWeights()
 
             if (!bSrc->hasProfileWeight() || !bDst->hasProfileWeight())
             {
-                edge->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT);
+                edge->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT, bDst);
             }
 
             slop = BasicBlock::GetSlopFraction(bSrc, bDst) + 1;

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -176,7 +176,7 @@ bool Compiler::fgGetProfileWeightForBasicBlock(IL_OFFSET offset, BasicBlock::wei
 
         if (hash % 3 == 0)
         {
-            weight = 0;
+            weight = BB_ZERO_WEIGHT;
         }
         else if (hash % 11 == 0)
         {
@@ -188,7 +188,7 @@ bool Compiler::fgGetProfileWeightForBasicBlock(IL_OFFSET offset, BasicBlock::wei
         }
 
         // The first block is never given a weight of zero
-        if ((offset == 0) && (weight == 0))
+        if ((offset == 0) && (weight == BB_ZERO_WEIGHT))
         {
             weight = (BasicBlock::weight_t)1 + (hash % 5);
         }
@@ -2470,7 +2470,7 @@ void Compiler::fgIncorporateEdgeCounts()
 //
 // Arguments:
 //    newWeight - proposed new weight
-//    bDst - destintion block for edge
+//    bDst - destination block for edge
 //    slop - profile slush fund
 //    wbUsedSlop [out] - true if we tapped into the slush fund
 //
@@ -2532,11 +2532,12 @@ bool flowList::setEdgeWeightMinChecked(BasicBlock::weight_t newWeight,
         }
 
         // If we are returning true then we should have adjusted the range so that
-        // the newWeight is in new range [Min..Max] or fgEdjeWeightMax is zero.
+        // the newWeight is in new range [Min..Max] or fgEdgeWeightMax is zero.
         // Also we should have set wbUsedSlop to true.
         if (result == true)
         {
-            assert((flEdgeWeightMax == 0) || ((newWeight <= flEdgeWeightMax) && (newWeight >= flEdgeWeightMin)));
+            assert((flEdgeWeightMax == BB_ZERO_WEIGHT) ||
+                   ((newWeight <= flEdgeWeightMax) && (newWeight >= flEdgeWeightMin)));
 
             if (wbUsedSlop != nullptr)
             {
@@ -2630,11 +2631,12 @@ bool flowList::setEdgeWeightMaxChecked(BasicBlock::weight_t newWeight,
         }
 
         // If we are returning true then we should have adjusted the range so that
-        // the newWeight is in new range [Min..Max] or fgEdjeWeightMax is zero
+        // the newWeight is in new range [Min..Max] or fgEdgeWeightMax is zero
         // Also we should have set wbUsedSlop to true, unless it is NULL
         if (result == true)
         {
-            assert((flEdgeWeightMax == 0) || ((newWeight <= flEdgeWeightMax) && (newWeight >= flEdgeWeightMin)));
+            assert((flEdgeWeightMax == BB_ZERO_WEIGHT) ||
+                   ((newWeight <= flEdgeWeightMax) && (newWeight >= flEdgeWeightMin)));
 
             assert((wbUsedSlop == nullptr) || (*wbUsedSlop == true));
         }
@@ -2808,7 +2810,7 @@ BasicBlock::weight_t Compiler::fgComputeMissingBlockWeights()
                     changed        = true;
                     modified       = true;
                     bDst->bbWeight = newWeight;
-                    if (newWeight == 0)
+                    if (newWeight == BB_ZERO_WEIGHT)
                     {
                         bDst->bbFlags |= BBF_RUN_RARELY;
                     }
@@ -2881,7 +2883,7 @@ void Compiler::fgComputeCalledCount(BasicBlock::weight_t returnWeight)
     // (i.e. the function never returns because it always throws)
     // then just use the first block weight rather than 0.
     //
-    if ((firstILBlock->countOfInEdges() == 1) || (returnWeight == 0))
+    if ((firstILBlock->countOfInEdges() == 1) || (returnWeight == BB_ZERO_WEIGHT))
     {
         assert(firstILBlock->hasProfileWeight()); // This should always be a profile-derived weight
         fgCalledCount = firstILBlock->bbWeight;
@@ -2896,7 +2898,7 @@ void Compiler::fgComputeCalledCount(BasicBlock::weight_t returnWeight)
     if (fgFirstBBisScratch())
     {
         fgFirstBB->setBBProfileWeight(fgCalledCount);
-        if (fgFirstBB->bbWeight == 0)
+        if (fgFirstBB->bbWeight == BB_ZERO_WEIGHT)
         {
             fgFirstBB->bbFlags |= BBF_RUN_RARELY;
         }
@@ -3311,14 +3313,14 @@ bool Compiler::fgProfileWeightsEqual(BasicBlock::weight_t weight1, BasicBlock::w
 //
 bool Compiler::fgProfileWeightsConsistent(BasicBlock::weight_t weight1, BasicBlock::weight_t weight2)
 {
-    if (weight2 == 0)
+    if (weight2 == BB_ZERO_WEIGHT)
     {
         return fgProfileWeightsEqual(weight1, weight2);
     }
 
     BasicBlock::weight_t const relativeDiff = (weight2 - weight1) / weight2;
 
-    return fgProfileWeightsEqual(relativeDiff, 0.0f);
+    return fgProfileWeightsEqual(relativeDiff, BB_ZERO_WEIGHT);
 }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2313,17 +2313,7 @@ private:
 
         noway_assert(newReturnBB->bbNext == nullptr);
 
-#ifdef DEBUG
-        if (comp->verbose)
-        {
-            printf("\n newReturnBB [" FMT_BB "] created\n", newReturnBB->bbNum);
-        }
-#endif
-
-        // We have profile weight, the weight is zero, and the block is run rarely,
-        // until we prove otherwise by merging other returns into this one.
-        newReturnBB->bbFlags |= (BBF_PROF_WEIGHT | BBF_RUN_RARELY);
-        newReturnBB->bbWeight = 0;
+        JITDUMP("\n newReturnBB [" FMT_BB "] created\n", newReturnBB->bbNum);
 
         GenTree* returnExpr;
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2509,16 +2509,6 @@ private:
                                 returnBlock->bbWeight, returnBlock->bbNum, mergedReturnBlock->bbNum);
 
                         mergedReturnBlock->setBBProfileWeight(newWeight);
-
-                        if (newWeight > BB_ZERO_WEIGHT)
-                        {
-                            mergedReturnBlock->bbFlags &= ~BBF_RUN_RARELY;
-                        }
-                        else
-                        {
-                            mergedReturnBlock->bbFlags |= BBF_RUN_RARELY;
-                        }
-
                         DISPBLOCK(mergedReturnBlock);
                     }
                 }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2750,13 +2750,6 @@ void Compiler::fgAddInternal()
         // will expect to find it.
         BasicBlock* mergedReturn = merger.EagerCreate();
         assert(mergedReturn == genReturnBB);
-        // Assume weight equal to entry weight for this BB.
-        mergedReturn->bbFlags &= ~BBF_PROF_WEIGHT;
-        mergedReturn->bbWeight = fgFirstBB->bbWeight;
-        if (mergedReturn->bbWeight > 0)
-        {
-            mergedReturn->bbFlags &= ~BBF_RUN_RARELY;
-        }
     }
     else
     {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2502,15 +2502,15 @@ private:
                     if (returnBlock->hasProfileWeight())
                     {
                         BasicBlock::weight_t const oldWeight =
-                            mergedReturnBlock->hasProfileWeight() ? mergedReturnBlock->bbWeight : 0.0f;
+                            mergedReturnBlock->hasProfileWeight() ? mergedReturnBlock->bbWeight : BB_ZERO_WEIGHT;
                         BasicBlock::weight_t const newWeight = oldWeight + returnBlock->bbWeight;
 
-                        JITDUMP("merging profile weight %.6f from " FMT_BB " to const return " FMT_BB "\n",
+                        JITDUMP("merging profile weight " FMT_WT " from " FMT_BB " to const return " FMT_BB "\n",
                                 returnBlock->bbWeight, returnBlock->bbNum, mergedReturnBlock->bbNum);
 
                         mergedReturnBlock->setBBProfileWeight(newWeight);
 
-                        if (newWeight > 0.0f)
+                        if (newWeight > BB_ZERO_WEIGHT)
                         {
                             mergedReturnBlock->bbFlags &= ~BBF_RUN_RARELY;
                         }

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -548,6 +548,9 @@ const bool dspGCtbls = true;
 #define DISPTREERANGE(range, t)                                                                                        \
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->gtDispTreeRange(range, t);
+#define DISPBLOCK(b)                                                                                                   \
+    if (JitTls::GetCompiler()->verbose)                                                                                \
+        JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
 #else // !DEBUG
 #define JITDUMP(...)
@@ -559,6 +562,7 @@ const bool dspGCtbls = true;
 #define DISPSTMT(t)
 #define DISPRANGE(range)
 #define DISPTREERANGE(range, t)
+#define DISPBLOCK(b)
 #define VERBOSE 0
 #endif // !DEBUG
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7678,11 +7678,6 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
                         nextWeight, newNextWeight);
 
                 nextBlock->setBBProfileWeight(newNextWeight);
-
-                if (newNextWeight == BB_ZERO_WEIGHT)
-                {
-                    nextBlock->bbFlags |= BBF_RUN_RARELY;
-                }
             }
             else
             {
@@ -7715,11 +7710,6 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
                                 nextNextBlock->bbNum, nextNextWeight, newNextNextWeight);
 
                         nextNextBlock->setBBProfileWeight(newNextNextWeight);
-
-                        if (newNextNextWeight == BB_ZERO_WEIGHT)
-                        {
-                            nextNextBlock->bbFlags |= BBF_RUN_RARELY;
-                        }
                     }
                     else
                     {
@@ -17178,16 +17168,6 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
                     block->bbNum, genReturnBB->bbNum);
 
             genReturnBB->setBBProfileWeight(newWeight);
-
-            if (newWeight > BB_ZERO_WEIGHT)
-            {
-                genReturnBB->bbFlags &= ~BBF_RUN_RARELY;
-            }
-            else
-            {
-                genReturnBB->bbFlags |= BBF_RUN_RARELY;
-            }
-
             DISPBLOCK(genReturnBB);
         }
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7666,7 +7666,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
             BasicBlock::weight_t const nextWeight    = nextBlock->bbWeight;
             BasicBlock::weight_t const newNextWeight = nextWeight - blockWeight;
 
-            // If the math would result in an negative weight then there's
+            // If the math would result in a negative weight then there's
             // no local repair we can do; just leave things inconsistent.
             //
             if (newNextWeight >= 0)
@@ -7679,7 +7679,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 
                 nextBlock->setBBProfileWeight(newNextWeight);
 
-                if (newNextWeight == 0.0f)
+                if (newNextWeight == BB_ZERO_WEIGHT)
                 {
                     nextBlock->bbFlags |= BBF_RUN_RARELY;
                 }
@@ -7716,7 +7716,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 
                         nextNextBlock->setBBProfileWeight(newNextNextWeight);
 
-                        if (newNextNextWeight == 0.0f)
+                        if (newNextNextWeight == BB_ZERO_WEIGHT)
                         {
                             nextNextBlock->bbFlags |= BBF_RUN_RARELY;
                         }
@@ -17170,15 +17170,16 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
 
         if (block->hasProfileWeight())
         {
-            BasicBlock::weight_t const oldWeight = genReturnBB->hasProfileWeight() ? genReturnBB->bbWeight : 0.0f;
+            BasicBlock::weight_t const oldWeight =
+                genReturnBB->hasProfileWeight() ? genReturnBB->bbWeight : BB_ZERO_WEIGHT;
             BasicBlock::weight_t const newWeight = oldWeight + block->bbWeight;
 
-            JITDUMP("merging profile weight %.6f from " FMT_BB " to common return " FMT_BB "\n", block->bbWeight,
+            JITDUMP("merging profile weight " FMT_WT " from " FMT_BB " to common return " FMT_BB "\n", block->bbWeight,
                     block->bbNum, genReturnBB->bbNum);
 
             genReturnBB->setBBProfileWeight(newWeight);
 
-            if (newWeight > 0.0f)
+            if (newWeight > BB_ZERO_WEIGHT)
             {
                 genReturnBB->bbFlags &= ~BBF_RUN_RARELY;
             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16321,7 +16321,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
                 {
                     // The edge weights for (block -> bTaken) are 100% of block's weight
 
-                    edgeTaken->setEdgeWeights(block->bbWeight, block->bbWeight);
+                    edgeTaken->setEdgeWeights(block->bbWeight, block->bbWeight, bTaken);
 
                     if (!bTaken->hasProfileWeight())
                     {
@@ -16338,7 +16338,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
                     if (bTaken->countOfInEdges() == 1)
                     {
                         // There is only one in edge to bTaken
-                        edgeTaken->setEdgeWeights(bTaken->bbWeight, bTaken->bbWeight);
+                        edgeTaken->setEdgeWeights(bTaken->bbWeight, bTaken->bbWeight, bTaken);
 
                         // Update the weight of block
                         block->inheritWeight(bTaken);
@@ -16359,21 +16359,21 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
                             edge         = fgGetPredForBlock(bUpdated->bbNext, bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
-                            edge->setEdgeWeights(newMinWeight, newMaxWeight);
+                            edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->bbNext);
                             break;
 
                         case BBJ_COND:
                             edge         = fgGetPredForBlock(bUpdated->bbNext, bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
-                            edge->setEdgeWeights(newMinWeight, newMaxWeight);
+                            edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->bbNext);
                             FALLTHROUGH;
 
                         case BBJ_ALWAYS:
                             edge         = fgGetPredForBlock(bUpdated->bbJumpDest, bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
-                            edge->setEdgeWeights(newMinWeight, newMaxWeight);
+                            edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->bbNext);
                             break;
 
                         default:

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4423,8 +4423,8 @@ void Compiler::optInvertWhileLoop(BasicBlock* block)
         JITDUMP("Setting weight of " FMT_BB " -> " FMT_BB " to %f (exit loop)\n", bTest->bbNum, bTest->bbNext->bbNum,
                 testToAfterWeight);
 
-        edgeTestToNext->setEdgeWeights(testToNextWeight, testToNextWeight);
-        edgeTestToAfter->setEdgeWeights(testToAfterWeight, testToAfterWeight);
+        edgeTestToNext->setEdgeWeights(testToNextWeight, testToNextWeight, bTest->bbJumpDest);
+        edgeTestToAfter->setEdgeWeights(testToAfterWeight, testToAfterWeight, bTest->bbNext);
 
         // Adjust edges out of block, using the same distribution.
         //
@@ -4444,8 +4444,8 @@ void Compiler::optInvertWhileLoop(BasicBlock* block)
         JITDUMP("Setting weight of " FMT_BB " -> " FMT_BB " to %f (avoid loop)\n", block->bbNum,
                 block->bbJumpDest->bbNum, blockToAfterWeight);
 
-        edgeBlockToNext->setEdgeWeights(blockToNextWeight, blockToNextWeight);
-        edgeBlockToAfter->setEdgeWeights(blockToAfterWeight, blockToAfterWeight);
+        edgeBlockToNext->setEdgeWeights(blockToNextWeight, blockToNextWeight, block->bbNext);
+        edgeBlockToAfter->setEdgeWeights(blockToAfterWeight, blockToAfterWeight, block->bbJumpDest);
 
 #ifdef DEBUG
         // Verify profile for the two target blocks is consistent.
@@ -7578,17 +7578,25 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
                     loopSkippedCount = head->bbJumpDest->bbWeight;
                 }
 
+                JITDUMP("%s; loopEnterCount " FMT_WT " loopSkipCount " FMT_WT "\n",
+                        fgHaveValidEdgeWeights ? "valid edge weights" : "no edge weights", loopEnteredCount,
+                        loopSkippedCount);
+
                 BasicBlock::weight_t loopTakenRatio = loopEnteredCount / (loopEnteredCount + loopSkippedCount);
 
+                JITDUMP("%s; loopEnterCount " FMT_WT " loopSkipCount " FMT_WT " taken ratio " FMT_WT "\n",
+                        fgHaveValidEdgeWeights ? "valid edge weights" : "no edge weights", loopEnteredCount,
+                        loopSkippedCount, loopTakenRatio);
+
                 // Calculate a good approximation of the preHead's block weight
-                BasicBlock::weight_t preHeadWeight = (head->bbWeight * loopTakenRatio) + 0.5f;
-                preHead->setBBWeight(max(preHeadWeight, 1));
+                BasicBlock::weight_t preHeadWeight = (head->bbWeight * loopTakenRatio);
+                preHead->setBBProfileWeight(preHeadWeight);
                 noway_assert(!preHead->isRunRarely());
             }
         }
     }
 
-    // Link in the preHead block.
+    // Link in the preHead block
     fgInsertBBbefore(top, preHead);
 
     // Ideally we would re-run SSA and VN if we optimized by doing loop hoisting.
@@ -7639,8 +7647,9 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
        All predecessors of 'beg', (which is the entry in the loop)
        now have to jump to 'preHead', unless they are dominated by 'head' */
 
-    preHead->bbRefs = 0;
-    fgAddRefPred(preHead, head);
+    preHead->bbRefs                 = 0;
+    flowList* const edgeToPreHeader = fgAddRefPred(preHead, head);
+    edgeToPreHeader->setEdgeWeights(preHead->bbWeight, preHead->bbWeight, preHead);
     bool checkNestedLoops = false;
 
     for (flowList* pred = top->bbPreds; pred; pred = pred->flNext)
@@ -7722,7 +7731,8 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
     noway_assert(!fgGetPredForBlock(top, preHead));
     fgRemoveRefPred(top, head);
-    fgAddRefPred(top, preHead);
+    flowList* const edgeFromPreHeader = fgAddRefPred(top, preHead);
+    edgeFromPreHeader->setEdgeWeights(preHead->bbWeight, preHead->bbWeight, top);
 
     /*
         If we found at least one back-edge in the flowgraph pointing to the top/entry of the loop
@@ -9308,11 +9318,11 @@ void Compiler::optOptimizeBools()
             BasicBlock::weight_t edgeSumMax = edge1->edgeWeightMax() + edge2->edgeWeightMax();
             if ((edgeSumMax >= edge1->edgeWeightMax()) && (edgeSumMax >= edge2->edgeWeightMax()))
             {
-                edge1->setEdgeWeights(edgeSumMin, edgeSumMax);
+                edge1->setEdgeWeights(edgeSumMin, edgeSumMax, b1->bbJumpDest);
             }
             else
             {
-                edge1->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT);
+                edge1->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT, b1->bbJumpDest);
             }
 
             /* Get rid of the second block (which is a BBJ_COND) */


### PR DESCRIPTION
Stop trying to update the common return block profile data during return
merging, as it is not yet known which return blocks will become tail calls.
Start updating constant return block profile data during return merging
as this is when we transform the flow.

Update the common return block profile data during return merging in
morph (adding more counts) and when creating tail calls (removing counts).

Update profile consistency checker to handle switches properly and to use
tolerant compares.

Add extra dumping when solving for edge weights or adjusting flow edge
weights to help track down where errors are coming from.

Add new `FMT_WT` formatting string for profile weights, and start using it
in `fgprofile.cpp`.