### PR TITLE
Remove misleading sentence in BinaryPrimitives remarks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/Reader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/Reader.cs
@@ -10,7 +10,6 @@ namespace System.Buffers.Binary
     /// Reads bytes as primitives with specific endianness
     /// </summary>
     /// <remarks>
-    /// For native formats, MemoryExtensions.Read{T}; should be used.
     /// Use these helpers when you need to read specific endianness.
     /// </remarks>
     public static partial class BinaryPrimitives


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48320 