### PR TITLE
Use string.Contains(char) wherever possible - fallback to IndexOf if possible

### DIFF
--- a/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
+++ b/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
@@ -167,7 +167,11 @@ namespace System.Diagnostics
                                         string majorVersion = majorVersions[i];
 
                                         // If this looks like a key of the form v{something}.{something}, we should see if it's a usable build.
-                                        if (majorVersion.Length > 1 && majorVersion[0] == 'v' && majorVersion.Contains(".")) // string.Contains(char) is .NetCore2.1+ specific
+#if (NETCOREAPP2_1_OR_GREATER)
+                                        if (majorVersion.Length > 1 && majorVersion[0] == 'v' && majorVersion.Contains('.'))
+#else
+                                        if (majorVersion.Length > 1 && majorVersion[0] == 'v' && majorVersion.IndexOf('.') != -1)
+#endif
                                         {
                                             int[] currentVersion = new int[] { -1, -1, -1 };
 

--- a/src/libraries/System.Speech/src/Result/RecognizedPhrase.cs
+++ b/src/libraries/System.Speech/src/Result/RecognizedPhrase.cs
@@ -675,7 +675,11 @@ namespace System.Speech.Recognition
             {
                 IntPtr valueStringBuffer = new((long)phraseBuffer + (int)property.pszValueOffset);
                 propertyValue = Marshal.PtrToStringUni(valueStringBuffer);
-                if (!isSapi53Header && isIdName && ((string)propertyValue).Contains("$"))
+#if NETCOREAPP2_1_OR_GREATER
+                if (!isSapi53Header && isIdName && ((string)propertyValue).Contains('$'))
+#else
+                if (!isSapi53Header && isIdName && ((string)propertyValue).IndexOf('$') != -1 )
+#endif
                 {
                     // SAPI 5.1 result that contains script fragments rather than output of executing script.
                     // Strip this information as script-based grammars aren't supported on 5.1.


### PR DESCRIPTION
Fix remaining violations of the discussed `string.Contains(string)` -> `string.Contains(char)` rule.

### Discussion
https://github.com/dotnet/runtime/issues/47180

### Additional context
#24068
https://github.com/dotnet/coreclr/pull/15740
#36310