### PR TITLE
Disable RC2 tests on Android. 

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Encryption.RC2.Tests;
 using System.Text;
 using Test.Cryptography;
 using Xunit;
-using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Dsa.Tests
 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Test.Cryptography;
 using Xunit;
+using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Dsa.Tests
 {
@@ -105,8 +106,7 @@ hpTvzzEtnljU3dHAHig4M/TxSeX5vUVJMEQxthvg2tcXtTjFzVL94ajmYZPonQnB
                 DSATestData.Dsa2048DeficientXParameters);
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ConditionalFact(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
         public static void ReadWriteDsa512EncryptedPkcs8()
         {
             // pbeWithSHA1And40BitRC2-CBC (PKCS12-PBE)
@@ -126,8 +126,7 @@ UCouQg==",
                 DSATestData.Dsa512Parameters);
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ConditionalFact(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
         public static void ReadWriteDsa576EncryptedPkcs8()
         {
             // pbeWithSHA1And128BitRC2-CBC (PKCS12-PBE)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
@@ -106,6 +106,7 @@ hpTvzzEtnljU3dHAHig4M/TxSeX5vUVJMEQxthvg2tcXtTjFzVL94ajmYZPonQnB
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public static void ReadWriteDsa512EncryptedPkcs8()
         {
             // pbeWithSHA1And40BitRC2-CBC (PKCS12-PBE)
@@ -126,6 +127,7 @@ UCouQg==",
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public static void ReadWriteDsa576EncryptedPkcs8()
         {
             // pbeWithSHA1And128BitRC2-CBC (PKCS12-PBE)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -201,6 +201,7 @@ qtlbnispri1a/EghiaPQ0po=";
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public void ReadNistP256EncryptedPkcs8_Pbes1_RC2_MD5()
         {
             const string base64 = @"

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Test.Cryptography;
 using Xunit;
+using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Tests
 {
@@ -200,8 +201,7 @@ qtlbnispri1a/EghiaPQ0po=";
                 EccTestData.GetNistP521Key2());
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ConditionalFact(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
         public void ReadNistP256EncryptedPkcs8_Pbes1_RC2_MD5()
         {
             const string base64 = @"

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Encryption.RC2.Tests;
 using System.Text;
 using Test.Cryptography;
 using Xunit;
-using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Tests
 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
     using RC2 = System.Security.Cryptography.RC2;
 
     [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
-    [PlatformSpecific(~TestPlatforms.Android)]
+    [ConditionalClass(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
     public static class RC2CipherTests
     {
         // These are the expected output of many decryptions. Changing these values requires re-generating test input.

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
     using RC2 = System.Security.Cryptography.RC2;
 
     [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
-    [SkipOnMono("Android does not support RC2", TestPlatforms.Android)]
+    [PlatformSpecific(~TestPlatforms.Android)]
     public static class RC2CipherTests
     {
         // These are the expected output of many decryptions. Changing these values requires re-generating test input.

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
     using RC2 = System.Security.Cryptography.RC2;
 
     [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
+    [SkipOnMono("Android does not support RC2", TestPlatforms.Android)]
     public static class RC2CipherTests
     {
         // These are the expected output of many decryptions. Changing these values requires re-generating test input.

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Factory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2Factory.cs
@@ -16,5 +16,7 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
         {
             return s_provider.Create();
         }
+
+        public static bool IsSupported { get; } = !PlatformDetection.IsAndroid;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
@@ -735,6 +735,7 @@ pgCJTk846cb+AizgZMeOsYpTOgu2UL6cQiLtsYNz7WpDK3iS7Agj9EoL2ao7QxA=";
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public static void ReadPbes2Rc2EncryptedDiminishedDP()
         {
             // PBES2: PBKDF2 + RC2-128
@@ -838,6 +839,7 @@ Dmw2pL/LzHORugcg9BxRkur91lenPNcLAvnke76tMGvSGkA82I9NpBDcGRK4cPie
         }
 
         [ConditionalFact(nameof(Supports384BitPrivateKey))]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public static void ReadPbes1Rc2EncryptedRsa384()
         {
             // PbeWithSha1AndRC2CBC

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
@@ -4,13 +4,14 @@
 using System.Text;
 using Test.Cryptography;
 using Xunit;
+using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Rsa.Tests
 {
     [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
     public static class RSAKeyFileTests
     {
-        public static bool Supports384BitPrivateKey { get; } = RSAFactory.Supports384PrivateKey;
+        public static bool Supports384BitPrivateKeyAndRC2 { get; } = RSAFactory.Supports384PrivateKey && RC2Factory.IsSupported;
         public static bool SupportsLargeExponent { get; } = RSAFactory.SupportsLargeExponent;
 
         [Theory]
@@ -734,8 +735,7 @@ pgCJTk846cb+AizgZMeOsYpTOgu2UL6cQiLtsYNz7WpDK3iS7Agj9EoL2ao7QxA=";
                 TestData.RSA16384Params);
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ConditionalFact(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
         public static void ReadPbes2Rc2EncryptedDiminishedDP()
         {
             // PBES2: PBKDF2 + RC2-128
@@ -838,8 +838,7 @@ Dmw2pL/LzHORugcg9BxRkur91lenPNcLAvnke76tMGvSGkA82I9NpBDcGRK4cPie
                 TestData.DiminishedDPParameters);
         }
 
-        [ConditionalFact(nameof(Supports384BitPrivateKey))]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ConditionalFact(nameof(Supports384BitPrivateKeyAndRC2))]
         public static void ReadPbes1Rc2EncryptedRsa384()
         {
             // PbeWithSha1AndRC2CBC

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Encryption.RC2.Tests;
 using System.Text;
 using Test.Cryptography;
 using Xunit;
-using System.Security.Cryptography.Encryption.RC2.Tests;
 
 namespace System.Security.Cryptography.Rsa.Tests
 {

--- a/src/libraries/System.Security.Cryptography.Cng/tests/RC2Provider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/RC2Provider.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    internal class RC2Provider : IRC2Provider
+    {
+        public RC2 Create()
+        {
+            return RC2.Create();
+        }
+    }
+
+    public partial class RC2Factory
+    {
+        private static readonly IRC2Provider s_provider = new RC2Provider();
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -23,6 +23,9 @@
              Link="CommonTest\AlgorithmImplementations\AES\DecryptorReusability.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs"
              Link="CommonTest\AlgorithmImplementations\AES\AesFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs"
+             Link="CommonTest\AlgorithmImplementations\RC2\RC2Factory.cs" />
+    <Compile Include="RC2Provider.cs" />
     <Compile Include="AesProvider.cs" />
     <Compile Include="TripleDESCngProvider.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/RC2Provider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/RC2Provider.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Security.Cryptography.Encryption.RC2.Tests
+{
+    using RC2 = System.Security.Cryptography.RC2;
+
+    internal class RC2Provider : IRC2Provider
+    {
+        public RC2 Create()
+        {
+            return RC2.Create();
+        }
+    }
+
+    public partial class RC2Factory
+    {
+        private static readonly IRC2Provider s_provider = new RC2Provider();
+    }
+}

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -10,6 +10,8 @@
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -62,6 +62,7 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs"
              Link="CommonTest\System\IO\PositionValueStream.cs" />
+    <Compile Include="RC2Provider.cs" />
     <Compile Include="EcDiffieHellmanOpenSslProvider.cs" />
     <Compile Include="EcDiffieHellmanOpenSslTests.cs" />
     <Compile Include="EcDsaOpenSslProvider.cs" />


### PR DESCRIPTION
RC2 isn't supported by Android, so disable the tests that validate it works.