### PR TITLE
Remove unnecessary references to System.ComponentModel.TypeConverter

### DIFF
--- a/src/libraries/System.Data.DataSetExtensions/ref/System.Data.DataSetExtensions.csproj
+++ b/src/libraries/System.Data.DataSetExtensions/ref/System.Data.DataSetExtensions.csproj
@@ -7,7 +7,6 @@
     <Compile Include="System.Data.DataSetExtensions.Forwards.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.ComponentModel.TypeConverter\ref\System.ComponentModel.TypeConverter.csproj" />
     <ProjectReference Include="..\..\System.Data.Common\ref\System.Data.Common.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Data.DataSetExtensions/src/System.Data.DataSetExtensions.csproj
+++ b/src/libraries/System.Data.DataSetExtensions/src/System.Data.DataSetExtensions.csproj
@@ -12,6 +12,5 @@
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Data.Common" />
     <Reference Include="System.Linq" />
-    <Reference Include="System.ComponentModel.TypeConverter" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -337,7 +337,6 @@
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.FileVersionInfo" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.IO.FileSystem.DriveInfo" />

--- a/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.csproj
@@ -9,6 +9,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.ComponentModel.TypeConverter\ref\System.ComponentModel.TypeConverter.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -109,7 +109,6 @@
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -237,7 +237,6 @@
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel.EventBasedAsync" />
     <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.TraceSource" />
     <Reference Include="System.IO.FileSystem" />


### PR DESCRIPTION
These references don't appear to be needed, so I removed them.