### PR TITLE
Don't swap under STRESS_REVERSE_FLAG in gtSetEvalOrder.

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4366,9 +4366,10 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 tryToSwap = (level < lvl2);
             }
 
-            // Try to force extra swapping when in the stress mode:
+            // Try to force extra swapping when in the stress mode, unless stmt list is already threaded,
+            // in that case the user can unexpect invalid gtPrev/gtNext after calling this function.
             if (compStressCompile(STRESS_REVERSE_FLAG, 60) && ((tree->gtFlags & GTF_REVERSE_OPS) == 0) &&
-                ((op2->OperKind() & GTK_CONST) == 0))
+                ((op2->OperKind() & GTK_CONST) == 0) && !fgStmtListThreaded)
             {
                 tryToSwap = true;
             }


### PR DESCRIPTION
There could be a situation when `gtSetEvalOrder` was called from `gtPrepareCost` <- `fgOptimizeBranch` <- `fgReorderBlocks` <- `fgInsertGCPolls` , in this case the users were not expecting such swaps and were failing when calling `fgDebugCheckStmtsList`.

The alternative fixes were:
1. call `gtSetEvalOrder` with new `bool doChanges = false` from `gtPrepareCost` - quite disruptive,  cases asm diffs in default;
2. call `fgSetBlockOrder` in `fgOptimizeBranch` or `fgReorderBlocks` - makes TP worse in default scenario;
3. add `fgTreeCostCalculated` and don't call `gtPrepareCost` when it is already known - quite disruptive,  cases asm diffs in default;

so because the issue happened only in JitStress=2 only on arm64 apple in 1 test I decided to go with the simplest fix for now.

Fixes https://github.com/dotnet/runtime/issues/48786.