### PR TITLE
update enterpriseTests setup

### DIFF
--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
@@ -6,8 +6,8 @@ namespace System.Net.Test.Common
     public static class EnterpriseTestConfiguration
     {
         public const string Realm = "LINUX.CONTOSO.COM";
-        public const string NegotiateAuthWebServer = "http://apacheweb.linux.contoso.com";
-        public const string AlternativeService = "http://altweb.linux.contoso.com:8080";
+        public const string NegotiateAuthWebServer = "http://apacheweb.linux.contoso.com/auth/kerberos/";
+        public const string AlternativeService = "http://altweb.linux.contoso.com:8080/auth/kerberos/";
 
         public static bool Enabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED"));
         public static NetworkCredential ValidNetworkCredentials => new NetworkCredential("user1", "password");

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
@@ -8,9 +8,12 @@ namespace System.Net.Test.Common
         public const string Realm = "LINUX.CONTOSO.COM";
         public const string NegotiateAuthWebServer = "http://apacheweb.linux.contoso.com/auth/kerberos/";
         public const string AlternativeService = "http://altweb.linux.contoso.com:8080/auth/kerberos/";
+        public const string NtlmAuthWebServer = "http://apacheweb.linux.contoso.com:8080/auth/ntlm/";
+        public const string DigestAuthWebServer = "http://apacheweb.linux.contoso.com/auth/digest/";
 
         public static bool Enabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED"));
-        public static NetworkCredential ValidNetworkCredentials => new NetworkCredential("user1", "password");
+        public static NetworkCredential ValidNetworkCredentials => new NetworkCredential("user1", "Password20");
+        public static NetworkCredential ValidDomainNetworkCredentials => new NetworkCredential("user1", "Password20", "LINUX" );
         public static NetworkCredential InvalidNetworkCredentials => new NetworkCredential("user1", "passwordxx");
     }
 }

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/README.md
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/README.md
@@ -39,6 +39,12 @@ docker-compose build
 # Start up test machines and network
 docker-compose up -d
 
+There should be three server containers and client:
+- kdc serves as Kerberos key center and Primary Domain Controller using Samba
+- apacheweb runs standard web server on port 80 and has various authentication methods enabled
+- altweb is identical container but running web on non-standard port. This primarily matters for Kerberos and SPN calculation
+- linuxclient is container where the tests actually run
+
 # Connect to the 'linuxclient' container
 docker exec -it linuxclient bash
 ```

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
@@ -5,18 +5,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install Kerberos client, apache Negotiate auth plugin, and diagnostics
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apache2 libapache2-mod-auth-kerb procps krb5-user iputils-ping dnsutils nano \
-                                               libapache2-mod-auth-ntlm-winbind samba
+                                               libapache2-mod-auth-ntlm-winbind samba samba-dsdb-modules samba-vfs-modules
 WORKDIR /setup
 
 COPY ./common/krb5.conf /etc/
 COPY ./apacheweb/apache2.conf /setup/apache2.conf
 COPY ./apacheweb/*.sh ./
 RUN chmod +x *.sh ; \
-    mkdir -p /setup/htdocs/auth/kerberos /setup/altdocs/auth/kerberos ; touch /setup/htdocs/index.html /setup/htdocs/auth/kerberos/index.html /setup/altdocs/auth/kerberos/index.html ;\
+    mkdir -p /setup/htdocs/auth/ntlm /setup/altdocs/auth/ntlm /setup/htdocs/auth/kerberos /setup/altdocs/auth/kerberos /setup/htdocs/auth/digest ;\
+    touch /setup/htdocs/index.html /setup/htdocs/auth/kerberos/index.html /setup/htdocs/auth/ntlm/index.html /setup/htdocs/auth/digest/index.html ;\
+    touch /setup/altdocs/auth/kerberos/index.html /setup/altdocs/auth/ntlm/index.html ;\
     cp /etc/apache2/apache2.conf /etc/apache2/apache2.conf.ORIG ;\
     mv -f apache2.conf /etc/apache2/apache2.conf
 
 EXPOSE 80/tcp
 EXPOSE 8080/tcp
 
-ENTRYPOINT ["/bin/sh", "/setup/run.sh"]
+ENTRYPOINT ["/bin/bash", "/setup/run.sh"]

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
@@ -1,23 +1,20 @@
-FROM httpd:2.4
+FROM ubuntu:18.04
 
-COPY ./common/krb5.conf /etc/
-COPY ./apacheweb/httpd.conf /usr/local/apache2/conf/httpd.conf
-
-WORKDIR /setup
-COPY ./apacheweb/*.sh ./
-RUN chmod +x *.sh ; \
-    mkdir -p /usr/local/apache2/altdocs ; \
-    cp /usr/local/apache2/htdocs/index.html /usr/local/apache2/altdocs
-
-# Prevents dialog prompting when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Kerberos client, apache Negotiate auth plugin, and diagnostics
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libapache2-mod-auth-kerb procps krb5-user iputils-ping dnsutils nano
+    apt-get install -y --no-install-recommends apache2 libapache2-mod-auth-kerb procps krb5-user iputils-ping dnsutils nano \
+                                               libapache2-mod-auth-ntlm-winbind samba
+WORKDIR /setup
 
-# Link apache2 kerb module to the right place since the apt-get install puts it in the wrong place for this docker image
-RUN ln -s /usr/lib/apache2/modules/mod_auth_kerb.so /usr/local/apache2/modules
+COPY ./common/krb5.conf /etc/
+COPY ./apacheweb/apache2.conf /setup/apache2.conf
+COPY ./apacheweb/*.sh ./
+RUN chmod +x *.sh ; \
+    mkdir -p /setup/htdocs/auth/kerberos /setup/altdocs/auth/kerberos ; touch /setup/htdocs/index.html /setup/htdocs/auth/kerberos/index.html /setup/altdocs/auth/kerberos/index.html ;\
+    cp /etc/apache2/apache2.conf /etc/apache2/apache2.conf.ORIG ;\
+    mv -f apache2.conf /etc/apache2/apache2.conf
 
 EXPOSE 80/tcp
 EXPOSE 8080/tcp

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
@@ -28,7 +28,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "/usr/local/apache2"
+ServerRoot "/usr/lib/apache2"
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory
@@ -124,7 +124,7 @@ LoadModule filter_module modules/mod_filter.so
 #LoadModule brotli_module modules/mod_brotli.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule ldap_module modules/mod_ldap.so
-LoadModule log_config_module modules/mod_log_config.so
+#LoadModule log_config_module modules/mod_log_config.so
 #LoadModule log_debug_module modules/mod_log_debug.so
 #LoadModule log_forensic_module modules/mod_log_forensic.so
 #LoadModule logio_module modules/mod_logio.so
@@ -138,7 +138,7 @@ LoadModule headers_module modules/mod_headers.so
 #LoadModule usertrack_module modules/mod_usertrack.so
 #LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
-LoadModule version_module modules/mod_version.so
+#LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
 #LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
@@ -172,7 +172,7 @@ LoadModule version_module modules/mod_version.so
 #LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
 #LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
 #LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
-LoadModule unixd_module modules/mod_unixd.so
+#LoadModule unixd_module modules/mod_unixd.so
 #LoadModule heartbeat_module modules/mod_heartbeat.so
 #LoadModule heartmonitor_module modules/mod_heartmonitor.so
 #LoadModule dav_module modules/mod_dav.so
@@ -263,8 +263,13 @@ ServerAdmin you@example.com
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/usr/local/apache2/htdocs"
-<Directory "/usr/local/apache2/htdocs">
+DocumentRoot "/setup/htdocs"
+<Directory "/setup/htdocs/>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/setup/htdocs/auth/kerberos">
     Options Indexes FollowSymLinks
     AllowOverride None
 
@@ -276,7 +281,7 @@ DocumentRoot "/usr/local/apache2/htdocs"
     Require valid-user
 </Directory>
 
-<Directory "/usr/local/apache2/altdocs">
+<Directory "/setup/altdocs/auth/kerberos">
     Options Indexes FollowSymLinks
     AllowOverride None
 
@@ -418,7 +423,7 @@ Require valid-user
     # TypesConfig points to the file containing the list of mappings from
     # filename extension to MIME-type.
     #
-    TypesConfig conf/mime.types
+    TypesConfig /etc/mime.types
 
     #
     # AddType allows you to add to or override the MIME configuration
@@ -554,10 +559,8 @@ SSLRandomSeed connect builtin
 
 <VirtualHost *:8080>
   ServerAdmin webmaster@contoso.com
-  DocumentRoot "/usr/local/apache2/altdocs"
+  DocumentRoot "/setup/altdocs"
   ServerName altservice.contoso.com:8080
-  ErrorLog "logs/altservice.contoso.com-error_log"
-  TransferLog "logs/altservice.contoso.com-access_log"
 </VirtualHost>
 
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
@@ -49,8 +49,12 @@ ServerRoot "/usr/lib/apache2"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+<IfDefine ALTPORT>
 Listen 8080
+</IfDefine>
+<IfDefine !ALTPORT>
+Listen 80
+</IfDefine>
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -85,7 +89,7 @@ LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 #LoadModule auth_form_module modules/mod_auth_form.so
-#LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
 #LoadModule allowmethods_module modules/mod_allowmethods.so
 #LoadModule isapi_module modules/mod_isapi.so
 #LoadModule file_cache_module modules/mod_file_cache.so
@@ -198,6 +202,10 @@ LoadModule dir_module modules/mod_dir.so
 #LoadModule userdir_module modules/mod_userdir.so
 LoadModule alias_module modules/mod_alias.so
 #LoadModule rewrite_module modules/mod_rewrite.so
+<IfDefine NTLM>
+LoadModule auth_ntlm_winbind_module modules/mod_auth_ntlm_winbind.so
+</IfDefine>
+LoadModule auth_kerb_module modules/mod_auth_kerb.so
 
 <IfModule unixd_module>
 #
@@ -269,6 +277,9 @@ DocumentRoot "/setup/htdocs"
     AllowOverride None
     Require all granted
 </Directory>
+<Directory "/setup/htdocs/auth">
+    Require all denied
+</Directory>
 <Directory "/setup/htdocs/auth/kerberos">
     Options Indexes FollowSymLinks
     AllowOverride None
@@ -280,7 +291,22 @@ DocumentRoot "/setup/htdocs"
     KrbMethodK5Passwd off
     Require valid-user
 </Directory>
-
+<Directory "/setup/htdocs/auth/digest">
+    AuthType Digest
+    AuthName "Digest Login"
+    AuthDigestProvider file
+    AuthUserFile "/setup/digest_pw"
+    Require valid-user
+</Directory>
+<IfDefine NTLM>
+<Directory "/setup/altdocs/auth/ntlm">
+    AuthName "NTLM Authentication"
+    AuthType NTLN
+    NTLMauth on
+    NTLMAuthHelper "/usr/bin/ntlm_auth --helper-protocol=squid-2.5-ntlmssp --diagnostic"
+    Require valid-user
+</Directory>
+</IfDefine>
 <Directory "/setup/altdocs/auth/kerberos">
     Options Indexes FollowSymLinks
     AllowOverride None
@@ -564,4 +590,6 @@ SSLRandomSeed connect builtin
 </VirtualHost>
 
 
-LoadModule auth_kerb_module modules/mod_auth_kerb.so
+<IFDefine NTLM>
+PidFile /tmp/ntlmapache.pid
+</IFDefine>

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
@@ -1,5 +1,21 @@
-#!/bin/sh
+#!/bin/bash -x
+
+echo "$@" > /tmp/args
 
 cp /SHARED/apacheweb.keytab /etc/krb5.keytab
+
+if [ "$1" == "-debug" ]; then
+  while [ 1 ];do
+    sleep 10000
+  done
+fi
+
+if [ "$1" == "-DNTLM" ]; then
+  ./setup-pdc.sh
+  /usr/sbin/apache2 -DALTPORT "$@"
+  shift
+fi
+
+./setup-digest.sh
 
 exec /usr/sbin/apache2 -DFOREGROUND "$@"

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
@@ -2,4 +2,4 @@
 
 cp /SHARED/apacheweb.keytab /etc/krb5.keytab
 
-exec httpd -DFOREGROUND "$@"
+exec /usr/sbin/apache2 -DFOREGROUND "$@"

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/setup-digest.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/setup-digest.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo -n 'user1:Digest Login:' > /setup/digest_pw
+echo -n 'user1:Digest Login:Password20' | md5sum | cut -d ' '  -f 1 >> /setup/digest_pw

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/setup-pdc.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/setup-pdc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rm -f /etc/samba/smb.conf
+# Configure domain and start daemons
+samba-tool domain  provision --use-rfc2307 --domain=linux --adminpass=password20. --realm=LINUX.CONTOSO.COM  --server-role=dc
+/etc/init.d/samba-ad-dc start
+
+# make sure Apache can connect
+usermod -a -G winbindd_priv daemon
+
+# Add user for testing
+samba-tool user create user1 Password20
+

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     hostname: apacheweb
     domainname: linux.contoso.com
     dns_search: linux.contoso.com
+    privileged: true
+    command: "-DNTLM"
     volumes:
       - shared-volume:/SHARED
     networks:
@@ -39,6 +41,7 @@ services:
     hostname: altweb
     domainname: linux.contoso.com
     dns_search: linux.contoso.com
+    command: -DALTPORT
     volumes:
       - shared-volume:/SHARED
     networks:

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/setup-kdc.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/setup-kdc.sh
@@ -15,8 +15,8 @@ kdb5_util create -r LINUX.CONTOSO.COM -P password -s
 krb5kdc
 
 # Add users
-kadmin.local -q "add_principal -pw password root/admin@LINUX.CONTOSO.COM"
-kadmin.local -q "add_principal -pw password user1@LINUX.CONTOSO.COM"
+kadmin.local -q "add_principal -pw Password20 root/admin@LINUX.CONTOSO.COM"
+kadmin.local -q "add_principal -pw Password20 user1@LINUX.CONTOSO.COM"
 
 # Add SPNs for services
 kadmin.local -q "add_principal -pw password HTTP/apacheweb.linux.contoso.com"

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
@@ -12,12 +12,15 @@ namespace System.Net.Http.Enterprise.Tests
     public class HttpClientAuthenticationTest
     {
         [Theory]
-        [InlineData(EnterpriseTestConfiguration.NegotiateAuthWebServer)]
-        [InlineData(EnterpriseTestConfiguration.AlternativeService)]
-        public async Task HttpClient_ValidAuthentication_Success(string url)
+        [InlineData(EnterpriseTestConfiguration.NegotiateAuthWebServer, false)]
+        [InlineData(EnterpriseTestConfiguration.AlternativeService, false)]
+        [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, true)]
+        [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, false)]
+        [InlineData(EnterpriseTestConfiguration.NtlmAuthWebServer, true)]
+        public async Task HttpClient_ValidAuthentication_Success(string url, bool useDomain)
         {
             using var handler = new HttpClientHandler();
-            handler.Credentials = EnterpriseTestConfiguration.ValidNetworkCredentials;
+            handler.Credentials = useDomain ? EnterpriseTestConfiguration.ValidDomainNetworkCredentials : EnterpriseTestConfiguration.ValidNetworkCredentials;
             using var client = new HttpClient(handler);
 
             using HttpResponseMessage response = await client.GetAsync(url);


### PR DESCRIPTION
this change should have no functional impact but it is stepping stone for some future improvements. 

There are essentially 2 changes here: 
1. Currently the web server expect Kerberos auth for everything. This change moves that requirement to /auth/kerberos. This will allow us to have additional authentication setups under /auth/ as well is opens possibly to test other features - like compression - easier.

2. this is somewhat internal optimization. httpd:2.4 requires Debian while the other containers use Ubuntu 18.04. This change unifies everything on Ubuntu18 so we do not need to fetch two base OS images for each run. 

Most of the changes in apache2.conf  are to deal with damages from the Debian->Ubuntu migration and to support goal above. 


contributes to #47351
contributes to #29270
contributes to #17845
contributes to #31133