### PR TITLE
Clean up Crossgen2 executions in installer after SDK P2 ingestion

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -18,14 +18,12 @@
       <CrossDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">x64</CrossDir>
       <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
       <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>
+
       <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
       <PublishReadyToRunCrossgen2ExtraArgs>@(PublishReadyToRunCrossgen2ExtraArgsList)</PublishReadyToRunCrossgen2ExtraArgs>
 
-      <JitTargetOSComponent>unix</JitTargetOSComponent>
-      <JitTargetOSComponent Condition="'$(TargetOS)' == 'windows'">win</JitTargetOSComponent>
-      <JitBuildArchitecture>$(TargetArchitecture)</JitBuildArchitecture>
-      <JitBuildArchitecture Condition="'$(CrossDir)' != ''">$(CrossDir)</JitBuildArchitecture>
-      <JitLibrary>$(Crossgen2Dir)\$(LibPrefix)clrjit_$(JitTargetOSComponent)_$(TargetArchitecture)_$(JitBuildArchitecture)$(LibSuffix)</JitLibrary>
+      <ScriptExt>.sh</ScriptExt>
+      <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">
@@ -45,47 +43,7 @@
                     DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup>
-      <Crossgen2Tool Include="$(Crossgen2Exe)" JitPath="$(JitLibrary)" />
+      <Crossgen2Tool Include="$(Crossgen2Exe)" TargetArch="$(TargetArchitecture)" TargetOS="$(TargetOS)" DotNetHostPath="$(RepoRoot)/dotnet$(ScriptExt)" />
     </ItemGroup>
   </Target>
-
-  <!-- Hack to patch DOTNET_ROOT for the duration of Crossgen2 compilation to unblock -->
-  <!-- Crossgen2 bring-up before SDK 6.0 Preview 2 propagates to the runtime repo. -->
-  <!-- https://github.com/dotnet/runtime/issues/48252 -->
-
-  <UsingTask
-    TaskName="SetEnvVar"
-    TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-
-    <ParameterGroup>
-      <Name ParameterType="System.String" Required="true" />
-      <Value ParameterType="System.String" Required="false" />
-    </ParameterGroup>
-
-    <Task>
-      <Using Namespace="System" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          Environment.SetEnvironmentVariable(Name, Value);
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <PropertyGroup>
-    <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-  </PropertyGroup>
-
-  <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
-    <SetEnvVar Name="DOTNET_ROOT" Value="$(DOTNET_INSTALL_DIR)" />
-  </Target>
-
-  <Target Name="RestoreDotnetRootAfterRunningCrossgen2" AfterTargets="_CreateR2RImages">
-    <SetEnvVar Name="DOTNET_ROOT" Value="$(OriginalDotnetRootValue)" />
-  </Target>
-
-  <!-- End of hack to patch DOTNET_ROOT for the duration of Crossgen2 compilation. -->
-  <!-- This can be removed once the runtime repo rolled forward to .NET 6 Preview 2 SDK repo drop. -->
-  <!-- https://github.com/dotnet/runtime/issues/48252 -->
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -16,8 +16,7 @@
     <PropertyGroup>
       <CrossDir />
       <CrossDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">x64</CrossDir>
-      <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
-      <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>
+      <Crossgen2Dll>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2\crossgen2.dll</Crossgen2Dll>
 
       <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
       <PublishReadyToRunCrossgen2ExtraArgs>@(PublishReadyToRunCrossgen2ExtraArgsList)</PublishReadyToRunCrossgen2ExtraArgs>
@@ -43,7 +42,7 @@
                     DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup>
-      <Crossgen2Tool Include="$(Crossgen2Exe)" TargetArch="$(TargetArchitecture)" TargetOS="$(TargetOS)" DotNetHostPath="$(RepoRoot)/dotnet$(ScriptExt)" />
+      <Crossgen2Tool Include="$(Crossgen2Dll)" TargetArch="$(TargetArchitecture)" TargetOS="$(TargetOS)" DotNetHostPath="$(RepoRoot)/dotnet$(ScriptExt)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/48252
/cc @dotnet/crossgen-contrib 