### PR TITLE
Fixes for building ARM64 Mac Catalyst test apps

### DIFF
--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -121,7 +121,7 @@ public class AppleAppBuilderTask : Task
     public override bool Execute()
     {
         Utils.Logger = Log;
-        bool isDevice = Arch.Equals("arm64", StringComparison.InvariantCultureIgnoreCase);
+        bool isDevice = Arch.Equals("arm64", StringComparison.InvariantCultureIgnoreCase) && TargetOS != TargetNames.MacCatalyst;
 
         if (!File.Exists(Path.Combine(AppDir, MainLibraryFileName)))
         {

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -132,7 +132,7 @@ internal class Xcode
         File.WriteAllText(Path.Combine(binDir, "CMakeLists.txt"), cmakeLists);
 
         var targetName = (Target == TargetNames.MacCatalyst) ? "Darwin" : Target.ToString();
-        var deployTarget = (Target == TargetNames.MacCatalyst) ? "" : " -DCMAKE_OSX_DEPLOYMENT_TARGET=10.1";
+        var deployTarget = (Target == TargetNames.MacCatalyst) ? " -DCMAKE_OSX_ARCHITECTURES=\"x86_64 arm64\"" : " -DCMAKE_OSX_DEPLOYMENT_TARGET=10.1";
         var cmakeArgs = new StringBuilder();
         cmakeArgs
             .Append("-S.")

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -203,7 +203,7 @@ internal class Xcode
                 default:
                     sdk = "maccatalyst";
                     args.Append(" -scheme \"" + Path.GetFileNameWithoutExtension(xcodePrjPath) + "\"")
-                        .Append(" -destination \"platform=macOS,arch=arm64e,variant=Mac Catalyst\"")
+                        .Append(" -destination \"platform=macOS,arch=arm64,variant=Mac Catalyst\"")
                         .Append(" -UseModernBuildSystem=YES")
                         .Append(" IPHONEOS_DEPLOYMENT_TARGET=14.2");
                     break;

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -203,7 +203,7 @@ internal class Xcode
                 default:
                     sdk = "maccatalyst";
                     args.Append(" -scheme \"" + Path.GetFileNameWithoutExtension(xcodePrjPath) + "\"")
-                        .Append(" -destination \"platform=macOS,arch=arm64,variant=Mac Catalyst\"")
+                        .Append(" -destination \"platform=macOS,arch=arm64e,variant=Mac Catalyst\"")
                         .Append(" -UseModernBuildSystem=YES")
                         .Append(" IPHONEOS_DEPLOYMENT_TARGET=14.2");
                     break;


### PR DESCRIPTION
This comprises two changes:

* Fix so Mac Catalyst ARM64 apps are not treated as "devices" by our App builder
* Fix so ARM64 test apps can be built on x64 hardware, and vice versa, rather than only allowing ARM64 apps to build with a native ARM64 computer and ARM64 invocation of build.sh

The resulting apps DO NOT RUN, but apparently neither does ARM64 Mono for regular macOS, so there's other work to be done there.

```
  System.Buffers.Tests -> /Users/directhex/Projects/runtime/artifacts/bin/System.Buffers.Tests/net6.0-Debug/maccatalyst-arm64/System.Buffers.Tests.dll
  System.Buffers.Tests -> /Users/directhex/Projects/runtime/artifacts/bin/System.Buffers.Tests/net6.0-Debug/maccatalyst-arm64/publish/
  Running: xcrun --sdk macosx --show-sdk-path
  Running: cmake -S. -BSystem.Buffers.Tests -GXcode -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="x86_64 arm64"
  Running: xcodebuild ONLY_ACTIVE_ARCH=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -scheme "System.Buffers.Tests" -destination "platform=macOS,arch=arm64,variant=Mac Catalyst" -UseModernBuildSystem=YES IPHONEOS_DEPLOYMENT_TARGET=14.2 -configuration Release

  APP size: 36.3 Mb.

  Xcode: /Users/directhex/Projects/runtime/artifacts/bin/System.Buffers.Tests/net6.0-Debug/maccatalyst-arm64/AppBundle/System.Buffers.Tests/System.Buffers.Tests.xcodeproj
  App: /Users/directhex/Projects/runtime/artifacts/bin/System.Buffers.Tests/net6.0-Debug/maccatalyst-arm64/AppBundle/System.Buffers.Tests/Release-maccatalyst/System.Buffers.Tests.app

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:09:14.12
```