### PR TITLE
Fix Mono MBR build break

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -6395,7 +6395,6 @@ static gboolean
 module_apply_changes (MonoImage *image, MonoArray *dmeta, MonoArray *dil, MonoArray *dpdb, MonoError *error)
 {
 #ifdef ENABLE_METADATA_UPDATE
-	MonoDomain *domain = mono_domain_get ();
 	/* TODO: use dpdb */
 	gpointer dmeta_bytes = (gpointer)mono_array_addr_internal (dmeta, char, 0);
 	int32_t dmeta_len = mono_array_length_internal (dmeta);
@@ -6403,7 +6402,7 @@ module_apply_changes (MonoImage *image, MonoArray *dmeta, MonoArray *dil, MonoAr
 	int32_t dil_len = mono_array_length_internal (dil);
 	gpointer dpdb_bytes = !dpdb ? NULL : (gpointer)mono_array_addr_internal (dpdb, char, 0);
 	int32_t dpdb_len = !dpdb ? 0 : mono_array_length_internal (dpdb);
-	mono_image_load_enc_delta (domain, image, dmeta_bytes, dmeta_len, dil_bytes, dil_len, error);
+	mono_image_load_enc_delta (image, dmeta_bytes, dmeta_len, dil_bytes, dil_len, error);
 	return is_ok (error);
 #else
 	mono_error_set_not_supported (error, "");


### PR DESCRIPTION
Logic collision between e2fde0bd626e7556965f565ba17368b75d49e3c4 and e42b687ad5f3a7809b819ff86dd4e5d1909fb9a7

Should fix the build on WebAssembly and Android  (and elsewhere with `/p:MonoMetadataUpdate=true`)

Fixes https://github.com/dotnet/runtime/issues/49103