### PR TITLE
[release/5.0] Fix optRemoveRedundantZeroInits for loops #48571

### DIFF
--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9391,13 +9391,13 @@ void Compiler::optRemoveRedundantZeroInits()
                         // The local hasn't been referenced before this assignment.
                         bool removedExplicitZeroInit = false;
 
-                        if (!bbInALoop || bbIsReturn)
+                        if (treeOp->gtOp2->IsIntegralConst(0))
                         {
-                            if (treeOp->gtOp2->IsIntegralConst(0))
-                            {
-                                bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
-                                bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
+                            bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
+                            bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
 
+                            if (!bbInALoop || bbIsReturn)
+                            {
                                 if (BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclNum) ||
                                     (lclDsc->lvIsStructField &&
                                     BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||

--- a/src/tests/JIT/opt/DSE/NotRedundantInitsAreRemoved_Github_48394.cs
+++ b/src/tests/JIT/opt/DSE/NotRedundantInitsAreRemoved_Github_48394.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public struct Struct1
+{
+    public long a;
+    public long b;
+}
+
+public class NotRedundantInitsAreRemoved_Github_48394
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue<T>(ref T obj) where T : new()
+    {
+        if (obj != null)
+            throw new Exception("obj was expected to be null");
+
+        obj = new T();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue(ref int val) 
+    {
+        if (val != 0)
+            throw new Exception("val was expected to be zero");
+
+        val = 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateAndAssignValue(ref Struct1 val)
+    {
+        if (val.a != 0 || val.b != 0)
+            throw new Exception("val was expected to be zero");
+
+        val.a = 42;
+        val.b = 43;
+    }
+
+    public static void TestRefs()
+    {
+        object obj = null;
+        int i = 0;
+        do
+        {
+            obj = null;
+            ValidateAndAssignValue(ref obj);
+        }
+        while (i++ < 2);
+    }
+
+    public static void TestInt()
+    {
+        int val = 0;
+        int i = 0;
+        do
+        {
+            val = 0;
+            ValidateAndAssignValue(ref val);
+        }
+        while (i++ < 2);
+    }
+
+    public static void TestStruct()
+    {
+        Struct1 val = default;
+        int i = 0;
+        do
+        {
+            val.a = 0;
+            val.b = 0; 
+            ValidateAndAssignValue(ref val);
+        }
+        while (i++ < 2);
+    }
+
+    public static unsafe void TestTakeAddress()
+    {
+        int a = 0;
+        int* pa = &a;
+        *pa = 42;
+        a = 0;
+        if (a != 0)
+            throw new Exception("a was expected to be zero");
+    }
+
+    public static unsafe void TestTakeAddress(bool cond)
+    {
+        int a = 0;
+        if (cond)
+        {
+            int* pa = &a;
+            *pa = 42;
+        }
+        a = 0;
+        if (a != 0)
+            throw new Exception("a was expected to be zero");
+    }
+
+    public static void ReproFrom_GitHub_48394()
+    {
+        bool x = false;
+        int c = 0;
+        try
+        {
+            while (true)
+            {
+                c = 0;
+                if (!x)
+                {
+                    c = c + 100;
+                    x = true;
+                }
+                else
+                {
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            if (c != 0)
+                throw new Exception("c was expected to be 100");
+        }
+    }
+
+    public static int Zero => 0;
+
+    public static void TestInt2()
+    {
+        int val = Zero;
+        int i = 0;
+
+    label:
+        val = Zero;
+        ValidateAndAssignValue(ref val);
+        i++;
+        if (i < 10)
+            goto label;
+    }
+
+    public static int Main()
+    {
+        ReproFrom_GitHub_48394();
+        TestTakeAddress();
+        TestTakeAddress(true);
+        TestTakeAddress(false);
+        TestInt();
+        TestInt2();
+        TestRefs();
+        TestStruct();
+        return 100;
+    }
+}

--- a/src/tests/JIT/opt/DSE/NotRedundantInitsAreRemoved_Github_48394.csproj
+++ b/src/tests/JIT/opt/DSE/NotRedundantInitsAreRemoved_Github_48394.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NotRedundantInitsAreRemoved_Github_48394.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/48394
Fix in master: https://github.com/dotnet/runtime/pull/48571

## Customer Impact
Jit tries to eliminate redundant (duplicated) zero initializations for all types of local variables if we don't do anything with them in-between. Unfortunately, there is a case with backward branches (loops) where it can drop zero inits where they're actually needed. It might lead to an unexpected behavior.

A simple repro:
```csharp
static void MakeSureIsNullAndSetValue(ref object obj)
{
    if (obj != null)
        throw new System.Exception("should be null at this point");
    obj = new object();
}

static void Test()
{
    object obj = null;
    int i = 0;
    do
    {
        obj = null; // this assignment shouldn't be removed
        MakeSureIsNullAndSetValue(ref obj);
    }
    while (i++ < 10);
}

Test();
```
It throws that exception in Release mode (only on .NET 5.0), Debug is fine since the optimization is not kicked in.
Jit-diff tools found a place in the BCL where JIT removes not-redundant assignment: https://github.com/dotnet/runtime/blob/d5ab93c4a8e45da2dab8924c2165000bf78f84e6/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs#L776 

## Testing
This PR adds a regression test.

## Risk
Low. The fix is pretty straightforward and disables the optimization once we hit a loop 

## Regression
Yes, the optimization was introduced in 5.0