### PR TITLE
Do not mutate IEnumerable and null values when formatting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -153,7 +153,8 @@ namespace Microsoft.Extensions.Logging
             return string.Format(CultureInfo.InvariantCulture, _format, formattedValues ?? Array.Empty<object>());
         }
 
-        internal string FormatQuick(object?[]? values)
+        // NOTE: This method mutates the items in the array if needed to avoid extra allocations, and should only be used when caller expects this to happen
+        internal string FormatWithOverwrite(object?[]? values)
         {
             if (values != null)
             {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Extensions.Logging
                 for (int i = 0; i < values.Length; i++)
                 {
                     object formattedValue = FormatArgument(values[i]);
+                    // If the formatted value is changed, we allocate and copy items to a new array to avoid mutating the array passed in to this method
                     if (!ReferenceEquals(formattedValue, values[i]))
                     {
                         formattedValues = new object[values.Length];

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.Logging
                     if (!ReferenceEquals(formattedValue, values[i]))
                     {
                         formattedValues = new object[values.Length];
-                        Array.Copy(values, 0, formattedValues, 0, i);
+                        Array.Copy(values, formattedValues, i);
                         formattedValues[i++] = formattedValue;
                         for (; i < values.Length; i++)
                         {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -129,6 +129,32 @@ namespace Microsoft.Extensions.Logging
 
         public string Format(object?[]? values)
         {
+            object?[]? formattedValues = values;
+
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    object formattedValue = FormatArgument(values[i]);
+                    if (!ReferenceEquals(formattedValue, values[i]))
+                    {
+                        formattedValues = new object[values.Length];
+                        Array.Copy(values, 0, formattedValues, 0, i);
+                        formattedValues[i++] = formattedValue;
+                        for (; i < values.Length; i++)
+                        {
+                            formattedValues[i] = FormatArgument(values[i]);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, _format, formattedValues ?? Array.Empty<object>());
+        }
+
+        internal string FormatQuick(object?[]? values)
+        {
             if (values != null)
             {
                 for (int i = 0; i < values.Length; i++)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3 };
 
-            public override string ToString() => _formatter.FormatQuick(ToArray());
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -617,7 +617,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4 };
 
-            public override string ToString() => _formatter.FormatQuick(ToArray());
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -686,7 +686,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4, _value5 };
 
-            public override string ToString() => _formatter.FormatQuick(ToArray());
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3 };
 
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.FormatQuick(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -617,7 +617,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4 };
 
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.FormatQuick(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -686,7 +686,7 @@ namespace Microsoft.Extensions.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4, _value5 };
 
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.FormatQuick(ToArray());
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -406,8 +406,8 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     // Dynamic object serialized as string
                     { new { a = 1, b = 2 }, "\"{ a = 1, b = 2 }\"" },
 
-                    // null serialized as special string
-                    { null, "\"(null)\"" }
+                    // null should not be serialized as special string in the state value, only in message
+                    { null, "null" }
                 };
                 return data;
             }

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/FormattedLogValuesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/FormattedLogValuesTest.cs
@@ -98,11 +98,11 @@ namespace Microsoft.Extensions.Logging.Test
         [Fact]
         public void LogValues_WithNullAndEnumerable_IsNotMutatingParameter()
         {
-            var format = "TestMessage {Param1} {Param2} {Param3} {Param4}";
-            var param1 = 1;
-            var param2 = (string)null;
-            var param3 = new[] { 1, 2, 3, 4 };
-            var param4 = "string";
+            string format = "TestMessage {Param1} {Param2} {Param3} {Param4}";
+            int param1 = 1;
+            string param2 = null;
+            int[] param3 = new[] { 1, 2, 3, 4 };
+            string param4 = "string";
 
             var logValues = new FormattedLogValues(format, param1, param2, param3, param4);
             logValues.ToString();

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/FormattedLogValuesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/FormattedLogValuesTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -92,6 +93,29 @@ namespace Microsoft.Extensions.Logging.Test
                 var logValues = new FormattedLogValues(format, new object[] { "arg1" });
                 logValues.ToString();
             });
+        }
+
+        [Fact]
+        public void LogValues_WithNullAndEnumerable_IsNotMutatingParameter()
+        {
+            var format = "TestMessage {Param1} {Param2} {Param3} {Param4}";
+            var param1 = 1;
+            var param2 = (string)null;
+            var param3 = new[] { 1, 2, 3, 4 };
+            var param4 = "string";
+
+            var logValues = new FormattedLogValues(format, param1, param2, param3, param4);
+            logValues.ToString();
+
+            var state = logValues.ToArray();
+            Assert.Equal(new[]
+            {
+                new KeyValuePair<string, object>("Param1", param1),
+                new KeyValuePair<string, object>("Param2", param2),
+                new KeyValuePair<string, object>("Param3", param3),
+                new KeyValuePair<string, object>("Param4", param4),
+                new KeyValuePair<string, object>("{OriginalFormat}", format),
+            }, state);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
@@ -197,9 +197,9 @@ namespace Microsoft.Extensions.Logging.Test
         public void LogMessage_WithNullParameter_DoesNotMutateArgument()
         {
             // Arrange
-            var format = "TestMessage {param1} {param2} {param3}";
-            var param1 = "foo";
-            var param2 = (string)null;
+            string format = "TestMessage {param1} {param2} {param3}";
+            string param1 = "foo";
+            string param2 = null;
             int param3 = 10;
             var testSink = new TestSink();
             var testLogger = new TestLogger("testlogger", testSink, enabled: true);

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
@@ -194,6 +194,34 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void LogMessage_WithNullParameter_DoesNotMutateArgument()
+        {
+            // Arrange
+            var format = "TestMessage {param1} {param2} {param3}";
+            var param1 = "foo";
+            var param2 = (string)null;
+            int param3 = 10;
+            var testSink = new TestSink();
+            var testLogger = new TestLogger("testlogger", testSink, enabled: true);
+
+            // Act
+            testLogger.LogInformation(format, param1, param2, param3);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes.First();
+            var actualLogValues = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object>>>(write.State);
+            AssertLogValues(new[]
+            {
+                new KeyValuePair<string, object>("param1", param1),
+                new KeyValuePair<string, object>("param2", param2),
+                new KeyValuePair<string, object>("param3", param3),
+                new KeyValuePair<string, object>("{OriginalFormat}", format)
+            },
+            actualLogValues.ToArray());
+        }
+
+        [Fact]
         public void DefineMessage_WithNoParameters_ThrowsException_WhenFormatString_HasNamedParameters()
         {
             // Arrange


### PR DESCRIPTION
This fixes https://github.com/dotnet/runtime/issues/36165, https://github.com/dotnet/runtime/issues/36025, and https://github.com/dotnet/runtime/issues/48873. 

I tossed my first fix I did that checked the array reference on every iteration in the loop and used the snippet @stephentoub proposed in the following discussion that was more elegant: https://github.com/dotnet/runtime/pull/38734

Not sure the FormatQuick (naming is hard!) is really needed (a few more bytes allocated according to my tests), but the LoggerMessage is supposed to be used for high-performance logging scenarios, so maybe worth it anyways.

I created a pull-request in benchmarks for related microbenchmarks: https://github.com/dotnet/performance/pull/1708