### PR TITLE
Allow for specify return value on System.Linq.Enumerable.*OrDefault methods

### DIFF
--- a/src/libraries/System.Linq.Queryable/ref/System.Linq.Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/ref/System.Linq.Queryable.cs
@@ -86,9 +86,9 @@ namespace System.Linq
         public static System.Linq.IQueryable<TSource> Except<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2) { throw null; }
         public static System.Linq.IQueryable<TSource> Except<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
-        public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
-        public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
+        public static TSource FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource defaultValue) { throw null; }
         public static TSource First<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource First<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static System.Linq.IQueryable<System.Linq.IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector) { throw null; }
@@ -106,9 +106,9 @@ namespace System.Linq
         public static System.Linq.IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Linq.IQueryable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Linq.Expressions.Expression<System.Func<TOuter, TKey>> outerKeySelector, System.Linq.Expressions.Expression<System.Func<TInner, TKey>> innerKeySelector, System.Linq.Expressions.Expression<System.Func<TOuter, TInner, TResult>> resultSelector) { throw null; }
         public static System.Linq.IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Linq.IQueryable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Linq.Expressions.Expression<System.Func<TOuter, TKey>> outerKeySelector, System.Linq.Expressions.Expression<System.Func<TInner, TKey>> innerKeySelector, System.Linq.Expressions.Expression<System.Func<TOuter, TInner, TResult>> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
-        public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
-        public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
+        public static TSource LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource defaultValue) { throw null; }
         public static TSource Last<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource Last<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static long LongCount<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
@@ -133,9 +133,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2) { throw null; }
         public static bool SequenceEqual<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
-        public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
-        public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
+        public static TSource SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource defaultValue) { throw null; }
         public static TSource Single<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource Single<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static System.Linq.IQueryable<TSource> SkipLast<TSource>(this System.Linq.IQueryable<TSource> source, int count) { throw null; }

--- a/src/libraries/System.Linq.Queryable/ref/System.Linq.Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/ref/System.Linq.Queryable.cs
@@ -86,7 +86,9 @@ namespace System.Linq
         public static System.Linq.IQueryable<TSource> Except<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2) { throw null; }
         public static System.Linq.IQueryable<TSource> Except<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
+        public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
+        public static TSource? FirstOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
         public static TSource First<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource First<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static System.Linq.IQueryable<System.Linq.IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector) { throw null; }
@@ -104,7 +106,9 @@ namespace System.Linq
         public static System.Linq.IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Linq.IQueryable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Linq.Expressions.Expression<System.Func<TOuter, TKey>> outerKeySelector, System.Linq.Expressions.Expression<System.Func<TInner, TKey>> innerKeySelector, System.Linq.Expressions.Expression<System.Func<TOuter, TInner, TResult>> resultSelector) { throw null; }
         public static System.Linq.IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Linq.IQueryable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Linq.Expressions.Expression<System.Func<TOuter, TKey>> outerKeySelector, System.Linq.Expressions.Expression<System.Func<TInner, TKey>> innerKeySelector, System.Linq.Expressions.Expression<System.Func<TOuter, TInner, TResult>> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
+        public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
+        public static TSource? LastOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
         public static TSource Last<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource Last<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static long LongCount<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
@@ -129,7 +133,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2) { throw null; }
         public static bool SequenceEqual<TSource>(this System.Linq.IQueryable<TSource> source1, System.Collections.Generic.IEnumerable<TSource> source2, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
+        public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
+        public static TSource? SingleOrDefault<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate, TSource? defaultValue) { throw null; }
         public static TSource Single<TSource>(this System.Linq.IQueryable<TSource> source) { throw null; }
         public static TSource Single<TSource>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, bool>> predicate) { throw null; }
         public static System.Linq.IQueryable<TSource> SkipLast<TSource>(this System.Linq.IQueryable<TSource> source, int count) { throw null; }

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -284,6 +284,20 @@ namespace System.Linq
              (s_FirstOrDefault_TSource_2 ??= new Func<IQueryable<object>, Expression<Func<object, bool>>, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition())
               .MakeGenericMethod(TSource);
 
+        private static MethodInfo? s_FirstOrDefault_TSource_3;
+
+        public static MethodInfo FirstOrDefault_TSource_3(Type TSource) =>
+            (s_FirstOrDefault_TSource_3 ??
+            (s_FirstOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            .MakeGenericMethod();
+
+        private static MethodInfo? s_FirstOrDefault_TSource_4;
+
+        public static MethodInfo FirstOrDefault_TSource_4(Type TSource) =>
+            (s_FirstOrDefault_TSource_4 ??
+             (s_FirstOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            .MakeGenericMethod(TSource);
+
         private static MethodInfo? s_GroupBy_TSource_TKey_2;
 
         public static MethodInfo GroupBy_TSource_TKey_2(Type TSource, Type TKey) =>
@@ -391,6 +405,20 @@ namespace System.Linq
         public static MethodInfo LastOrDefault_TSource_2(Type TSource) =>
              (s_LastOrDefault_TSource_2 ??= new Func<IQueryable<object>, Expression<Func<object, bool>>, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition())
               .MakeGenericMethod(TSource);
+
+        private static MethodInfo? s_LastOrDefault_TSource_3;
+
+        public static MethodInfo LastOrDefault_TSource_3(Type TSource) =>
+            (s_LastOrDefault_TSource_3 ??
+             (s_LastOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            .MakeGenericMethod(TSource);
+
+        private static MethodInfo? s_LastOrDefault_TSource_4;
+
+        public static MethodInfo LastOrDefault_TSource_4(Type TSource) =>
+            (s_LastOrDefault_TSource_4 ??
+             (s_LastOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_LongCount_TSource_1;
 
@@ -535,6 +563,20 @@ namespace System.Linq
         public static MethodInfo SingleOrDefault_TSource_2(Type TSource) =>
              (s_SingleOrDefault_TSource_2 ??= new Func<IQueryable<object>, Expression<Func<object, bool>>, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition())
               .MakeGenericMethod(TSource);
+
+        private static MethodInfo? s_SingleOrDefault_TSource_3;
+
+        public static MethodInfo SingleOrDefault_TSource_3(Type TSource) =>
+            (s_SingleOrDefault_TSource_3 ??
+            (s_SingleOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             .MakeGenericMethod(TSource);
+
+        private static MethodInfo? s_SingleOrDefault_TSource_4;
+
+        public static MethodInfo SingleOrDefault_TSource_4(Type TSource) =>
+            (s_SingleOrDefault_TSource_4 ??
+            (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             .MakeGenericMethod();
 
         private static MethodInfo? s_Skip_TSource_2;
 

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -295,7 +295,7 @@ namespace System.Linq
 
         public static MethodInfo FirstOrDefault_TSource_4(Type TSource) =>
             (s_FirstOrDefault_TSource_4 ??
-             (s_FirstOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_FirstOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_GroupBy_TSource_TKey_2;
@@ -417,7 +417,7 @@ namespace System.Linq
 
         public static MethodInfo LastOrDefault_TSource_4(Type TSource) =>
             (s_LastOrDefault_TSource_4 ??
-             (s_LastOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_LongCount_TSource_1;
@@ -575,7 +575,7 @@ namespace System.Linq
 
         public static MethodInfo SingleOrDefault_TSource_4(Type TSource) =>
             (s_SingleOrDefault_TSource_4 ??
-            (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object?, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
              .MakeGenericMethod();
 
         private static MethodInfo? s_Skip_TSource_2;

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -288,14 +288,14 @@ namespace System.Linq
 
         public static MethodInfo FirstOrDefault_TSource_3(Type TSource) =>
             (s_FirstOrDefault_TSource_3 ??
-            (s_FirstOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_FirstOrDefault_TSource_3 = new Func<IQueryable<object>, object, object>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod();
 
         private static MethodInfo? s_FirstOrDefault_TSource_4;
 
         public static MethodInfo FirstOrDefault_TSource_4(Type TSource) =>
             (s_FirstOrDefault_TSource_4 ??
-             (s_FirstOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_FirstOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_GroupBy_TSource_TKey_2;
@@ -410,14 +410,14 @@ namespace System.Linq
 
         public static MethodInfo LastOrDefault_TSource_3(Type TSource) =>
             (s_LastOrDefault_TSource_3 ??
-             (s_LastOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_3 = new Func<IQueryable<object>, object, object>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_LastOrDefault_TSource_4;
 
         public static MethodInfo LastOrDefault_TSource_4(Type TSource) =>
             (s_LastOrDefault_TSource_4 ??
-             (s_LastOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_LongCount_TSource_1;

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -568,7 +568,7 @@ namespace System.Linq
 
         public static MethodInfo SingleOrDefault_TSource_3(Type TSource) =>
             (s_SingleOrDefault_TSource_3 ??
-            (s_SingleOrDefault_TSource_3 = new Func<IQueryable<object>, object?, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_SingleOrDefault_TSource_3 = new Func<IQueryable<object>, object, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
              .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_SingleOrDefault_TSource_4;
@@ -576,7 +576,7 @@ namespace System.Linq
         public static MethodInfo SingleOrDefault_TSource_4(Type TSource) =>
             (s_SingleOrDefault_TSource_4 ??
             (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
-             .MakeGenericMethod();
+             .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_Skip_TSource_2;
 

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -289,7 +289,7 @@ namespace System.Linq
         public static MethodInfo FirstOrDefault_TSource_3(Type TSource) =>
             (s_FirstOrDefault_TSource_3 ??
             (s_FirstOrDefault_TSource_3 = new Func<IQueryable<object>, object, object>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
-            .MakeGenericMethod();
+            .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_FirstOrDefault_TSource_4;
 

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -568,14 +568,14 @@ namespace System.Linq
 
         public static MethodInfo SingleOrDefault_TSource_3(Type TSource) =>
             (s_SingleOrDefault_TSource_3 ??
-            (s_SingleOrDefault_TSource_3 = new Func<IQueryable<object>, object, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_SingleOrDefault_TSource_3 = new Func<IQueryable<object>, object, object>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
              .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_SingleOrDefault_TSource_4;
 
         public static MethodInfo SingleOrDefault_TSource_4(Type TSource) =>
             (s_SingleOrDefault_TSource_4 ??
-            (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object?>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
+            (s_SingleOrDefault_TSource_4 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object, object>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
              .MakeGenericMethod(TSource);
 
         private static MethodInfo? s_Skip_TSource_2;

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -865,7 +865,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("FirstOrDefault`1", typeof(Enumerable))]
-        public static TSource? FirstOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        public static TSource FirstOrDefault<TSource>(this IQueryable<TSource> source, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -892,7 +892,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("FirstOrDefault`1", typeof(Enumerable))]
-        public static TSource? FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        public static TSource FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -944,7 +944,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("LastOrDefault`1", typeof(Enumerable))]
-        public static TSource? LastOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        public static TSource LastOrDefault<TSource>(this IQueryable<TSource> source, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -971,7 +971,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("LastOrDefault`1", typeof(Enumerable))]
-        public static TSource? LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        public static TSource LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -1023,7 +1023,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("SingleOrDefault`1", typeof(Enumerable))]
-        public static TSource? SingleOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        public static TSource SingleOrDefault<TSource>(this IQueryable<TSource> source, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -1051,7 +1051,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("SingleOrDefault`1", typeof(Enumerable))]
-        public static TSource? SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        public static TSource SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource defaultValue)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -865,6 +865,18 @@ namespace System.Linq
         }
 
         [DynamicDependency("FirstOrDefault`1", typeof(Enumerable))]
+        public static TSource? FirstOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.FirstOrDefault_TSource_3(typeof(TSource)),
+                    source.Expression, Expression.Constant(defaultValue, typeof(TSource))));
+        }
+
+        [DynamicDependency("FirstOrDefault`1", typeof(Enumerable))]
         public static TSource? FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
@@ -877,6 +889,21 @@ namespace System.Linq
                     CachedReflectionInfo.FirstOrDefault_TSource_2(typeof(TSource)),
                     source.Expression, Expression.Quote(predicate)
                     ));
+        }
+
+        [DynamicDependency("FirstOrDefault`1", typeof(Enumerable))]
+        public static TSource? FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            if (predicate == null)
+                throw Error.ArgumentNull(nameof(predicate));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.FirstOrDefault_TSource_4(typeof(TSource)),
+                    source.Expression, Expression.Quote(predicate), Expression.Constant(defaultValue, typeof(TSource))
+                ));
         }
 
         [DynamicDependency("Last`1", typeof(Enumerable))]
@@ -917,6 +944,18 @@ namespace System.Linq
         }
 
         [DynamicDependency("LastOrDefault`1", typeof(Enumerable))]
+        public static TSource? LastOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.LastOrDefault_TSource_3(typeof(TSource)),
+                    source.Expression, Expression.Constant(defaultValue, typeof(TSource))));
+        }
+
+        [DynamicDependency("LastOrDefault`1", typeof(Enumerable))]
         public static TSource? LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
@@ -929,6 +968,21 @@ namespace System.Linq
                     CachedReflectionInfo.LastOrDefault_TSource_2(typeof(TSource)),
                     source.Expression, Expression.Quote(predicate)
                     ));
+        }
+
+        [DynamicDependency("LastOrDefault`1", typeof(Enumerable))]
+        public static TSource? LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            if (predicate == null)
+                throw Error.ArgumentNull(nameof(predicate));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.LastOrDefault_TSource_4(typeof(TSource)),
+                    source.Expression, Expression.Quote(predicate), Expression.Constant(defaultValue, typeof(TSource))
+                ));
         }
 
         [DynamicDependency("Single`1", typeof(Enumerable))]
@@ -969,6 +1023,19 @@ namespace System.Linq
         }
 
         [DynamicDependency("SingleOrDefault`1", typeof(Enumerable))]
+        public static TSource? SingleOrDefault<TSource>(this IQueryable<TSource> source, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.SingleOrDefault_TSource_3(typeof(TSource)),
+                    source.Expression, Expression.Constant(defaultValue, typeof(TSource))));
+
+        }
+
+        [DynamicDependency("SingleOrDefault`1", typeof(Enumerable))]
         public static TSource? SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             if (source == null)
@@ -981,6 +1048,21 @@ namespace System.Linq
                     CachedReflectionInfo.SingleOrDefault_TSource_2(typeof(TSource)),
                     source.Expression, Expression.Quote(predicate)
                     ));
+        }
+
+        [DynamicDependency("SingleOrDefault`1", typeof(Enumerable))]
+        public static TSource? SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, TSource? defaultValue)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+            if (predicate == null)
+                throw Error.ArgumentNull(nameof(predicate));
+            return source.Provider.Execute<TSource>(
+                Expression.Call(
+                    null,
+                    CachedReflectionInfo.SingleOrDefault_TSource_4(typeof(TSource)),
+                    source.Expression, Expression.Quote(predicate), Expression.Constant(defaultValue, typeof(TSource))
+                ));
         }
 
         [DynamicDependency("ElementAt`1", typeof(Enumerable))]

--- a/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
@@ -47,7 +47,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void OneElementTruePredicateDefault()
+        {
+            int[] source = { 4 };
+            Assert.Equal(4, source.AsQueryable().FirstOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void OneElementFalsePredicate()
+        {
+            int[] source = { 3 };
+            Assert.Equal(0, source.AsQueryable().FirstOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void OneElementFalsePredicateDefault()
         {
             int[] source = { 3 };
             Assert.Equal(5, source.AsQueryable().FirstOrDefault(i => i % 2 == 0, 5));
@@ -61,22 +75,37 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ManyElementsPredicateFalseForAllDefault()
+        {
+            int[] source = { 9, 5, 1, 3, 17, 21 };
+            Assert.Equal(2, source.AsQueryable().FirstOrDefault(i => i % 2 == 0), 2);
+        }
+
+        [Fact]
         public void PredicateTrueForSome()
         {
             int[] source = { 3, 7, 10, 7, 9, 2, 11, 17, 13, 8 };
             Assert.Equal(10, source.AsQueryable().FirstOrDefault(i => i % 2 == 0));
+        }
+        [Fact]
+        public void PredicateTrueForSomeDefault()
+        {
+            int[] source = { 3, 7, 10, 7, 9, 2, 11, 17, 13, 8 };
+            Assert.Equal(10, source.AsQueryable().FirstOrDefault(i => i % 2 == 0, 5));
         }
 
         [Fact]
         public void NullSource()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((IQueryable<int>)null).FirstOrDefault());
+            AssertExtensions.Throws<ArgumentNullException>("source", () => ((IQueryable<int>)null).FirstOrDefault(5));
         }
 
         [Fact]
         public void NullSourcePredicateUsed()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((IQueryable<int>)null).FirstOrDefault(i => i != 2));
+            AssertExtensions.Throws<ArgumentNullException>("source", () => ((IQueryable<int>)null).FirstOrDefault(i => i != 2, 5));
         }
 
         [Fact]
@@ -84,6 +113,7 @@ namespace System.Linq.Tests
         {
             Expression<Func<int, bool>> predicate = null;
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).AsQueryable().FirstOrDefault(predicate));
+            AssertExtensions.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).AsQueryable().FirstOrDefault(predicate, 5));
         }
 
         [Fact]

--- a/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
@@ -17,6 +17,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyDefault()
+        {
+            int[] source = { };
+            int defaultValue = 5;
+
+            Assert.Equal(defaultValue, source.AsQueryable().FirstOrDefault(defaultValue));
+        }
+
+        [Fact]
         public void ManyElementsFirstIsDefault()
         {
             int?[] source = { null, -10, 2, 4, 3, 0, 2 };
@@ -35,6 +44,13 @@ namespace System.Linq.Tests
         {
             int[] source = { 4 };
             Assert.Equal(4, source.AsQueryable().FirstOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void OneElementFalsePredicate()
+        {
+            int[] source = { 3 };
+            Assert.Equal(5, source.AsQueryable().FirstOrDefault(i => i % 2 == 0, 5));
         }
 
         [Fact]

--- a/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
@@ -78,7 +78,7 @@ namespace System.Linq.Tests
         public void ManyElementsPredicateFalseForAllDefault()
         {
             int[] source = { 9, 5, 1, 3, 17, 21 };
-            Assert.Equal(2, source.AsQueryable().FirstOrDefault(i => i % 2 == 0), 2);
+            Assert.Equal(2, source.AsQueryable().FirstOrDefault(i => i % 2 == 0, 2));
         }
 
         [Fact]

--- a/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
@@ -15,6 +15,14 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
+        public void EmptyDefault()
+        {
+            int[] source = { };
+            int defaultValue = 5;
+            Assert.Equal(defaultValue, source.AsQueryable().LastOrDefault(defaultValue));
+        }
+
+        [Fact]
         public void OneElement()
         {
             int[] source = { 5 };

--- a/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
@@ -30,6 +30,13 @@ namespace System.Linq.Tests.LegacyTests
         }
 
         [Fact]
+        public void OneElementFalsePredicate()
+        {
+            int[] source = { 3 };
+            Assert.Equal(5, source.AsQueryable().LastOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void ManyElementsLastIsDefault()
         {
             int?[] source = { -10, 2, 4, 3, 0, 2, null };

--- a/src/libraries/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
@@ -23,9 +23,23 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyDefault()
+        {
+            int[] source = { };
+            int defaultValue = 5;
+            Assert.Equal(defaultValue, source.AsQueryable().SingleOrDefault(5));
+        }
+
+        [Fact]
         public void EmptySourceWithPredicate()
         {
             Assert.Null(Enumerable.Empty<int?>().AsQueryable().SingleOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void EmptySourceWithPredicateDefault()
+        {
+            Assert.Equal(5, Enumerable.Empty<int?>().AsQueryable().SingleOrDefault(i => i % 2 == 0, 5));
         }
 
         [Theory]

--- a/src/libraries/System.Linq.Queryable/tests/TrimCompatibilityTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/TrimCompatibilityTests.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Tests
                     .Where(m => m.GetParameters().Length > 0);
 
             // If you are adding a new method to this class, ensure the method meets these requirements
-            Assert.Equal(111, methods.Count());
+            Assert.Equal(117, methods.Count());
             foreach (MethodInfo method in methods)
             {
                 ParameterInfo[] parameters = method.GetParameters();

--- a/src/libraries/System.Linq/ref/System.Linq.cs
+++ b/src/libraries/System.Linq/ref/System.Linq.cs
@@ -59,7 +59,9 @@ namespace System.Linq
         public static System.Collections.Generic.IEnumerable<TSource> Except<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> Except<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
+        public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
         public static TSource First<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource First<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static System.Collections.Generic.IEnumerable<System.Linq.IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
@@ -77,7 +79,9 @@ namespace System.Linq
         public static System.Collections.Generic.IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner, TResult> resultSelector) { throw null; }
         public static System.Collections.Generic.IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner, TResult> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
+        public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
         public static TSource Last<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource Last<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static long LongCount<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
@@ -144,7 +148,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static bool SequenceEqual<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
+        public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
         public static TSource Single<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource Single<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> SkipLast<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, int count) { throw null; }

--- a/src/libraries/System.Linq/ref/System.Linq.cs
+++ b/src/libraries/System.Linq/ref/System.Linq.cs
@@ -59,9 +59,9 @@ namespace System.Linq
         public static System.Collections.Generic.IEnumerable<TSource> Except<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> Except<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
-        public static TSource? FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
+        public static TSource FirstOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource defaultValue) { throw null; }
         public static TSource First<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource First<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static System.Collections.Generic.IEnumerable<System.Linq.IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
@@ -79,9 +79,9 @@ namespace System.Linq
         public static System.Collections.Generic.IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner, TResult> resultSelector) { throw null; }
         public static System.Collections.Generic.IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner, TResult> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
-        public static TSource? LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
+        public static TSource LastOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource defaultValue) { throw null; }
         public static TSource Last<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource Last<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static long LongCount<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
@@ -148,9 +148,9 @@ namespace System.Linq
         public static bool SequenceEqual<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static bool SequenceEqual<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource? defaultValue) { throw null; }
+        public static TSource SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource defaultValue) { throw null; }
         public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
-        public static TSource? SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource? defaultValue) { throw null; }
+        public static TSource SingleOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate, TSource defaultValue) { throw null; }
         public static TSource Single<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
         public static TSource Single<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, bool> predicate) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> SkipLast<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, int count) { throw null; }

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -35,7 +35,7 @@ namespace System.Linq
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
-            var first = source.TryGetFirst(out bool found);
+            TSource? first = source.TryGetFirst(out bool found);
             return found ? first! : defaultValue;
         }
 
@@ -44,7 +44,7 @@ namespace System.Linq
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
         {
-            var first = source.TryGetFirst(predicate, out bool found);
+            TSource? first = source.TryGetFirst(predicate, out bool found);
             return found ? first! : defaultValue;
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
-            TSource? first = source.TryGetFirst(out bool found);
+            TSource? first = source.TryGetFirst(default, out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoElementsException();
@@ -21,7 +21,7 @@ namespace System.Linq
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            TSource? first = source.TryGetFirst(predicate, out bool found);
+            TSource? first = source.TryGetFirst(predicate, default, out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoMatchException();
@@ -31,19 +31,16 @@ namespace System.Linq
         }
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
-            source.TryGetFirst(out _);
+            source.TryGetFirst(default, out _);
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue) =>
             source.TryGetFirst(defaultValue, out _)!;
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
-            source.TryGetFirst(predicate, out _);
+            source.TryGetFirst(predicate, default, out _);
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue) =>
             source.TryGetFirst(predicate, defaultValue, out _)!;
-
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found) =>
-            source.TryGetFirst(default(TSource), out found);
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, TSource defaultValue, out bool found)
         {
@@ -80,9 +77,6 @@ namespace System.Linq
             found = false;
             return defaultValue;
         }
-
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found) =>
-            source.TryGetFirst(predicate, default, out found);
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -31,12 +31,21 @@ namespace System.Linq
         }
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
-            source.TryGetFirst(out bool _);
+            source.TryGetFirst(out _);
+
+        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue) =>
+            source.TryGetFirst(defaultValue, out _);
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
-            source.TryGetFirst(predicate, out bool _);
+            source.TryGetFirst(predicate, out _);
 
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found)
+        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue) =>
+            source.TryGetFirst(predicate, defaultValue, out _);
+
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found) =>
+            source.TryGetFirst(default(TSource), out found);
+
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, TSource? defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -69,10 +78,13 @@ namespace System.Linq
             }
 
             found = false;
-            return default;
+            return defaultValue;
         }
 
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found) =>
+            source.TryGetFirst(predicate, default(TSource), out found);
+
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -94,7 +106,7 @@ namespace System.Linq
             }
 
             found = false;
-            return default;
+            return defaultValue;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -33,19 +33,19 @@ namespace System.Linq
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
             source.TryGetFirst(out _);
 
-        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue) =>
-            source.TryGetFirst(defaultValue, out _);
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue) =>
+            source.TryGetFirst(defaultValue, out _)!;
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             source.TryGetFirst(predicate, out _);
 
-        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue) =>
-            source.TryGetFirst(predicate, defaultValue, out _);
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue) =>
+            source.TryGetFirst(predicate, defaultValue, out _)!;
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found) =>
             source.TryGetFirst(default(TSource), out found);
 
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, TSource? defaultValue, out bool found)
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, TSource defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -82,7 +82,7 @@ namespace System.Linq
         }
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found) =>
-            source.TryGetFirst(predicate, default(TSource), out found);
+            source.TryGetFirst(predicate, default, out found);
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
-            TSource? first = source.TryGetFirst(default, out bool found);
+            TSource? first = source.TryGetFirst(out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoElementsException();
@@ -21,7 +21,7 @@ namespace System.Linq
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            TSource? first = source.TryGetFirst(predicate, default, out bool found);
+            TSource? first = source.TryGetFirst(predicate, out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoMatchException();
@@ -31,18 +31,25 @@ namespace System.Linq
         }
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
-            source.TryGetFirst(default, out _);
+            source.TryGetFirst(out _);
 
-        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue) =>
-            source.TryGetFirst(defaultValue, out _)!;
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+        {
+            var first = source.TryGetFirst(out bool found);
+            return found ? first! : defaultValue;
+        }
 
         public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
-            source.TryGetFirst(predicate, default, out _);
+            source.TryGetFirst(predicate, out _);
 
-        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue) =>
-            source.TryGetFirst(predicate, defaultValue, out _)!;
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
+        {
+            var first = source.TryGetFirst(predicate, out bool found);
+            return found ? first! : defaultValue;
+        }
 
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, TSource defaultValue, out bool found)
+
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found)
         {
             if (source == null)
             {
@@ -75,10 +82,10 @@ namespace System.Linq
             }
 
             found = false;
-            return defaultValue;
+            return default;
         }
 
-        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
+        private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
             if (source == null)
             {
@@ -100,7 +107,7 @@ namespace System.Linq
             }
 
             found = false;
-            return defaultValue;
+            return default;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -30,8 +30,8 @@ namespace System.Linq
             return last!;
         }
 
-        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source)
-            => source.TryGetLast(out _);
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source) =>
+            source.TryGetLast(out _);
 
 
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -32,17 +32,17 @@ namespace System.Linq
 
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source)
             => source.TryGetLast(out _);
-        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue)
-            => source.TryGetLast(defaultValue, out _);
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+            => source.TryGetLast(defaultValue, out _)!;
 
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
             => source.TryGetLast(predicate, out bool _);
-        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue)
-            => source.TryGetLast(predicate, defaultValue, out bool _);
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
+            => source.TryGetLast(predicate, defaultValue, out bool _)!;
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, out bool found)
-            => source.TryGetLast(default(TSource?), out found);
-        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, TSource? defaultValue, out bool found)
+            => source.TryGetLast(default(TSource), out found);
+        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, TSource defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -87,7 +87,7 @@ namespace System.Linq
         }
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
-            => source.TryGetLast(predicate, default(TSource?), out found);
+            => source.TryGetLast(predicate, default, out found);
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {
             if (source == null)

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -32,14 +32,17 @@ namespace System.Linq
 
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source)
             => source.TryGetLast(out _);
+
+
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
-            var last = source.TryGetLast(out bool found);
+            TSource? last = source.TryGetLast(out bool found);
             return found ? last! : defaultValue;
         }
 
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source.TryGetLast(predicate, out bool _);
+            => source.TryGetLast(predicate, out _);
+
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
         {
             var last = source.TryGetLast(out bool found);
@@ -89,6 +92,7 @@ namespace System.Linq
             found = false;
             return default;
         }
+
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
             if (source == null)

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -33,16 +33,20 @@ namespace System.Linq
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source)
             => source.TryGetLast(out _);
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
-            => source.TryGetLast(defaultValue, out _)!;
+        {
+            var last = source.TryGetLast(out bool found);
+            return found ? last! : defaultValue;
+        }
 
         public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
             => source.TryGetLast(predicate, out bool _);
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
-            => source.TryGetLast(predicate, defaultValue, out bool _)!;
+        {
+            var last = source.TryGetLast(out bool found);
+            return found ? last! : defaultValue;
+        }
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, out bool found)
-            => source.TryGetLast(default(TSource), out found);
-        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, TSource defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -83,12 +87,9 @@ namespace System.Linq
             }
 
             found = false;
-            return defaultValue;
+            return default;
         }
-
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
-            => source.TryGetLast(predicate, default, out found);
-        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -143,7 +144,7 @@ namespace System.Linq
             }
 
             found = false;
-            return defaultValue;
+            return default;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -30,13 +30,19 @@ namespace System.Linq
             return last!;
         }
 
-        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source) =>
-            source.TryGetLast(out bool _);
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source)
+            => source.TryGetLast(out _);
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue)
+            => source.TryGetLast(defaultValue, out _);
 
-        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
-            source.TryGetLast(predicate, out bool _);
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+            => source.TryGetLast(predicate, out bool _);
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue)
+            => source.TryGetLast(predicate, defaultValue, out bool _);
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, out bool found)
+            => source.TryGetLast(default(TSource?), out found);
+        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, TSource? defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -77,10 +83,12 @@ namespace System.Linq
             }
 
             found = false;
-            return default;
+            return defaultValue;
         }
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
+            => source.TryGetLast(predicate, default(TSource?), out found);
+        private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue, out bool found)
         {
             if (source == null)
             {
@@ -135,7 +143,7 @@ namespace System.Linq
             }
 
             found = false;
-            return default;
+            return defaultValue;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -45,7 +45,7 @@ namespace System.Linq
 
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
         {
-            var last = source.TryGetLast(out bool found);
+            var last = source.TryGetLast(predicate, out bool found);
             return found ? last! : defaultValue;
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static TSource Single<TSource>(this IEnumerable<TSource> source)
         {
-            var single = source.TryGetSingle(out bool found);
+            TSource? single = source.TryGetSingle(out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoElementsException();
@@ -20,10 +20,10 @@ namespace System.Linq
         }
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            var single = source.TryGetSingle(predicate, out bool found);
+            TSource? single = source.TryGetSingle(predicate, out bool found);
             if (!found)
             {
-                ThrowHelper.ThrowNoElementsException();
+                ThrowHelper.ThrowNoMatchException();
             }
 
             return single!;

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -10,85 +10,46 @@ namespace System.Linq
     {
         public static TSource Single<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            var single = source.TryGetSingle(out bool found);
+            if (!found)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                ThrowHelper.ThrowNoElementsException();
             }
 
-            if (source is IList<TSource> list)
-            {
-                switch (list.Count)
-                {
-                    case 0:
-                        ThrowHelper.ThrowNoElementsException();
-                        return default;
-                    case 1:
-                        return list[0];
-                }
-            }
-            else
-            {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
-                {
-                    if (!e.MoveNext())
-                    {
-                        ThrowHelper.ThrowNoElementsException();
-                    }
-
-                    TSource result = e.Current;
-                    if (!e.MoveNext())
-                    {
-                        return result;
-                    }
-                }
-            }
-
-            ThrowHelper.ThrowMoreThanOneElementException();
-            return default;
+            return single!;
         }
-
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            var single = source.TryGetSingle(predicate, out bool found);
+            if (!found)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                ThrowHelper.ThrowNoElementsException();
             }
 
-            if (predicate == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
-            }
-
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                while (e.MoveNext())
-                {
-                    TSource result = e.Current;
-                    if (predicate(result))
-                    {
-                        while (e.MoveNext())
-                        {
-                            if (predicate(e.Current))
-                            {
-                                ThrowHelper.ThrowMoreThanOneMatchException();
-                            }
-                        }
-
-                        return result;
-                    }
-                }
-            }
-
-            ThrowHelper.ThrowNoMatchException();
-            return default;
+            return single!;
         }
 
         public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source)
-            => source.SingleOrDefault(default(TSource));
+            => source.TryGetSingle(out _);
 
         public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
-            if (source == null)
+            var single = source.TryGetSingle(out bool found);
+            return found ? single! : defaultValue;
+        }
+
+        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+            => source.TryGetSingle(predicate, out _);
+
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
+        {
+            var single = source.TryGetSingle(predicate, out bool found);
+            return found ? single! : defaultValue;
+        }
+
+        private static TSource? TryGetSingle<TSource>(this IEnumerable<TSource> source, out bool found)
+        {
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -98,8 +59,10 @@ namespace System.Linq
                 switch (list.Count)
                 {
                     case 0:
-                        return defaultValue;
+                        found = false;
+                        return default;
                     case 1:
+                        found = true;
                         return list[0];
                 }
             }
@@ -109,25 +72,25 @@ namespace System.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return defaultValue;
+                        found = false;
+                        return default;
                     }
 
                     TSource result = e.Current;
                     if (!e.MoveNext())
                     {
+                        found = true;
                         return result;
                     }
                 }
             }
 
+            found = false;
             ThrowHelper.ThrowMoreThanOneElementException();
             return default;
         }
 
-        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source.SingleOrDefault(predicate, default);
-
-        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue)
+        private static TSource? TryGetSingle<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
             if (source == null)
             {
@@ -153,13 +116,14 @@ namespace System.Linq
                                 ThrowHelper.ThrowMoreThanOneMatchException();
                             }
                         }
-
+                        found = true;
                         return result;
                     }
                 }
             }
 
-            return defaultValue;
+            found = false;
+            return default;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -84,6 +84,9 @@ namespace System.Linq
         }
 
         public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source)
+            => source.SingleOrDefault(default(TSource));
+
+        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue)
         {
             if (source == null)
             {
@@ -95,7 +98,7 @@ namespace System.Linq
                 switch (list.Count)
                 {
                     case 0:
-                        return default;
+                        return defaultValue;
                     case 1:
                         return list[0];
                 }
@@ -106,7 +109,7 @@ namespace System.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        return default;
+                        return defaultValue;
                     }
 
                     TSource result = e.Current;
@@ -122,6 +125,9 @@ namespace System.Linq
         }
 
         public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+            => source.SingleOrDefault(predicate, default);
+
+        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource? defaultValue)
         {
             if (source == null)
             {
@@ -153,7 +159,7 @@ namespace System.Linq
                 }
             }
 
-            return default;
+            return defaultValue;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -86,7 +86,7 @@ namespace System.Linq
         public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source)
             => source.SingleOrDefault(default(TSource));
 
-        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource? defaultValue)
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
             if (source == null)
             {

--- a/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
@@ -39,6 +39,15 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().FirstOrDefault());
         }
 
+        private static void TestEmptyIListDefault<T>(T defaultValue)
+        {
+            T[] source = { };
+
+            Assert.IsAssignableFrom<IList<T>>(source);
+
+            Assert.Equal(defaultValue, source.RunOnce().FirstOrDefault(defaultValue));
+        }
+
         [Fact]
         public void EmptyIListT()
         {
@@ -46,6 +55,14 @@ namespace System.Linq.Tests
             TestEmptyIList<string>();
             TestEmptyIList<DateTime>();
             TestEmptyIList<FirstOrDefaultTests>();
+        }
+
+        [Fact]
+        public void EmptyIListDefault()
+        {
+            TestEmptyIListDefault(5); // int
+            TestEmptyIListDefault("Hello"); // string
+            TestEmptyIListDefault(DateTime.UnixEpoch); //DateTime
         }
 
         [Fact]
@@ -57,6 +74,17 @@ namespace System.Linq.Tests
             Assert.IsAssignableFrom<IList<int>>(source);
 
             Assert.Equal(expected, source.FirstOrDefault());
+        }
+
+        [Fact]
+        public void IListOneElementDefault()
+        {
+            int[] source = { 5 };
+            int expected = 5;
+
+            Assert.IsAssignableFrom<IList<int>>(source);
+
+            Assert.Equal(expected, source.FirstOrDefault(3));
         }
 
         [Fact]
@@ -94,6 +122,20 @@ namespace System.Linq.Tests
             Assert.Null(source as IList<T>);
 
             Assert.Equal(expected, source.RunOnce().FirstOrDefault());
+        }
+
+        private static void TestEmptyNotIListDefault<T>(T defaultValue)
+        {
+            static IEnumerable<T1> EmptySource<T1>()
+            {
+                yield break;
+            }
+
+            var source = EmptySource<T>();
+
+            Assert.Null(source as IList<T>);
+
+            Assert.Equal(defaultValue, source.RunOnce().FirstOrDefault(defaultValue));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
@@ -189,6 +189,16 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void OneElementTruePredicateDefault()
+        {
+            int[] source = { 4 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 4;
+
+            Assert.Equal(expected, source.FirstOrDefault(predicate, 5));
+        }
+
+        [Fact]
         public void ManyElementsPredicateFalseForAll()
         {
             int[] source = { 9, 5, 1, 3, 17, 21 };
@@ -196,6 +206,16 @@ namespace System.Linq.Tests
             int expected = default(int);
 
             Assert.Equal(expected, source.FirstOrDefault(predicate));
+        }
+
+        [Fact]
+        public void ManyElementsPredicateFalseForAllDefault()
+        {
+            int[] source = { 9, 5, 1, 3, 17, 21 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 5;
+
+            Assert.Equal(expected, source.FirstOrDefault(predicate, 5));
         }
 
         [Fact]
@@ -209,6 +229,16 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void PredicateTrueOnlyForLastDefault()
+        {
+            int[] source = { 9, 5, 1, 3, 17, 21, 50 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 50;
+
+            Assert.Equal(expected, source.FirstOrDefault(predicate, 5));
+        }
+
+        [Fact]
         public void PredicateTrueForSome()
         {
             int[] source = { 3, 7, 10, 7, 9, 2, 11, 17, 13, 8 };
@@ -216,6 +246,16 @@ namespace System.Linq.Tests
             int expected = 10;
 
             Assert.Equal(expected, source.FirstOrDefault(predicate));
+        }
+
+        [Fact]
+        public void PredicateTrueForSomeDefault()
+        {
+            int[] source = { 3, 7, 10, 7, 9, 2, 11, 17, 13, 8 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 10;
+
+            Assert.Equal(expected, source.FirstOrDefault(predicate, 5));
         }
 
         [Fact]
@@ -232,12 +272,14 @@ namespace System.Linq.Tests
         public void NullSource()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).FirstOrDefault());
+            AssertExtensions.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).FirstOrDefault(5));
         }
 
         [Fact]
         public void NullSourcePredicateUsed()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).FirstOrDefault(i => i != 2));
+            AssertExtensions.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).FirstOrDefault(i => i != 2, 5));
         }
 
         [Fact]
@@ -245,6 +287,7 @@ namespace System.Linq.Tests
         {
             Func<int, bool> predicate = null;
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).FirstOrDefault(predicate));
+            AssertExtensions.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).FirstOrDefault(predicate, 5));
         }
     }
 }

--- a/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
@@ -39,6 +39,15 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().LastOrDefault());
         }
 
+        private static void TestEmptyIListDefault<T>(T defaultValue)
+        {
+            T[] source = { };
+
+            Assert.IsAssignableFrom<IList<T>>(source);
+
+            Assert.Equal(defaultValue, source.RunOnce().LastOrDefault(defaultValue));
+        }
+
         [Fact]
         public void EmptyIListT()
         {
@@ -46,6 +55,14 @@ namespace System.Linq.Tests
             TestEmptyIList<string>();
             TestEmptyIList<DateTime>();
             TestEmptyIList<LastOrDefaultTests>();
+        }
+
+        [Fact]
+        public void EmptyIList()
+        {
+            TestEmptyIListDefault(5); // int
+            TestEmptyIListDefault("Hello"); // string
+            TestEmptyIListDefault(DateTime.UnixEpoch);
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
@@ -110,6 +110,28 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.LastOrDefault());
         }
 
+        [Fact]
+        public void IListTManyElementsLastHasDefault()
+        {
+            int?[] source = { -10, 2, 4, 3, 0, 2, null };
+            int? expected = null;
+
+            Assert.IsAssignableFrom<IList<int?>>(source);
+
+            Assert.Equal(expected, source.LastOrDefault(5));
+        }
+
+        [Fact]
+        public void IListTManyElementsLastIsHasDefault()
+        {
+            int?[] source = { -10, 2, 4, 3, 0, 2, null, 19 };
+            int? expected = 19;
+
+            Assert.IsAssignableFrom<IList<int?>>(source);
+
+            Assert.Equal(expected, source.LastOrDefault(5));
+        }
+
         private static IEnumerable<T> EmptySource<T>()
         {
             yield break;
@@ -176,6 +198,16 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void OneElementIListTruePredicateDefault()
+        {
+            int[] source = { 4 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 4;
+
+            Assert.Equal(expected, source.LastOrDefault(predicate, 5));
+        }
+
+        [Fact]
         public void ManyElementsIListPredicateFalseForAll()
         {
             int[] source = { 9, 5, 1, 3, 17, 21 };
@@ -183,6 +215,16 @@ namespace System.Linq.Tests
             int expected = default(int);
 
             Assert.Equal(expected, source.LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void ManyElementsIListPredicateFalseForAllDefault()
+        {
+            int[] source = { 9, 5, 1, 3, 17, 21 };
+            Func<int, bool> predicate = IsEven;
+            int expected = 5;
+
+            Assert.Equal(expected, source.LastOrDefault(predicate, 5));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/LastOrDefaultTests.cs
@@ -76,6 +76,17 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.LastOrDefault());
         }
 
+        [Fact]
+        public void IListTOneElementDefault()
+        {
+            int[] source = { 5 };
+            int expected = 5;
+
+            Assert.IsAssignableFrom<IList<int>>(source);
+
+            Assert.Equal(expected, source.LastOrDefault(4));
+        }
+
 
         [Fact]
         public void IListTManyElementsLastIsDefault()

--- a/src/libraries/System.Linq/tests/SingleOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/SingleOrDefaultTests.cs
@@ -37,12 +37,30 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyIListDefault()
+        {
+            int?[] source = { };
+            int expected = 5;
+
+            Assert.Equal(expected, source.SingleOrDefault(5));
+        }
+
+        [Fact]
         public void SingleElementIList()
         {
             int[] source = { 4 };
             int expected = 4;
 
             Assert.Equal(expected, source.SingleOrDefault());
+        }
+
+        [Fact]
+        public void SingleElementIListDefault()
+        {
+            int[] source = { 4 };
+            int expected = 4;
+
+            Assert.Equal(expected, source.SingleOrDefault(5));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/SingleOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/SingleOrDefaultTests.cs
@@ -72,6 +72,14 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ManyElementIListDefault()
+        {
+            int[] source = { 4, 4, 4, 4, 4 };
+
+            Assert.Throws<InvalidOperationException>(() => source.SingleOrDefault(5));
+        }
+
+        [Fact]
         public void EmptyNotIList()
         {
             IEnumerable<int> source = RepeatedNumberGuaranteedNotCollectionType(0, 0);
@@ -107,12 +115,30 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptySourceWithPredicateDefault()
+        {
+            int[] source = { };
+            int expected = 5;
+
+            Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void SingleElementPredicateTrue()
         {
             int[] source = { 4 };
             int expected = 4;
 
             Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void SingleElementPredicateTrueDefault()
+        {
+            int[] source = { 4 };
+            int expected = 4;
+
+            Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0, 5));
         }
 
         [Fact]
@@ -125,12 +151,30 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SingleElementPredicateFalseDefault()
+        {
+            int[] source = { 3 };
+            int expected = 5;
+
+            Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void ManyElementsPredicateFalseForAll()
         {
             int[] source = { 3, 1, 7, 9, 13, 19 };
             int expected = default(int);
 
             Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void ManyElementsPredicateFalseForAllDefault()
+        {
+            int[] source = { 3, 1, 7, 9, 13, 19 };
+            int expected = 5;
+
+            Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0, 5));
         }
 
         [Fact]
@@ -143,11 +187,28 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ManyElementsPredicateTrueForLastDefault()
+        {
+            int[] source = { 3, 1, 7, 9, 13, 19, 20 };
+            int expected = 20;
+
+            Assert.Equal(expected, source.SingleOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void ManyElementsPredicateTrueForFirstAndFifth()
         {
             int[] source = { 2, 3, 1, 7, 10, 13, 19, 9 };
 
             Assert.Throws<InvalidOperationException>(() => source.SingleOrDefault(i => i % 2 == 0));
+        }
+
+        [Fact]
+        public void ManyElementsPredicateTrueForFirstAndFifthDefault()
+        {
+            int[] source = { 2, 3, 1, 7, 10, 13, 19, 9 };
+
+            Assert.Throws<InvalidOperationException>(() => source.SingleOrDefault(i => i % 2 == 0, 5));
         }
 
         [Theory]
@@ -175,11 +236,27 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ThrowsOnNullSourceDefault()
+        {
+            int[] source = null;
+            AssertExtensions.Throws<ArgumentNullException>("source", () => source.SingleOrDefault(5));
+            AssertExtensions.Throws<ArgumentNullException>("source", () => source.SingleOrDefault(i => i % 2 == 0, 5));
+        }
+
+        [Fact]
         public void ThrowsOnNullPredicate()
         {
             int[] source = { };
             Func<int, bool> nullPredicate = null;
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => source.SingleOrDefault(nullPredicate));
+        }
+
+        [Fact]
+        public void ThrowsOnNullPredicateDefault()
+        {
+            int[] source = { };
+            Func<int, bool> nullPredicate = null;
+            AssertExtensions.Throws<ArgumentNullException>("predicate", () => source.SingleOrDefault(nullPredicate, 5));
         }
     }
 }


### PR DESCRIPTION
Fixes #20064