### PR TITLE
[wasm] Enable Aggressive Trimming as default for wasm AOT functional tests

### DIFF
--- a/src/tests/FunctionalTests/wasm/AOT/browser/Wasm.Aot.Browser.Test.csproj
+++ b/src/tests/FunctionalTests/wasm/AOT/browser/Wasm.Aot.Browser.Test.csproj
@@ -3,6 +3,7 @@
     <RunAOTCompilation>true</RunAOTCompilation>
     <Scenario>WasmTestOnBrowser</Scenario>
     <ExpectedExitCode>42</ExpectedExitCode>
+    <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <WasmMainJSPath>runtime.js</WasmMainJSPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Default the wasm AOT browser functional test to using `EnableAggressiveTrimming` because the number of assemblies that are compiled Ahead Of Time is reduced from 180 to 22, and the test still passes.

