### PR TITLE
Increase jitstress job run frequency

### DIFF
--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -1,18 +1,18 @@
 trigger: none
 
 schedules:
-- cron: "0 4 * * 1,3,5"
-  displayName: Mon, Wed, Fri at 8:00 PM (UTC-8:00)
+- cron: "0 4 * * *"
+  displayName: Daily at 8:00 PM (UTC-8:00)
   branches:
     include:
     - main
   always: true
-- cron: "0 4 * * 0,2,4,6"
-  displayName: Sun, Tue, Thu, Sat at 8:00 PM (UTC-8:00)
+- cron: "0 4 * * *"
+  displayName: Daily (if changes) at 8:00 PM (UTC-8:00)
   branches:
     include:
     - release/*.*
-  always: true
+  always: false
 
 jobs:
 

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -1,18 +1,18 @@
 trigger: none
 
 schedules:
-- cron: "0 7 * * 0,2,4,6"
-  displayName: Sun, Tue, Thu, Sat at 11:00 PM (UTC-8:00)
+- cron: "0 7 * * *"
+  displayName: Daily at 11:00 PM (UTC-8:00)
   branches:
     include:
     - main
   always: true
-- cron: "0 7 * * 1,3,5"
-  displayName: Mon, Wed, Fri at 11:00 PM (UTC-8:00)
+- cron: "0 7 * * *"
+  displayName: Daily (if changes) at 11:00 PM (UTC-8:00)
   branches:
     include:
     - release/*.*
-  always: true
+  always: false
 
 jobs:
 


### PR DESCRIPTION
Change #41856 reduced stress job frequency to once per day, alternating
between main and the release branches. However, the release branches
get few changes yet still run the job. (Also, all the release branches
run the job at the same time.)

Change to running the job daily in main, where most development
happens. Also change the runs to daily in the release branches, but
change to only run if the branch has changed since the last run.