### PR TITLE
add STRESS_PROMOTE_LESS_STRUCTS mode.

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3594,6 +3594,31 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     return (hash < weight);
 }
 
+//------------------------------------------------------------------------
+// compPromoteLessStructs: helper to determine if the local
+//   should not be promoted under a stress mode.
+//
+// Arguments:
+//   lclNum - local number to test
+//
+// Returns:
+//   true if this local should not be promoted.
+//
+// Notes:
+//   Reject ~50% of the potential promotions if STRESS_PROMOTE_LESS_STRUCTS is active.
+//
+bool Compiler::compPromoteLessStructs(unsigned lclNum)
+{
+    bool       rejectThisPromo = false;
+    const bool promoteLess     = compStressCompile(STRESS_PROMOTE_LESS_STRUCTS, 50);
+    if (promoteLess)
+    {
+
+        rejectThisPromo = (((info.compMethodHash() ^ lclNum) & 1) == 0);
+    }
+    return rejectThisPromo;
+}
+
 #endif // DEBUG
 
 void Compiler::compInitDebuggingInfo()

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3595,7 +3595,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
 }
 
 //------------------------------------------------------------------------
-// compPromoteLessStructs: helper to determine if the local
+// compPromoteFewerStructs: helper to determine if the local
 //   should not be promoted under a stress mode.
 //
 // Arguments:
@@ -3605,12 +3605,12 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
 //   true if this local should not be promoted.
 //
 // Notes:
-//   Reject ~50% of the potential promotions if STRESS_PROMOTE_LESS_STRUCTS is active.
+//   Reject ~50% of the potential promotions if STRESS_PROMOTE_FEWER_STRUCTS is active.
 //
-bool Compiler::compPromoteLessStructs(unsigned lclNum)
+bool Compiler::compPromoteFewerStructs(unsigned lclNum)
 {
     bool       rejectThisPromo = false;
-    const bool promoteLess     = compStressCompile(STRESS_PROMOTE_LESS_STRUCTS, 50);
+    const bool promoteLess     = compStressCompile(STRESS_PROMOTE_FEWER_STRUCTS, 50);
     if (promoteLess)
     {
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9315,7 +9315,7 @@ public:
         return compStressCompile(STRESS_RANDOM_INLINE, 50);
     }
 
-    bool compPromoteLessStructs(unsigned lclNum);
+    bool compPromoteFewerStructs(unsigned lclNum);
 
 #endif // DEBUG
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9315,6 +9315,8 @@ public:
         return compStressCompile(STRESS_RANDOM_INLINE, 50);
     }
 
+    bool compPromoteLessStructs(unsigned lclNum);
+
 #endif // DEBUG
 
     bool compTailCallStress()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9268,6 +9268,7 @@ public:
         STRESS_MODE(GENERIC_VARN)                                                               \
         STRESS_MODE(PROFILER_CALLBACKS) /* Will generate profiler hooks for ELT callbacks */    \
         STRESS_MODE(BYREF_PROMOTION) /* Change undoPromotion decisions for byrefs */            \
+        STRESS_MODE(PROMOTE_LESS_STRUCTS) /* Don't promote some structs that can be promoted */ \
                                                                                                 \
         /* After COUNT_VARN, stress level 2 does all of these all the time */                   \
                                                                                                 \

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9268,7 +9268,7 @@ public:
         STRESS_MODE(GENERIC_VARN)                                                               \
         STRESS_MODE(PROFILER_CALLBACKS) /* Will generate profiler hooks for ELT callbacks */    \
         STRESS_MODE(BYREF_PROMOTION) /* Change undoPromotion decisions for byrefs */            \
-        STRESS_MODE(PROMOTE_LESS_STRUCTS) /* Don't promote some structs that can be promoted */ \
+        STRESS_MODE(PROMOTE_FEWER_STRUCTS)/* Don't promote some structs that can be promoted */ \
                                                                                                 \
         /* After COUNT_VARN, stress level 2 does all of these all the time */                   \
                                                                                                 \

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2104,6 +2104,11 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
         // TODO-1stClassStructs: a temporary solution to keep diffs small, it will be fixed later.
         shouldPromote = false;
     }
+    else if (compiler->compStressCompile(STRESS_PROMOTE_LESS_STRUCTS, 50))
+    {
+        // Do not promote some structs, that can be promoted, to stress promoted/unpromoted moves.
+        shouldPromote = false;
+    }
 
     //
     // If the lvRefCnt is zero and we have a struct promoted parameter we can end up with an extra store of

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2105,10 +2105,10 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
         shouldPromote = false;
     }
 #if defined(DEBUG)
-    else if (compiler->compPromoteLessStructs(lclNum))
+    else if (compiler->compPromoteFewerStructs(lclNum))
     {
         // Do not promote some structs, that can be promoted, to stress promoted/unpromoted moves.
-        JITDUMP("Not promoting promotable struct local V%02u, because of STRESS_PROMOTE_LESS_STRUCTS\n", lclNum);
+        JITDUMP("Not promoting promotable struct local V%02u, because of STRESS_PROMOTE_FEWER_STRUCTS\n", lclNum);
         shouldPromote = false;
     }
 #endif

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2104,11 +2104,14 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
         // TODO-1stClassStructs: a temporary solution to keep diffs small, it will be fixed later.
         shouldPromote = false;
     }
-    else if (compiler->compStressCompile(STRESS_PROMOTE_LESS_STRUCTS, 50))
+#if defined(DEBUG)
+    else if (compiler->compPromoteLessStructs(lclNum))
     {
         // Do not promote some structs, that can be promoted, to stress promoted/unpromoted moves.
+        JITDUMP("Not promoting promotable struct local V%02u, because of STRESS_PROMOTE_LESS_STRUCTS\n", lclNum);
         shouldPromote = false;
     }
+#endif
 
     //
     // If the lvRefCnt is zero and we have a struct promoted parameter we can end up with an extra store of

--- a/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
+++ b/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- https://github.com/dotnet/runtime/issues/49189 -->
+    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'x86'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/49189 -->
+    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'x86'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Right now we don't have profitability heuristics for promotion, so everything that can be promoted is promoted. 
It makes most structs with the same type to be always promoted and we see only their fields. 
This mode rejects promotion for some lclVars so we can see more copies like `LCL_VAR structType1 V01, promoted = LCL_VAR structType1, not promoted` that are harder for codegen.