### PR TITLE
cgroup: fix memory leak in GetCGroupMemoryUsage

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -428,6 +428,7 @@ private:
             }
         }
 
+        free(mem_usage_filename);
         return result;
     }
 

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -415,6 +415,7 @@ private:
             }
         }
 
+        free(mem_usage_filename);
         return result;
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48822.

This is a 5.0 regression introduced in https://github.com/dotnet/runtime/pull/34334.

cc @janvorli @omajid @hlippke @gerlachch