### PR TITLE
Fix decoding empty cert collection

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
@@ -22,20 +22,25 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_X509DecodeCollection")]
-        private static extern int X509DecodeCollection(ref byte buf, int bufLen, IntPtr[]? ptrs, int handlesLen);
+        private static extern int X509DecodeCollection(ref byte buf, int bufLen, IntPtr[]? ptrs, out int handlesLen);
         internal static SafeX509Handle[] X509DecodeCollection(ReadOnlySpan<byte> data)
         {
+            const int INSUFFICIENT_BUFFER = -1;
+            const int SUCCESS = 1;
+
             ref byte buf = ref MemoryMarshal.GetReference(data);
-            int negativeSize = X509DecodeCollection(ref buf, data.Length, null, 0);
-            if (negativeSize > 0)
+            int size = 0;
+            int ret = X509DecodeCollection(ref buf, data.Length, null, out size);
+            if (ret == SUCCESS && size == 0)
+                return Array.Empty<SafeX509Handle>();
+
+            if (ret != INSUFFICIENT_BUFFER)
                 throw new CryptographicException();
 
-            IntPtr[] ptrs = new IntPtr[-negativeSize];
-
-            int ret = X509DecodeCollection(ref buf, data.Length, ptrs, ptrs.Length);
-            if (ret != 1)
+            IntPtr[] ptrs = new IntPtr[size];
+            ret = X509DecodeCollection(ref buf, data.Length, ptrs, out size);
+            if (ret != SUCCESS)
                 throw new CryptographicException();
-
 
             SafeX509Handle[] handles = new SafeX509Handle[ptrs.Length];
             for (var i = 0; i < handles.Length; i++)

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_X509DecodeCollection")]
-        private static extern int X509DecodeCollection(ref byte buf, int bufLen, IntPtr[]? ptrs, out int handlesLen);
+        private static extern int X509DecodeCollection(ref byte buf, int bufLen, IntPtr[]? ptrs, ref int handlesLen);
         internal static SafeX509Handle[] X509DecodeCollection(ReadOnlySpan<byte> data)
         {
             const int INSUFFICIENT_BUFFER = -1;

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
 
             ref byte buf = ref MemoryMarshal.GetReference(data);
             int size = 0;
-            int ret = X509DecodeCollection(ref buf, data.Length, null, out size);
+            int ret = X509DecodeCollection(ref buf, data.Length, null, ref size);
             if (ret == SUCCESS && size == 0)
                 return Array.Empty<SafeX509Handle>();
 
@@ -38,7 +38,7 @@ internal static partial class Interop
                 throw new CryptographicException();
 
             IntPtr[] ptrs = new IntPtr[size];
-            ret = X509DecodeCollection(ref buf, data.Length, ptrs, out size);
+            ret = X509DecodeCollection(ref buf, data.Length, ptrs, ref size);
             if (ret != SUCCESS)
                 throw new CryptographicException();
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.h
@@ -7,7 +7,13 @@
 PALEXPORT jobject /*X509Certificate*/ AndroidCryptoNative_X509Decode(const uint8_t *buf, int32_t len);
 PALEXPORT int32_t AndroidCryptoNative_X509Encode(jobject /*X509Certificate*/ cert, uint8_t *buf, int32_t len);
 
-PALEXPORT int32_t AndroidCryptoNative_X509DecodeCollection(const uint8_t *buf, int32_t bufLen, jobject /*X509Certificate*/ *out, int32_t outLen);
+/*
+Decodes a collection of certificates.
+
+Returns 1 on success, -1 on insufficient buffer, 0 otherwise.
+The outLen parameter will be set to the length required for decoding the collection.
+*/
+PALEXPORT int32_t AndroidCryptoNative_X509DecodeCollection(const uint8_t *buf, int32_t bufLen, jobject /*X509Certificate*/ *out, int32_t *outLen);
 
 // Matches managed X509ContentType enum
 enum


### PR DESCRIPTION
This was incorrectly throwing `CryptographicException` on an empty collection instead of just returning an empty collection.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs