### PR TITLE
Fix isByteReg() assert for x86

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -238,6 +238,8 @@ BasicBlock::weight_t LinearScan::getWeight(RefPosition* refPos)
 // in time (more of a 'bank' of registers).
 regMaskTP LinearScan::allRegs(RegisterType rt)
 {
+    assert(rt != TYP_BYTE);
+
     if (rt == TYP_FLOAT)
     {
         return availableFloatRegs;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -238,8 +238,6 @@ BasicBlock::weight_t LinearScan::getWeight(RefPosition* refPos)
 // in time (more of a 'bank' of registers).
 regMaskTP LinearScan::allRegs(RegisterType rt)
 {
-    assert(rt != TYP_BYTE);
-
     if (rt == TYP_FLOAT)
     {
         return availableFloatRegs;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3207,8 +3207,24 @@ void LinearScan::BuildStoreLocDef(GenTreeLclVarCommon* storeLoc,
             srcInterval->assignRelatedInterval(varDefInterval);
         }
     }
-    RefPosition* def =
-        newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, allRegs(varDsc->TypeGet()), index);
+
+    regMaskTP defCandidates = RBM_NONE;
+    var_types type          = varDsc->TypeGet();
+
+#ifdef TARGET_X86
+    if (varTypeIsByte(type))
+    {
+        defCandidates = allByteRegs();
+    }
+    else
+    {
+        defCandidates = allRegs(type);
+    }
+#else
+    defCandidates = allRegs(type);
+#endif // TARGET_X86
+
+    RefPosition* def = newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, defCandidates, index);
     if (varDefInterval->isWriteThru)
     {
         // We always make write-thru defs reg-optional, as we can store them if they don't


### PR DESCRIPTION
The change is similar to the one done in https://github.com/dotnet/runtime/pull/46567. If the type if `BYTE`, the use byte regs.

Fixes the following jitstressregs failures on Windows x86

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-47307-head-c9ab37658a344842be/System.Linq.Queryable.Tests/console.2ce37104.log?sv=2019-07-07&se=2021-03-10T08%3A39%3A45Z&sr=c&sp=rl&sig=GdS1KlEkJHVcKz7lwpZeszudWYokZpr%2Bt7IGv4c61co%3D

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-47307-head-c9ab37658a344842be/System.Linq.Tests/console.4bc4fd10.log?sv=2019-07-07&se=2021-03-10T08%3A39%3A45Z&sr=c&sp=rl&sig=GdS1KlEkJHVcKz7lwpZeszudWYokZpr%2Bt7IGv4c61co%3D