### PR TITLE
[RyuJIT] Fix eeGetRelocTypeHint for macOS/Linux x64

### DIFF
--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -59,11 +59,11 @@
     #define CODEHEAP_START_ADDRESS  0x64480000000
     #define CLR_UPPER_ADDRESS_MAX   0x644FC000000
 
-#if !defined(HOST_UNIX)
+#if !defined(TARGET_ARM64)
     #define USE_UPPER_ADDRESS       1
 #else
     #define USE_UPPER_ADDRESS       0
-#endif // !HOST_UNIX
+#endif // !TARGET_ARM64
 
 #else
     #error Please add a new #elif clause and define all portability macros for the new platform


### PR DESCRIPTION
During https://github.com/dotnet/runtime/pull/44562 I noticed that `eeGetRelocTypeHint` never returns `IMAGE_REL_BASED_REL32 ` on macOS and Linux x64, let's see if this define won't break anything