### PR TITLE
Make 303 redirects do GET like Net Framework

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -44,12 +44,14 @@ namespace System.Net.Http.Functional.Tests
             foreach (int statusCode in new[] { 300, 301, 302, 303, 307, 308 })
             {
                 yield return new object[] { statusCode, "GET", "GET" };
-                yield return new object[] { statusCode, "POST", statusCode <= 303 ? "GET" : "POST" };
-                yield return new object[] { statusCode, "PUT", statusCode == 303 ? "GET" : "PUT" };
-                yield return new object[] { statusCode, "DELETE", statusCode == 303 ? "GET" : "DELETE" };
-                yield return new object[] { statusCode, "PATCH", statusCode == 303 ? "GET" : "PATCH" };
-                yield return new object[] { statusCode, "OPTIONS", statusCode == 303 ? "GET" : "OPTIONS" };
                 yield return new object[] { statusCode, "HEAD", "HEAD" };
+
+                yield return new object[] { statusCode, "POST", statusCode <= 303 ? "GET" : "POST" };
+
+                yield return new object[] { statusCode, "DELETE", statusCode == 303 ? "GET" : "DELETE" };
+                yield return new object[] { statusCode, "OPTIONS", statusCode == 303 ? "GET" : "OPTIONS" };
+                yield return new object[] { statusCode, "PATCH", statusCode == 303 ? "GET" : "PATCH" };
+                yield return new object[] { statusCode, "PUT", statusCode == 303 ? "GET" : "PUT" };
                 yield return new object[] { statusCode, "MYCUSTOMMETHOD", statusCode == 303 ? "GET" : "MYCUSTOMMETHOD" };
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -50,6 +50,7 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { statusCode, "PATCH", statusCode == 303 ? "GET" : "PATCH" };
                 yield return new object[] { statusCode, "OPTIONS", statusCode == 303 ? "GET" : "OPTIONS" };
                 yield return new object[] { statusCode, "HEAD", "HEAD" };
+                yield return new object[] { statusCode, "MYCUSTOMMETHOD", statusCode == 303 ? "GET" : "MYCUSTOMMETHOD" };
             }
         }
         public HttpClientHandlerTest_AutoRedirect(ITestOutputHelper output) : base(output) { }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -45,6 +45,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 yield return new object[] { statusCode, "GET", "GET" };
                 yield return new object[] { statusCode, "POST", statusCode <= 303 ? "GET" : "POST" };
+                yield return new object[] { statusCode, "PUT", statusCode <= 303 ? "GET" : "PUT" };
                 yield return new object[] { statusCode, "HEAD", "HEAD" };
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -45,7 +45,10 @@ namespace System.Net.Http.Functional.Tests
             {
                 yield return new object[] { statusCode, "GET", "GET" };
                 yield return new object[] { statusCode, "POST", statusCode <= 303 ? "GET" : "POST" };
-                yield return new object[] { statusCode, "PUT", statusCode <= 303 ? "GET" : "PUT" };
+                yield return new object[] { statusCode, "PUT", statusCode == 303 ? "GET" : "PUT" };
+                yield return new object[] { statusCode, "DELETE", statusCode == 303 ? "GET" : "DELETE" };
+                yield return new object[] { statusCode, "PATCH", statusCode == 303 ? "GET" : "PATCH" };
+                yield return new object[] { statusCode, "OPTIONS", statusCode == 303 ? "GET" : "OPTIONS" };
                 yield return new object[] { statusCode, "HEAD", "HEAD" };
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -145,7 +145,7 @@ namespace System.Net.Http
                 case HttpStatusCode.MultipleChoices:
                     return requestMethod == HttpMethod.Post;
                 case HttpStatusCode.SeeOther:
-                    return requestMethod != HttpMethod.Head;
+                    return requestMethod != HttpMethod.Get && requestMethod != HttpMethod.Head;
                 default:
                     return false;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -142,9 +142,12 @@ namespace System.Net.Http
             {
                 case HttpStatusCode.Moved:
                 case HttpStatusCode.Found:
-                case HttpStatusCode.SeeOther:
                 case HttpStatusCode.MultipleChoices:
-                    return requestMethod == HttpMethod.Post || requestMethod == HttpMethod.Put;
+                    return requestMethod == HttpMethod.Post;
+                case HttpStatusCode.SeeOther:
+                    return requestMethod == HttpMethod.Post || requestMethod == HttpMethod.Put
+                        || requestMethod == HttpMethod.Delete || requestMethod == HttpMethod.Patch
+                        || requestMethod == HttpMethod.Options;
                 default:
                     return false;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -144,7 +144,7 @@ namespace System.Net.Http
                 case HttpStatusCode.Found:
                 case HttpStatusCode.SeeOther:
                 case HttpStatusCode.MultipleChoices:
-                    return requestMethod == HttpMethod.Post;
+                    return requestMethod == HttpMethod.Post || requestMethod == HttpMethod.Put;
                 default:
                     return false;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -145,9 +145,7 @@ namespace System.Net.Http
                 case HttpStatusCode.MultipleChoices:
                     return requestMethod == HttpMethod.Post;
                 case HttpStatusCode.SeeOther:
-                    return requestMethod == HttpMethod.Post || requestMethod == HttpMethod.Put
-                        || requestMethod == HttpMethod.Delete || requestMethod == HttpMethod.Patch
-                        || requestMethod == HttpMethod.Options;
+                    return requestMethod != HttpMethod.Head;
                 default:
                     return false;
             }


### PR DESCRIPTION
Make 303 redirects do GET like Net Framework

In Net Framework, PUT redirects on a 303 do a GET.
Net 5.0 breaks compatibility with this.
See #28998
This commit causes redirects of a 303 to do a GET
for POST (existing behavior), PUT, DELETE, PATCH and OPTIONS

Fix #28998