### PR TITLE
Fix HttpClientHandler_ServerCertificates_Test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -33,6 +33,7 @@ namespace System.Net.Http.Functional.Tests
         // This enables customizing ServerCertificateCustomValidationCallback in WinHttpHandler variants:
         protected bool AllowAllHttp2Certificates { get; set; } = true;
         protected new HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion, allowAllHttp2Certificates: AllowAllHttp2Certificates);
+        protected override HttpClient CreateHttpClient() => CreateHttpClient(CreateHttpClientHandler());
 
         [Fact]
         public void Ctor_ExpectedDefaultValues()


### PR DESCRIPTION
Fixes #49028, which is a regression caused by an overlook in #48817. `HttpClientHandler_ServerCertificates_Test` should also have a custom overload for `CreateHttpClient()` not only `CreateHttpClientHandler()`, otherwise `ServerCertificateCustomValidationCallback` won't be configured correctly in member test cases using `CreateHttpClient()`.