### PR TITLE
Add Android functional test for invariant culture only mode

### DIFF
--- a/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Android.Device_Emulator.InvariantCultureOnlyMode.Test.csproj
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Android.Device_Emulator.InvariantCultureOnlyMode.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <MonoForceInterpreter>true</MonoForceInterpreter>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <TestRuntime>true</TestRuntime>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <MainLibraryFileName>Android.Device_Emulator.InvariantCultureOnlyMode.Test.dll</MainLibraryFileName>
+    <IncludesTestRunner>false</IncludesTestRunner>
+    <ExpectedExitCode>42</ExpectedExitCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Program.cs
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Program.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        var culture = new CultureInfo("es-ES", false);
+        // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
+        int result = culture.LCID == 0x1000 && culture.NativeName == "Invariant Language (Invariant Country)" ? 42 : 1;
+
+        return result;
+    }
+}


### PR DESCRIPTION
Contributes to #43865

1. .`/build.sh mono+libs -os Android -arch x64 -c Release`  
2. `./dotnet.sh build /t:Test src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode /p:TargetOS=Android /p:TargetArchitecture=x64 /p:Configuration=Release`