### PR TITLE
Add IsIPv6UniqueLocal property

### DIFF
--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -240,6 +240,7 @@ namespace System.Net
         public bool IsIPv6Multicast { get { throw null; } }
         public bool IsIPv6SiteLocal { get { throw null; } }
         public bool IsIPv6Teredo { get { throw null; } }
+        public bool IsIPv6UniqueLocal { get { throw null; } }
         public long ScopeId { get { throw null; } set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? comparand) { throw null; }
         public byte[] GetAddressBytes() { throw null; }

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -485,16 +485,12 @@ namespace System.Net
             }
         }
 
-        /// <devdoc>
-        ///   <para>
-        ///     Determines if an address is an IPv6 Unique Local address
-        ///   </para>
-        /// </devdoc>
+        /// <summary>Gets whether the address is an IPv6 Unique Local address.</summary>
         public bool IsIPv6UniqueLocal
         {
             get
             {
-                return IsIPv6 && ((_numbers[0] & 0xFE00) == 0xFC00);
+                return IsIPv6 && ((_numbers[0]! & 0xFE00) == 0xFC00);
             }
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -490,7 +490,7 @@ namespace System.Net
         {
             get
             {
-                return IsIPv6 && ((_numbers[0]! & 0xFE00) == 0xFC00);
+                return IsIPv6 && ((_numbers![0] & 0xFE00) == 0xFC00);
             }
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -485,6 +485,19 @@ namespace System.Net
             }
         }
 
+        /// <devdoc>
+        ///   <para>
+        ///     Determines if an address is an IPv6 Unique Local address
+        ///   </para>
+        /// </devdoc>
+        public bool IsIPv6UniqueLocal
+        {
+            get
+            {
+                return IsIPv6 && ((_numbers[0] & 0xFE00) == 0xFC00);
+            }
+        }
+
         // 0:0:0:0:0:FFFF:x.x.x.x
         public bool IsIPv4MappedToIPv6
         {

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -234,6 +234,14 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        public static void IsIPv6UniqueLocal_Get_Success()
+        {
+            Assert.True(IPAddress.Parse("FC00::/7").IsIPv6UniqueLocal);
+            Assert.False(IPAddress.Parse("Fe08::1").IsIPv6UniqueLocal);
+            Assert.False(IPV4Address1().IsIPv6UniqueLocal);
+        }
+
+        [Fact]
         public static void Equals_Compare_Success()
         {
             IPAddress ip1 = IPAddress.Parse(IpV4AddressString1); //IpV4

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -236,7 +236,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void IsIPv6UniqueLocal_Get_Success()
         {
-            Assert.True(IPAddress.Parse("FC00::/7").IsIPv6UniqueLocal);
+            Assert.True(IPAddress.Parse("FC00::1").IsIPv6UniqueLocal);
             Assert.False(IPAddress.Parse("Fe08::1").IsIPv6UniqueLocal);
             Assert.False(IPV4Address1().IsIPv6UniqueLocal);
         }


### PR DESCRIPTION
IsIPv6UniqueLocal boolean property was added to IPAddress. 
In September 2004 was deprecated the definition of the IPv6 site local range. As a result, in October 2005 for use in private IPv6 networks was defined the associated term **unique local addresses**.

Fix [#45148](https://github.com/dotnet/runtime/issues/45148)