### PR TITLE
Address remaning master mentions that should be main

### DIFF
--- a/docs/design/coreclr/botr/guide-for-porting.md
+++ b/docs/design/coreclr/botr/guide-for-porting.md
@@ -15,7 +15,7 @@ Porting the .NET Runtime to a new architecture typically follows along the
 following path.
 
 As engineering continues along the development path, it is best if the logic can
-be placed into the master repository of the runtime as soon as possible. This
+be placed into the main branch of the runtime as soon as possible. This
 will have 2 major effects.
 
 1.  Individual commits are easier to review.

--- a/docs/project/branching-guide.md
+++ b/docs/project/branching-guide.md
@@ -3,18 +3,18 @@ Branching Guide
 
 We will have the following branches in the corefx repository:
 
-* **master**
+* **main**
  * Where most development happens
  * Submit your PRs here unless you are adding API to a type that exists in the full .NET Framework
 
 * **release/[name]**
- * Release branches snapped from master.
+ * Release branches snapped from main.
  * Do not submit pull requests to these branches
  * Fixes here do not flow to follow-up releases
- * Generally, fixes after a snap needing to make it in to a release will go in to master and get cherry-picked to the release branch.
+ * Generally, fixes after a snap needing to make it in to a release will go in to main and get cherry-picked to the release branch.
 
 * **dev/[name]**
  * Features (aka topics) under active development by more than one developer.
  * Submit PRs here only if you've made prior arrangements to work on something in one of these branches.
  * It is up to the developers creating these branches to decide what level of review is required
- * These features will only ship if they are successfully pulled to master or future via the standard PR and API review process.
+ * These features will only ship if they are successfully pulled to main or future via the standard PR and API review process.

--- a/src/coreclr/scripts/superpmi.md
+++ b/src/coreclr/scripts/superpmi.md
@@ -73,7 +73,7 @@ python f:\gh\runtime\src\coreclr\scripts\superpmi.py replay -filter tests
 To generate ASM diffs, use the `asmdiffs` command. This requires a "diff" and "baseline"
 JIT. By default, the "diff" JIT is determined automatically as for the "replay" command,
 described above. Also by default, the baseline JIT is determined based on comparing the
-state of your branch with the `master` branch, and downloading an appropriate baseline JIT from the JIT
+state of your branch with the `main` branch, and downloading an appropriate baseline JIT from the JIT
 rolling build system. Alternatively, you can specify the path to a baseline JIT
 compiler using the `-base_jit_path` argument.
 


### PR DESCRIPTION
Did a second search of master in the repo since all the M2M changes went
in and found some remaining places that weren't addressed in the
previous change.