### PR TITLE
Fix crossgen2 shared framework name and clean-up

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <AspNetCoreAppCurrent>net$(AspNetCoreAppCurrentVersion)</AspNetCoreAppCurrent>
     <NetCoreAppToolCurrent>net$(NetCoreAppToolCurrentVersion)</NetCoreAppToolCurrent>
     <NetCoreAppCurrentToolTargetFrameworkMoniker>$(NetCoreAppCurrentIdentifier),Version=v$(NetCoreAppToolCurrentVersion)</NetCoreAppCurrentToolTargetFrameworkMoniker>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
+    <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>
     <NetCoreAppCurrentBrandName>.NET $(NetCoreAppCurrentVersion)</NetCoreAppCurrentBrandName>
   </PropertyGroup>
 

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SharedFrameworkName Condition="'$(SharedFrameworkName)' == ''">Microsoft.NETCore.App</SharedFrameworkName>
+    <LocalFrameworkOverrideName Condition="'$(LocalFrameworkOverrideName)' == ''">$(MicrosoftNetCoreAppFrameworkName)</LocalFrameworkOverrideName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' and
@@ -13,26 +13,26 @@
 
   <!-- Add Known* items if the SDK doesn't support the TargetFramework yet. -->
   <ItemGroup Condition="'$(_UseLocalTargetingRuntimePack)' == 'true'">
-    <KnownFrameworkReference Include="$(SharedFrameworkName)"
+    <KnownFrameworkReference Include="$(LocalFrameworkOverrideName)"
                              DefaultRuntimeFrameworkVersion="$(ProductVersion)"
                              IsTrimmable="true"
                              LatestRuntimeFrameworkVersion="$(ProductVersion)"
-                             RuntimeFrameworkName="$(SharedFrameworkName)"
-                             RuntimePackNamePatterns="$(SharedFrameworkName).Runtime.**RID**"
+                             RuntimeFrameworkName="$(LocalFrameworkOverrideName)"
+                             RuntimePackNamePatterns="$(LocalFrameworkOverrideName).Runtime.**RID**"
                              RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;linux-musl-arm;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;maccatalyst-x64;maccatalyst-arm64;android-arm64;android-arm;android-x64;android-x86;browser-wasm;osx-arm64"
                              TargetFramework="$(NetCoreAppCurrent)"
-                             TargetingPackName="$(SharedFrameworkName).Ref"
+                             TargetingPackName="$(LocalFrameworkOverrideName).Ref"
                              TargetingPackVersion="$(ProductVersion)"
                              Condition="'@(KnownFrameworkReference)' == '' or !@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
-    <KnownAppHostPack Include="$(SharedFrameworkName)" 
-                      AppHostPackNamePattern="$(SharedFrameworkName).Host.**RID**"
+    <KnownAppHostPack Include="$(LocalFrameworkOverrideName)" 
+                      AppHostPackNamePattern="$(LocalFrameworkOverrideName).Host.**RID**"
                       AppHostPackVersion="$(ProductVersion)"
                       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64"
                       TargetFramework="$(NetCoreAppCurrent)"
                       Condition="'@(KnownAppHostPack)' == '' or !@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
-    <KnownCrossgen2Pack Include="$(SharedFrameworkName).Crossgen2"
+    <KnownCrossgen2Pack Include="$(LocalFrameworkOverrideName).Crossgen2"
                         TargetFramework="$(NetCoreAppCurrent)"
-                        Crossgen2PackNamePattern="$(SharedFrameworkName).Crossgen2.**RID**"
+                        Crossgen2PackNamePattern="$(LocalFrameworkOverrideName).Crossgen2.**RID**"
                         Crossgen2PackVersion="$(ProductVersion)"
                         Crossgen2RuntimeIdentifiers="linux-musl-x64;linux-x64;win-x64"
                         Condition="'@(KnownCrossgen2Pack)' == '' or !@(KnownCrossgen2Pack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
@@ -76,7 +76,7 @@
     </PropertyGroup>
     <ItemGroup>
       <Reference Remove="@(Reference)"
-                 Condition="'%(Reference.FrameworkReferenceName)' == '$(SharedFrameworkName)'" />
+                 Condition="'%(Reference.FrameworkReferenceName)' == '$(LocalFrameworkOverrideName)'" />
     </ItemGroup>
   </Target>
 
@@ -97,9 +97,9 @@
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <PackageDownload Remove="@(PackageDownload)"
-                       Condition="'$(UsePackageDownload)' == 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
+                       Condition="'$(UsePackageDownload)' == 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(LocalFrameworkOverrideName).Runtime'))" />
       <PackageReference Remove="@(PackageReference)"
-                        Condition="'$(UsePackageDownload)' != 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
+                        Condition="'$(UsePackageDownload)' != 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(LocalFrameworkOverrideName).Runtime'))" />
     </ItemGroup>
   </Target>
 
@@ -111,23 +111,23 @@
       <ResolvedTargetingPack Path="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
                              NuGetPackageVersion="$(ProductVersion)"
                              PackageDirectory="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
-                             Condition="'%(ResolvedTargetingPack.RuntimeFrameworkName)' == '$(SharedFrameworkName)' and
+                             Condition="'%(ResolvedTargetingPack.RuntimeFrameworkName)' == '$(LocalFrameworkOverrideName)' and
                                         Exists('$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml')" />
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)"
-                           Condition="'%(ResolvedRuntimePack.FrameworkName)' == '$(SharedFrameworkName)'" />
+                           Condition="'%(ResolvedRuntimePack.FrameworkName)' == '$(LocalFrameworkOverrideName)'" />
       <ResolvedFrameworkReference TargetingPackPath="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
                                   TargetingPackVersion="$(ProductVersion)"
-                                  Condition="'%(Identity)' == '$(SharedFrameworkName)'" />
+                                  Condition="'%(Identity)' == '$(LocalFrameworkOverrideName)'" />
     </ItemGroup>
   </Target>
 
-  <!-- Update the local targeting pack's version as it's written into the runtimeconfig.json file to select the shared framework. -->
+  <!-- Update the local targeting pack's version as it's written into the runtimeconfig.json file to select the right framework. -->
   <Target Name="UpdateRuntimeFrameworkVersion"
           Condition="'$(_UseLocalTargetingRuntimePack)' == 'true'"
           AfterTargets="ResolveTargetingPackAssets">
     <ItemGroup>
       <RuntimeFramework Version="$(ProductVersion)"
-                        Condition="'%(RuntimeFramework.FrameworkName)' == '$(SharedFrameworkName)'" />
+                        Condition="'%(RuntimeFramework.FrameworkName)' == '$(LocalFrameworkOverrideName)'" />
     </ItemGroup>
   </Target>
   

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
+    <SharedFrameworkName>$(MicrosoftNetCoreAppFrameworkName)</SharedFrameworkName>
     <SharedFrameworkName Condition="'$(PgoInstrument)' != ''">$(SharedFrameworkName).PGO</SharedFrameworkName>
     <IsShipping Condition="'$(PgoInstrument)' != ''">false</IsShipping>
     <SharedFrameworkFriendlyName>.NET Runtime</SharedFrameworkFriendlyName>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -6,7 +6,7 @@
     <SkipBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</SkipBuild>
     <PlatformPackageType>RuntimePack</PlatformPackageType>
     <SharedFrameworkName>$(SharedFrameworkName).Crossgen2</SharedFrameworkName>
-    <OverridePackageId>$(SharedFrameworkName).Crossgen2.$(RuntimeIdentifier)</OverridePackageId>
+    <OverridePackageId>$(SharedFrameworkName).$(RuntimeIdentifier)</OverridePackageId>
     <ArchiveName>dotnet-crossgen2</ArchiveName>
     <SharedFrameworkHostFileNameOverride>crossgen2</SharedFrameworkHostFileNameOverride>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;osx-x64;osx-arm64;win-x64</RuntimeIdentifiers>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -144,7 +144,7 @@
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
-    <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', '$(SharedFrameworkName)', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
+    <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', '$(MicrosoftNetCoreAppFrameworkName)', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
 
     <MicrosoftNetCoreAppRefPackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.ref'))</MicrosoftNetCoreAppRefPackDir>
     <MicrosoftNetCoreAppRefPackRefDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'ref', '$(NetCoreAppCurrent)'))</MicrosoftNetCoreAppRefPackRefDir>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -57,10 +57,10 @@
           Outputs="$(MicrosoftNetCoreAppRuntimePackDir)data\PlatformManifest.txt"
           Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFile)"
-                              PackageId="$(SharedFrameworkName).Runtime.$(PackageRID)"
+                              PackageId="$(MicrosoftNetCoreAppFrameworkName).Runtime.$(PackageRID)"
                               PackageVersion="$(ProductVersion)"
                               PlatformManifestFile="$(MicrosoftNetCoreAppRuntimePackDir)data\PlatformManifest.txt"
-                              PreferredPackages="$(SharedFrameworkName).Runtime.$(PackageRID)"
+                              PreferredPackages="$(MicrosoftNetCoreAppFrameworkName).Runtime.$(PackageRID)"
                               PermitDllAndExeFilesLackingFileVersion="true" />
   </Target>
 
@@ -72,10 +72,10 @@
           Outputs="$(MicrosoftNetCoreAppRefPackDataDir)PlatformManifest.txt"
           Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFile)"
-                              PackageId="$(SharedFrameworkName).Ref"
+                              PackageId="$(MicrosoftNetCoreAppFrameworkName).Ref"
                               PackageVersion="$(ProductVersion)"
                               PlatformManifestFile="$(MicrosoftNetCoreAppRefPackDataDir)PlatformManifest.txt"
-                              PreferredPackages="$(SharedFrameworkName).Ref"
+                              PreferredPackages="$(MicrosoftNetCoreAppFrameworkName).Ref"
                               PermitDllAndExeFilesLackingFileVersion="true" />
   </Target>
 
@@ -84,7 +84,7 @@
   <Target Name="GenerateTestSharedFrameworkAssets"
           AfterTargets="BuildExternalsProject"
           Inputs="$(NETCoreAppTestSharedFrameworkPath)*.*"
-          Outputs="$(NETCoreAppTestSharedFrameworkPath)$(SharedFrameworkName).deps.json"
+          Outputs="$(NETCoreAppTestSharedFrameworkPath)$(MicrosoftNetCoreAppFrameworkName).deps.json"
           Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)"
@@ -129,7 +129,7 @@
       <FrameworkListRootAttribute Include="Name" Value="$(NetCoreAppCurrentBrandName)" />
       <FrameworkListRootAttribute Include="TargetFrameworkIdentifier" Value="$(NetCoreAppCurrentIdentifier)" />
       <FrameworkListRootAttribute Include="TargetFrameworkVersion" Value="$(NetCoreAppCurrentVersion)" />
-      <FrameworkListRootAttribute Include="FrameworkName" Value="$(SharedFrameworkName)" />
+      <FrameworkListRootAttribute Include="FrameworkName" Value="$(MicrosoftNetCoreAppFrameworkName)" />
     </ItemGroup>
 
     <CreateFrameworkListFile Files="@(RuntimePackLibFile);@(RuntimePackNativeFile)"

--- a/src/libraries/ref.proj
+++ b/src/libraries/ref.proj
@@ -62,7 +62,7 @@
       <FrameworkListRootAttribute Include="Name" Value="$(NetCoreAppCurrentBrandName)" />
       <FrameworkListRootAttribute Include="TargetFrameworkIdentifier" Value="$(NetCoreAppCurrentIdentifier)" />
       <FrameworkListRootAttribute Include="TargetFrameworkVersion" Value="$(NetCoreAppCurrentVersion)" />
-      <FrameworkListRootAttribute Include="FrameworkName" Value="$(SharedFrameworkName)" />
+      <FrameworkListRootAttribute Include="FrameworkName" Value="$(MicrosoftNetCoreAppFrameworkName)" />
     </ItemGroup>
 
     <CreateFrameworkListFile Files="@(RefPackLibFile)"


### PR DESCRIPTION
Fix crossgen2 RID specific package names and use more specific property
names to avoid confusion about shared framework meanings.