### PR TITLE
[release/5.0] cgroup: fix memory leak in GetCGroupMemoryUsage

### DIFF
--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -422,6 +422,7 @@ private:
             }
         }
 
+        free(mem_usage_filename);
         return result;
     }
 

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -411,6 +411,7 @@ private:
             }
         }
 
+        free(mem_usage_filename);
         return result;
     }
 


### PR DESCRIPTION
Issue: #48822
Fix in main: #48911

## Customer Impact
The memory usage of the application increases linearly over time (memory leak) when running on a system with cgroup enabled. Reported by customer (@gerlachch).

## Testing
Add hoc testing. We do not have test infrastructure that would catch this bug currently.

## Risk
Low. Very straightforward change.

## Regression
Regression in .NET 5. Introduced by adding support for cgroup2 (#34334).