### PR TITLE
Reset assignedInterval during verifyFinalAllocation

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -10955,6 +10955,21 @@ void LinearScan::verifyFinalAllocation()
                 }
                 if (regNum == REG_NA)
                 {
+                    // If this interval is still assigned to a register
+                    if (interval->physReg != REG_NA)
+                    {
+                        // then unassign it if no new register was assigned to the RefTypeDef
+                        if (RefTypeIsDef(currentRefPosition->refType))
+                        {
+                            assert(interval->assignedReg != nullptr);
+                            if (interval->assignedReg->assignedInterval == interval)
+                            {
+                                interval->assignedReg->assignedInterval = nullptr;
+                            }
+                            interval->assignedReg = nullptr;
+                        }
+                    }
+
                     dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, interval);
                 }
                 else if (RefTypeIsDef(currentRefPosition->refType))

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -10966,6 +10966,7 @@ void LinearScan::verifyFinalAllocation()
                             {
                                 interval->assignedReg->assignedInterval = nullptr;
                             }
+                            interval->physReg     = REG_NA;
                             interval->assignedReg = nullptr;
                         }
                     }
@@ -11107,6 +11108,16 @@ void LinearScan::verifyFinalAllocation()
                 if (currentRefPosition->spillAfter || currentRefPosition->lastUse)
                 {
                     assert(!currentRefPosition->spillAfter || currentRefPosition->IsActualRef());
+
+                    if (RefTypeIsDef(currentRefPosition->refType))
+                    {
+                        // If an interval got assigned to a different register (while the different
+                        // register got spilled), then clear the assigned interval of current register.
+                        if (interval->physReg != REG_NA && interval->physReg != regNum)
+                        {
+                            interval->assignedReg->assignedInterval = nullptr;
+                        }
+                    }
 
                     interval->physReg     = REG_NA;
                     interval->assignedReg = nullptr;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1509,7 +1509,7 @@ private:
         // For SIMD types longer than 8 bytes Caller is responsible for saving and restoring Upper bytes.
         return ((type == TYP_SIMD16) || (type == TYP_SIMD12));
     }
-    static const var_types LargeVectorSaveType  = TYP_DOUBLE;
+    static const var_types LargeVectorSaveType = TYP_DOUBLE;
 #else // !defined(TARGET_AMD64) && !defined(TARGET_ARM64)
 #error("Unknown target architecture for FEATURE_SIMD")
 #endif // !defined(TARGET_AMD64) && !defined(TARGET_ARM64)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -510,9 +510,6 @@ public:
     void tinyDump();
 #endif // DEBUG
 
-    // RefPosition   * getNextRefPosition();
-    // LsraLocation    getNextRefLocation();
-
     // DATA
 
     // interval to which this register is currently allocated.
@@ -1512,7 +1509,7 @@ private:
         // For SIMD types longer than 8 bytes Caller is responsible for saving and restoring Upper bytes.
         return ((type == TYP_SIMD16) || (type == TYP_SIMD12));
     }
-    static const var_types LargeVectorSaveType = TYP_DOUBLE;
+    static const var_types LargeVectorSaveType  = TYP_DOUBLE;
 #else // !defined(TARGET_AMD64) && !defined(TARGET_ARM64)
 #error("Unknown target architecture for FEATURE_SIMD")
 #endif // !defined(TARGET_AMD64) && !defined(TARGET_ARM64)


### PR DESCRIPTION
My latest changes to EH Var for single defs exposed 2 more issues where we were not resetting the `assignedInterval` of a assigned reg:
1. For `RefTypeDef`, if an interval doesn't get assigned to a new register, then reset the `assignedInterval` of the `regRecord` that is currently assigned to that interval.
2. Again, for `RefTypeDef`, if an interval got assigned to a different register than the original `assignReg` of that interval and if that refposition is spilled immediately, then reset the `assignedInterval` of such `regRecord`.

Both of the above scenarios were exposed because they were EH Vars. In `verifyFinalAllocation()`, there are multiple places where we check for `RefTypeDef` and take action and I looked into consolidating all the logic at single place, but I was not sure if it will regress in the way we print the "Final allocation table". Hence, to honor the time, I went ahead and did the spot fixing of these 2 scenarios, but in future, will try to refactor various scenarios.

Fixes errors:

- https://dev.azure.com/dnceng/public/_build/results?buildId=1024357&view=ms.vss-test-web.build-test-results-tab
- https://dev.azure.com/dnceng/public/_build/results?buildId=1021926&view=ms.vss-test-web.build-test-results-tab