### PR TITLE
[AndroidCrypto] Fix incremental hash

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -26,11 +26,12 @@ jmethodID g_randNextBytesMethod;
 
 // java/security/MessageDigest
 jclass    g_mdClass;
-jmethodID g_mdGetInstanceMethod;
-jmethodID g_mdDigestMethod;
-jmethodID g_mdDigestCurrentMethodId;
-jmethodID g_mdResetMethod;
-jmethodID g_mdUpdateMethod;
+jmethodID g_mdGetInstance;
+jmethodID g_mdClone;
+jmethodID g_mdDigest;
+jmethodID g_mdDigestWithInputBytes;
+jmethodID g_mdReset;
+jmethodID g_mdUpdate;
 
 // javax/crypto/Mac
 jclass    g_macClass;
@@ -438,11 +439,12 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_randNextBytesMethod =     GetMethod(env, false, g_randClass, "nextBytes", "([B)V");
 
     g_mdClass =                 GetClassGRef(env, "java/security/MessageDigest");
-    g_mdGetInstanceMethod =     GetMethod(env, true,  g_mdClass, "getInstance", "(Ljava/lang/String;)Ljava/security/MessageDigest;");
-    g_mdResetMethod =           GetMethod(env, false, g_mdClass, "reset", "()V");
-    g_mdDigestMethod =          GetMethod(env, false, g_mdClass, "digest", "([B)[B");
-    g_mdDigestCurrentMethodId = GetMethod(env, false, g_mdClass, "digest", "()[B");
-    g_mdUpdateMethod =          GetMethod(env, false, g_mdClass, "update", "([B)V");
+    g_mdGetInstance =           GetMethod(env, true,  g_mdClass, "getInstance", "(Ljava/lang/String;)Ljava/security/MessageDigest;");
+    g_mdClone =                 GetMethod(env, false, g_mdClass, "clone", "()Ljava/lang/Object;");
+    g_mdDigest =                GetMethod(env, false, g_mdClass, "digest", "()[B");
+    g_mdDigestWithInputBytes =  GetMethod(env, false, g_mdClass, "digest", "([B)[B");
+    g_mdReset =                 GetMethod(env, false, g_mdClass, "reset", "()V");
+    g_mdUpdate =                GetMethod(env, false, g_mdClass, "update", "([B)V");
 
     g_macClass =                GetClassGRef(env, "javax/crypto/Mac");
     g_macGetInstanceMethod =    GetMethod(env, true,  g_macClass, "getInstance", "(Ljava/lang/String;)Ljavax/crypto/Mac;");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -34,12 +34,13 @@ jmethodID g_mdReset;
 jmethodID g_mdUpdate;
 
 // javax/crypto/Mac
-jclass    g_macClass;
-jmethodID g_macGetInstanceMethod;
-jmethodID g_macDoFinalMethod;
-jmethodID g_macUpdateMethod;
-jmethodID g_macInitMethod;
-jmethodID g_macResetMethod;
+jclass    g_MacClass;
+jmethodID g_MacGetInstance;
+jmethodID g_MacClone;
+jmethodID g_MacDoFinal;
+jmethodID g_MacInit;
+jmethodID g_MacReset;
+jmethodID g_MacUpdate;
 
 // javax/crypto/spec/SecretKeySpec
 jclass    g_sksClass;
@@ -446,12 +447,13 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_mdReset =                 GetMethod(env, false, g_mdClass, "reset", "()V");
     g_mdUpdate =                GetMethod(env, false, g_mdClass, "update", "([B)V");
 
-    g_macClass =                GetClassGRef(env, "javax/crypto/Mac");
-    g_macGetInstanceMethod =    GetMethod(env, true,  g_macClass, "getInstance", "(Ljava/lang/String;)Ljavax/crypto/Mac;");
-    g_macDoFinalMethod =        GetMethod(env, false, g_macClass, "doFinal", "()[B");
-    g_macUpdateMethod =         GetMethod(env, false, g_macClass, "update", "([B)V");
-    g_macInitMethod =           GetMethod(env, false, g_macClass, "init", "(Ljava/security/Key;)V");
-    g_macResetMethod =          GetMethod(env, false, g_macClass, "reset", "()V");
+    g_MacClass =          GetClassGRef(env, "javax/crypto/Mac");
+    g_MacGetInstance =    GetMethod(env, true,  g_MacClass, "getInstance", "(Ljava/lang/String;)Ljavax/crypto/Mac;");
+    g_MacClone =          GetMethod(env, false, g_MacClass, "clone", "()Ljava/lang/Object;");
+    g_MacDoFinal =        GetMethod(env, false, g_MacClass, "doFinal", "()[B");
+    g_MacUpdate =         GetMethod(env, false, g_MacClass, "update", "([B)V");
+    g_MacInit =           GetMethod(env, false, g_MacClass, "init", "(Ljava/security/Key;)V");
+    g_MacReset =          GetMethod(env, false, g_MacClass, "reset", "()V");
 
     g_sksClass =                GetClassGRef(env, "javax/crypto/spec/SecretKeySpec");
     g_sksCtor =                 GetMethod(env, false, g_sksClass, "<init>", "([BLjava/lang/String;)V");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -35,11 +35,12 @@ extern jmethodID g_randNextBytesMethod;
 
 // java/security/MessageDigest
 extern jclass    g_mdClass;
-extern jmethodID g_mdGetInstanceMethod;
-extern jmethodID g_mdDigestMethod;
-extern jmethodID g_mdDigestCurrentMethodId;
-extern jmethodID g_mdResetMethod;
-extern jmethodID g_mdUpdateMethod;
+extern jmethodID g_mdGetInstance;
+extern jmethodID g_mdClone;
+extern jmethodID g_mdDigest;
+extern jmethodID g_mdDigestWithInputBytes;
+extern jmethodID g_mdReset;
+extern jmethodID g_mdUpdate;
 
 // javax/crypto/Mac
 extern jclass    g_macClass;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -43,12 +43,13 @@ extern jmethodID g_mdReset;
 extern jmethodID g_mdUpdate;
 
 // javax/crypto/Mac
-extern jclass    g_macClass;
-extern jmethodID g_macGetInstanceMethod;
-extern jmethodID g_macDoFinalMethod;
-extern jmethodID g_macUpdateMethod;
-extern jmethodID g_macInitMethod;
-extern jmethodID g_macResetMethod;
+extern jclass    g_MacClass;
+extern jmethodID g_MacGetInstance;
+extern jmethodID g_MacClone;
+extern jmethodID g_MacDoFinal;
+extern jmethodID g_MacInit;
+extern jmethodID g_MacReset;
+extern jmethodID g_MacUpdate;
 
 // javax/crypto/spec/SecretKeySpec
 extern jclass    g_sksClass;

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
@@ -512,6 +512,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Android)] // Android doesn't support cloning the current state for HMAC, so it doesn't support GetCurrentHash
         [MemberData(nameof(GetHMACs))]
         public static void VerifyGetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -526,6 +527,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Android)] // Android doesn't support cloning the current state for HMAC, so it doesn't support GetCurrentHash
         [MemberData(nameof(GetHMACs))]
         public static void VerifyBounds_GetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {


### PR DESCRIPTION
We were actually completing and resetting the hash on `GetCurrentHash`.

- Make a clone to get the current hash without resetting.
- Clone is not currently supported by the HMAC implementations on Android. I made our native layer in `pal_hmac` to try to clone, but unless/until the implementations on Android support it, the operation will fail.
- Disable the tests for `IncrementalHash.GetCurrentHash` with HMAC on Android (due to lack of clone support)

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs