### PR TITLE
Fix bug in EventSource default channelKeyword allocation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -5376,7 +5376,7 @@ namespace System.Diagnostics.Tracing
             if (!channelTab.TryGetValue((int)channel, out ChannelInfo? info))
             {
                 // If we were not given an explicit channel, allocate one.
-                if (channelKeyword != 0)
+                if (channelKeyword == 0)
                 {
                     channelKeyword = nextChannelKeywordBit;
                     nextChannelKeywordBit >>= 1;


### PR DESCRIPTION
Fix #27002 

There is a bug in EventSource that allocates the default `channelKeyword` when none is set. Instead of checking whether the `channelKeyword` is `0` it was checking that it wasn't `0`.

I successfully verified that this enables EventSource to emit logs to Event Log using the repro in the issue.

Credits to @KalleOlaviNiemitalo for debugging this all the way down to the root cause!
