### PR TITLE
Speed up interface checking and casting

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -278,14 +278,10 @@ namespace System.Runtime.CompilerServices
         [DebuggerStepThrough]
         private static object? IsInstanceOfClass(void* toTypeHnd, object? obj)
         {
-            if (obj == null)
+            if (obj == null || RuntimeHelpers.GetMethodTable(obj) == toTypeHnd)
                 return obj;
 
-            MethodTable* mt = RuntimeHelpers.GetMethodTable(obj);
-            if (mt == toTypeHnd)
-                return obj;
-
-            mt = mt->ParentMethodTable;
+            MethodTable* mt = RuntimeHelpers.GetMethodTable(obj)->ParentMethodTable;
             for (; ; )
             {
                 if (mt == toTypeHnd)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Internal.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.CompilerServices
 {


### PR DESCRIPTION
16% - 38% faster* for `IsInstanceOfInterface` & `ChkCastInterface`

* Less arguments in addressing modes `[rdx + 8]` vs `[rdx + r8*8 + 8]`; for lower latency and greater CPU port availability for more instruction parallelism (*see "Intel Optimization Reference Manual" sections "3.5.1.2 Using LEA" and "3.5.1.6 Address Calculations")
  - 2 operand addressing has latency of 1 clock and 2 ports available so a reciprocal throughput of 0.5 clocks
  - 3 operand addressing has latency of 3 clocks and 1 port available so a reciprocal throughput of 1 clock
* Reduce branches, conditional jumps reduced from 8 to 5
* 4 `dec`s exchanged for 1 `add` with less data depenency

*Results https://github.com/dotnet/runtime/pull/49257#issuecomment-792220175

/cc @VSadov 

```diff
-       xor      r8d, r8d
+       cmp      rcx, 4
+       jge      SHORT G_M5541_IG06                     >---\
        align    [0 bytes]                                  |
-                       ;; bbWeight=0.50 PerfScore 3.50     |
+                       ;; bbWeight=0.50 PerfScore 4.00     |
                                                            |
-G_M57878_IG04:                             <---\           |
-       cmp      qword ptr [rdx+8*r8], rsi      |           |
-       je       SHORT G_M57878_IG06            |           |
-       dec      rcx                            |           |
-       je       SHORT G_M57878_IG05            |           |
-       cmp      qword ptr [rdx+8*r8+8], rsi    |           |
-       je       SHORT G_M57878_IG06            |           |
-       dec      rcx                            |           |
-       je       SHORT G_M57878_IG05            |           |
-       cmp      qword ptr [rdx+8*r8+16], rsi   |           |
-       je       SHORT G_M57878_IG06            |           |
-       dec      rcx                            |           |
-       je       SHORT G_M57878_IG05            |           |
-       cmp      qword ptr [rdx+8*r8+24], rsi   |           |
-       je       SHORT G_M57878_IG06            |           |
-       je       SHORT G_M57878_IG05            |           |
-       add      r8, 4                          |           |
-       jmp      SHORT G_M57878_IG04        >---/           |
-                       ;; bbWeight=4    PerfScore 77.00    |
+G_M5541_IG04:                              <---\           |
+       lea      r8, [rdx+32]                   |           |
+       cmp      qword ptr [rdx], rsi           |           |
+       je       SHORT G_M5541_IG08             |           |
+       cmp      qword ptr [rdx+8], rsi         |           |
+       je       SHORT G_M5541_IG08             |           |
+       cmp      qword ptr [rdx+16], rsi        |           |
+       je       SHORT G_M5541_IG08             |           |
+       cmp      qword ptr [rdx+24], rsi        |           |
+       je       SHORT G_M5541_IG08             |           |
+       mov      rdx, r8                        |           |
+       add      rcx, -4                        |           |
+       cmp      rcx, 4                         |           |
+       jge      SHORT G_M5541_IG04         >---/           |
+                       ;; bbWeight=4    PerfScore 57.00    |
+                                                           |
+G_M5541_IG05:                                              |
+       test     rcx, rcx                                   |
+       je       SHORT G_M5541_IG07                         |
+                       ;; bbWeight=0.50 PerfScore 0.62     |
+                                                           |
+G_M5541_IG06:                              <---\       <---/
+       lea      r8, [rdx+8]                    |
+       cmp      qword ptr [rdx], rsi           |
+       je       SHORT G_M5541_IG08             |
+       mov      rdx, r8                        |
        dec      rcx                            |
+       test     rcx, rcx                       |
+       jg       SHORT G_M5541_IG06         >---/
+                       ;; bbWeight=4    PerfScore 21.00
```