### PR TITLE
Fix assert(interval->physReg != REG_NA && interval->physReg != REG_STK)

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6532,6 +6532,8 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreeLclVar* treeNode, Ref
         }
         interval->assignedReg = nullptr;
         interval->physReg     = REG_NA;
+        interval->isActive    = false;
+
         // Set this as contained if it is not a multi-reg (we could potentially mark it s contained
         // if all uses are from spill, but that adds complexity.
         if ((currentRefPosition->refType == RefTypeUse) && !treeNode->IsMultiReg())


### PR DESCRIPTION
During resolution, an interval should be marked inactive once there is no register assignment to the corresponding refPosition.

Fixes following jitstressres failures on Windows x86

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-47307-head-9a04ddee2ee04376ae/System.Linq.Parallel.Tests/console.0e35ac6f.log?sv=2019-07-07&se=2021-03-15T02%3A22%3A01Z&sr=c&sp=rl&sig=zdrZjpHUrBJpYgQAvQb%2B81EHbJ%2FAhhe7BloSTARNazg%3D