### PR TITLE
Disable IsAtLeastLibgdiplus6 for Apple Silicon

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
@@ -7,7 +7,7 @@ namespace System.Drawing.Tests
 {
     public class GdiplusTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX), nameof(PlatformDetection.IsDrawingSupported))]
         public void IsAtLeastLibgdiplus6()
         {
             Assert.True(Helpers.GetIsWindowsOrAtLeastLibgdiplus6());

--- a/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
@@ -7,7 +7,8 @@ namespace System.Drawing.Tests
 {
     public class GdiplusTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX), nameof(PlatformDetection.IsDrawingSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49111", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMacOsAppleSilicon))]
         public void IsAtLeastLibgdiplus6()
         {
             Assert.True(Helpers.GetIsWindowsOrAtLeastLibgdiplus6());


### PR DESCRIPTION
Related to #49111.

~~I didn't make this an issue...  Perhaps that is preferred...~~

~~But perhaps there should be a separate test that Drawing is supported with an issue.~~