### PR TITLE
Do not bundle mscordaccore.dll in a singlefile package.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -12,13 +12,18 @@
     <PackageOverridesFile Include="$(MSBuildThisFileDirectory)PackageOverrides.txt" />
   </ItemGroup>
 
+  <!--
+  Native files that are always included in the singlefile bundle can be listed here.
+
+  Example:
+    <SingleFileHostIncludeFilename Include="somefile.dll" />
+  -->
   <ItemGroup>
     <!-- LINUX -->
 
     <!-- OSX -->
 
     <!-- Windows -->
-    <SingleFileHostIncludeFilename Include="mscordaccore.dll" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
We used to force inclusion of `mscordaccore.dll` in a singlefile bundle, so it would be extracted next to `coreclr.dll`
Since now by default all native parts of the runtime, including `coreclr.dll` are statically linked into the app, this is not necessary.

Note: if inclusion of `mscordaccore.dll` is specified via other means it will be included, just won't be included by default.

we specifically kept `mcscordaccore.dll` in the bundle so it will be used to create dumps. Re: https://github.com/dotnet/runtime/issues/32823#issuecomment-624910826
That is now on a different plan. (see: https://github.com/dotnet/runtime/pull/49033)