### PR TITLE
[release/6.0-preview2] Turn off LKG calculation

### DIFF
--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -79,14 +79,6 @@ $CommonSetupArguments="--channel master --queue $Queue --build-number $BuildNumb
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 
 
-#This grabs the LKG version number of dotnet and passes it to our scripts
-$VersionJSON = Get-Content global.json | ConvertFrom-Json
-$DotNetVersion = $VersionJSON.tools.dotnet
-# TODO: Change this back to parsing when we have a good story for dealing with TFM changes or when the LKG in runtime gets updated to include net6.0
-# $SetupArguments = "--dotnet-versions $DotNetVersion $SetupArguments"
-$SetupArguments = "--dotnet-versions 6.0.100-alpha.1.20553.6 $SetupArguments"
-
-
 if ($RunFromPerformanceRepo) {
     $SetupArguments = "--perf-hash $CommitSha $CommonSetupArguments"
     

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -237,16 +237,6 @@ fi
 common_setup_arguments="--channel master --queue $queue --build-number $build_number --build-configs $configurations --architecture $architecture"
 setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
 
-
-if [[ "$use_latest_dotnet" = false ]]; then
-    # Get the tools section from the global.json.
-    # This grabs the LKG version number of dotnet and passes it to our scripts
-    dotnet_version=`cat global.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["tools"]["dotnet"])'`
-    # TODO: Change this back to parsing when we have a good story for dealing with TFM changes or when the LKG in runtime gets updated to include net6.0
-    # setup_arguments="--dotnet-versions $dotnet_version $setup_arguments"
-    setup_arguments="--dotnet-versions 6.0.100-alpha.1.20553.6 $setup_arguments"
-fi
-
 if [[ "$run_from_perf_repo" = true ]]; then
     payload_directory=
     workitem_directory=$source_directory


### PR DESCRIPTION
This change moves the performance infrastructure to use
the latest version of dotnet for building and running BDN.
This does not change what bits are tested.