### PR TITLE
Allow libraries outerloop OSX_arm64 to be triggered from PR

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -87,8 +87,7 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'OSX_arm64') }}:
-      - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-        - OSX.1100.ARM64.Open
+      - OSX.1100.ARM64.Open
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'OSX_x64') }}:

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -32,8 +32,7 @@ jobs:
           - Linux_arm64
           - Linux_musl_arm64
       - ${{ if eq(variables['includeOsxOuterloop'], true) }}:        
-        - ${{ if eq(variables['isFullMatrix'], true) }}:
-          - OSX_arm64
+        - OSX_arm64
         - OSX_x64
       jobParameters:
         testGroup: innerloop
@@ -79,8 +78,7 @@ jobs:
           - Linux_x64
           - Linux_musl_x64
         - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
-          - ${{ if eq(variables['isFullMatrix'], true) }}:
-            - OSX_arm64
+          - OSX_arm64
           - OSX_x64
         helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
         jobParameters:


### PR DESCRIPTION
@safern I think this is what you were suggesting in #47919.  I hadn't added innerloop runs yet because 

- I was sure we had sufficient capacity.
- I wanted to have the tests running for a few days in outerloop to make sure things were stable.

/cc @steveisok 