### PR TITLE
[wasm][debugger] Add resolved assemblies to cache to help mono.cecil find them

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -769,7 +769,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             catch (Exception e)
             {
-                System.Console.WriteLine($"Failed to load assembly: ({e.Message})");
                 logger.LogDebug($"Failed to load assembly: ({e.Message})");
                 yield break;
             }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -769,6 +769,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             catch (Exception e)
             {
+                System.Console.WriteLine($"Failed to load assembly: ({e.Message})");
                 logger.LogDebug($"Failed to load assembly: ({e.Message})");
                 yield break;
             }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -732,7 +732,7 @@ namespace Microsoft.WebAssembly.Diagnostics
     internal class CustomResolver : DefaultAssemblyResolver
     {
 
-        public void Register(AssemblyDefinition assembly)
+        public void RegisterAssembly(AssemblyDefinition assembly)
         {
             this.RegisterAssembly(assembly);
         }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -439,7 +439,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 this.image = ModuleDefinition.ReadModule(new MemoryStream(assembly), rp);
             }
             if (this.image != null)
-                resolver.Register(this.image.Assembly);
+                resolver.RegisterAssembly(this.image.Assembly);
             Populate();
         }
 
@@ -731,10 +731,9 @@ namespace Microsoft.WebAssembly.Diagnostics
 
     internal class CustomResolver : DefaultAssemblyResolver
     {
-
-        public void RegisterAssembly(AssemblyDefinition assembly)
+        public new void RegisterAssembly(AssemblyDefinition assembly)
         {
-            this.RegisterAssembly(assembly);
+            base.RegisterAssembly(assembly);
         }
     }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -391,7 +391,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal string Url { get; }
         public bool TriedToLoadSymbolsOnDemand { get; set; }
 
-        public AssemblyInfo(IAssemblyResolver resolver, string url, byte[] assembly, byte[] pdb)
+        public AssemblyInfo(CustomResolver resolver, string url, byte[] assembly, byte[] pdb)
         {
             this.id = Interlocked.Increment(ref next_id);
 
@@ -438,7 +438,8 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 this.image = ModuleDefinition.ReadModule(new MemoryStream(assembly), rp);
             }
-
+            if (this.image != null)
+                resolver.Register(this.image.Assembly);
             Populate();
         }
 
@@ -728,18 +729,27 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
+    internal class CustomResolver : DefaultAssemblyResolver
+    {
+
+        public void Register(AssemblyDefinition assembly)
+        {
+            this.RegisterAssembly(assembly);
+        }
+    }
+
     internal class DebugStore
     {
         private List<AssemblyInfo> assemblies = new List<AssemblyInfo>();
         private readonly HttpClient client;
         private readonly ILogger logger;
-        private readonly IAssemblyResolver resolver;
+        private readonly CustomResolver resolver;
 
         public DebugStore(ILogger logger, HttpClient client)
         {
             this.client = client;
             this.logger = logger;
-            this.resolver = new DefaultAssemblyResolver();
+            this.resolver = new CustomResolver();
         }
 
         public DebugStore(ILogger logger) : this(logger, new HttpClient())

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1008,9 +1008,9 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task DebugAssemblyWithDependencyOnCecilLoad()
+        public async Task BreakpointInAssemblyUsingTypeFromAnotherAssembly_BothDynamicallyLoaded()
         {
-            int line = 12;
+            int line = 7;
             await SetBreakpoint(".*/library-dependency-debugger-test1.cs$", line, 0, use_regex: true);
             await LoadAssemblyDynamically(
                     Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test2.dll"),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1006,6 +1006,30 @@ namespace DebuggerTests
                 "dotnet://debugger-test.dll/debugger-test2.cs", 56, 4,
                 "BreakOnDebuggerBreakCommand");
         }
+
+        [Fact]
+        public async Task DebugAssemblyWithDependencyOnCecilLoad()
+        {
+            int line = 12;
+            await SetBreakpoint(".*/library-dependency-debugger-test1.cs$", line, 0, use_regex: true);
+            await LoadAssemblyDynamically(
+                    Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test2.dll"),
+                    Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test2.pdb"));
+            await LoadAssemblyDynamically(
+                    Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test1.dll"),
+                    Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test1.pdb"));
+
+            var source_location = "dotnet://library-dependency-debugger-test1.dll/library-dependency-debugger-test1.cs";
+            Assert.Contains(source_location, scripts.Values);
+
+            var pause_location = await EvaluateAndCheck(
+               "window.setTimeout(function () { invoke_static_method('[library-dependency-debugger-test1] TestDependency:IntAdd', 5, 10); }, 1);",
+               source_location, line, 8,
+               "IntAdd");
+            var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+            CheckNumber(locals, "a", 5);
+            CheckNumber(locals, "b", 10);
+        }
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }

--- a/src/mono/wasm/debugger/tests/Directory.Build.props
+++ b/src/mono/wasm/debugger/tests/Directory.Build.props
@@ -7,6 +7,10 @@
     <Configuration>Debug</Configuration>
     <RuntimeConfiguration>Release</RuntimeConfiguration>
 
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>219</NoWarn>
+    <RunAnalyzers>false</RunAnalyzers>
+
     <AppDir>$(ArtifactsBinDir)debugger-test\$(Configuration)\publish</AppDir>
     <OutDir>$(ArtifactsBinDir)debugger-test\$(Configuration)\wasm</OutDir>
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -15,6 +15,8 @@
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" Private="true"/>
     <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" Private="true"/>
+    <ProjectReference Include="..\library-dependency-debugger-test1\library-dependency-debugger-test1.csproj" Private="true"/>
+    <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" Private="true"/>
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded/lazy-debugger-test-embedded.csproj
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded/lazy-debugger-test-embedded.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>Library</OutputType>
-    <NoWarn>219</NoWarn>
-    <RunAnalyzers>false</RunAnalyzers>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.csproj
@@ -1,8 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>Library</OutputType>
-    <NoWarn>219</NoWarn>
-    <RunAnalyzers>false</RunAnalyzers>
-  </PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
@@ -1,10 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-
 public class TestDependency
 {
     public static int IntAdd(int a, int b)

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+public class TestDependency
+{
+    public static int IntAdd(int a, int b)
+    {
+        System.Console.WriteLine("rodei o intadd");
+        int c = a + b;
+        return c;
+    }
+}
+public class SomeAttribute : Attribute
+{
+    public SomeAttribute(SomeEnum something)
+    {
+        Something = something;
+    }
+
+    public SomeEnum Something { get; }
+}
+
+[Some(SomeEnum.Something)] // <-- comment this to make blazor WASM debugging work
+public class SomeClass
+{
+
+}

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.csproj
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
+    <NoWarn>219</NoWarn>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.csproj
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test1/library-dependency-debugger-test1.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>Library</OutputType>
-    <NoWarn>219</NoWarn>
-    <RunAnalyzers>false</RunAnalyzers>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" />
   </ItemGroup>

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 public enum SomeEnum
 {

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+public enum SomeEnum
+{
+    Something
+}
+

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.csproj
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
+    <NoWarn>219</NoWarn>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.csproj
+++ b/src/mono/wasm/debugger/tests/library-dependency-debugger-test2/library-dependency-debugger-test2.csproj
@@ -1,8 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>Library</OutputType>
-    <NoWarn>219</NoWarn>
-    <RunAnalyzers>false</RunAnalyzers>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
When mono.cecil is loading the assembly and this assembly references to another assembly, it searchs for this assembly on a cache and on folders, in our case, we were not adding the assemblies loaded in this cache, so mono.cecil was failing and it was not possible to set breakpoint in any assembly that references another assembly.
Fix #47792 