### PR TITLE
Fix majority of failures in libraries-jitstressregs after EHWriteThru enabled

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -10773,7 +10773,7 @@ void LinearScan::verifyFinalAllocation()
         {
             // Free Registers.
             // We could use the freeRegisters() method, but we'd have to carefully manage the active intervals.
-            for (regNumber reg = REG_FIRST; reg < ACTUAL_REG_COUNT; reg = REG_NEXT(reg))
+            for (regNumber reg = REG_FIRST; reg < ACTUAL_REG_COUNT && regsToFree != RBM_NONE; reg = REG_NEXT(reg))
             {
                 regMaskTP regMask = genRegMask(reg);
                 if ((regsToFree & regMask) != RBM_NONE)
@@ -10952,6 +10952,7 @@ void LinearScan::verifyFinalAllocation()
                 else if (RefTypeIsDef(currentRefPosition->refType))
                 {
                     interval->isActive = true;
+
                     if (VERBOSE)
                     {
                         if (interval->isConstant && (currentRefPosition->treeNode != nullptr) &&
@@ -11023,11 +11024,17 @@ void LinearScan::verifyFinalAllocation()
                     }
                     else
                     {
-                        if (!currentRefPosition->copyReg)
+                        if (RefTypeIsDef(currentRefPosition->refType))
                         {
-                            interval->physReg     = regNum;
-                            interval->assignedReg = regRecord;
+                            // Interval was assigned to a different register.
+                            // Clear the assigned interval of current register.
+                            if (interval->physReg != REG_NA && interval->physReg != regNum)
+                            {
+                                interval->assignedReg->assignedInterval = nullptr; 
+                            }
                         }
+                        interval->physReg     = regNum;
+                        interval->assignedReg = regRecord;
                         regRecord->assignedInterval = interval;
                     }
                 }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -10761,7 +10761,7 @@ void LinearScan::verifyFinalAllocation()
         }
 
         LsraLocation newLocation = currentRefPosition->nodeLocation;
-        currentLocation = newLocation;
+        currentLocation          = newLocation;
 
         switch (currentRefPosition->refType)
         {
@@ -11006,11 +11006,11 @@ void LinearScan::verifyFinalAllocation()
                             // Clear the assigned interval of current register.
                             if (interval->physReg != REG_NA && interval->physReg != regNum)
                             {
-                                interval->assignedReg->assignedInterval = nullptr; 
+                                interval->assignedReg->assignedInterval = nullptr;
                             }
                         }
-                        interval->physReg     = regNum;
-                        interval->assignedReg = regRecord;
+                        interval->physReg           = regNum;
+                        interval->assignedReg       = regRecord;
                         regRecord->assignedInterval = interval;
                     }
                 }


### PR DESCRIPTION
When we verify final allocation, we were not resetting the `assignedInterval` if the interval got assigned to a different register. This was not consistent to what we do during allocation.

Fixed following failures:

https://dev.azure.com/dnceng/public/_build/results?buildId=989595&view=ms.vss-test-web.build-test-results-tab&runId=30998546&resultId=169282&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-47307-head-5f85fedec0cd4ff9a0/System.Net.Security.Tests/console.73e69194.log?sv=2019-07-07&se=2021-03-03T08%3A52%3A21Z&sr=c&sp=rl&sig=naQOrM%2BszKDyDAO8m%2BU%2Fu149f4cjodTk1dYCKl9cvKs%3D

Failures are present on arch/OS:
- Linux arm64
- Linux arm
- Linux x64
- Windows x86
- Windows x64