### PR TITLE
Remove illink workaround

### DIFF
--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -76,11 +76,6 @@
       <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared.xml" />
       <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.LibraryBuild.xml" />
       <_SuppressionsXmls Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\$(ProjectILLinkSuppressionsFile).LibraryBuild.xml" />
-
-      <!-- netstandard2.1-only System.ComponentModel.Annotations XML file is not bin-placed during -allConfigurations builds
-           due to the linker not being run on the assembly (eng\illink.targets). Manually include it. -->
-      <_SuppressionsXmls Condition="'$(BuildAllConfigurations)' == 'true'"
-                         Include="$(LibrariesProjectRoot)System.ComponentModel.Annotations\$(ProjectILLinkSuppressionsFile).xml" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
System.ComponentModel.Annotations is now building NetCoreAppCurrent, just like any other library in the shared fx.