### PR TITLE
Add ArrayPool event for dropped buffers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
@@ -160,7 +160,7 @@ namespace System.Buffers
                 log.BufferReturned(bufferId, array.Length, Id);
                 if (!haveBucket)
                 {
-                    log.BufferDropped(bufferId, bucket, Id, ArrayPoolEventSource.NoBucketId, ArrayPoolEventSource.BufferDroppedReason.Full);
+                    log.BufferDropped(bufferId, array.Length, Id, ArrayPoolEventSource.NoBucketId, ArrayPoolEventSource.BufferDroppedReason.Full);
                 }
             }
         }
@@ -269,10 +269,13 @@ namespace System.Buffers
                     if (lockTaken) _lock.Exit(false);
                 }
 
-                ArrayPoolEventSource log = ArrayPoolEventSource.Log;
-                if (log.IsEnabled() && !returned)
+                if (!returned)
                 {
-                    log.BufferDropped(array.GetHashCode(), _bufferLength, _poolId, Id, ArrayPoolEventSource.BufferDroppedReason.Full);
+                    ArrayPoolEventSource log = ArrayPoolEventSource.Log;
+                    if (log.IsEnabled())
+                    {
+                        log.BufferDropped(array.GetHashCode(), _bufferLength, _poolId, Id, ArrayPoolEventSource.BufferDroppedReason.Full);
+                    }
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
@@ -110,10 +110,11 @@ namespace System.Buffers
 
             if (log.IsEnabled())
             {
-                int bufferId = buffer.GetHashCode(), bucketId = -1; // no bucket for an on-demand allocated buffer
-                log.BufferRented(bufferId, buffer.Length, Id, bucketId);
-                log.BufferAllocated(bufferId, buffer.Length, Id, bucketId, index >= _buckets.Length ?
-                    ArrayPoolEventSource.BufferAllocatedReason.OverMaximumSize : ArrayPoolEventSource.BufferAllocatedReason.PoolExhausted);
+                int bufferId = buffer.GetHashCode();
+                log.BufferRented(bufferId, buffer.Length, Id, ArrayPoolEventSource.NoBucketId);
+                log.BufferAllocated(bufferId, buffer.Length, Id, ArrayPoolEventSource.NoBucketId, index >= _buckets.Length ?
+                    ArrayPoolEventSource.BufferAllocatedReason.OverMaximumSize :
+                    ArrayPoolEventSource.BufferAllocatedReason.PoolExhausted);
             }
 
             return buffer;
@@ -136,7 +137,8 @@ namespace System.Buffers
             int bucket = Utilities.SelectBucketIndex(array.Length);
 
             // If we can tell that the buffer was allocated, drop it. Otherwise, check if we have space in the pool
-            if (bucket < _buckets.Length)
+            bool haveBucket = bucket < _buckets.Length;
+            if (haveBucket)
             {
                 // Clear the array if the user requests
                 if (clearArray)
@@ -154,7 +156,12 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             if (log.IsEnabled())
             {
-                log.BufferReturned(array.GetHashCode(), array.Length, Id);
+                int bufferId = array.GetHashCode();
+                log.BufferReturned(bufferId, array.Length, Id);
+                if (!haveBucket)
+                {
+                    log.BufferDropped(bufferId, bucket, Id, ArrayPoolEventSource.NoBucketId, ArrayPoolEventSource.BufferDroppedReason.Full);
+                }
             }
         }
 
@@ -240,6 +247,8 @@ namespace System.Buffers
                     throw new ArgumentException(SR.ArgumentException_BufferNotFromPool, nameof(array));
                 }
 
+                bool returned;
+
                 // While holding the spin lock, if there's room available in the bucket,
                 // put the buffer into the next available slot.  Otherwise, we just drop it.
                 // The try/finally is necessary to properly handle thread aborts on platforms
@@ -249,7 +258,8 @@ namespace System.Buffers
                 {
                     _lock.Enter(ref lockTaken);
 
-                    if (_index != 0)
+                    returned = _index != 0;
+                    if (returned)
                     {
                         _buffers[--_index] = array;
                     }
@@ -257,6 +267,12 @@ namespace System.Buffers
                 finally
                 {
                     if (lockTaken) _lock.Exit(false);
+                }
+
+                ArrayPoolEventSource log = ArrayPoolEventSource.Log;
+                if (log.IsEnabled() && !returned)
+                {
+                    log.BufferDropped(array.GetHashCode(), _bufferLength, _poolId, Id, ArrayPoolEventSource.BufferDroppedReason.Full);
                 }
             }
         }


### PR DESCRIPTION
This will fire an event when an array is returned to the pool and is either too big to be stored or the pool is too full to store it.

@jkotas, @davidfowl, any concerns? This should help to highlight if the pool isn't actually being effective, e.g. what percentage of returned buffers are being dropped.  But let me know if you think it's problematic or misguided for some reason.