### PR TITLE
Fix EC key file import tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
@@ -39,7 +39,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
             Assert.Equal(NTE_PERM, ex.HResult);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadWriteNistP521Pkcs8_LimitedPrivate()
         {
             const string base64 = @"
@@ -50,7 +50,7 @@ FmY=";
             ReadWriteBase64Pkcs8(base64, EccTestData.GetNistP521Key2());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -70,7 +70,7 @@ PFzVQfJ396S+yx4IIC4=";
                 EccTestData.GetNistP521Key2());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey_PasswordBytes()
         {
             const string base64 = @"
@@ -90,7 +90,7 @@ PFzVQfJ396S+yx4IIC4=";
                 EccTestData.GetNistP521Key2());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadWriteNistP256ECPrivateKey_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -102,7 +102,7 @@ AwEH";
                 EccTestData.GetNistP256ReferenceKey());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadWriteNistP256ExplicitECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -134,7 +134,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
                 SupportsExplicitCurves);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public void ReadWriteNistP256ExplicitEncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
@@ -39,7 +39,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
             Assert.Equal(NTE_PERM, ex.HResult);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadWriteNistP521Pkcs8_LimitedPrivate()
         {
             const string base64 = @"
@@ -47,10 +47,10 @@ MGACAQAwEAYHKoZIzj0CAQYFK4EEACMESTBHAgEBBEIBpV+HhaVzC67h1rPTAQaf
 f9ZNiwTM6lfv1ZYeaPM/q0NUUWbKZVPNOP9xPRKJxpi9fQhrVeAbW9XtJ+NjA3ax
 FmY=";
 
-            ReadWriteBase64Pkcs8(base64, EccTestData.GetNistP521Key2());
+            ReadWriteBase64Pkcs8(base64, EccTestData.GetNistP521Key2(), CanDeriveNewPublicKey);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -67,10 +67,11 @@ PFzVQfJ396S+yx4IIC4=";
                     PbeEncryptionAlgorithm.TripleDes3KeyPkcs12,
                     HashAlgorithmName.SHA1,
                     12321),
-                EccTestData.GetNistP521Key2());
+                EccTestData.GetNistP521Key2(),
+                CanDeriveNewPublicKey);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey_PasswordBytes()
         {
             const string base64 = @"
@@ -87,10 +88,11 @@ PFzVQfJ396S+yx4IIC4=";
                     PbeEncryptionAlgorithm.Aes256Cbc,
                     HashAlgorithmName.SHA1,
                     12321),
-                EccTestData.GetNistP521Key2());
+                EccTestData.GetNistP521Key2(),
+                CanDeriveNewPublicKey);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadWriteNistP256ECPrivateKey_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -99,10 +101,11 @@ AwEH";
 
             ReadWriteBase64ECPrivateKey(
                 base64,
-                EccTestData.GetNistP256ReferenceKey());
+                EccTestData.GetNistP256ReferenceKey(),
+                CanDeriveNewPublicKey);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadWriteNistP256ExplicitECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -115,7 +118,7 @@ axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54W
 K84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8
 YyVRAgEB",
                 EccTestData.GetNistP256ReferenceKeyExplicit(),
-                SupportsExplicitCurves);
+                SupportsExplicitCurves && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -134,7 +137,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
                 SupportsExplicitCurves);
         }
 
-        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
+        [Fact]
         public void ReadWriteNistP256ExplicitEncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -154,7 +157,7 @@ hjy6jYfLa1BCJhvq+WbNc7zEb2MfXVhnImaG+XTqXI0c",
                     HashAlgorithmName.SHA256,
                     1234),
                 EccTestData.GetNistP256ReferenceKeyExplicit(),
-                SupportsExplicitCurves);
+                SupportsExplicitCurves && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -163,7 +166,7 @@ hjy6jYfLa1BCJhvq+WbNc7zEb2MfXVhnImaG+XTqXI0c",
             ReadWriteBase64ECPrivateKey(
                 "MCYCAQEEFMXZRFR94RXbJYjcb966O0c+nE2WoAsGCSskAwMCCAEBAQ==",
                 EccTestData.BrainpoolP160r1Key1,
-                SupportsBrainpool);
+                SupportsBrainpool && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -201,7 +204,7 @@ heDtThcoFBJUsNhEHrc=",
             ReadWriteBase64ECPrivateKey(
                 "MCMCAQEEFQPBmVrfrowFGNwT3+YwS7AQF+akEqAHBgUrgQQAAQ==",
                 EccTestData.Sect163k1Key1,
-                SupportsSect163k1);
+                SupportsSect163k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -226,7 +229,7 @@ AAAAAAABBBUAAAAAAAAAAAAAAAAAAAAAAAAAAAEEKwQC/hPAU3u8EayqB9eT3k5t
 XlyU7ugCiQcPsF04/1gyHy6ABTbVOMzao9kCFQQAAAAAAAAAAAACAQii4MwNmfil
 7wIBAg==",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -290,7 +293,7 @@ RVA9DXUNz5+yUlfGzgErHYGwRLaLCACU6+WAC34Kkyk=",
 MDICAQEEJAC08a4ef9zUsOggU8CKkIhSsmIx5sAWcPzGw+osXT/tQO3wN6AHBgUr
 gQQAEA==",
                 EccTestData.Sect283k1Key1,
-                SupportsSect283k1);
+                SupportsSect283k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -304,7 +307,7 @@ yJQ13lJCBBUAyVF9BtUkDTz/OMdLILbNTW+d1NkDFQDSwPsVdghg3vHu9NaW5naH
 VhUXVAQrBAevaZiVRhA9eTKfzD10iA8zu+gDywHsIyEbWWat6h0/h/fqWEiu8LfK
 nwIVBAAAAAAAAAAAAAHmD8iCHMdNrq/BAgEC",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -377,7 +380,7 @@ vW82QOEXDhi1gO24nhx2gUeqVTHjhFq14blAu5l5",
             ReadWriteBase64ECPrivateKey(
                 "MCYCAQEEFQD00koUBxIvRFlnvh2TwAk6ZTZ5hqAKBggqhkjOPQMAAQ==",
                 EccTestData.C2pnb163v1Key1,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1 && CanDeriveNewPublicKey);
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -30,6 +30,8 @@ namespace System.Security.Cryptography.Tests
         // allowed explicit in ECDH or ECDSA but not the other.
         public static bool SupportsExplicitCurves { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupported;
 
+        public static bool CanDeriveNewPublicKey { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
+
         private static bool IsCurveSupported(Oid oid)
         {
             return EcDiffieHellman.Tests.ECDiffieHellmanFactory.IsCurveValid(oid);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
@@ -40,5 +40,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         public static bool ExplicitCurvesSupported => s_provider.ExplicitCurvesSupported;
+
+        public static bool CanDeriveNewPublicKey => s_provider.CanDeriveNewPublicKey;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
+        bool CanDeriveNewPublicKey { get; }
     }
 
     public static partial class ECDiffieHellmanFactory

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
@@ -14,6 +14,9 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         // probe for this capability before depending on it.
         internal static bool ECDsa224Available =>
             ECDiffieHellmanFactory.IsCurveValid(new Oid(ECDSA_P224_OID_VALUE));
+        
+        internal static bool CanDeriveNewPublicKey { get; }
+            = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
 
         [Theory, MemberData(nameof(TestCurvesFull))]
         public static void TestNamedCurves(CurveDef curveDef)
@@ -385,7 +388,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public static void ImportFromPrivateOnlyKey()
         {
             byte[] expectedX = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -10,6 +10,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
     [SkipOnMono("Not supported on Browser", TestPlatforms.Browser)]
     public class ECDsaImportExportTests : ECDsaTestsBase
     {
+        internal static bool CanDeriveNewPublicKey { get; }
+            = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
+
 #if NETCOREAPP
         [Fact]
         public static void DiminishedCoordsRoundtrip()
@@ -320,7 +323,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(CanDeriveNewPublicKey))]
         public static void ImportFromPrivateOnlyKey()
         {
             byte[] expectedX = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray();

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -520,7 +520,7 @@ EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveTyp
         goto error;
     }
 
-    loc[paramSpec] = (*env)->NewObject(env, g_ECParameterSpecClass, g_ECParameterSpecCtor, loc[group], loc[G], bn[ORDER], bn[COFACTOR]);
+    loc[paramSpec] = (*env)->NewObject(env, g_ECParameterSpecClass, g_ECParameterSpecCtor, loc[group], loc[G], bn[ORDER], cofactorInt);
 
     if ((qx && qy) || d)
     {

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Android.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Android.cs
@@ -17,18 +17,9 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             return IsValueOrFriendlyNameValid(oid.FriendlyName);
         }
 
-        public bool ExplicitCurvesSupported
-        {
-            get
-            {
-                if (PlatformDetection.IsOSXLike)
-                {
-                    return false;
-                }
+        public bool ExplicitCurvesSupported => true;
 
-                return true;
-            }
-        }
+        public bool CanDeriveNewPublicKey => false;
 
         private static bool IsValueOrFriendlyNameValid(string friendlyNameOrValue)
         {

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -34,6 +34,8 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
+        public bool CanDeriveNewPublicKey => true;
+
         private static bool IsValueOrFriendlyNameValid(string friendlyNameOrValue)
         {
             if (string.IsNullOrEmpty(friendlyNameOrValue))

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Windows.cs
@@ -22,6 +22,8 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
+        public bool CanDeriveNewPublicKey => true;
+
         private static bool NativeOidFriendlyNameExists(string oidFriendlyName)
         {
             if (string.IsNullOrEmpty(oidFriendlyName))

--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngProvider.cs
@@ -36,6 +36,8 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
+        public bool CanDeriveNewPublicKey => true;
+
         private static bool NativeOidFriendlyNameExists(string oidFriendlyName)
         {
             if (string.IsNullOrEmpty(oidFriendlyName))

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -32,6 +32,9 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ECDiffieHellmanCngProvider.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
@@ -150,9 +153,6 @@
     <Compile Condition="'$(TargetsWindows)' == 'true'" Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs"
              Link="CommonTest\AlgorithmImplementations\AES\AesCipherTests.cs" />
     <Compile Include="ECDiffieHellmanCngTests.cs" />
-    <Compile Include="ECDiffieHellmanCngProvider.cs" />
-    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs"
-             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDiffieHellmanOpenSslProvider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDiffieHellmanOpenSslProvider.cs
@@ -25,6 +25,8 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         public bool IsCurveValid(Oid oid) => _ecdsaProvider.IsCurveValid(oid);
 
         public bool ExplicitCurvesSupported => _ecdsaProvider.ExplicitCurvesSupported;
+
+        public bool CanDeriveNewPublicKey => true;
     }
 
     public partial class ECDiffieHellmanFactory


### PR DESCRIPTION
Fixes the two main classes of EC key fail import test failures.

1) Fix import of cofactor value.
2) Conditionally disable tests on Android that require the ability to derive a new public key from a key file that only has the curve + parameters and the private key. This is unsupported on Android.

There's still a few more failures that I'll continue to investigate, but I wanted to put out these fixes since they block the largest number of tests.