### PR TITLE
Run all libraries tests in macOS-arm64 outerloop

### DIFF
--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -78,7 +78,6 @@ jobs:
           - Linux_x64
           - Linux_musl_x64
         - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
-          - OSX_arm64
           - OSX_x64
         helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
         jobParameters:
@@ -86,6 +85,20 @@ jobs:
           isFullMatrix: ${{ variables['isFullMatrix'] }}
           runTests: true
           testScope: outerloop
+          liveRuntimeBuildConfig: release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: Debug
+        platforms:
+        - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
+          - OSX_arm64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+          isFullMatrix: ${{ variables['isFullMatrix'] }}
+          runTests: true
+          testScope: all
           liveRuntimeBuildConfig: release
 
   - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:


### PR DESCRIPTION
If I understand it, `outerloop` does not include `innerloop` library tests.  Try running `all` tests instead.

