### PR TITLE
Clean up test run scripts

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -64,7 +64,7 @@ WARNING:   When setting properties based on their current state (for example:
   <Target Name="GenerateBashExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\$(MSBuildProjectName).sh"
-    DependsOnTargets="FetchExternalPropertiesForXpalt;$(BashScriptSnippetGen);GetJitDisasmBashScript;GetIlasmRoundTripBashScript">
+    DependsOnTargets="FetchExternalPropertiesForXpalt;$(BashScriptSnippetGen);GetIlasmRoundTripBashScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -453,7 +453,6 @@ $(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
-$(JitDisasmBashScript)
 $(IlasmRoundTripBashScript)
 # Allow precommands to override the ExePath
 ExePath=$(InputAssemblyName)

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -63,7 +63,7 @@ WARNING:   When setting properties based on their current state (for example:
   <Target Name="GenerateBatchExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\$(MSBuildProjectName).cmd"
-    DependsOnTargets="FetchExternalProperties;$(BatchScriptSnippetGen);GetJitDisasmBatchScript;GetIlasmRoundTripBatchScript">
+    DependsOnTargets="FetchExternalProperties;$(BatchScriptSnippetGen);GetIlasmRoundTripBatchScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -433,8 +433,6 @@ REM Environment Variables
 $(BatchEnvironmentVariables)
 
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-
-$(JitDisasmBatchScript)
 
 $(IlasmRoundTripBatchScript)
 

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -20,54 +20,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="GetJitDisasmBashScript"
-          Returns="$(JitDisasmBashScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)).Replace("\","/"))</JitDisasmOut>
-      <JitDisasmBashScript>
-<![CDATA[
-# JitDisasm Script
-if [ ! -z $RunningJitDisasm ]
-then
-    echo $CORE_ROOT/corerun "$CORE_ROOT/jit-dasm.dll" --crossgen $CORE_ROOT/crossgen --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
-    "$CORE_ROOT/corerun" "$CORE_ROOT/jit-dasm.dll" --crossgen $CORE_ROOT/crossgen --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
-    _jdExitCode=$?
-    if [ $_jdExitCode -ne 0 ]
-    then
-        echo EXECUTION OF JIT-DASM - FAILED $_jdExitCode
-        exit 1
-    fi
-fi
-]]>
-      </JitDisasmBashScript>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="GetJitDisasmBatchScript"
-          Returns="$(JitDisasmBatchScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)))</JitDisasmOut>
-      <JitDisasmBatchScript>
-<![CDATA[
-REM JitDisasm Script
-if defined RunningJitDisasm (
-  echo %CORE_ROOT%\corerun %CORE_ROOT%\jit-dasm.dll --crossgen %CORE_ROOT%/crossgen.exe --platform %CORE_ROOT%%3B%25cd%25 --output $(JitDisasmOut) $(InputAssemblyName)
-  %CORE_ROOT%\corerun %CORE_ROOT%\jit-dasm.dll --crossgen %CORE_ROOT%/crossgen.exe --platform %CORE_ROOT%%3B%25cd%25 --output $(JitDisasmOut) $(InputAssemblyName)
-  IF NOT "!ERRORLEVEL!"=="0" (
-    ECHO EXECUTION OF JIT-DASM - FAILED !ERRORLEVEL!
-    Exit /b 1
-  )
-  Exit /b 0
-)
-    ]]>
-      </JitDisasmBatchScript>
-    </PropertyGroup>
-  </Target>
-
   <!--
   ***********************************************************************************************
   ildasm / ilasm round trip testing

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -655,27 +655,19 @@ if [ "$__TargetOS" == "Android" ]; then
     build_MSBuild_projects "Create_Android_App" "$__RepoRootDir/src/tests/run.proj" "Create Android Apps" "/t:BuildAllAndroidApp" "/p:RunWithAndroid=true"
 fi
 
-__testNativeBinDir="$__IntermediatesDir"/tests
-
 if [[ "$__RunTests" -ne 0 ]]; then
 
     echo "Run Tests..."
 
-    nextCommand="$__TestDir/run.sh --testRootDir=$__TestBinDir --coreClrBinDir=$__BinDir --coreFxBinDir=$CORE_ROOT --testNativeBinDir=$__testNativeBinDir"
+    nextCommand="$__TestDir/run.sh --testRootDir=$__TestBinDir"
     echo "$nextCommand"
     eval $nextCommand
 
     echo "Tests run successful."
 else
-    echo "To run all tests use 'run.sh' where:"
-    echo "    testRootDir      = $__TestBinDir"
-    echo "    coreClrBinDir    = $__BinDir"
-    echo "    coreFxBinDir     = $CORE_ROOT"
-    echo "    testNativeBinDir = $__testNativeBinDir"
-    echo " -------------------------------------------------- "
-    echo " Example run.sh command"
+    echo "To run all tests use:"
     echo ""
-    echo " src/tests/run.sh --coreOverlayDir=$CORE_ROOT --testNativeBinDir=$__testNativeBinDir --testRootDir=$__TestBinDir --copyNativeTestBin $__BuildType"
+    echo " src/tests/run.sh --testRootDir=$__TestBinDir $__BuildType"
     echo " -------------------------------------------------- "
     echo "To run single test use the following command:"
     echo "    bash ${__TestBinDir}/__TEST_PATH__/__TEST_NAME__.sh -coreroot=${CORE_ROOT}"

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -665,10 +665,12 @@ if [[ "$__RunTests" -ne 0 ]]; then
 
     echo "Tests run successful."
 else
-    echo "To run all tests use:"
+    echo "To run all the tests use:"
     echo ""
-    echo " src/tests/run.sh --testRootDir=$__TestBinDir $__BuildType"
-    echo " -------------------------------------------------- "
-    echo "To run single test use the following command:"
+    echo "    src/tests/run.sh $__BuildType"
+    echo ""
+    echo "To run a single test use:"
+    echo ""
     echo "    bash ${__TestBinDir}/__TEST_PATH__/__TEST_NAME__.sh -coreroot=${CORE_ROOT}"
+    echo ""
 fi

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -11,7 +11,7 @@ set __BuildType=Debug
 set __TargetOS=windows
 
 set "__ProjectDir=%~dp0"
-set "__RepoRootDir=%~dp0\..\.."
+set "__RepoRootDir=%~dp0..\.."
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__ProjectFilesDir=%__ProjectDir%"
@@ -25,7 +25,6 @@ set __Sequential=
 set __msbuildExtraArgs=
 set __LongGCTests=
 set __GCSimulatorTests=
-set __JitDisasm=
 set __IlasmRoundTrip=
 set __DoCrossgen=
 set __CrossgenAltJit=
@@ -55,7 +54,6 @@ if /i "%1" == "vs2017"                                  (set __VSVersion=%1&shif
 if /i "%1" == "vs2019"                                  (set __VSVersion=%1&shift&goto Arg_Loop)
 
 if /i "%1" == "TestEnv"                                 (set __TestEnv=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "AgainstPackages"                         (echo error: Remove /AgainstPackages switch&&echo /b 1)
 if /i "%1" == "sequential"                              (set __Sequential=1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen"                                (set __DoCrossgen=1&shift&goto Arg_Loop)
 if /i "%1" == "crossgenaltjit"                          (set __DoCrossgen=1&set __CrossgenAltJit=%2&shift&shift&goto Arg_Loop)
@@ -65,7 +63,6 @@ if /i "%1" == "jitstress"                               (set COMPlus_JitStress=%
 if /i "%1" == "jitstressregs"                           (set COMPlus_JitStressRegs=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitminopts"                              (set COMPlus_JITMinOpts=1&shift&goto Arg_Loop)
 if /i "%1" == "jitforcerelocs"                          (set COMPlus_ForceRelocs=1&shift&goto Arg_Loop)
-if /i "%1" == "jitdisasm"                               (set __JitDisasm=1&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
@@ -75,11 +72,8 @@ REM This test feature is currently intentionally undocumented
 if /i "%1" == "runlargeversionbubblecrossgentests"      (set RunCrossGen=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
-REM tieredcompilation is on by default now, but setting this environment variable is harmless and I didn't want to break any automation that might be using it just yet
-if /i "%1" == "tieredcompilation"                       (set COMPLUS_TieredCompilation=1&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                                  (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"                                 (set __TestTimeout=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "altjitarch"                              (set __AltJitArch=%2&shift&shift&goto Arg_Loop)
 
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"                           (set COMPlus_GCStress=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
@@ -132,10 +126,6 @@ if defined __GCSimulatorTests (
     set __RuntestPyArgs=%__RuntestPyArgs% --gcsimulator
 )
 
-if defined __JitDisasm (
-    set __RuntestPyArgs=%__RuntestPyArgs% --jitdisasm
-)
-
 if defined __IlasmRoundTrip (
     set __RuntestPyArgs=%__RuntestPyArgs% --ilasmroundtrip
 )
@@ -168,17 +158,24 @@ if defined __PrintLastResultsOnly (
     set __RuntestPyArgs=%__RuntestPyArgs% --analyze_results_only
 )
 
-if defined __AltJitArch (
-    set __RuntestPyArgs=%__RuntestPyArgs% -altjit_arch %__AltJitArch%
-)
-
 if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python "%__RepoRootDir%\src\tests\run.py" %__RuntestPyArgs%
-echo !NEXTCMD!
-!NEXTCMD!
+REM Find python and set it to the variable PYTHON
+set _C=-c "import sys; sys.stdout.write(sys.executable)"
+(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
+set _C=
+set /p PYTHON=<%TEMP%\pythonlocation.txt
+
+if NOT DEFINED PYTHON (
+    echo %__MsgPrefix%Error: Could not find a Python installation.
+    exit /b 1
+)
+
+set NEXTCMD=%PYTHON% "%__RepoRootDir%\src\tests\run.py" %__RuntestPyArgs%
+echo %NEXTCMD%
+%NEXTCMD%
 
 exit /b %ERRORLEVEL%
 
@@ -297,8 +294,6 @@ REM ============================================================================
 
 :PrecompileAssembly
 
-if defined __JitDisasm goto :jitdisasm
-
 REM Skip mscorlib since it is already precompiled.
 if /I "%3" == "mscorlib.dll" exit /b 0
 if /I "%3" == "mscorlib.ni.dll" exit /b 0
@@ -316,27 +311,6 @@ if %__exitCode% neq 0 (
 )
 
 echo %__MsgPrefix%Successfully precompiled %2
-exit /b 0
-
-:jitdisasm
-
-if /I "%3" == "mscorlib.ni.dll" exit /b 0
-
-echo "%1\corerun" "%1\jit-dasm.dll" --crossgen %1\crossgen.exe --platform %CORE_ROOT% --output %__TestWorkingDir%\dasm "%2"
-"%1\corerun" "%1\jit-dasm.dll" --crossgen %1\crossgen.exe --platform %CORE_ROOT% --output %__TestWorkingDir%\dasm "%2"
-set /a __exitCode = %errorlevel%
-
-if "%__exitCode%" == "-2146230517" (
-    echo %2 is not a managed assembly.
-    exit /b 0
-)
-
-if %__exitCode% neq 0 (
-    echo Unable to precompile %2
-    exit /b 0
-)
-
-echo %__MsgPrefix%Successfully precompiled and generated dasm for %2
 exit /b 0
 
 :PrecompileFX
@@ -429,16 +403,6 @@ if defined __GCSimulatorTests (
     set RunningGCSimulatorTests=1
 )
 
-if defined __JitDisasm (
-    if defined __DoCrossgen (
-        echo %__MsgPrefix%Running jit disasm on framework and test assemblies
-    )
-    if not defined __DoCrossgen (
-       echo %__MsgPrefix%Running jit disasm on test assemblies only
-    )
-    set RunningJitDisasm=1
-)
-
 if defined __IlasmRoundTrip (
     echo %__MsgPrefix%Running Ilasm round trip
     set RunningIlasmRoundTrip=1
@@ -488,28 +452,27 @@ echo TestEnv ^<test_env_script^> - Run a custom script before every test to set 
 echo sequential                - Run tests sequentially (no parallelism).
 echo crossgen                  - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests.
 echo crossgenaltjit ^<altjit^>   - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests, using the given altjit.
-echo link ^<ILlink^>             - Runs the tests after linking via the IL linker ^<ILlink^>.
 echo RunCrossgenTests          - Runs ReadytoRun tests
+echo RunCrossgen2Tests         - Runs ReadytoRun tests compiled with Crossgen2
 echo jitstress ^<n^>             - Runs the tests with COMPlus_JitStress=n
 echo jitstressregs ^<n^>         - Runs the tests with COMPlus_JitStressRegs=n
 echo jitminopts                - Runs the tests with COMPlus_JITMinOpts=1
 echo jitforcerelocs            - Runs the tests with COMPlus_ForceRelocs=1
-echo jitdisasm                 - Runs jit-dasm on the tests
-echo ilasmroundtrip            - Runs ilasm round trip on the tests
-echo longgc                    - Run the long-running GC tests
-echo gcsimulator               - Run the GC Simulator tests
+echo gcname ^<name^>             - Runs the tests with COMPlus_GCName=name
 echo gcstresslevel ^<n^>         - Runs the tests with COMPlus_GCStress=n. n=0 means no GC Stress. Otherwise, n is a bitmask of the following:
 echo                               1: GC on all allocations and 'easy' places
 echo                               2: GC on transitions to preemptive GC
 echo                               4: GC on every allowable JITed instruction
 echo                               8: GC on every allowable NGEN instruction
 echo                              16: GC only on a unique stack trace
-echo tieredcompilation         - Run the tests with COMPlus_TieredCompilation=1
-echo gcname ^<name^>             - Runs the tests with COMPlus_GCName=name
-echo timeout ^<n^>               - Sets the per-test timeout in milliseconds ^(default is 10 minutes = 10 * 60 * 1000 = 600000^).
-echo                             Note: some options override this ^(gcstresslevel, longgc, gcsimulator^).
+echo gcsimulator               - Run the GC Simulator tests
+echo longgc                    - Run the long-running GC tests
+echo ilasmroundtrip            - Runs ilasm round trip on the tests
+echo link ^<ILlink^>             - Runs the tests after linking via the IL linker ^<ILlink^>.
 echo printlastresultsonly      - Print the last test results without running tests.
 echo runincontext              - Run each tests in an unloadable AssemblyLoadContext
+echo timeout ^<n^>               - Sets the per-test timeout in milliseconds ^(default is 10 minutes = 10 * 60 * 1000 = 600000^).
+echo                             Note: some options override this ^(gcstresslevel, longgc, gcsimulator^).
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
 echo.

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -26,11 +26,6 @@
 # prone to failure; however, copying into the Core_Root directory may create
 # naming conflicts.
 #
-# If you are running tests on a different target than the host that built, the
-# native tests components must be copied from:
-# artifacts/obj/<OS>.<Arch>.<BuildType>/tests to the target. If the location is not
-# standard please pass the -test_native_bin_location flag to the script.
-#
 # Use the instructions here:
 #    https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/coreclr/windows-test-instructions.md
 #    https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/coreclr/unix-test-instructions.md
@@ -78,12 +73,7 @@ Note that for linux targets the native components to the tests are still built
 by the product build. This requires all native components to be either copied
 into the Core_Root directory or the test's managed directory. The latter is
 prone to failure; however, copying into the Core_Root directory may create
-naming conflicts.
-
-If you are running tests on a different target than the host that built, the
-native tests components must be copied from:
-artifacts/obj/<OS>.<Arch>.<BuildType>/tests to the target. If the location is not
-standard please pass the -test_native_bin_location flag to the script.""")
+naming conflicts.""")
 
 parser = argparse.ArgumentParser(description=description)
 
@@ -92,17 +82,11 @@ parser.add_argument("-arch", dest="arch", nargs='?', default="x64")
 parser.add_argument("-build_type", dest="build_type", nargs='?', default="Debug")
 parser.add_argument("-test_location", dest="test_location", nargs="?", default=None)
 parser.add_argument("-core_root", dest="core_root", nargs='?', default=None)
-parser.add_argument("-product_location", dest="product_location", nargs='?', default=None)
 parser.add_argument("-runtime_repo_location", dest="runtime_repo_location", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 parser.add_argument("-test_env", dest="test_env", default=None)
 parser.add_argument("-crossgen_altjit", dest="crossgen_altjit", default=None)
 
 # Optional arguments which change execution.
-
-# Rid is used only for restoring packages. This is a unspecified and undocumented
-# environment variable that needs to be passed to build.proj. Do not use this
-# unless you are attempting to target package restoration for another host/arch/os
-parser.add_argument("-rid", dest="rid", nargs="?", default=None)
 
 parser.add_argument("--il_link", dest="il_link", action="store_true", default=False)
 parser.add_argument("--long_gc", dest="long_gc", action="store_true", default=False)
@@ -119,9 +103,6 @@ parser.add_argument("--analyze_results_only", dest="analyze_results_only", actio
 parser.add_argument("--verbose", dest="verbose", action="store_true", default=False)
 parser.add_argument("--limited_core_dumps", dest="limited_core_dumps", action="store_true", default=False)
 parser.add_argument("--run_in_context", dest="run_in_context", action="store_true", default=False)
-
-# Only used on Unix
-parser.add_argument("-test_native_bin_location", dest="test_native_bin_location", nargs='?', default=None)
 
 ################################################################################
 # Globals
@@ -1052,50 +1033,16 @@ def setup_args(args):
                               "Error setting limited_core_dumps")
 
     coreclr_setup_args.verify(args,
-                              "test_native_bin_location",
-                              lambda arg: True,
-                              "Error setting test_native_bin_location")
-
-    coreclr_setup_args.verify(args,
                               "run_in_context",
                               lambda arg: True,
                               "Error setting run_in_context")
-
-    is_same_os = False
-    is_same_arch = False
-    is_same_build_type = False
-
-    # We will write out build information into the test directory. This is used
-    # by run.py to determine whether we need to rebuild the test wrappers.
-    if os.path.isfile(os.path.join(coreclr_setup_args.test_location, "build_info.json")):
-        with open(os.path.join(coreclr_setup_args.test_location, "build_info.json")) as file_handle:
-            build_info = json.load(file_handle)
-        is_same_os = build_info["build_os"] == coreclr_setup_args.host_os
-        is_same_arch = build_info["build_arch"] == coreclr_setup_args.arch
-        is_same_build_type = build_info["build_type"] == coreclr_setup_args.build_type
-
-    if coreclr_setup_args.host_os != "windows" and not (is_same_os and is_same_arch and is_same_build_type):
-        test_native_bin_location = None
-        if args.test_native_bin_location is None:
-            test_native_bin_location = os.path.join(os.path.join(coreclr_setup_args.artifacts_location, "tests", "coreclr", "obj", "%s.%s.%s" % (coreclr_setup_args.host_os, coreclr_setup_args.arch, coreclr_setup_args.build_type)))
-        else:
-            test_native_bin_location = args.test_native_bin_location
-
-        coreclr_setup_args.verify(test_native_bin_location,
-                                  "test_native_bin_location",
-                                  lambda test_native_bin_location: os.path.isdir(test_native_bin_location),
-                                  "Error setting test_native_bin_location")
-    else:
-        setattr(coreclr_setup_args, "test_native_bin_location", None)
 
     print("host_os                  : %s" % coreclr_setup_args.host_os)
     print("arch                     : %s" % coreclr_setup_args.arch)
     print("build_type               : %s" % coreclr_setup_args.build_type)
     print("runtime_repo_location    : %s" % coreclr_setup_args.runtime_repo_location)
-    print("product_location         : %s" % coreclr_setup_args.product_location)
     print("core_root                : %s" % coreclr_setup_args.core_root)
     print("test_location            : %s" % coreclr_setup_args.test_location)
-    print("test_native_bin_location : %s" % coreclr_setup_args.test_native_bin_location)
 
     coreclr_setup_args.crossgen_path = os.path.join(coreclr_setup_args.core_root, "crossgen%s" % (".exe" if coreclr_setup_args.host_os == "windows" else ""))
     coreclr_setup_args.corerun_path = os.path.join(coreclr_setup_args.core_root, "corerun%s" % (".exe" if coreclr_setup_args.host_os == "windows" else ""))

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -357,7 +357,7 @@ else
     echo \"CORE_ROOT set to ${CORE_ROOT}\"
 fi
 
-""" % (self.unique_name, self.core_root)
+""" % (self.unique_name, self.args.core_root)
 
         line_sep = os.linesep
 

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -74,7 +74,6 @@ function check_cpu_architecture {
 ################################################################################
 
 ARCH=$(check_cpu_architecture)
-echo "Running on  CPU- $ARCH"
 
 # Exit code constants
 readonly EXIT_CODE_SUCCESS=0       # Script ran normally.
@@ -211,34 +210,28 @@ do
 done
 
 ################################################################################
-# Runtests
+# Set environment variables affecting tests.
+# (These should be run.py arguments.)
 ################################################################################
 
 if ((disableEventLogging == 0)); then
     export COMPlus_EnableEventLog=1
 fi
 
-export COMPlus_gcServer="$serverGC"
+if ((serverGC != 0)); then
+    export COMPlus_gcServer="$serverGC"
+fi
 
 ################################################################################
-# Run.py
+# Call run.py to run tests.
 ################################################################################
 
 runtestPyArguments=("-arch" "${buildArch}" "-build_type" "${buildConfiguration}")
 scriptPath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 repoRootDir=$scriptPath/../..
 
-if [ -z "$testRootDir" ]; then
-    echo "testRootDir and other existing arguments is no longer required. If the "
-    echo "default location is incorrect or does not exist, please use "
-    echo "--testRootDir to explicitly override the defaults."
-
-    echo ""
-fi
-
 echo "Build Architecture            : ${buildArch}"
 echo "Build Configuration           : ${buildConfiguration}"
-
 
 if [ "$buildArch" = "wasm" ]; then
     runtestPyArguments+=("-os" "Browser")
@@ -316,6 +309,6 @@ __Python=python
 fi
 
 # Run the tests using cross platform run.py
-echo "python $repoRootDir/src/tests/run.py ${runtestPyArguments[@]}"
+echo "$__Python $repoRootDir/src/tests/run.py ${runtestPyArguments[@]}"
 $__Python "$repoRootDir/src/tests/run.py" "${runtestPyArguments[@]}"
 exit "$?"

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -6,67 +6,37 @@ function print_usage {
     echo ''
     echo 'Typical command line:'
     echo ''
-    echo 'src/tests/run.sh <arch> <configurations>'
+    echo 'src/tests/run.sh <options>'
     echo ''
     echo 'Optional arguments:'
+    echo '  -h|--help                        : Show usage information.'
+    echo '  -v, --verbose                    : Show output from each test.'
+    echo '  <arch>                           : One of x64, x86, arm, arm64, wasm. Defaults to current architecture.'
+    echo '  Android                          : Set build OS to Android.'
+    echo '  --test-env=<path>                : Script to set environment variables for tests'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. runtime/artifacts/tests/windows.x64.Debug).'
-    echo '  --testNativeBinDir=<path>        : Directory of the native CoreCLR test build (e.g. runtime/artifacts/obj/Linux.x64.Debug/tests).'
-    echo '  --coreOverlayDir=<path>          : Directory containing core binaries and test dependencies.'
-    echo '  --coreClrBinDir=<path>           : Directory of the CoreCLR build (e.g. runtime/artifacts/bin/coreclr/Linux.x64.Debug).'
-    echo '  --build-overlay-only             : Build coreoverlay only, and skip running tests.'
     echo '  --disableEventLogging            : Disable the events logged by both VM and Managed Code'
     echo '  --sequential                     : Run tests sequentially (default is to run in parallel).'
-    echo '  -v, --verbose                    : Show output from each test.'
-    echo '  -h|--help                        : Show usage information.'
-    echo '  --useServerGC                    : Enable server GC for this test run'
-    echo '  --test-env                       : Script to set environment variables for tests'
     echo '  --crossgen                       : Precompiles the framework managed assemblies'
-    echo '  --runcrossgentests               : Runs the ready to run tests' 
-    echo '  --runcrossgen2tests              : Runs the ready to run tests compiled with Crossgen2' 
+    echo '  --runcrossgentests               : Runs the ReadyToRun tests' 
+    echo '  --runcrossgen2tests              : Runs the ReadyToRun tests compiled with Crossgen2' 
     echo '  --jitstress=<n>                  : Runs the tests with COMPlus_JitStress=n'
     echo '  --jitstressregs=<n>              : Runs the tests with COMPlus_JitStressRegs=n'
     echo '  --jitminopts                     : Runs the tests with COMPlus_JITMinOpts=1'
     echo '  --jitforcerelocs                 : Runs the tests with COMPlus_ForceRelocs=1'
-    echo '  --jitdisasm                      : Runs jit-dasm on the tests'
+    echo '  --gcname=<n>                     : Runs the tests with COMPlus_GCName=n'
     echo '  --gcstresslevel=<n>              : Runs the tests with COMPlus_GCStress=n'
     echo '    0: None                                1: GC on all allocs and '"'easy'"' places'
     echo '    2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr'
     echo '    8: GC on every allowable NGEN instr   16: GC only on a unique stack trace'
-    echo '  --gcname=<n>                     : Runs the tests with COMPlus_GCName=n'
-    echo '  --long-gc                        : Runs the long GC tests'
-    echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '  --gcsimulator                    : Runs the GCSimulator tests'
-    echo '  --tieredcompilation              : Runs the tests with COMPlus_TieredCompilation=1'
+    echo '  --long-gc                        : Runs the long GC tests'
+    echo '  --useServerGC                    : Enable server GC for this test run'
+    echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
-    echo '  --xunitOutputPath=<path>         : Create xUnit XML report at the specifed path (default: <test root>/coreclrtests.xml)'
     echo '  --printLastResultsOnly           : Print the results of the last run'
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
-}
-
-function set_up_core_dump_generation {
-    # We will only enable dump generation here if we're on Mac or Linux
-    if [[ ! ( "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ) ]]; then
-        return
-    fi
-
-    # We won't enable dump generation on OS X/macOS if the machine hasn't been
-    # configured with the kern.corefile pattern we expect.
-    if [[ ( "$(uname -s)" == "Darwin" && "$(sysctl -n kern.corefile)" != "core.%P" ) ]]; then
-        echo "WARNING: Core dump generation not being enabled due to unexpected kern.corefile value."
-        return
-    fi
-
-    # Allow dump generation
-    ulimit -c unlimited
-
-    if [ "$(uname -s)" == "Linux" ]; then
-        if [ -e /proc/self/coredump_filter ]; then
-            # Include memory in private and shared file-backed mappings in the dump.
-            # This ensures that we can see disassembly from our shared libraries when
-            # inspecting the contents of the dump. See 'man core' for details.
-            echo 0x3F > /proc/self/coredump_filter
-        fi
-    fi
+    echo '  --limitedDumpGeneration          : '
 }
 
 function check_cpu_architecture {
@@ -116,27 +86,16 @@ buildArch=$ARCH
 buildOS=
 buildConfiguration="Debug"
 testRootDir=
-testNativeBinDir=
-coreOverlayDir=
-coreClrBinDir=
-mscorlibDir=
-coreClrObjs=
-coverageOutputDir=
 testEnv=
-playlistFile=
-showTime=
-noLFConversion=
 gcsimulator=
 longgc=
 limitedCoreDumps=
-illinker=
 ((disableEventLogging = 0))
 ((serverGC = 0))
 
 # Handle arguments
 verbose=0
 doCrossgen=0
-jitdisasm=0
 ilasmroundtrip=
 printLastResultsOnly=
 runSequential=0
@@ -194,9 +153,6 @@ do
         --jitminopts)
             export COMPlus_JITMinOpts=1
             ;;
-        --copyNativeTestBin)
-            export copyNativeTestBin=1
-            ;;
         --jitforcerelocs)
             export COMPlus_ForceRelocs=1
             ;;
@@ -204,38 +160,11 @@ do
             export ILLINK=${i#*=}
             export DoLink=true
             ;;
-        --tieredcompilation)
-            export COMPlus_TieredCompilation=1
-            ;;
-        --jitdisasm)
-            jitdisasm=1
-            ;;
         --ilasmroundtrip)
             ((ilasmroundtrip = 1))
             ;;
         --testRootDir=*)
             testRootDir=${i#*=}
-            ;;
-        --testNativeBinDir=*)
-            testNativeBinDir=${i#*=}
-            ;;
-        --coreOverlayDir=*)
-            coreOverlayDir=${i#*=}
-            ;;
-        --coreClrBinDir=*)
-            coreClrBinDir=${i#*=}
-            ;;
-        --mscorlibDir=*)
-            mscorlibDir=${i#*=}
-            ;;
-        --testDir=*)
-            testDirectories[${#testDirectories[@]}]=${i#*=}
-            ;;
-        --testDirFile=*)
-            set_test_directories "${i#*=}"
-            ;;
-        --runFailingTestsOnly)
-            ((runFailingTestsOnly = 1))
             ;;
         --disableEventLogging)
             ((disableEventLogging = 1))
@@ -258,18 +187,6 @@ do
         --gcsimulator)
             ((gcsimulator = 1))
             ;;
-        --playlist=*)
-            playlistFile=${i#*=}
-            ;;
-        --coreclr-coverage)
-            CoreClrCoverage=ON
-            ;;
-        --coreclr-objs=*)
-            coreClrObjs=${i#*=}
-            ;;
-        --coverage-output-dir=*)
-            coverageOutputDir=${i#*=}
-            ;;
         --test-env=*)
             testEnv=${i#*=}
             ;;            
@@ -279,17 +196,8 @@ do
         --gcname=*)
             export COMPlus_GCName=${i#*=}
             ;;
-        --show-time)
-            showTime=ON
-            ;;
-        --no-lf-conversion)
-            noLFConversion=ON
-            ;;
         --limitedDumpGeneration)
             limitedCoreDumps=ON
-            ;;
-        --xunitOutputPath=*)
-            xunitOutputPath=${i#*=}
             ;;
         --runincontext)
             runincontext=1
@@ -345,16 +253,6 @@ if [ ! -z "$testRootDir" ]; then
     echo "Test Location                 : ${testRootDir}"
 fi
 
-if [ ! -z "$coreClrBinDir" ]; then
-    runtestPyArguments+=("-product_location" "$coreClrBinDir")
-    echo "Product Location              : ${coreClrBinDir}"
-fi
-
-if [ ! -z "$testNativeBinDir" ]; then
-    runtestPyArguments+=("-test_native_bin_location" "$testNativeBinDir")
-    echo "Test Native Bin Location      : ${testNativeBinDir}"
-fi
-
 if [ ! -z "${testEnv}" ]; then
     runtestPyArguments+=("-test_env" "${testEnv}")
     echo "Test Env                      : ${testEnv}"
@@ -370,11 +268,6 @@ fi
 if [ ! -z "$gcsimulator" ]; then
     echo "Running GC simulator tests"
     runtestPyArguments+=("--gcsimulator")
-fi
-
-if [[ ! "$jitdisasm" -eq 0 ]]; then
-    echo "Running jit disasm"
-    runtestPyArguments+=("--jitdisasm")
 fi
 
 if [ ! -z "$ilasmroundtrip" ]; then


### PR DESCRIPTION
Remove unused, obsolete arguments.

Remove never-used jitdisasm support.

Add better support for finding Python in run.cmd (taken from build-runtime.cmd).