### PR TITLE
Improve SuperPMI download progress

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -338,6 +338,17 @@ def download_progress_hook(count, block_size, total_size):
     sys.stdout.write("\rDownloading %d/%d..." % (count - 1, total_size / max(block_size, 1)))
     sys.stdout.flush()
 
+def download_with_progress(uri, target_location):
+    """ Do an URI download, with logging.
+
+    Args:
+        uri (string)              : URI to download
+        target_location (string)  : local path to put the downloaded object
+    """
+    logging.info("Download: %s -> %s", uri, target_location)
+    urllib.request.urlretrieve(uri, target_location, reporthook=download_progress_hook)
+    sys.stdout.write("\n") # Add newline after progress hook
+
 def is_zero_length_file(fpath):
     """ Determine if a file system path refers to an existing file that is zero length
 
@@ -1871,8 +1882,7 @@ def determine_coredis_tools(coreclr_args):
             logging.warning("Warning: Core_Root does not exist at \"%s\"; creating it now", coreclr_args.core_root)
             os.makedirs(coreclr_args.core_root)
         coredistools_uri = az_blob_storage_superpmi_container_uri + "/libcoredistools/{}-{}/{}".format(coreclr_args.host_os.lower(), coreclr_args.arch.lower(), coredistools_dll_name)
-        logging.info("Download: %s -> %s", coredistools_uri, coredistools_location)
-        urllib.request.urlretrieve(coredistools_uri, coredistools_location, reporthook=download_progress_hook)
+        download_with_progress(coredistools_uri, coredistools_location)
 
     assert os.path.isfile(coredistools_location)
     return coredistools_location
@@ -1908,8 +1918,7 @@ def determine_pmi_location(coreclr_args):
                 logging.info("Using PMI found at %s", pmi_location)
             else:
                 pmi_uri = az_blob_storage_superpmi_container_uri + "/pmi/pmi.dll"
-                logging.info("Download: %s -> %s", pmi_uri, pmi_location)
-                urllib.request.urlretrieve(pmi_uri, pmi_location, reporthook=download_progress_hook)
+                download_with_progress(pmi_uri, pmi_location)
 
     assert os.path.isfile(pmi_location)
     return pmi_location
@@ -2361,9 +2370,7 @@ def download_urls(urls, target_dir, verbose=True, fail_if_not_found=True):
                 download_path = os.path.join(temp_location, item_name)
 
                 try:
-                    if verbose:
-                        logging.info("Download: %s -> %s", url, download_path)
-                    urllib.request.urlretrieve(url, download_path, reporthook=download_progress_hook)
+                    download_with_progress(url, download_path)
                 except urllib.error.HTTPError as httperror:
                     if (httperror == 404) and fail_if_not_found:
                         raise httperror
@@ -2392,9 +2399,7 @@ def download_urls(urls, target_dir, verbose=True, fail_if_not_found=True):
                 download_path = os.path.join(target_dir, item_name)
 
                 try:
-                    if verbose:
-                        logging.info("Download: %s -> %s", url, download_path)
-                    urllib.request.urlretrieve(url, download_path, reporthook=download_progress_hook)
+                    download_with_progress(url, download_path)
                     local_files.append(download_path)
                 except urllib.error.HTTPError as httperror:
                     if (httperror == 404) and fail_if_not_found:


### PR DESCRIPTION
Refactor download into a function.

Add newline after download is done.

Allow baseline JIT download to show it is being downloaded
(it was suppressed before).