### PR TITLE
Do not create R2R in memory hashes if profiler is not present or hasn't added types

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -288,6 +288,7 @@ void Module::NotifyProfilerLoadFinished(HRESULT hr)
             m_dwCustomAttributeCount = GetMDImport()->GetCountWithTokenKind(mdtCustomAttribute);
         }
 
+        BOOL profilerCallbackHappened = FALSE;
         // Notify the profiler, this may cause metadata to be updated
         {
             BEGIN_PIN_PROFILER(CORProfilerTrackModuleLoads());
@@ -300,13 +301,15 @@ void Module::NotifyProfilerLoadFinished(HRESULT hr)
                     g_profControlBlock.pProfInterface->ModuleAttachedToAssembly((ModuleID) this,
                                                                                 (AssemblyID)m_pAssembly);
                 }
+
+                profilerCallbackHappened = TRUE;
             }
             END_PIN_PROFILER();
         }
 
         // If there are more types than before, add these new types to the
         // assembly
-        if (!IsResource())
+        if (!IsResource() && profilerCallbackHappened)
         {
             UpdateNewlyAddedTypes();
         }

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -220,6 +220,14 @@ void Module::UpdateNewlyAddedTypes()
     DWORD countExportedTypesAfterProfilerUpdate = GetMDImport()->GetCountWithTokenKind(mdtExportedType);
     DWORD countCustomAttributeCount = GetMDImport()->GetCountWithTokenKind(mdtCustomAttribute);
 
+    if (m_dwTypeCount == countTypesAfterProfilerUpdate
+        && m_dwExportedTypeCount == countExportedTypesAfterProfilerUpdate
+        && m_dwCustomAttributeCount == countCustomAttributeCount)
+    {
+        // The profiler added no new types, do not create the in memory hashes
+        return;
+    }
+
     // R2R pre-computes an export table and tries to avoid populating a class hash at runtime. However the profiler can
     // still add new types on the fly by calling here. If that occurs we fallback to the slower path of creating the
     // in memory hashtable as usual.
@@ -300,12 +308,7 @@ void Module::NotifyProfilerLoadFinished(HRESULT hr)
         // assembly
         if (!IsResource())
         {
-            if (m_dwTypeCount != GetMDImport()->GetCountWithTokenKind(mdtTypeDef)
-                || m_dwExportedTypeCount != GetMDImport()->GetCountWithTokenKind(mdtExportedType)
-                || m_dwCustomAttributeCount != GetMDImport()->GetCountWithTokenKind(mdtCustomAttribute))
-            {
-                UpdateNewlyAddedTypes();
-            }
+            UpdateNewlyAddedTypes();
         }
 
         {

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -309,7 +309,7 @@ void Module::NotifyProfilerLoadFinished(HRESULT hr)
 
         // If there are more types than before, add these new types to the
         // assembly
-        if (!IsResource() && profilerCallbackHappened)
+        if (profilerCallbackHappened && !IsResource())
         {
             UpdateNewlyAddedTypes();
         }
@@ -13843,4 +13843,3 @@ void EEConfig::DebugCheckAndForceIBCFailure(BitForMask bitForMask)
     }
 }
 #endif // defined(_DEBUG) && !defined(DACCESS_COMPILE)
-

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -300,7 +300,12 @@ void Module::NotifyProfilerLoadFinished(HRESULT hr)
         // assembly
         if (!IsResource())
         {
-            UpdateNewlyAddedTypes();
+            if (m_dwTypeCount != GetMDImport()->GetCountWithTokenKind(mdtTypeDef)
+                || m_dwExportedTypeCount != GetMDImport()->GetCountWithTokenKind(mdtExportedType)
+                || m_dwCustomAttributeCount != GetMDImport()->GetCountWithTokenKind(mdtCustomAttribute))
+            {
+                UpdateNewlyAddedTypes();
+            }
         }
 
         {


### PR DESCRIPTION
There is a check missing in Module::UpdateNewlyAddedTypes that causes all modules to create the in memory R2R hash instead of using the baked in one, even if a profiler is not present or hasn't added types.