### PR TITLE
Override WriteAsync in StreamPipeWriter

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -311,15 +311,18 @@ namespace System.IO.Pipelines
                         _head = segment;
                     }
 
-                    // Write data after the buffered data
-                    if (data.Length > 0 && writeToStream)
+                    if (writeToStream)
                     {
-                        await InnerStream.WriteAsync(data, localToken).ConfigureAwait(false);
-                    }
+                        // Write data after the buffered data
+                        if (data.Length > 0)
+                        {
+                            await InnerStream.WriteAsync(data, localToken).ConfigureAwait(false);
+                        }
 
-                    if ((_bytesBuffered > 0 || data.Length > 0) && writeToStream)
-                    {
-                        await InnerStream.FlushAsync(localToken).ConfigureAwait(false);
+                        if (_bytesBuffered > 0 || data.Length > 0)
+                        {
+                            await InnerStream.FlushAsync(localToken).ConfigureAwait(false);
+                        }
                     }
 
                     // Mark bytes as written *after* flushing

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -317,7 +317,7 @@ namespace System.IO.Pipelines
                         await InnerStream.WriteAsync(data, localToken).ConfigureAwait(false);
                     }
 
-                    if (_bytesBuffered > 0 && writeToStream)
+                    if ((_bytesBuffered > 0 || data.Length > 0) && writeToStream)
                     {
                         await InnerStream.FlushAsync(localToken).ConfigureAwait(false);
                     }

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -590,7 +590,6 @@ namespace System.IO.Pipelines.Tests
             PipeWriter writer = PipeWriter.Create(new ThrowsOperationCanceledExceptionStream());
 
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await writer.WriteAsync(new byte[1]));
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await writer.FlushAsync());
         }
 
         private class ThrowsOperationCanceledExceptionStream : WriteOnlyStream


### PR DESCRIPTION
- This allows passing through directly to the underlying Stream without copying the data into another buffer first.