### PR TITLE
Remove top-level range check nodes

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3679,7 +3679,7 @@ GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* 
     if ((tree->gtGetOp1()->OperGet() == GT_ARR_BOUNDS_CHECK) &&
         ((tree->gtGetOp1()->gtFlags & GTF_ARR_BOUND_INBND) != 0))
     {
-        optRemoveRangeCheck(tree, stmt);
+        optRemoveCommaBasedRangeCheck(tree, stmt);
         return optAssertionProp_Update(tree, tree, stmt);
     }
     return nullptr;
@@ -3941,10 +3941,9 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
 
 /*****************************************************************************
  *
- *  Given a tree consisting of a comma node with a bounds check, remove any
- *  redundant bounds check that has already been checked in the program flow.
+ *  Given a tree with a bounds check, remove it if it has already been checked in the program flow.
  */
-GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree)
+GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     if (optLocalAssertionProp)
     {
@@ -4062,12 +4061,23 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
             gtDispTree(tree, nullptr, nullptr, true);
         }
 #endif
+        if (arrBndsChk == stmt->GetRootNode())
+        {
+            // We have a top-level bounds check node.
+            // This can happen when trees are broken up due to inlining.
+            // optRemoveStandaloneRangeCheck will return the modified tree (side effects or a no-op).
+            GenTree* newTree = optRemoveStandaloneRangeCheck(arrBndsChk, stmt);
+
+            return optAssertionProp_Update(newTree, arrBndsChk, stmt);
+        }
 
         // Defer actually removing the tree until processing reaches its parent comma, since
-        // optRemoveRangeCheck needs to rewrite the whole comma tree.
+        // optRemoveCommaBasedRangeCheck needs to rewrite the whole comma tree.
         arrBndsChk->gtFlags |= GTF_ARR_BOUND_INBND;
+
         return nullptr;
     }
+
     return nullptr;
 }
 
@@ -4160,7 +4170,7 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
             return optAssertionProp_Ind(assertions, tree, stmt);
 
         case GT_ARR_BOUNDS_CHECK:
-            return optAssertionProp_BndsChk(assertions, tree);
+            return optAssertionProp_BndsChk(assertions, tree, stmt);
 
         case GT_COMMA:
             return optAssertionProp_Comma(assertions, tree, stmt);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6007,7 +6007,9 @@ private:
 public:
     void optInit();
 
-    void optRemoveRangeCheck(GenTree* tree, Statement* stmt);
+    GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, Statement* stmt);
+    GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statement* stmt);
+    void Compiler::optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt);
     bool optIsRangeCheckRemovable(GenTree* tree);
 
 protected:
@@ -7286,7 +7288,7 @@ public:
     GenTree* optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, Statement* stmt);
     GenTree* optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
-    GenTree* optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree);
+    GenTree* optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -388,6 +388,13 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
                     if ((checkConstVal >= 0) && (checkConstVal < actualConstVal))
                     {
                         GenTree* comma = check->gtGetParent(nullptr);
+
+                        // We should never see cases other than these in the IR,
+                        // as the check node does not produce a value.
+                        assert(((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
+                               (check == compCurStmt->GetRootNode()));
+
+                        // Still, we guard here so that release builds do not try to optimize trees we don't understand.
                         if (((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
                             (check == compCurStmt->GetRootNode()))
                         {

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -391,7 +391,8 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
 
                         // We should never see cases other than these in the IR,
                         // as the check node does not produce a value.
-                        assert(((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
+                        assert(((comma != nullptr) && comma->OperIs(GT_COMMA) &&
+                                (comma->gtGetOp1() == check || comma->TypeIs(TYP_VOID))) ||
                                (check == compCurStmt->GetRootNode()));
 
                         // Still, we guard here so that release builds do not try to optimize trees we don't understand.

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -388,12 +388,13 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
                     if ((checkConstVal >= 0) && (checkConstVal < actualConstVal))
                     {
                         GenTree* comma = check->gtGetParent(nullptr);
-                        if ((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check))
+                        if (((comma != nullptr) && comma->OperIs(GT_COMMA) && (comma->gtGetOp1() == check)) ||
+                            (check == compCurStmt->GetRootNode()))
                         {
-                            optRemoveRangeCheck(comma, compCurStmt);
                             // Both `tree` and `check` have been removed from the statement.
                             // 'tree' was replaced with 'nop' or side effect list under 'comma'.
-                            return comma->gtGetOp1();
+                            // optRemoveRangeCheck returns this modified tree.
+                            return optRemoveRangeCheck(check, comma, compCurStmt);
                         }
                     }
                 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8216,7 +8216,7 @@ void Compiler::AddModifiedElemTypeAllContainingLoops(unsigned lnum, CORINFO_CLAS
 // Arguments:
 //    check  -  Range check tree, the raw CHECK node (ARRAY, SIMD or HWINTRINSIC).
 //    comma  -  GT_COMMA to which the "check" belongs, "nullptr" if the check is a standalone one.
-//    stmt   -  Statement the indexing nodes belongs to.
+//    stmt   -  Statement the indexing nodes belong to.
 //
 // Return Value:
 //    Rewritten "check" - no-op if it has no side effects or the tree that contains them.
@@ -8302,6 +8302,14 @@ GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, 
 //------------------------------------------------------------------------------
 // optRemoveStandaloneRangeCheck : A thin wrapper over optRemoveRangeCheck that removes standalone checks.
 //
+// Arguments:
+//    check - The standalone top-level CHECK node.
+//    stmt  - The statement "check" is a root node of.
+//
+// Return Value:
+//    If "check" has no side effects, it is retuned, bashed to a no-op.
+//    If it has side effects, the tree that executes them is returned.
+//
 GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statement* stmt)
 {
     assert(check != nullptr);
@@ -8313,6 +8321,10 @@ GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statem
 
 //------------------------------------------------------------------------------
 // optRemoveCommaBasedRangeCheck : A thin wrapper over optRemoveRangeCheck that removes COMMA-based checks.
+//
+// Arguments:
+//    comma - GT_COMMA of which the first operand is the CHECK to be removed.
+//    stmt  - The statement "comma" belongs to.
 //
 void Compiler::optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt)
 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8328,7 +8328,7 @@ GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statem
 //
 void Compiler::optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt)
 {
-    assert(comma != nullptr);
+    assert(comma != nullptr && comma->OperIs(GT_COMMA));
     assert(stmt != nullptr);
     assert(comma->gtGetOp1()->OperIsBoundsCheck());
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8224,7 +8224,7 @@ void Compiler::AddModifiedElemTypeAllContainingLoops(unsigned lnum, CORINFO_CLAS
 // Assumptions:
 //    This method is capable of removing checks of two kinds: COMMA-based and standalone top-level ones.
 //    In case of a COMMA-based check, "check" must be a non-null first operand of a non-null COMMA.
-//    If case of a standalone check, "comma" must be null and "check" - "stmt"'s root.
+//    In case of a standalone check, "comma" must be null and "check" - "stmt"'s root.
 //
 GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, Statement* stmt)
 {
@@ -8238,7 +8238,7 @@ GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, 
     noway_assert(check->OperIsBoundsCheck());
 
     GenTree* tree = comma != nullptr ? comma : check;
-    
+
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5068,7 +5068,7 @@ void Compiler::optPerformStaticOptimizations(unsigned loopNum, LoopCloneContext*
             {
                 LcJaggedArrayOptInfo* arrIndexInfo = optInfo->AsLcJaggedArrayOptInfo();
                 compCurBB                          = arrIndexInfo->arrIndex.useBlock;
-                optRemoveRangeCheck(arrIndexInfo->arrIndex.bndsChks[arrIndexInfo->dim], arrIndexInfo->stmt);
+                optRemoveCommaBasedRangeCheck(arrIndexInfo->arrIndex.bndsChks[arrIndexInfo->dim], arrIndexInfo->stmt);
                 DBEXEC(dynamicPath, optDebugLogLoopCloning(arrIndexInfo->arrIndex.useBlock, arrIndexInfo->stmt));
             }
             break;
@@ -8211,24 +8211,34 @@ void Compiler::AddModifiedElemTypeAllContainingLoops(unsigned lnum, CORINFO_CLAS
 }
 
 //------------------------------------------------------------------------------
-// optRemoveRangeCheck : Given an array index node, mark it as not needing a range check.
+// optRemoveRangeCheck : Given an indexing node, mark it as not needing a range check.
 //
 // Arguments:
-//    tree   -  Range check tree
-//    stmt   -  Statement the tree belongs to
-
-void Compiler::optRemoveRangeCheck(GenTree* tree, Statement* stmt)
+//    check  -  Range check tree, the raw CHECK node (ARRAY, SIMD or HWINTRINSIC).
+//    comma  -  GT_COMMA to which the "check" belongs, "nullptr" if the check is a standalone one.
+//    stmt   -  Statement the indexing nodes belongs to.
+//
+// Return Value:
+//    Rewritten "check" - no-op if it has no side effects or the tree that contains them.
+//
+// Assumptions:
+//    This method is capable of removing checks of two kinds: COMMA-based and standalone top-level ones.
+//    In case of a COMMA-based check, "check" must be a non-null first operand of a non-null COMMA.
+//    If case of a standalone check, "comma" must be null and "check" - "stmt"'s root.
+//
+GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, Statement* stmt)
 {
 #if !REARRANGE_ADDS
     noway_assert(!"can't remove range checks without REARRANGE_ADDS right now");
 #endif
 
-    noway_assert(tree->gtOper == GT_COMMA);
+    noway_assert(stmt != nullptr);
+    noway_assert((comma != nullptr && comma->OperIs(GT_COMMA) && comma->gtGetOp1() == check) ||
+                 (check != nullptr && check->OperIsBoundsCheck() && comma == nullptr));
+    noway_assert(check->OperIsBoundsCheck());
 
-    GenTree* bndsChkTree = tree->AsOp()->gtOp1;
-
-    noway_assert(bndsChkTree->OperIsBoundsCheck());
-
+    GenTree* tree = comma != nullptr ? comma : check;
+    
 #ifdef DEBUG
     if (verbose)
     {
@@ -8239,19 +8249,40 @@ void Compiler::optRemoveRangeCheck(GenTree* tree, Statement* stmt)
 
     // Extract side effects
     GenTree* sideEffList = nullptr;
-    gtExtractSideEffList(bndsChkTree, &sideEffList, GTF_ASG);
+    gtExtractSideEffList(check, &sideEffList, GTF_ASG);
 
-    // Just replace the bndsChk with a NOP as an operand to the GT_COMMA, if there are no side effects.
-    tree->AsOp()->gtOp1 = (sideEffList != nullptr) ? sideEffList : gtNewNothingNode();
-    // TODO-CQ: We should also remove the GT_COMMA, but in any case we can no longer CSE the GT_COMMA.
-    tree->gtFlags |= GTF_DONT_CSE;
+    if (sideEffList != nullptr)
+    {
+        // We've got some side effects.
+        if (tree->OperIs(GT_COMMA))
+        {
+            // Make the comma handle them.
+            tree->AsOp()->gtOp1 = sideEffList;
+        }
+        else
+        {
+            // Make the statement execute them instead of the check.
+            stmt->SetRootNode(sideEffList);
+            tree = sideEffList;
+        }
+    }
+    else
+    {
+        check->gtBashToNOP();
+    }
+
+    if (tree->OperIs(GT_COMMA))
+    {
+        // TODO-CQ: We should also remove the GT_COMMA, but in any case we can no longer CSE the GT_COMMA.
+        tree->gtFlags |= GTF_DONT_CSE;
+    }
 
     gtUpdateSideEffects(stmt, tree);
 
-    /* Recalculate the GetCostSz(), etc... */
+    // Recalculate the GetCostSz(), etc...
     gtSetStmtInfo(stmt);
 
-    /* Re-thread the nodes if necessary */
+    // Re-thread the nodes if necessary
     if (fgStmtListThreaded)
     {
         fgSetStmtSeq(stmt);
@@ -8264,6 +8295,32 @@ void Compiler::optRemoveRangeCheck(GenTree* tree, Statement* stmt)
         gtDispTree(tree);
     }
 #endif
+
+    return check;
+}
+
+//------------------------------------------------------------------------------
+// optRemoveStandaloneRangeCheck : A thin wrapper over optRemoveRangeCheck that removes standalone checks.
+//
+GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statement* stmt)
+{
+    assert(check != nullptr);
+    assert(stmt != nullptr);
+    assert(check == stmt->GetRootNode());
+
+    return optRemoveRangeCheck(check, nullptr, stmt);
+}
+
+//------------------------------------------------------------------------------
+// optRemoveCommaBasedRangeCheck : A thin wrapper over optRemoveRangeCheck that removes COMMA-based checks.
+//
+void Compiler::optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt)
+{
+    assert(comma != nullptr);
+    assert(stmt != nullptr);
+    assert(comma->gtGetOp1()->OperIsBoundsCheck());
+
+    optRemoveRangeCheck(comma->gtGetOp1()->AsBoundsChk(), comma, stmt);
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -187,13 +187,15 @@ bool RangeCheck::BetweenBounds(Range& range, GenTree* upper, int arrSize)
 void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree* treeParent)
 {
     // Check if we are dealing with a bounds check node.
-    if (!(treeParent->OperIs(GT_COMMA) || (treeParent->OperIsBoundsCheck() && treeParent == stmt->GetRootNode())))
+    bool isComma        = treeParent->OperIs(GT_COMMA);
+    bool isTopLevelNode = treeParent == stmt->GetRootNode();
+    if (!(isComma || isTopLevelNode))
     {
         return;
     }
 
     // If we are not looking at array bounds check, bail.
-    GenTree* tree = treeParent->OperIs(GT_COMMA) ? treeParent->AsOp()->gtOp1 : treeParent;
+    GenTree* tree = isComma ? treeParent->AsOp()->gtOp1 : treeParent;
     if (!tree->OperIsBoundsCheck())
     {
         return;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -187,18 +187,19 @@ bool RangeCheck::BetweenBounds(Range& range, GenTree* upper, int arrSize)
 void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree* treeParent)
 {
     // Check if we are dealing with a bounds check node.
-    if (treeParent->OperGet() != GT_COMMA)
+    if (!(treeParent->OperIs(GT_COMMA) || (treeParent->OperIsBoundsCheck() && treeParent == stmt->GetRootNode())))
     {
         return;
     }
 
     // If we are not looking at array bounds check, bail.
-    GenTree* tree = treeParent->AsOp()->gtOp1;
+    GenTree* tree = treeParent->OperIs(GT_COMMA) ? treeParent->AsOp()->gtOp1 : treeParent;
     if (!tree->OperIsBoundsCheck())
     {
         return;
     }
 
+    GenTree*          comma   = treeParent->OperIs(GT_COMMA) ? treeParent : nullptr;
     GenTreeBoundsChk* bndsChk = tree->AsBoundsChk();
     m_pCurBndsChk             = bndsChk;
     GenTree* treeIndex        = bndsChk->gtIndex;
@@ -258,7 +259,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         if ((idxVal < arrSize) && (idxVal >= 0))
         {
             JITDUMP("Removing range check\n");
-            m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+            m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);
             return;
         }
     }
@@ -299,7 +300,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
     if (BetweenBounds(range, bndsChk->gtArrLen, arrSize))
     {
         JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
-        m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+        m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);
     }
     return;
 }


### PR DESCRIPTION
See #49113 for context.

The change is two-fold: refactoring of `optRemoveRangeCheck` to handle both types of checks ("flattened" `COMMA`s and regular `COMMA`s) and threading the support through the relevant phases.

I decided to concentrate the new logic in `optRemoveRangeCheck` instead of leaning on the calling code to check what type of check do they have. This lead to a non-obvious (and arguably non-ideal) design, but that was the best I could come up with.

I also added two helpers that wrap this new `optRemoveRangeCheck` for code that does know what type of check it is dealing with.

This fixes the original reproduction:
```CS
public static void CheckZero(Span<int> a)
{
    static int Value() => 42;

    if (!a.IsEmpty)
    {
        a[0] = Value();
    }
}
```
```asm
G_M7183_IG02:
       mov      rax, bword ptr [rcx]
       mov      edx, dword ptr [rcx+8]
G_M7183_IG03:
       test     edx, edx
       jbe      SHORT G_M7183_IG05
G_M7183_IG04:
       mov      dword ptr [rax], 42
G_M7183_IG05:
       ret
```
It also works for a non-zero constant (the change in range check elimination is responsible for that):
```CS
public static void CheckOne(Span<int> a)
{
    static int Value() => 42;

    if (a.Length > 1)
    {
        a[0] = Value();
    }
}
```
```asm
       mov      rax, bword ptr [rcx]
       mov      edx, dword ptr [rcx+8]
G_M7183_IG03:
       cmp      edx, 1
       jle      SHORT G_M7183_IG05
G_M7183_IG04:
       mov      dword ptr [rax], 42
G_M7183_IG05:
       ret
```

There are some diffs as well (mostly in CoreLib):
<details>
<summary>The diffs</summary>

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 33745766
Total bytes of diff: 33745610
Total bytes of delta: -156 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -120 : System.Private.CoreLib.dasm (-0.00% of base)
         -27 : System.Net.Http.dasm (-0.00% of base)
          -9 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)

3 total files with Code Size differences (3 improved, 0 regressed), 268 unchanged.

Top method improvements (bytes):
         -27 (-9.31% of base) : System.Net.Http.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -26 (-34.21% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:EncodeRune(System.Text.Rune,System.Span`1[Byte],byref):int:this
         -26 (-32.91% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Encoding:EncodeRune(System.Text.Rune,System.Span`1[Byte],byref):int:this
         -25 (-28.09% of base) : System.Private.CoreLib.dasm - System.Decimal:TryGetBits(System.Decimal,System.Span`1[Int32],byref):bool
         -15 (-19.48% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.ComEventsSink:GetVariant(byref):byref
         -10 (-13.16% of base) : System.Private.CoreLib.dasm - System.Decimal:GetBits(System.Decimal,System.Span`1[Int32]):int
         -10 (-6.85% of base) : System.Private.CoreLib.dasm - System.Text.Rune:TryEncodeToUtf16(System.Span`1[Char],byref):bool:this
          -9 (-4.15% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Ctf.CtfMetadataLegacyParser:FindCloseBrace(System.String,int):int
          -8 (-1.28% of base) : System.Private.CoreLib.dasm - System.IO.Path:Populate83FileNameFromRandomBytes(long,int,System.Span`1[Char])

Top method improvements (percentages):
         -26 (-34.21% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:EncodeRune(System.Text.Rune,System.Span`1[Byte],byref):int:this
         -26 (-32.91% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Encoding:EncodeRune(System.Text.Rune,System.Span`1[Byte],byref):int:this
         -25 (-28.09% of base) : System.Private.CoreLib.dasm - System.Decimal:TryGetBits(System.Decimal,System.Span`1[Int32],byref):bool
         -15 (-19.48% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.ComEventsSink:GetVariant(byref):byref
         -10 (-13.16% of base) : System.Private.CoreLib.dasm - System.Decimal:GetBits(System.Decimal,System.Span`1[Int32]):int
         -27 (-9.31% of base) : System.Net.Http.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -10 (-6.85% of base) : System.Private.CoreLib.dasm - System.Text.Rune:TryEncodeToUtf16(System.Span`1[Char],byref):bool:this
          -9 (-4.15% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Ctf.CtfMetadataLegacyParser:FindCloseBrace(System.String,int):int
          -8 (-1.28% of base) : System.Private.CoreLib.dasm - System.IO.Path:Populate83FileNameFromRandomBytes(long,int,System.Span`1[Char])

--------------------------------------------------------------------------------

benchmarks.run.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 7261
Total bytes of diff: 7078
Total bytes of delta: -183 (-2.52% of base)
    diff is an improvement.


Top file improvements (bytes):
         -61 : 5812.dasm (-2.37% of base)
         -60 : 5896.dasm (-2.28% of base)
         -27 : 5425.dasm (-9.31% of base)
         -13 : 3441.dasm (-1.34% of base)
         -10 : 10817.dasm (-6.90% of base)
          -8 : 5026.dasm (-1.39% of base)
          -4 : 15357.dasm (-5.48% of base)

7 total files with Code Size differences (7 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -61 (-2.37% of base) : 5812.dasm - System.Net.Security.SafeDeleteContext:InitializeSecurityContext(byref,byref,System.String,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -60 (-2.28% of base) : 5896.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -27 (-9.31% of base) : 5425.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -13 (-1.34% of base) : 3441.dasm - System.Text.RegularExpressions.RegexCharClass:ToStringClass(byref):this
         -10 (-6.90% of base) : 10817.dasm - System.Text.Rune:TryEncodeToUtf16(System.Span`1[Char],byref):bool:this
          -8 (-1.39% of base) : 5026.dasm - System.IO.Path:Populate83FileNameFromRandomBytes(long,int,System.Span`1[Char])
          -4 (-5.48% of base) : 15357.dasm - Span.IndexerBench:TestWriteViaIndexer1(System.Span`1[Byte]):ubyte

Top method improvements (percentages):
         -27 (-9.31% of base) : 5425.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -10 (-6.90% of base) : 10817.dasm - System.Text.Rune:TryEncodeToUtf16(System.Span`1[Char],byref):bool:this
          -4 (-5.48% of base) : 15357.dasm - Span.IndexerBench:TestWriteViaIndexer1(System.Span`1[Byte]):ubyte
         -61 (-2.37% of base) : 5812.dasm - System.Net.Security.SafeDeleteContext:InitializeSecurityContext(byref,byref,System.String,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -60 (-2.28% of base) : 5896.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
          -8 (-1.39% of base) : 5026.dasm - System.IO.Path:Populate83FileNameFromRandomBytes(long,int,System.Span`1[Char])
         -13 (-1.34% of base) : 3441.dasm - System.Text.RegularExpressions.RegexCharClass:ToStringClass(byref):this

7 total methods with Code Size differences (7 improved, 0 regressed), 0 unchanged.

--------------------------------------------------------------------------------

libraries.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 32144
Total bytes of diff: 31341
Total bytes of delta: -803 (-2.50% of base)
    diff is an improvement.


Top file improvements (bytes):
         -61 : 111334.dasm (-2.37% of base)
         -61 : 197642.dasm (-2.37% of base)
         -61 : 196472.dasm (-2.37% of base)
         -61 : 201258.dasm (-2.37% of base)
         -60 : 201260.dasm (-2.28% of base)
         -60 : 196474.dasm (-2.28% of base)
         -60 : 111336.dasm (-2.28% of base)
         -60 : 197644.dasm (-2.28% of base)
         -27 : 112999.dasm (-9.31% of base)
         -27 : 143170.dasm (-45.00% of base)
         -19 : 197639.dasm (-2.88% of base)
         -19 : 203166.dasm (-8.84% of base)
         -19 : 203165.dasm (-9.36% of base)
         -19 : 197638.dasm (-2.19% of base)
         -19 : 201213.dasm (-1.99% of base)
         -19 : 203164.dasm (-9.18% of base)
         -19 : 203168.dasm (-9.36% of base)
         -19 : 201214.dasm (-2.22% of base)
         -19 : 203163.dasm (-9.18% of base)
         -18 : 209389.dasm (-0.90% of base)

26 total files with Code Size differences (26 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -61 (-2.37% of base) : 201258.dasm - System.Net.Security.SafeDeleteContext:InitializeSecurityContext(byref,byref,System.String,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -60 (-2.28% of base) : 201260.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -27 (-9.31% of base) : 112999.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -27 (-45.00% of base) : 143170.dasm - System.Runtime.InteropServices.ComEventsSink:GetVariant(byref):byref
         -19 (-2.88% of base) : 197639.dasm - System.Net.Security.NegotiateStreamPal:MakeSignature(System.Net.Security.SafeDeleteContext,System.Byte[],int,int,byref):int
         -19 (-8.84% of base) : 203166.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,double):System.Numerics.Tensors.Tensor`1[Double]
         -19 (-9.36% of base) : 203165.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,int):System.Numerics.Tensors.Tensor`1[Int32]
         -19 (-2.19% of base) : 197638.dasm - System.Net.Security.NegotiateStreamPal:VerifySignature(System.Net.Security.SafeDeleteContext,System.Byte[],int,int):int
         -19 (-1.99% of base) : 201213.dasm - System.Net.Security.NegotiateStreamPal:Decrypt(System.Net.Security.SafeDeleteContext,System.Byte[],int,int,bool,bool,byref,int):int
         -19 (-9.18% of base) : 203164.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,short):System.Numerics.Tensors.Tensor`1[Int16]
         -19 (-9.36% of base) : 203168.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,long):System.Numerics.Tensors.Tensor`1[Int64]
         -19 (-2.22% of base) : 201214.dasm - System.Net.Security.NegotiateStreamPal:DecryptNtlm(System.Net.Security.SafeDeleteContext,System.Byte[],int,int,bool,byref,int):int
         -19 (-9.18% of base) : 203163.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,ubyte):System.Numerics.Tensors.Tensor`1[Byte]
         -18 (-0.90% of base) : 209389.dasm - Internal.Cryptography.Pbkdf2Implementation:FillKeyDerivation(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],int,System.String,System.Span`1[Byte])

Top method improvements (percentages):
         -27 (-45.00% of base) : 143170.dasm - System.Runtime.InteropServices.ComEventsSink:GetVariant(byref):byref
         -19 (-9.36% of base) : 203165.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,int):System.Numerics.Tensors.Tensor`1[Int32]
         -19 (-9.36% of base) : 203168.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,long):System.Numerics.Tensors.Tensor`1[Int64]
         -27 (-9.31% of base) : 112999.dasm - System.Net.Http.HPack.IntegerEncoder:Encode(int,int,System.Span`1[Byte],byref):bool
         -19 (-9.18% of base) : 203164.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,short):System.Numerics.Tensors.Tensor`1[Int16]
         -19 (-9.18% of base) : 203163.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,ubyte):System.Numerics.Tensors.Tensor`1[Byte]
         -19 (-8.84% of base) : 203166.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,double):System.Numerics.Tensors.Tensor`1[Double]
         -15 (-7.46% of base) : 203162.dasm - System.Numerics.Tensors.Tensor:CreateIdentity(int,bool,System.__Canon):System.Numerics.Tensors.Tensor`1[__Canon]
          -9 (-4.04% of base) : 99528.dasm - Microsoft.Diagnostics.Tracing.Ctf.CtfMetadataLegacyParser:FindCloseBrace(System.String,int):int
         -19 (-2.88% of base) : 197639.dasm - System.Net.Security.NegotiateStreamPal:MakeSignature(System.Net.Security.SafeDeleteContext,System.Byte[],int,int,byref):int
         -61 (-2.37% of base) : 111334.dasm - System.Net.Security.SafeDeleteContext:InitializeSecurityContext(byref,byref,System.String,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -60 (-2.28% of base) : 201260.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -19 (-2.22% of base) : 201214.dasm - System.Net.Security.NegotiateStreamPal:DecryptNtlm(System.Net.Security.SafeDeleteContext,System.Byte[],int,int,bool,byref,int):int
         -19 (-2.19% of base) : 197638.dasm - System.Net.Security.NegotiateStreamPal:VerifySignature(System.Net.Security.SafeDeleteContext,System.Byte[],int,int):int

26 total methods with Code Size differences (26 improved, 0 regressed), 0 unchanged

--------------------------------------------------------------------------------

tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 116705
Total bytes of diff: 88209
Total bytes of delta: -28496 (-24.42% of base)
    diff is an improvement.


Top file improvements (bytes):
        -251 : 88901.dasm (-41.35% of base)
        -251 : 88487.dasm (-41.35% of base)
        -238 : 88535.dasm (-42.20% of base)
        -238 : 88949.dasm (-42.20% of base)
        -237 : 136116.dasm (-45.84% of base)
        -237 : 136104.dasm (-45.84% of base)
        -232 : 136115.dasm (-42.80% of base)
        -232 : 136117.dasm (-42.80% of base)
        -232 : 136105.dasm (-42.80% of base)
        -231 : 88488.dasm (-43.10% of base)
        -231 : 88902.dasm (-43.10% of base)
        -228 : 87668.dasm (-40.50% of base)
        -228 : 87263.dasm (-42.46% of base)
        -228 : 87253.dasm (-40.50% of base)
        -228 : 87667.dasm (-42.46% of base)
        -228 : 87677.dasm (-40.50% of base)
        -228 : 87678.dasm (-42.46% of base)
        -228 : 87262.dasm (-40.50% of base)
        -228 : 87264.dasm (-40.50% of base)
        -228 : 87679.dasm (-40.50% of base)

224 total files with Code Size differences (224 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -251 (-41.35% of base) : 88901.dasm - testout1:Sub_Funclet_449():int
        -251 (-41.35% of base) : 88487.dasm - testout1:Sub_Funclet_449():int
        -238 (-42.20% of base) : 88535.dasm - testout1:Sub_Funclet_385():int
        -238 (-42.20% of base) : 88949.dasm - testout1:Sub_Funclet_385():int
        -237 (-45.84% of base) : 136116.dasm - testout1:Sub_Funclet_414():this
        -237 (-45.84% of base) : 136104.dasm - testout1:Sub_Funclet_452():this
        -232 (-42.80% of base) : 136115.dasm - testout1:Sub_Funclet_413():this
        -232 (-42.80% of base) : 136117.dasm - testout1:Sub_Funclet_415():this
        -232 (-42.80% of base) : 136105.dasm - testout1:Sub_Funclet_453():this
        -231 (-43.10% of base) : 88488.dasm - testout1:Sub_Funclet_450():int
        -231 (-43.10% of base) : 88902.dasm - testout1:Sub_Funclet_450():int
        -228 (-40.50% of base) : 87668.dasm - testout1:Sub_Funclet_453():int
        -228 (-42.46% of base) : 87263.dasm - testout1:Sub_Funclet_414():int
        -228 (-40.50% of base) : 87253.dasm - testout1:Sub_Funclet_453():int
        -228 (-42.46% of base) : 87667.dasm - testout1:Sub_Funclet_452():int
        -228 (-40.50% of base) : 87677.dasm - testout1:Sub_Funclet_413():int
        -228 (-42.46% of base) : 87678.dasm - testout1:Sub_Funclet_414():int
        -228 (-40.50% of base) : 87262.dasm - testout1:Sub_Funclet_413():int
        -228 (-40.50% of base) : 87264.dasm - testout1:Sub_Funclet_415():int
        -228 (-40.50% of base) : 87679.dasm - testout1:Sub_Funclet_415():int

Top method improvements (percentages):
        -202 (-47.09% of base) : 88973.dasm - testout1:Sub_Funclet_410():int
        -202 (-47.09% of base) : 88560.dasm - testout1:Sub_Funclet_410():int
        -225 (-46.88% of base) : 99855.dasm - testout1:Sub_Funclet_449():int
        -225 (-46.68% of base) : 99441.dasm - testout1:Sub_Funclet_449():int
        -208 (-45.92% of base) : 99856.dasm - testout1:Sub_Funclet_450():int
        -237 (-45.84% of base) : 136116.dasm - testout1:Sub_Funclet_414():this
        -237 (-45.84% of base) : 136104.dasm - testout1:Sub_Funclet_452():this
        -208 (-45.71% of base) : 99442.dasm - testout1:Sub_Funclet_450():int
        -129 (-45.58% of base) : 88900.dasm - testout1:Sub_Funclet_448():int
        -129 (-45.58% of base) : 88486.dasm - testout1:Sub_Funclet_448():int
        -218 (-43.60% of base) : 136129.dasm - testout1:Sub_Funclet_427():this
        -218 (-43.60% of base) : 136155.dasm - testout1:Sub_Funclet_389():this
        -200 (-43.10% of base) : 136154.dasm - testout1:Sub_Funclet_388():this
        -200 (-43.10% of base) : 136128.dasm - testout1:Sub_Funclet_426():this
        -231 (-43.10% of base) : 88488.dasm - testout1:Sub_Funclet_450():int
        -231 (-43.10% of base) : 88902.dasm - testout1:Sub_Funclet_450():int
        -208 (-42.89% of base) : 98616.dasm - testout1:Sub_Funclet_453():int
        -208 (-42.89% of base) : 98625.dasm - testout1:Sub_Funclet_413():int
        -208 (-42.89% of base) : 98627.dasm - testout1:Sub_Funclet_415():int
        -232 (-42.80% of base) : 136115.dasm - testout1:Sub_Funclet_413():this

224 total methods with Code Size differences (224 improved, 0 regressed), 0 unchanged.

--------------------------------------------------------------------------------
```
</details>

Fixes #49113.