### PR TITLE
Deal with Homebrew prefix not being /usr/local (Apple Silicon)

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -55,7 +55,7 @@ check_prereqs()
         if ! pkg-config openssl ; then
             # We export the proper PKG_CONFIG_PATH where openssl was installed by Homebrew
             # It's important to _export_ it since build-commons.sh is sourced by other scripts such as build-native.sh
-            export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig
+            export PKG_CONFIG_PATH=`brew --prefix`/opt/openssl@1.1/lib/pkgconfig:`brew --prefix`/opt/openssl/lib/pkgconfig
             # We try again with the PKG_CONFIG_PATH in place, if pkg-config still can't find OpenSSL, exit with an error, cmake won't find OpenSSL either
             pkg-config openssl || { echo >&2 "Please install openssl before running this script, see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/macos-requirements.md"; exit 1; }
         fi

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -55,7 +55,7 @@ check_prereqs()
         if ! pkg-config openssl ; then
             # We export the proper PKG_CONFIG_PATH where openssl was installed by Homebrew
             # It's important to _export_ it since build-commons.sh is sourced by other scripts such as build-native.sh
-            export PKG_CONFIG_PATH=`brew --prefix`/opt/openssl@1.1/lib/pkgconfig:`brew --prefix`/opt/openssl/lib/pkgconfig
+            export PKG_CONFIG_PATH=$(brew --prefix)/opt/openssl@1.1/lib/pkgconfig:$(brew --prefix)/opt/openssl/lib/pkgconfig
             # We try again with the PKG_CONFIG_PATH in place, if pkg-config still can't find OpenSSL, exit with an error, cmake won't find OpenSSL either
             pkg-config openssl || { echo >&2 "Please install openssl before running this script, see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/macos-requirements.md"; exit 1; }
         fi

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -14,7 +14,8 @@ if(CLR_CMAKE_TARGET_UNIX)
     add_compile_options(-Wno-unknown-warning-option)
 
     if (NOT CLR_CMAKE_TARGET_ANDROID)
-        set(ICU_HOMEBREW_INC_PATH "/usr/local/opt/icu4c/include")
+        execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set(ICU_HOMEBREW_INC_PATH "${brew_prefix}/opt/icu4c/include")
 
         find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
         if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -509,7 +509,8 @@ elseif(HOST_OSX)
   include(FindPkgConfig)
   # FIXME: Handle errors
   # Defines ICU_INCLUDEDIR/ICU_LIBDIR
-  set(ENV{PKG_CONFIG_PATH} "{$PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig")
+  execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(ENV{PKG_CONFIG_PATH} "{$PKG_CONFIG_PATH}:${brew_prefix}/lib/pkgconfig:${brew_prefix}/opt/icu4c/lib/pkgconfig")
   pkg_check_modules(ICU icu-uc)
   set(OSX_ICU_LIBRARY_PATH /usr/lib/libicucore.dylib)
   set(ICU_FLAGS "-DTARGET_UNIX -DU_DISABLE_RENAMING -Wno-reserved-id-macro -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-extra-semi-stmt -Wno-unknown-warning-option -Wno-deprecated-declarations")


### PR DESCRIPTION
As per [the documentation](https://docs.brew.sh/Installation), Homebrew uses a different install directory for Brew on Intel vs. Apple Silicon. We have hardcoded the Intel location in a couple of places, so instead switch to pulling the prefix from `brew --prefix`