### PR TITLE
Fix DacTableGen build on Windows ARM64

### DIFF
--- a/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
+++ b/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
@@ -24,8 +24,16 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="VSInstallationPath" />
     </Exec>
 
+    <PropertyGroup>
+      <_MsDiaSubDir>$(BuildArchitecture)</_MsDiaSubDir>
+      <_MsDiaSubDir Condition="'$(BuildArchitecture)' == 'x86'" />
+      <_MsDiaSubDir Condition="'$(BuildArchitecture)' == 'x64'">amd64</_MsDiaSubDir>
+    </PropertyGroup>
+
     <ItemGroup>
-      <Content Include="$(VSInstallationPath)\DIA SDK\bin\amd64\msdia140.dll" CopyToOutputDirectory="PreserveNewest" />
+      <Content
+        Include="$([MSBuild]::NormalizePath('$(VSInstallationPath)\DIA SDK\bin','$(_MsDiaSubDir)','msdia140.dll'))"
+        CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Building Runtime on a Windows ARM64 machine would produce the ARM64 version of `DacTableGen.exe` with the x64 version of `msdia140.dll`, which would result in a `BadImageFormatException`.  The fix is to copy the correct version of `msdia140.dll`.  Below is the tree structure of the `%VSINSTALLDIR%DIA SDK\BIN` directory:
```
DIA SDK\BIN
│   msdia140.dll
├───amd64
│       msdia140.dll
├───arm
│       msdia140.dll
└───arm64
        msdia140.dll
```