### PR TITLE
Remove Deterministic setting which is already the default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -255,7 +255,6 @@
     <LangVersion Condition="'$(MSBuildProjectExtension)' == '.vbproj'">latest</LangVersion>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
-    <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>


### PR DESCRIPTION
The SDK already enables deterministic builds by default. No need to set this property again.