### PR TITLE
Don't default PackageVersion for NuGet Pack task generated packages

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -10,7 +10,7 @@
 
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">6.0.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == '' and '$(MSBuildProjectExtension)' == '.pkgproj'">6.0.0</PackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>


### PR DESCRIPTION
Specifying a default PackageVersion causes Arcade's calculated
Version not be used and instead the VersionSuffix-less Version be used
which indicates a stable packages. That later fails during publishing to
a non stable feed.

This is a mitigation for the official build breaks and a better
implementation that supports not reving the patch major during servicing
needs to be figured out.

Fixes https://github.com/dotnet/runtime/issues/49051