### PR TITLE
Remove unneeded UnsupportedOSPlatform("browser") attribute

### DIFF
--- a/src/libraries/System.Net.WebSockets/ref/System.Net.WebSockets.cs
+++ b/src/libraries/System.Net.WebSockets/ref/System.Net.WebSockets.cs
@@ -26,10 +26,8 @@ namespace System.Net.WebSockets
         public abstract System.Threading.Tasks.Task CloseAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string? statusDescription, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task CloseOutputAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string? statusDescription, System.Threading.CancellationToken cancellationToken);
         public static System.ArraySegment<byte> CreateClientBuffer(int receiveBufferSize, int sendBufferSize) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static System.Net.WebSockets.WebSocket CreateClientWebSocket(System.IO.Stream innerStream, string? subProtocol, int receiveBufferSize, int sendBufferSize, System.TimeSpan keepAliveInterval, bool useZeroMaskingKey, System.ArraySegment<byte> internalBuffer) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         public static System.Net.WebSockets.WebSocket CreateFromStream(System.IO.Stream stream, bool isServer, string? subProtocol, System.TimeSpan keepAliveInterval) { throw null; }
         public static System.ArraySegment<byte> CreateServerBuffer(int receiveBufferSize) { throw null; }
         public abstract void Dispose();

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -24,7 +23,6 @@ namespace System.Net.WebSockets
     ///   a send operation while another is in progress or a receive operation while another is in progress will
     ///   result in an exception.
     /// </remarks>
-    [UnsupportedOSPlatform("browser")]
     internal sealed partial class ManagedWebSocket : WebSocket
     {
         /// <summary>Creates a <see cref="ManagedWebSocket"/> from a <see cref="Stream"/> connected to a websocket endpoint.</summary>
@@ -429,7 +427,9 @@ namespace System.Net.WebSockets
             // pass around (the CancellationTokenRegistration), so if it is cancelable, just immediately go to the fallback path.
             // Similarly, it should be rare that there are multiple outstanding calls to SendFrameAsync, but if there are, again
             // fall back to the fallback path.
+#pragma warning disable CA1416 // Validate platform compatibility, will not wait because timeout equals 0
             return cancellationToken.CanBeCanceled || !_sendFrameAsyncLock.Wait(0, default) ?
+#pragma warning restore CA1416
                 SendFrameFallbackAsync(opcode, endOfMessage, payloadBuffer, cancellationToken) :
                 SendFrameLockAcquiredNonCancelableAsync(opcode, endOfMessage, payloadBuffer);
         }
@@ -570,7 +570,9 @@ namespace System.Net.WebSockets
 
         private void SendKeepAliveFrameAsync()
         {
+#pragma warning disable CA1416 // Validate platform compatibility, will not wait because timeout equals 0
             bool acquiredLock = _sendFrameAsyncLock.Wait(0);
+#pragma warning restore CA1416
             if (acquiredLock)
             {
                 // This exists purely to keep the connection alive; don't wait for the result, and ignore any failures.

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -134,7 +133,6 @@ namespace System.Net.WebSockets
         /// <param name="subProtocol">The agreed upon sub-protocol that was used when creating the connection.</param>
         /// <param name="keepAliveInterval">The keep-alive interval to use, or <see cref="Timeout.InfiniteTimeSpan"/> to disable keep-alives.</param>
         /// <returns>The created <see cref="WebSocket"/>.</returns>
-        [UnsupportedOSPlatform("browser")]
         public static WebSocket CreateFromStream(Stream stream, bool isServer, string? subProtocol, TimeSpan keepAliveInterval)
         {
             if (stream == null)
@@ -174,7 +172,6 @@ namespace System.Net.WebSockets
             throw new PlatformNotSupportedException();
         }
 
-        [UnsupportedOSPlatform("browser")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static WebSocket CreateClientWebSocket(Stream innerStream,
             string? subProtocol, int receiveBufferSize, int sendBufferSize,


### PR DESCRIPTION
SemaphoreSlim.Wait(int millisecondsTimeout) will not wait when passed timeout == 0, in that case we can suppress the warning instead of adding `UnsupportedOSPlatform("browser")` attribute.

I have skimmed through other annotations, doesn't seem there is an another similar case

CC @jeffhandley @marek-safar