### PR TITLE
Add debugger displays / type proxies for Timer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -16,6 +16,9 @@
       <method name="GetDelegateContinuationsForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>
+    <type fullname="System.Threading.Timer">
+      <property name="AllTimers" />
+    </type>
     <type fullname="System.Threading.ThreadPool">
       <method name="GetQueuedWorkItemsForDebugger" />
       <method name="GetGloballyQueuedWorkItemsForDebugger" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -30,11 +30,9 @@ namespace System.Threading
         internal static readonly CancellationTokenSource s_neverCanceledSource = new CancellationTokenSource();
 
         /// <summary>Delegate used with <see cref="Timer"/> to trigger cancellation of a <see cref="CancellationTokenSource"/>.</summary>
-        private static readonly TimerCallback s_timerCallback = obj =>
-        {
-            Debug.Assert(obj is CancellationTokenSource, $"Expected {typeof(CancellationTokenSource)}, got {obj}");
-            ((CancellationTokenSource)obj).NotifyCancellation(throwOnFirstException: false); // skip ThrowIfDisposed() check in Cancel()
-        };
+        private static readonly TimerCallback s_timerCallback = TimerCallback;
+        private static void TimerCallback(object? state) => // separated out into a named method to improve Timer diagnostics in a debugger
+            ((CancellationTokenSource)state!).NotifyCancellation(throwOnFirstException: false); // skip ThrowIfDisposed() check in Cancel()
 
         /// <summary>The current state of the CancellationTokenSource.</summary>
         private volatile int _state;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
@@ -34,9 +35,13 @@ namespace System.Threading
     // Note that all instance methods of this class require that the caller hold a lock on the TimerQueue instance.
     // We partition the timers across multiple TimerQueues, each with its own lock and set of short/long lists,
     // in order to minimize contention when lots of threads are concurrently creating and destroying timers often.
+    [DebuggerDisplay("Count = {CountForDebugger}")]
+    [DebuggerTypeProxy(typeof(TimerQueueDebuggerTypeProxy))]
     internal partial class TimerQueue
     {
         #region Shared TimerQueue instances
+        /// <summary>Mapping from a tick count to a time to use when debugging to translate tick count values.</summary>
+        internal static readonly (long TickCount, DateTime Time) s_tickCountToTimeMap = (TickCount64, DateTime.UtcNow);
 
         public static TimerQueue[] Instances { get; } = CreateTimerQueues();
 
@@ -48,6 +53,52 @@ namespace System.Threading
                 queues[i] = new TimerQueue(i);
             }
             return queues;
+        }
+
+        // This method is not thread-safe and should only be used from the debugger.
+        private int CountForDebugger
+        {
+            get
+            {
+                int count = 0;
+                foreach (TimerQueueTimer _ in GetTimersForDebugger())
+                {
+                    count++;
+                }
+
+                return count;
+            }
+        }
+
+        // This method is not thread-safe and should only be used from the debugger.
+        internal IEnumerable<TimerQueueTimer> GetTimersForDebugger()
+        {
+            // This should ideally take lock(this), but doing so can hang the debugger
+            // if another thread holds the lock.  It could instead use Monitor.TryEnter,
+            // but doing so doesn't work while dump debugging.  So, it doesn't take the
+            // lock at all; it's theoretically possible but very unlikely this could result
+            // in a circular list that causes the debugger to hang, too.
+
+            for (TimerQueueTimer? timer = _shortTimers; timer != null; timer = timer._next)
+            {
+                yield return timer;
+            }
+
+            for (TimerQueueTimer? timer = _longTimers; timer != null; timer = timer._next)
+            {
+                yield return timer;
+            }
+        }
+
+        private sealed class TimerQueueDebuggerTypeProxy
+        {
+            private readonly TimerQueue _queue;
+
+            public TimerQueueDebuggerTypeProxy(TimerQueue queue) =>
+                _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public TimerQueueTimer[] Items => new List<TimerQueueTimer>(_queue.GetTimersForDebugger()).ToArray();
         }
 
         #endregion
@@ -386,6 +437,8 @@ namespace System.Threading
     }
 
     // A timer in our TimerQueue.
+    [DebuggerDisplay("{DisplayString,nq}")]
+    [DebuggerTypeProxy(typeof(TimerDebuggerTypeProxy))]
     internal sealed partial class TimerQueueTimer : IThreadPoolWorkItem
     {
         // The associated timer queue.
@@ -425,7 +478,6 @@ namespace System.Threading
         private bool _canceled;
         private object? _notifyWhenNoCallbacksRunning; // may be either WaitHandle or Task<bool>
 
-
         internal TimerQueueTimer(TimerCallback timerCallback, object? state, uint dueTime, uint period, bool flowExecutionContext)
         {
             _timerCallback = timerCallback;
@@ -442,6 +494,23 @@ namespace System.Threading
             // the lock is permitted beyond this point!
             if (dueTime != Timeout.UnsignedInfinite)
                 Change(dueTime, period);
+        }
+
+        internal string DisplayString
+        {
+            get
+            {
+                string? typeName = _timerCallback.Method.DeclaringType?.FullName;
+                if (typeName is not null)
+                {
+                    typeName += ".";
+                }
+
+                return
+                    "DueTime = " + (_dueTime == Timeout.UnsignedInfinite ? "(not set)" : TimeSpan.FromMilliseconds(_dueTime)) + ", " +
+                    "Period = " + (_period == Timeout.UnsignedInfinite ? "(not set)" : TimeSpan.FromMilliseconds(_period)) + ", " +
+                    typeName + _timerCallback.Method.Name + "(" + (_state?.ToString() ?? "null") + ")";
+            }
         }
 
         internal bool Change(uint dueTime, uint period)
@@ -646,6 +715,40 @@ namespace System.Threading
             var t = (TimerQueueTimer)state;
             t._timerCallback(t._state);
         };
+
+        internal sealed class TimerDebuggerTypeProxy
+        {
+            private readonly TimerQueueTimer _timer;
+
+            public TimerDebuggerTypeProxy(Timer timer) => _timer = timer._timer._timer;
+            public TimerDebuggerTypeProxy(TimerQueueTimer timer) => _timer = timer;
+
+            public DateTime? EstimatedNextTimeUtc
+            {
+                get
+                {
+                    if (_timer._dueTime != Timeout.UnsignedInfinite)
+                    {
+                        // In TimerQueue's static ctor, we snap a tick count and the current time, as a way of being
+                        // able to translate from tick counts to times.  This is only approximate, for a variety of
+                        // reasons (e.g. drift, clock changes, etc.), but when dump debugging we are unable to use
+                        // TickCount in a meaningful way, so this at least provides a reasonable approximation.
+                        long msOffset = _timer._startTicks - TimerQueue.s_tickCountToTimeMap.TickCount + _timer._dueTime;
+                        return (TimerQueue.s_tickCountToTimeMap.Time + TimeSpan.FromMilliseconds(msOffset));
+                    }
+
+                    return null;
+                }
+            }
+
+            public TimeSpan? DueTime => _timer._dueTime == Timeout.UnsignedInfinite ? null : TimeSpan.FromMilliseconds(_timer._dueTime);
+
+            public TimeSpan? Period => _timer._period == Timeout.UnsignedInfinite ? null : TimeSpan.FromMilliseconds(_timer._period);
+
+            public TimerCallback Callback => _timer._timerCallback;
+
+            public object? State => _timer._state;
+        }
     }
 
     // TimerHolder serves as an intermediary between Timer and TimerQueueTimer, releasing the TimerQueueTimer
@@ -691,12 +794,13 @@ namespace System.Threading
         }
     }
 
-
+    [DebuggerDisplay("{DisplayString,nq}")]
+    [DebuggerTypeProxy(typeof(TimerQueueTimer.TimerDebuggerTypeProxy))]
     public sealed class Timer : MarshalByRefObject, IDisposable, IAsyncDisposable
     {
         internal const uint MaxSupportedTimeout = 0xfffffffe;
 
-        private TimerHolder _timer;
+        internal TimerHolder _timer;
 
         public Timer(TimerCallback callback,
                      object? state,
@@ -859,6 +963,26 @@ namespace System.Threading
         public ValueTask DisposeAsync()
         {
             return _timer.CloseAsync();
+        }
+
+        private string DisplayString => _timer._timer.DisplayString;
+
+        /// <summary>Gets a list of all timers for debugging purposes.</summary>
+        private static IEnumerable<TimerQueueTimer> AllTimers // intended to be used by devs from debugger
+        {
+            get
+            {
+                var timers = new List<TimerQueueTimer>();
+
+                foreach (TimerQueue queue in TimerQueue.Instances)
+                {
+                    timers.AddRange(queue.GetTimersForDebugger());
+                }
+
+                timers.Sort((t1, t2) => t1._dueTime.CompareTo(t2._dueTime));
+
+                return timers;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a private Timer.AllTimers property that can be used in the debugger to get a list of all timers, and debugger display strings for Timer / TimerQueueTimer that help to make sense of the state in a timer and when it'll fire next.

There's one oddity here that I worked around but it leads to another (IMHO less bad oddity).  The VS debugger does lazy evaluation of things like debugger displays, so if you have a long list of something with displays, it'll only evaluate them when they're in view.  The most relevant piece of information about a timer is when it will next fire, and computing that from the state in the timer requires getting the current tick count.  Thus, the debugger display for a timer needs to fetch TickCount, which obviously depends on the moment its read.  If you then had a list of 1000 timers but only 10 were in view, only those 10 would have their displays calculated, based on the current tick count.  Time marches on and you scroll down, exposing another 10, at which point their displays are calculated based on the now current TickCount.  This leads to weird inconsistencies in the view.  To work around that, I have the Timer.AllTimers property configured not to return a Timer or TimerQueueTimer, but actually an instance of the debugger type proxy, which I've also enabled to store a "current" tick count; that way, I can eagerly create all of the proxies and imbue each with the same view of time.  This mostly solves the aforementioned problem, but at the expense of the type column saying the instance is a TimerDebuggerTypeProxy rather than a Timer or TimerQueueTimer.  For now given the tradeoff, I think that's ok.  There are other inconsistencies, e.g. if you navigate from the proxy to the actual wrapped timer and view its display, since it's then factoring in a different "now", it'll show different results.  Not much we can do about it.  And this is all expert-level hidden away anyway, since Timer.AllTimers is private.

![image](https://user-images.githubusercontent.com/2642209/109896330-bfb4cf80-7c5e-11eb-92f1-a7b487168f04.png)


cc: @davidfowl, @r-ramesh, @kouvel 