### PR TITLE
[RyuJIT] Make casthelpers cold for sealed classes

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3968,7 +3968,6 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS) ||
             call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTANY) ||
             call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS_SPECIAL))
-
         {
             GenTree* arg1 = gtArgEntryByArgNum(call, 1)->GetNode();
             if (arg1->gtOper != GT_LCL_VAR)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3959,22 +3959,16 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
     }
     else if (!optLocalAssertionProp && (call->gtCallType == CT_HELPER))
     {
-        CorInfoHelpFunc helper = eeGetHelperNum(call->gtCallMethHnd);
+        if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFINTERFACE) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFARRAY) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFCLASS) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFANY) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTINTERFACE) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTARRAY) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTANY) ||
+            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS_SPECIAL))
 
-        if ((helper == CORINFO_HELP_CHKCASTCLASS_SPECIAL) && (call->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN))
-        {
-            return nullptr;
-        }
-
-        if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) ||
-            (helper == CORINFO_HELP_ISINSTANCEOFARRAY) ||
-            (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
-            (helper == CORINFO_HELP_ISINSTANCEOFANY) ||
-            (helper == CORINFO_HELP_CHKCASTINTERFACE) ||
-            (helper == CORINFO_HELP_CHKCASTARRAY) ||
-            (helper == CORINFO_HELP_CHKCASTCLASS) ||
-            (helper == CORINFO_HELP_CHKCASTANY) ||
-            (helper == CORINFO_HELP_CHKCASTCLASS_SPECIAL))
         {
             GenTree* arg1 = gtArgEntryByArgNum(call, 1)->GetNode();
             if (arg1->gtOper != GT_LCL_VAR)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3959,15 +3959,22 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
     }
     else if (!optLocalAssertionProp && (call->gtCallType == CT_HELPER))
     {
-        if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFINTERFACE) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFARRAY) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFCLASS) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFANY) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTINTERFACE) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTARRAY) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTANY) ||
-            call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS_SPECIAL))
+        CorInfoHelpFunc helper = eeGetHelperNum(call->gtCallMethHnd);
+
+        if ((helper == CORINFO_HELP_CHKCASTCLASS_SPECIAL) && (call->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN))
+        {
+            return nullptr;
+        }
+
+        if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) ||
+            (helper == CORINFO_HELP_ISINSTANCEOFARRAY) ||
+            (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
+            (helper == CORINFO_HELP_ISINSTANCEOFANY) ||
+            (helper == CORINFO_HELP_CHKCASTINTERFACE) ||
+            (helper == CORINFO_HELP_CHKCASTARRAY) ||
+            (helper == CORINFO_HELP_CHKCASTCLASS) ||
+            (helper == CORINFO_HELP_CHKCASTANY) ||
+            (helper == CORINFO_HELP_CHKCASTCLASS_SPECIAL))
         {
             GenTree* arg1 = gtArgEntryByArgNum(call, 1)->GetNode();
             if (arg1->gtOper != GT_LCL_VAR)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2354,12 +2354,12 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
     {
         case BBJ_COND:
         case BBJ_SWITCH:
-        case BBJ_THROW:
 
             /* can never happen */
-            noway_assert(!"Conditional, switch, or throw block with empty body!");
+            noway_assert(!"Conditional or switch block with empty body!");
             break;
 
+        case BBJ_THROW:
         case BBJ_CALLFINALLY:
         case BBJ_RETURN:
         case BBJ_EHCATCHRET:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11075,9 +11075,6 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
         condTrue = gtNewIconNode(0, TYP_REF);
     }
 
-#define USE_QMARK_TREES
-
-#ifdef USE_QMARK_TREES
     GenTree* qmarkMT;
     //
     // Generate first QMARK - COLON tree
@@ -11090,6 +11087,12 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     //
     temp    = new (this, GT_COLON) GenTreeColon(TYP_REF, condTrue, condFalse);
     qmarkMT = gtNewQmarkNode(TYP_REF, condMT, temp);
+
+    if (isCastClass && impIsClassExact(pResolvedToken->hClass) && condTrue->OperIs(GT_CALL))
+    {
+        // condTrue is used only for throwing InvalidCastException in case of casting to an exact class.
+        condTrue->AsCall()->gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN;
+    }
 
     GenTree* qmarkNull;
     //
@@ -11119,7 +11122,6 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     JITDUMP("Marked V%02u as a single def temp\n", tmp);
     lvaSetClass(tmp, pResolvedToken->hClass);
     return gtNewLclvNode(tmp, TYP_REF);
-#endif
 }
 
 #ifndef DEBUG

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17698,6 +17698,11 @@ void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
     // Finally remove the nested qmark stmt.
     fgRemoveStmt(block, stmt);
 
+    if (true2Expr->OperIs(GT_CALL) && (true2Expr->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN))
+    {
+        fgConvertBBToThrowBB(helperBlock);
+    }
+
 #ifdef DEBUG
     if (verbose)
     {


### PR DESCRIPTION
```csharp
string  Test_sealed(object o) => (string)o;
Program Test(object o) => (Program)o;


public class Program { } // not sealed
```
Currently we optimize such casts in JIT to the following:
```
if (o == null)
    return null;
else if (GetMethodTable(o) == %pMT%)
    return o;
else
    return CORINFO_HELP_CHKCASTCLASS_SPECIAL;
```
In case of "sealed" classes that `CORINFO_HELP_CHKCASTCLASS_SPECIAL` is only used to throw `InvalidCastException` for cases when the input object is of a wrong type, so we can mark the whole block as rarely-executed.

```asm
; Method Pr:Test_sealed(System.Object):System.String:this
G_M52918_IG01:
       sub      rsp, 40
G_M52918_IG02:
       mov      rax, rdx
       test     rax, rax
       je       SHORT G_M52918_IG04
G_M52918_IG03:
       mov      rcx, 0xD1FFAB1E
       cmp      qword ptr [rax], rcx
       jne      SHORT G_M52918_IG05
G_M52918_IG04:
       add      rsp, 40
       ret      
G_M52918_IG05:
       call     CORINFO_HELP_CHKCASTCLASS_SPECIAL
       int3     
; Total bytes of code: 38



; Method Pr:Test(System.Object):Program:this
G_M38393_IG01:
       sub      rsp, 40
G_M38393_IG02:
       mov      rax, rdx
       test     rax, rax
       je       SHORT G_M38393_IG05
G_M38393_IG03:
       mov      rcx, 0xD1FFAB1E
       cmp      qword ptr [rax], rcx
       je       SHORT G_M38393_IG05
G_M38393_IG04:
       call     CORINFO_HELP_CHKCASTCLASS_SPECIAL
G_M38393_IG05:
       nop      
G_M38393_IG06:
       add      rsp, 40
       ret      
; Total bytes of code: 38

```
Jit-diff:
```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 53833604
Total bytes of diff: 53849742
Total bytes of delta: 16138 (0.03% of base)
    diff is a regression.


Top file regressions (bytes):
       11545 : Microsoft.CodeAnalysis.VisualBasic.dasm (0.20% of base)
        3738 : Microsoft.CodeAnalysis.CSharp.dasm (0.08% of base)
         759 : CommandLine.dasm (0.15% of base)
         474 : System.Private.Xml.dasm (0.01% of base)
         474 : System.Data.Common.dasm (0.03% of base)
         332 : System.DirectoryServices.dasm (0.08% of base)
         204 : Microsoft.CSharp.dasm (0.05% of base)
         199 : System.Configuration.ConfigurationManager.dasm (0.06% of base)
          82 : Newtonsoft.Json.Bson.dasm (0.09% of base)
          76 : System.Management.dasm (0.02% of base)
          71 : System.Data.Odbc.dasm (0.04% of base)
          70 : System.Threading.Tasks.Parallel.dasm (0.03% of base)
          69 : Microsoft.VisualBasic.Core.dasm (0.01% of base)
          61 : System.Diagnostics.EventLog.dasm (0.07% of base)
          58 : System.Linq.Expressions.dasm (0.01% of base)
          49 : System.DirectoryServices.AccountManagement.dasm (0.01% of base)
          39 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)
          38 : System.IO.Packaging.dasm (0.04% of base)
          24 : System.Diagnostics.PerformanceCounter.dasm (0.03% of base)
          24 : Microsoft.Extensions.FileProviders.Physical.dasm (0.13% of base)

Top file improvements (bytes):
        -909 : System.Threading.Tasks.Dataflow.dasm (-0.09% of base)
        -638 : FSharp.Core.dasm (-0.02% of base)
        -118 : Newtonsoft.Json.dasm (-0.01% of base)
         -75 : System.Private.CoreLib.dasm (-0.00% of base)
         -54 : System.DirectoryServices.Protocols.dasm (-0.06% of base)
         -52 : System.Collections.dasm (-0.01% of base)
         -49 : System.ComponentModel.TypeConverter.dasm (-0.02% of base)
         -48 : System.Runtime.Serialization.Formatters.dasm (-0.05% of base)
         -43 : xunit.runner.utility.netcoreapp10.dasm (-0.02% of base)
         -37 : System.Collections.Specialized.dasm (-0.14% of base)
         -35 : System.Security.AccessControl.dasm (-0.04% of base)
         -32 : System.ObjectModel.dasm (-0.03% of base)
         -30 : System.IO.Pipelines.dasm (-0.04% of base)
         -28 : System.Net.Quic.dasm (-0.04% of base)
         -27 : System.Resources.Extensions.dasm (-0.08% of base)
         -27 : System.Security.Cryptography.X509Certificates.dasm (-0.02% of base)
         -26 : System.Data.OleDb.dasm (-0.01% of base)
         -22 : System.Speech.dasm (-0.01% of base)
         -18 : System.Net.HttpListener.dasm (-0.01% of base)
         -17 : System.Private.DataContractSerialization.dasm (-0.00% of base)

100 total files with Code Size differences (46 improved, 54 regressed), 171 unchanged.

Top method regressions (bytes):
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,__Canon):Nullable`1:this
         812 ( 9.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,ubyte):Nullable`1:this
         812 ( 9.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,short):Nullable`1:this
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,int):Nullable`1:this
         812 ( 7.50% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,Vector`1):Nullable`1:this
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,long):Nullable`1:this
         812 ( 8.84% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,Nullable`1):Nullable`1:this
         810 ( 8.97% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,double):Nullable`1:this
         289 ( 3.12% of base) : CommandLine.dasm - ResultExtensions:Flatten(Result`2):Result`2 (8 methods)
         276 ( 8.32% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:Visit(BoundNode,Vector`1):Nullable`1:this
         248 (16.40% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - StateMachineMethodToClassRewriter:TryUnwrapBoundStateMachineScope(byref,byref):bool:this (8 methods)
         230 ( 8.12% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:Visit(BoundNode,Nullable`1):Nullable`1:this
         228 ( 8.20% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:Visit(BoundNode,ubyte):Nullable`1:this
         228 ( 8.20% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:Visit(BoundNode,short):Nullable`1:this
         185 ( 3.18% of base) : CommandLine.dasm - <>c__13`2:<Collect>b__13_0(Result`2,Result`2):Result`2:this (8 methods)
         152 ( 0.94% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodToClassRewriter`1:RewriteBlock(BoundBlock,ArrayBuilder`1,ArrayBuilder`1):BoundBlock:this (8 methods)
         114 ( 2.48% of base) : System.Data.Common.dasm - SqlConvert:ChangeType2(Object,int,Type,IFormatProvider):Object
         105 ( 1.46% of base) : CommandLine.dasm - Trial:Collect(IEnumerable`1):Result`2 (8 methods)
         105 ( 1.61% of base) : CommandLine.dasm - ResultExtensions:Collect(IEnumerable`1):Result`2 (8 methods)
          93 ( 3.08% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindExpression(ExpressionSyntax,bool,bool,bool,DiagnosticBag):BoundExpression:this

Top method improvements (bytes):
        -650 (-53.76% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,IdentifierTokenSyntax,TypeParameterListSyntax,ParameterListSyntax,SimpleAsClauseSyntax,HandlesClauseSyntax,ImplementsClauseSyntax):this
        -476 (-42.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DeclareStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,KeywordSyntax,LiteralExpressionSyntax,KeywordSyntax,LiteralExpressionSyntax,ParameterListSyntax,SimpleAsClauseSyntax):this
        -336 (-38.31% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PropertyStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,IdentifierTokenSyntax,ParameterListSyntax,AsClauseSyntax,EqualsValueSyntax,ImplementsClauseSyntax):this
        -297 (-42.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DelegateStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,TypeParameterListSyntax,ParameterListSyntax,SimpleAsClauseSyntax):this
        -297 (-42.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EventStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,ParameterListSyntax,SimpleAsClauseSyntax,ImplementsClauseSyntax):this
        -215 (-12.86% of base) : FSharp.Core.dasm - FSharpRef`1:CompareTo(Object,IComparer):int:this (8 methods)
        -163 (-4.38% of base) : System.Private.CoreLib.dasm - EventProvider:WriteEvent(byref,long,long,long,ref):bool:this
        -160 (-6.92% of base) : FSharp.Core.dasm - FSharpList`1:CompareTo(Object,IComparer):int:this (8 methods)
        -144 (-7.70% of base) : FSharp.Core.dasm - FSharpOption`1:CompareTo(Object,IComparer):int:this (8 methods)
        -112 (-7.87% of base) : System.Threading.Tasks.Dataflow.dasm - <>c:<.ctor>b__9_5(Task,Object):this (16 methods)
        -102 (-7.08% of base) : System.Threading.Tasks.Dataflow.dasm - <>c:<.ctor>b__9_6(Task,Object):this (16 methods)
         -99 (-8.61% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxFactory:MethodDeclaration(SyntaxList`1,SyntaxTokenList,TypeSyntax,ExplicitInterfaceSpecifierSyntax,SyntaxToken,TypeParameterListSyntax,ParameterListSyntax,SyntaxList`1,BlockSyntax,ArrowExpressionClauseSyntax,SyntaxToken):MethodDeclarationSyntax
         -86 (-4.28% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:EmitExpressionCore(BoundExpression,bool):this
         -77 (-5.29% of base) : System.Private.CoreLib.dasm - UnicodeEncoding:GetCharCount(long,int,DecoderNLS):int:this
         -75 (-2.58% of base) : CommandLine.dasm - ParserResultExtensions:MapResult(ParserResult`1,Func`2,Func`2):Nullable`1 (16 methods)
         -72 (-13.74% of base) : System.Threading.Tasks.Dataflow.dasm - <>c:<ProcessMessageWithTask>b__8_0(Task,Object):this (8 methods)
         -69 (-0.70% of base) : System.Data.Common.dasm - XmlTreeGen:SchemaTree(XmlDocument,XmlWriter,DataSet,DataTable,bool):this
         -63 (-6.29% of base) : Newtonsoft.Json.dasm - DataTableConverter:CreateRow(JsonReader,DataTable,JsonSerializer)
         -62 (-3.52% of base) : System.Private.Xml.dasm - XmlSerializationWriterCodeGen:WritePrimitive(String,String,String,Object,String,TypeMapping,bool,bool,bool):this
         -62 (-13.63% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Conversions:ClassifyExpressionReclassification(BoundExpression,TypeSymbol,Binder,byref):int

Top method regressions (percentages):
          36 (21.56% of base) : System.Private.CoreLib.dasm - MethodBuilder:Equals(Object):bool:this
          19 (19.59% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - NameSyntax:get_Arity():int:this
         248 (16.40% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - StateMachineMethodToClassRewriter:TryUnwrapBoundStateMachineScope(byref,byref):bool:this (8 methods)
          27 (15.79% of base) : System.Data.Common.dasm - DefaultValueTypeConverter:ConvertFrom(ITypeDescriptorContext,CultureInfo,Object):Object:this
          30 (15.38% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodToStateMachineRewriter:TryUnwrapBoundStateMachineScope(byref,byref):bool:this
           9 (15.25% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitRuntimeVariablesExpression(Expression):this
           7 (10.45% of base) : System.Private.CoreLib.dasm - <>c:<AssignCancellationToken>b__49_1(Object):this
          12 ( 9.76% of base) : System.Private.Xml.dasm - ReflectionXmlSerializationWriter:IsDefaultValue(TypeMapping,Object,Object,bool):bool:this
          19 ( 9.69% of base) : CommandLine.dasm - UnParserExtensions:IsEmpty(Object):bool
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,__Canon):Nullable`1:this
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,int):Nullable`1:this
         812 ( 9.17% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,long):Nullable`1:this
         812 ( 9.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,ubyte):Nullable`1:this
         812 ( 9.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,short):Nullable`1:this
         810 ( 8.97% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,double):Nullable`1:this
          20 ( 8.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:HasSideEffects(BoundStatement):bool
         812 ( 8.84% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:VisitInternal(BoundNode,Nullable`1):Nullable`1:this
          20 ( 8.47% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:IsRef(BoundExpression):bool:this
          20 ( 8.44% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LocalRewriter:HasSideEffects(BoundStatement):bool
         276 ( 8.32% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - BoundTreeVisitor`2:Visit(BoundNode,Vector`1):Nullable`1:this

Top method improvements (percentages):
        -650 (-53.76% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,IdentifierTokenSyntax,TypeParameterListSyntax,ParameterListSyntax,SimpleAsClauseSyntax,HandlesClauseSyntax,ImplementsClauseSyntax):this
        -476 (-42.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DeclareStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,KeywordSyntax,LiteralExpressionSyntax,KeywordSyntax,LiteralExpressionSyntax,ParameterListSyntax,SimpleAsClauseSyntax):this
        -297 (-42.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - DelegateStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,TypeParameterListSyntax,ParameterListSyntax,SimpleAsClauseSyntax):this
        -297 (-42.13% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - EventStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,KeywordSyntax,IdentifierTokenSyntax,ParameterListSyntax,SimpleAsClauseSyntax,ImplementsClauseSyntax):this
        -336 (-38.31% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - PropertyStatementSyntax:.ctor(ushort,ref,ref,SyntaxNode,GreenNode,KeywordSyntax,IdentifierTokenSyntax,ParameterListSyntax,AsClauseSyntax,EqualsValueSyntax,ImplementsClauseSyntax):this
         -20 (-28.57% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SyntaxFactory:ParseSyntaxTree(SourceText,ParseOptions,String,CancellationToken):SyntaxTree
         -25 (-22.12% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LocalRewriter:VisitObjectCreationInitializer(BoundObjectInitializerExpressionBase,BoundExpression,BoundExpression):BoundNode:this
         -15 (-22.06% of base) : System.Net.HttpListener.dasm - <>c:<GetClientCertificateAsync>b__42_0(AsyncCallback,Object):IAsyncResult:this
         -15 (-22.06% of base) : System.Net.HttpListener.dasm - <>c:<GetContextAsync>b__44_0(AsyncCallback,Object):IAsyncResult:this
         -21 (-20.59% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSemanticModel:GetSpeculativeAliasInfoCore(int,SyntaxNode,int):IAliasSymbol:this
         -21 (-20.59% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - VBSemanticModel:GetSpeculativeAliasInfoCore(int,SyntaxNode,int):IAliasSymbol:this
         -12 (-20.00% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitUnaryExpression(Expression,int):this
         -12 (-20.00% of base) : System.Linq.Expressions.dasm - LambdaCompiler:EmitConvertUnaryExpression(Expression,int):this
         -27 (-19.85% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:WarnOnRecursiveAccess(BoundExpression,int,DiagnosticBag):this
         -44 (-19.56% of base) : Microsoft.CodeAnalysis.CSharp.dasm - LocalRewriter:AddObjectOrCollectionInitializers(byref,byref,ArrayBuilder`1,BoundExpression,BoundExpression):this
         -14 (-18.92% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:ParseSyntaxTree(SourceText,ParseOptions,String,CancellationToken):SyntaxTree
         -17 (-17.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySemanticModel:Bind(Binder,CSharpSyntaxNode,DiagnosticBag):BoundNode:this
         -30 (-16.67% of base) : System.Runtime.Serialization.Formatters.dasm - ObjectReader:ParseMemberEnd(ParseRecord):this
         -10 (-16.39% of base) : System.DirectoryServices.dasm - SchemaNameCollection:System.Collections.IList.Insert(int,Object):this
         -44 (-16.36% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:ComputeCaseClauseCondition(BoundCaseClause,byref,BoundExpression,DiagnosticBag):BoundCaseClause:this

6913 total methods with Code Size differences (2805 improved, 4108 regressed), 261298 unchanged.

```
Size improvement examples: 
https://www.diffchecker.com/4hK014gu 
https://www.diffchecker.com/tWgKrbyl (from my understanding - it merged cold tails)
but mostly it's a regression due to additional jumps (from cold blocks).

/cc @AndyAyersMS @VSadov 