### PR TITLE
Fix test run.cmd - Add quotes around the python command

### DIFF
--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -173,7 +173,7 @@ if NOT DEFINED PYTHON (
     exit /b 1
 )
 
-set NEXTCMD=%PYTHON% "%__RepoRootDir%\src\tests\run.py" %__RuntestPyArgs%
+set NEXTCMD="%PYTHON%" "%__RepoRootDir%\src\tests\run.py" %__RuntestPyArgs%
 echo %NEXTCMD%
 %NEXTCMD%
 


### PR DESCRIPTION
Fixes an error with there is a space in the python path