### PR TITLE
WinHttpHandler: HttpClientHandlerTestBase.AllowAllCertificates should not be static

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -30,6 +30,10 @@ namespace System.Net.Http.Functional.Tests
 
         public HttpClientHandler_ServerCertificates_Test(ITestOutputHelper output) : base(output) { }
 
+        // This enables customizing ServerCertificateCustomValidationCallback in WinHttpHandler variants:
+        protected bool AllowAllHttp2Certificates { get; set; } = true;
+        protected new HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion, allowAllHttp2Certificates: AllowAllHttp2Certificates);
+
         [Fact]
         public void Ctor_ExpectedDefaultValues()
         {
@@ -451,15 +455,19 @@ namespace System.Net.Http.Functional.Tests
             File.WriteAllText(sslCertFile, "");
             psi.Environment.Add("SSL_CERT_FILE", sslCertFile);
 
-            RemoteExecutor.Invoke(async (useVersionString) =>
+            RemoteExecutor.Invoke(async (useVersionString, allowAllHttp2CertificatesString) =>
             {
                 const string Url = "https://www.microsoft.com";
 
-                using (HttpClient client = CreateHttpClient(useVersionString))
+                HttpClientHandler handler = CreateHttpClientHandler(
+                    Version.Parse(useVersionString),
+                    allowAllHttp2Certificates: bool.Parse(allowAllHttp2CertificatesString));
+
+                using (HttpClient client = CreateHttpClient(handler, useVersionString))
                 {
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(Url));
                 }
-            }, UseVersion.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+            }, UseVersion.ToString(), AllowAllHttp2Certificates.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Functional.Tests
 #endif
             };
 
-        protected HttpClient CreateHttpClient(string useVersionString) =>
+        protected static HttpClient CreateHttpClient(string useVersionString) =>
             CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Functional.Tests
 #endif
             };
 
-        protected static HttpClient CreateHttpClient(string useVersionString) =>
+        protected HttpClient CreateHttpClient(string useVersionString) =>
             CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -10,15 +10,13 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected static bool AllowAllCertificates { get; set; } = true;
-
-        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
+        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null, bool allowAllHttp2Certificates = true)
         {
             useVersion ??= HttpVersion.Version11;
 
             WinHttpClientHandler handler = new WinHttpClientHandler(useVersion);
 
-            if (useVersion >= HttpVersion20.Value && AllowAllCertificates)
+            if (useVersion >= HttpVersion20.Value && allowAllHttp2Certificates)
             {
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -10,9 +10,9 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected static bool AllowAllCertificates { get; set; } = true;
+        protected bool AllowAllCertificates { get; set; } = true;
 
-        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
+        protected WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
             useVersion ??= HttpVersion.Version11;
 
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
 
         protected WinHttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion);
 
-        protected static WinHttpClientHandler CreateHttpClientHandler(string useVersionString) =>
+        protected WinHttpClientHandler CreateHttpClientHandler(string useVersionString) =>
             CreateHttpClientHandler(Version.Parse(useVersionString));
 
         protected static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri, Version version, bool exactVersion = false) =>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -10,9 +10,9 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected bool AllowAllCertificates { get; set; } = true;
+        protected static bool AllowAllCertificates { get; set; } = true;
 
-        protected WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
+        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
             useVersion ??= HttpVersion.Version11;
 
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
 
         protected WinHttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion);
 
-        protected WinHttpClientHandler CreateHttpClientHandler(string useVersionString) =>
+        protected static WinHttpClientHandler CreateHttpClientHandler(string useVersionString) =>
             CreateHttpClientHandler(Version.Parse(useVersionString));
 
         protected static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri, Version version, bool exactVersion = false) =>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -277,7 +277,7 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion20.Value;
 
         public PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test(ITestOutputHelper output) : base(output) {
-            AllowAllCertificates = false;
+            AllowAllHttp2Certificates = false;
         }
     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -18,13 +18,13 @@ namespace System.Net.Http.Functional.Tests
 
         public static bool IsMsQuicSupported => QuicImplementationProviders.MsQuic.IsSupported;
 
-        protected static HttpClientHandler CreateHttpClientHandler(Version useVersion = null, QuicImplementationProvider quicImplementationProvider = null)
+        protected static HttpClientHandler CreateHttpClientHandler(Version useVersion = null, QuicImplementationProvider quicImplementationProvider = null, bool allowAllHttp2Certificates = true)
         {
             useVersion ??= HttpVersion.Version11;
 
             HttpClientHandler handler = (PlatformDetection.SupportsAlpn && useVersion != HttpVersion.Version30) ? new HttpClientHandler() : new VersionHttpClientHandler(useVersion);
 
-            if (useVersion >= HttpVersion.Version20)
+            if (useVersion >= HttpVersion.Version20 && allowAllHttp2Certificates)
             {
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }


### PR DESCRIPTION
The default value of this property is `true`. Tests like like `PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test` are altering this global state, which may cause subsequently executed tests to fail because their prerequisites are not met:
https://github.com/dotnet/runtime/blob/1d9e50cb4735df46d3de0cee5791e97295eaf588/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs#L275-L282

This is the root cause of the failures I discovered in https://github.com/dotnet/runtime/pull/48704#issuecomment-786025511, and a prerequisite to proceed with that PR, since the new tests are incorrect there (although they are all skipped on today's CI machines, so we can't see the failures in the PR).

/cc @geoffkizer @wfurt 

#### Update
Instead of changing the static property to an instance one, `allowAllHttp2Certificates` is now a parameter of the general, shared overload of `CreateHttpClientHandler(...)`. This way individual test classes can implement their mechanism to manage this parameter, so far the only one is `HttpClientHandler_ServerCertificates_Test`.