### PR TITLE
Fix SIMD12 assert when passing on stack on x64 Unix, arm64 Unix/Windows.

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1157,7 +1157,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
                 {
 #if !defined(TARGET_64BIT) || defined(OSX_ARM64_ABI)
                     assert(info->GetByteSize() == 12);
-#else // TARGET_64BIT && !OSX_ARM64_ABI
+#else  // TARGET_64BIT && !OSX_ARM64_ABI
                     assert(info->GetByteSize() == 16);
 #endif // FEATURE_SIMD && FEATURE_PUT_STRUCT_ARG_STK
                 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1155,7 +1155,11 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
 #if defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
                 if (type == TYP_SIMD12)
                 {
+#if !defined(TARGET_64BIT) || defined(OSX_ARM64_ABI)
                     assert(info->GetByteSize() == 12);
+#else // TARGET_64BIT && !OSX_ARM64_ABI
+                    assert(info->GetByteSize() == 16);
+#endif // FEATURE_SIMD && FEATURE_PUT_STRUCT_ARG_STK
                 }
                 else
 #endif // defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_49101/Runtime_49101.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_49101/Runtime_49101.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Diagnostics;
+
+public class Runtime_49101
+{
+    struct S
+    {
+        public Vector3 v;
+        public int anotherField;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, float f1, float f2, float f3, float f4, float f5, float f6, float f7, float f8, float f9, Vector3 v)
+    {
+        Debug.Assert(v == Vector3.One);
+        if (v == Vector3.One)
+        {
+            return 100;
+        }
+        return 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector3 Get()
+    {
+        return Vector3.One;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Main()
+    {
+        S s;
+        s.v = Get();
+        return Test(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, s.v);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_49101/Runtime_49101.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_49101/Runtime_49101.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix an assert failure when passing SIMD12 field on the stack using 16-byte slot.