### PR TITLE
Improve liveness for 'STORE_BLK(lcl_var)'.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2689,6 +2689,8 @@ public:
 
     GenTree* gtNewOneConNode(var_types type);
 
+    GenTreeLclVar* gtNewStoreLclVar(unsigned dstLclNum, GenTree* src);
+
 #ifdef FEATURE_SIMD
     GenTree* gtNewSIMDVectorZero(var_types simdType, var_types baseType, unsigned size);
 #endif

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6264,6 +6264,15 @@ GenTree* Compiler::gtNewOneConNode(var_types type)
     return one;
 }
 
+GenTreeLclVar* Compiler::gtNewStoreLclVar(unsigned dstLclNum, GenTree* src)
+{
+    GenTreeLclVar* store = new (this, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, src->TypeGet(), dstLclNum);
+    store->gtOp1         = src;
+    store->gtFlags       = (src->gtFlags & GTF_COMMON_MASK);
+    store->gtFlags |= GTF_VAR_DEF | GTF_ASG;
+    return store;
+}
+
 #ifdef FEATURE_SIMD
 //---------------------------------------------------------------------
 // gtNewSIMDVectorZero: create a GT_SIMD node for Vector<T>.Zero

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -394,8 +394,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             if (tree->OperIs(GT_ASG) || tree->OperIsBlkOp())
             {
                 GenTreeLclVarCommon* dummyLclVarTree = nullptr;
-                bool                 entire          = false;
-                if (tree->DefinesLocal(this, &dummyLclVarTree, &entire))
+                if (tree->DefinesLocal(this, &dummyLclVarTree))
                 {
                     if (lvaVarAddrExposed(dummyLclVarTree->GetLclNum()))
                     {
@@ -405,10 +404,6 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
                         // memory but not GcHeap memory, so track their
                         // states separately.
                         byrefStatesMatchGcHeapStates = false;
-                    }
-                    if (entire)
-                    {
-                        fgMarkUseDef(dummyLclVarTree);
                     }
                 }
                 else

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -394,7 +394,8 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             if (tree->OperIs(GT_ASG) || tree->OperIsBlkOp())
             {
                 GenTreeLclVarCommon* dummyLclVarTree = nullptr;
-                if (tree->DefinesLocal(this, &dummyLclVarTree))
+                bool                 entire          = false;
+                if (tree->DefinesLocal(this, &dummyLclVarTree, &entire))
                 {
                     if (lvaVarAddrExposed(dummyLclVarTree->GetLclNum()))
                     {
@@ -404,6 +405,10 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
                         // memory but not GcHeap memory, so track their
                         // states separately.
                         byrefStatesMatchGcHeapStates = false;
+                    }
+                    if (entire)
+                    {
+                        fgMarkUseDef(dummyLclVarTree);
                     }
                 }
                 else

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2069,6 +2069,7 @@ void Lowering::RehomeArgForFastTailCall(unsigned int lclNum,
                 comp->lvaSetStruct(tmpLclNum, comp->lvaGetStruct(lclNum), false);
                 GenTree* loc = new (comp, GT_LCL_VAR_ADDR) GenTreeLclVar(GT_LCL_VAR_ADDR, TYP_STRUCT, tmpLclNum);
                 loc->gtType  = TYP_BYREF;
+                loc->gtFlags |= GTF_VAR_DEF;
                 GenTreeBlk* storeBlk = new (comp, GT_STORE_BLK)
                     GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, loc, value, comp->typGetBlkLayout(callerArgDsc->lvExactSize));
                 storeBlk->gtFlags |= GTF_ASG;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -490,10 +490,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
         unsigned lclNum               = comp->lvaGrabTemp(true DEBUGARG("Lowering is creating a new local variable"));
         comp->lvaTable[lclNum].lvType = rhs->TypeGet();
 
-        GenTreeLclVar* store = new (comp, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, rhs->TypeGet(), lclNum);
-        store->gtOp1         = rhs;
-        store->gtFlags       = (rhs->gtFlags & GTF_COMMON_MASK);
-        store->gtFlags |= GTF_VAR_DEF;
+        GenTreeLclVar* store = comp->gtNewStoreLclVar(lclNum, rhs);
 
         switchBBRange.InsertAfter(node, store);
         switchBBRange.Remove(node);
@@ -2063,25 +2060,14 @@ void Lowering::RehomeArgForFastTailCall(unsigned int lclNum,
             comp->lvaTable[tmpLclNum].lvDoNotEnregister = comp->lvaTable[lcl->GetLclNum()].lvDoNotEnregister;
             GenTree* value                              = comp->gtNewLclvNode(lclNum, tmpTyp);
 
-            // TODO-1stClassStructs: This can be simplified with 1st class structs work.
             if (tmpTyp == TYP_STRUCT)
             {
                 comp->lvaSetStruct(tmpLclNum, comp->lvaGetStruct(lclNum), false);
-                GenTree* loc = new (comp, GT_LCL_VAR_ADDR) GenTreeLclVar(GT_LCL_VAR_ADDR, TYP_STRUCT, tmpLclNum);
-                loc->gtType  = TYP_BYREF;
-                loc->gtFlags |= GTF_VAR_DEF;
-                GenTreeBlk* storeBlk = new (comp, GT_STORE_BLK)
-                    GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, loc, value, comp->typGetBlkLayout(callerArgDsc->lvExactSize));
-                storeBlk->gtFlags |= GTF_ASG;
-                BlockRange().InsertBefore(insertTempBefore, LIR::SeqTree(comp, storeBlk));
-                LowerNode(storeBlk);
             }
-            else
-            {
-                GenTree* assignExpr = comp->gtNewTempAssign(tmpLclNum, value);
-                ContainCheckRange(value, assignExpr);
-                BlockRange().InsertBefore(insertTempBefore, LIR::SeqTree(comp, assignExpr));
-            }
+            GenTreeLclVar* storeLclVar = comp->gtNewStoreLclVar(tmpLclNum, value);
+            ContainCheckRange(value, storeLclVar);
+            BlockRange().InsertBefore(insertTempBefore, LIR::SeqTree(comp, storeLclVar));
+            LowerNode(storeLclVar);
         }
 
         lcl->SetLclNum(tmpLclNum);


### PR DESCRIPTION
The rule for an untracked variable was weaker so converting a tracked variable to untracked sometimes gave us better code.

Don't set `lvMustInit ` for tracked `lclVars` that are compiler temps if they don't contain GC fields.


<details>
  <summary>Tiny SPMI improvements on master but I need it for my future changes.</summary>
  

```
tests.pmi.windows.x64.checked.mch
3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged.
Top method improvements (bytes):
          -7 (-3.61% of base) : 247502.dasm - TailCallOptTest:Caller2(System.Object,long,double,TypedDouble,TwoInts,TypedDouble):bool
          -7 (-3.37% of base) : 247500.dasm - TailCallOptTest:Caller1(System.Object,long,double,TypedDouble,TypedDouble,TypedDouble):bool
          -7 (-3.66% of base) : 249520.dasm - Program:Caller(int,int,int,int,MyStruct):int

libraries.pmi.windows.x64.checked.mch
1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.
          -7 (-13.21% of base) : 7338.dasm - Microsoft.FSharp.Text.StructuredPrintfImpl.LayoutOps:boundedUnfoldL(Microsoft.FSharp.Core.FSharpFunc`2[__Canon,__Canon],Microsoft.FSharp.Core.FSharpFunc`2[Nullable`1,__Canon],Microsoft.FSharp.Core.FSharpFunc`2[Nullable`1,Boolean],System.Nullable`1[Int32],int):Microsoft.FSharp.Collections.FSharpList`1[[Microsoft.FSharp.Text.StructuredPrintfImpl.Layout, FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
```

</details>

Diff example:
[before.txt](https://github.com/dotnet/runtime/files/6046989/before.txt)
[after.txt](https://github.com/dotnet/runtime/files/6046990/after.txt)
