### PR TITLE
[wasm] Avoid error-ing out in AOT only mode if an AOT image is not fo…

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -1977,11 +1977,14 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 			}
 		}
 		if (!sofile) {
+			// Maybe do these on more platforms ?
+#ifndef HOST_WASM
 			if (mono_aot_only && !mono_use_interpreter && assembly->image->tables [MONO_TABLE_METHOD].rows) {
 				aot_name = g_strdup_printf ("%s%s", assembly->image->name, MONO_SOLIB_EXT);
-				g_error ("Failed to load AOT module '%s' in aot-only mode.\n", aot_name);
+				g_error ("Failed to load AOT module '%s' ('%s') in aot-only mode.\n", aot_name, assembly->image->name);
 				g_free (aot_name);
 			}
+#endif
 			return;
 		}
 	}


### PR DESCRIPTION
…und since apps

can load assemblies which were not AOT-ed, if they don't attempt to execute code from them.