### PR TITLE
Remove StructWithPublicDefaultConstructor test

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
@@ -117,7 +117,9 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             Assert.Null(anotherClass.ColorNull);
             Assert.Equal(12, anotherClass.Integer);
             Assert.Null(anotherClass.IntegerNull);
-            Assert.Equal(ExpectStructWithPublicDefaultConstructorInvoked, anotherClass.StructWithConstructor.ConstructorInvoked);
+            // re-enable once https://github.com/dotnet/csharplang/issues/99 is implemented
+            // see https://github.com/dotnet/runtime/issues/49069
+            // Assert.Equal(ExpectStructWithPublicDefaultConstructorInvoked, anotherClass.StructWithConstructor.ConstructorInvoked);
         }
 
         [Theory]

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Tests;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
@@ -14,7 +13,9 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         public int? Integer { get; }
         public int? IntegerNull { get; }
 
-        public StructWithPublicDefaultConstructor StructWithConstructor { get; }
+        // re-enable once https://github.com/dotnet/csharplang/issues/99 is implemented
+        // see https://github.com/dotnet/runtime/issues/49069
+        //public StructWithPublicDefaultConstructor StructWithConstructor { get; }
 
 #pragma warning disable SA1129
         public ClassWithOptionalArgsCtorWithStructs(
@@ -31,8 +32,8 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             ConsoleColor? color = ConsoleColor.DarkGreen,
             ConsoleColor? colorNull = null,
             int? integer = 12,
-            int? integerNull = null,
-            StructWithPublicDefaultConstructor structWithConstructor = default
+            int? integerNull = null
+            //StructWithPublicDefaultConstructor structWithConstructor = default
         )
 #pragma warning restore SA1129
         {
@@ -40,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             ColorNull = colorNull;
             Integer = integer;
             IntegerNull = integerNull;
-            StructWithConstructor = structWithConstructor;
+            //StructWithConstructor = structWithConstructor;
         }
 
         public struct CustomStruct { }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -6,22 +6,13 @@
     <CLSCompliant>false</CLSCompliant>
     <IsPackable>true</IsPackable>
     <IsRuntimeAssembly>false</IsRuntimeAssembly>
-    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferencesInPackage</TargetsForTfmSpecificBuildOutput>
     <PackageDescription>Suite of xUnit.net tests to check for container compatibility with Microsoft.Extensions.DependencyInjection.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\tests\TestStructs\System.TestStructs.ilproj" Pack="true" PrivateAssets="All" />
     <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
   </ItemGroup>
-
-  <!-- Remove when NuGet exposes this as an official feature, tracking issue: https://github.com/NuGet/Home/issues/3891 -->
-  <Target Name="IncludeProjectReferencesInPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Pack', 'true'))" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.sln
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.sln
@@ -1,4 +1,8 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{30201F60-A891-4C3F-A1A6-DDDD1C8525E3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bcl.AsyncInterfaces", "..\Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj", "{047FD3F2-B3A0-4639-B4F0-40D29E61725D}"
@@ -27,13 +31,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessContr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{B7FC8A33-9FB0-4E58-B3EC-06F4B95BF6D2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.TestStructs", "..\System.Runtime\tests\TestStructs\System.TestStructs.ilproj", "{6B002B34-089C-4BC4-91DD-57D350DEA91C}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C720B37D-E4D9-4B8C-B993-71F5C9C5A381}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{3C9BFC55-DE9A-42C0-A843-2F7D703EEB7D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F109FFD1-2A08-4114-9FC5-A119229B4983}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DependencyInjection.Specification.Tests", "..\Microsoft.Extensions.DependencyInjection.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj", "{4532D9F9-1E0D-4A62-8038-D3454B255E86}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,10 +101,10 @@ Global
 		{B7FC8A33-9FB0-4E58-B3EC-06F4B95BF6D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7FC8A33-9FB0-4E58-B3EC-06F4B95BF6D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7FC8A33-9FB0-4E58-B3EC-06F4B95BF6D2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B002B34-089C-4BC4-91DD-57D350DEA91C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B002B34-089C-4BC4-91DD-57D350DEA91C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6B002B34-089C-4BC4-91DD-57D350DEA91C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B002B34-089C-4BC4-91DD-57D350DEA91C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4532D9F9-1E0D-4A62-8038-D3454B255E86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4532D9F9-1E0D-4A62-8038-D3454B255E86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4532D9F9-1E0D-4A62-8038-D3454B255E86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4532D9F9-1E0D-4A62-8038-D3454B255E86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -120,7 +124,7 @@ Global
 		{04BA3E3C-6979-4792-B19E-C797AD607F42} = {F109FFD1-2A08-4114-9FC5-A119229B4983}
 		{BA9F4FC9-6312-4E3D-BC54-300444064F6A} = {3C9BFC55-DE9A-42C0-A843-2F7D703EEB7D}
 		{B7FC8A33-9FB0-4E58-B3EC-06F4B95BF6D2} = {3C9BFC55-DE9A-42C0-A843-2F7D703EEB7D}
-		{6B002B34-089C-4BC4-91DD-57D350DEA91C} = {C720B37D-E4D9-4B8C-B993-71F5C9C5A381}
+		{4532D9F9-1E0D-4A62-8038-D3454B255E86} = {F109FFD1-2A08-4114-9FC5-A119229B4983}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {68A7BDA7-8093-433C-BF7A-8A6A7560BD02}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection\src\Microsoft.Extensions.DependencyInjection.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj"/>
-    <ProjectReference Include="..\..\..\System.Runtime\tests\TestStructs\System.TestStructs.ilproj" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="4.0.0" />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
-    <ProjectReference Include="..\..\..\System.Runtime\tests\TestStructs\System.TestStructs.ilproj" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.DependencyInjection.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
 


### PR DESCRIPTION
Commenting out this test until the C# language feature is implemented. This allows us to ship the DI Specification tests without shipping the TestStructs project.

Contributes to #49069