### PR TITLE
Support single file in DependencyModel

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -129,12 +129,13 @@ namespace Microsoft.Extensions.DependencyModel
         {
             // Assemblies loaded in memory (e.g. single file) return empty string from Location.
             // In these cases, don't try probing next to the assembly.
-            if (string.IsNullOrEmpty(assembly.Location))
+            string assemblyLocation = assembly.Location;
+            if (string.IsNullOrEmpty(assemblyLocation))
             {
                 return null;
             }
 
-            string depsJsonFile = Path.ChangeExtension(assembly.Location, DepsJsonExtension);
+            string depsJsonFile = Path.ChangeExtension(assemblyLocation, DepsJsonExtension);
             bool depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
 
             if (!depsJsonFileExists)
@@ -143,7 +144,7 @@ namespace Microsoft.Extensions.DependencyModel
                 // and CodeBase will be different, so also try the CodeBase
                 string assemblyCodeBase = GetNormalizedCodeBasePath(assembly);
                 if (!string.IsNullOrEmpty(assemblyCodeBase) &&
-                    assembly.Location != assemblyCodeBase)
+                    assemblyLocation != assemblyCodeBase)
                 {
                     depsJsonFile = Path.ChangeExtension(assemblyCodeBase, DepsJsonExtension);
                     depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -127,6 +127,13 @@ namespace Microsoft.Extensions.DependencyModel
 
         private string GetDepsJsonPath(Assembly assembly)
         {
+            // Assemblies loaded in memory (e.g. single file) return empty string from Location.
+            // In these cases, don't try probing next to the assembly.
+            if (string.IsNullOrEmpty(assembly.Location))
+            {
+                return null;
+            }
+
             string depsJsonFile = Path.ChangeExtension(assembly.Location, DepsJsonExtension);
             bool depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
 

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextLoaderTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextLoaderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
+using System.IO;
 using System.Reflection;
 using Xunit;
 
@@ -89,6 +90,20 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         {
             var loader = new DependencyContextLoader();
             Assert.Null(loader.Load(typeof(Moq.Mock).Assembly));
+        }
+
+        [Fact]
+        public void LoadReturnsNullWhenAssemblyLocationIsEmpty()
+        {
+            var loader = new DependencyContextLoader();
+            Assert.Null(loader.Load(new EmptyLocationAssembly()));
+        }
+
+        private class EmptyLocationAssembly : Assembly
+        {
+            public override string Location => string.Empty;
+            public override AssemblyName GetName() => new AssemblyName("EmptyLocation");
+            public override Stream? GetManifestResourceStream(string name) => null;
         }
     }
 }


### PR DESCRIPTION
When used in a single file application, Assembly.CodeBase will throw an exception. Check for this situation by checking if Assembly.Location is empty before trying to probe next to the assembly.

Fix #47527