### PR TITLE
Apple Silicon platform detection

### DIFF
--- a/docs/workflow/testing/libraries/filtering-tests.md
+++ b/docs/workflow/testing/libraries/filtering-tests.md
@@ -62,6 +62,10 @@ This attribute returns the 'failing' category, which is disabled by default.
 ```cs
 [ActiveIssue(string issue, TestPlatforms platforms, TargetFrameworkMonikers frameworks)]
 ```
+**Disable using PlatformDetection filter:**
+```cs
+[ActiveIssue(string issue, typeof(PlatformDetection), nameof(PlatformDetection.{member name}))]
+```
 Use this attribute over test methods to skip failing tests only on the specific platforms and the specific target frameworks.
 
 #### SkipOnTargetFrameworkAttribute

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -40,6 +40,8 @@ namespace System
         public static bool IsNotOSX => !IsOSX;
         public static bool IsMacOsMojaveOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 14);
         public static bool IsMacOsCatalinaOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 15);
+        public static bool IsMacOsAppleSilicon => IsOSX && IsArm64Process;
+        public static bool IsNotMacOsAppleSilicon => !IsMacOsAppleSilicon;
 
         // RedHat family covers RedHat and CentOS
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -181,8 +181,10 @@ namespace System.Tests
             Assert.Equal(expected, actual);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMacOsAppleSilicon)] // [ActiveIssue("https://github.com/dotnet/runtime/issues/49106")]
+        [Fact]
         [PlatformSpecific(TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49106", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMacOsAppleSilicon))]
+
         public void OSVersion_ValidVersion_OSX()
         {
             Version version = Environment.OSVersion.Version;

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -181,7 +181,7 @@ namespace System.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMacOsAppleSilicon)] // [ActiveIssue("https://github.com/dotnet/runtime/issues/49106")]
         [PlatformSpecific(TestPlatforms.OSX)]
         public void OSVersion_ValidVersion_OSX()
         {

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -184,7 +184,6 @@ namespace System.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49106", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMacOsAppleSilicon))]
-
         public void OSVersion_ValidVersion_OSX()
         {
             Version version = Environment.OSVersion.Version;


### PR DESCRIPTION
`IsNotMacOsAppleSilicon` & disable `OSVersion_ValidVersion_OSX()`

See #49106

Prepares for disabling failing libraries tests on Apple Silicon