### PR TITLE
Add EnumBuilder.CreateType back in the public API

### DIFF
--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -13,10 +13,8 @@ namespace System.Reflection.Emit
         public override string? CodeBase { get { throw null; } }
         public override System.Reflection.MethodInfo? EntryPoint { get { throw null; } }
         public override string? FullName { get { throw null; } }
-        [System.ObsoleteAttribute("The Global Assembly Cache is not supported.", DiagnosticId = "SYSLIB0005", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
-        public override bool GlobalAssemblyCache { get { throw null; } }
         public override long HostContext { get { throw null; } }
-        public override string ImageRuntimeVersion { get { throw null; } }
+        public override bool IsCollectible { get { throw null; } }
         public override bool IsDynamic { get { throw null; } }
         public override string Location { get { throw null; } }
         public override System.Reflection.Module ManifestModule { get { throw null; } }
@@ -65,6 +63,7 @@ namespace System.Reflection.Emit
         public override System.Reflection.CallingConventions CallingConvention { get { throw null; } }
         public override System.Type? DeclaringType { get { throw null; } }
         public bool InitLocals { get { throw null; } set { } }
+        public override int MetadataToken { get { throw null; } }
         public override System.RuntimeMethodHandle MethodHandle { get { throw null; } }
         public override System.Reflection.Module Module { get { throw null; } }
         public override string Name { get { throw null; } }
@@ -79,7 +78,6 @@ namespace System.Reflection.Emit
         public override object Invoke(object? obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object?[]? parameters, System.Globalization.CultureInfo? culture) { throw null; }
         public override object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object?[]? parameters, System.Globalization.CultureInfo? culture) { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
-        public override int MetadataToken { get { throw null; } }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
         public void SetImplementationFlags(System.Reflection.MethodImplAttributes attributes) { }
@@ -98,7 +96,6 @@ namespace System.Reflection.Emit
         public override bool IsConstructedGenericType { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsTypeDefinition { get { throw null; } }
-        public override bool IsVariableBoundArray { get { throw null; } }
         public override System.Reflection.Module Module { get { throw null; } }
         public override string Name { get { throw null; } }
         public override string? Namespace { get { throw null; } }
@@ -106,6 +103,8 @@ namespace System.Reflection.Emit
         public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
         public System.Reflection.Emit.FieldBuilder UnderlyingField { get { throw null; } }
         public override System.Type UnderlyingSystemType { get { throw null; } }
+        [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+        public System.Type? CreateType() { throw null; }
         [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
         public System.Reflection.TypeInfo? CreateTypeInfo() { throw null; }
         public System.Reflection.Emit.FieldBuilder DefineLiteral(string literalName, object? literalValue) { throw null; }
@@ -151,6 +150,7 @@ namespace System.Reflection.Emit
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
         public override object? InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object? target, object?[]? args, System.Reflection.ParameterModifier[]? modifiers, System.Globalization.CultureInfo? culture, string[]? namedParameters) { throw null; }
         protected override bool IsArrayImpl() { throw null; }
+        public override bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Reflection.TypeInfo? typeInfo) { throw null; }
         protected override bool IsByRefImpl() { throw null; }
         protected override bool IsCOMObjectImpl() { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
@@ -215,7 +215,6 @@ namespace System.Reflection.Emit
         public override bool IsGenericTypeDefinition { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsTypeDefinition { get { throw null; } }
-        public override bool IsVariableBoundArray { get { throw null; } }
         public override int MetadataToken { get { throw null; } }
         public override System.Reflection.Module Module { get { throw null; } }
         public override string Name { get { throw null; } }
@@ -268,6 +267,7 @@ namespace System.Reflection.Emit
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
         public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object? target, object?[]? args, System.Reflection.ParameterModifier[]? modifiers, System.Globalization.CultureInfo? culture, string[]? namedParameters) { throw null; }
         protected override bool IsArrayImpl() { throw null; }
+        public override bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Reflection.TypeInfo? typeInfo) { throw null; }
         public override bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Type? c) { throw null; }
         protected override bool IsByRefImpl() { throw null; }
         protected override bool IsCOMObjectImpl() { throw null; }
@@ -296,7 +296,6 @@ namespace System.Reflection.Emit
         public override bool ContainsGenericParameters { get { throw null; } }
         public override System.Type? DeclaringType { get { throw null; } }
         public bool InitLocals { get { throw null; } set { } }
-        public override bool IsConstructedGenericMethod { get { throw null; } }
         public override bool IsGenericMethod { get { throw null; } }
         public override bool IsGenericMethodDefinition { get { throw null; } }
         public override bool IsSecurityCritical { get { throw null; } }
@@ -370,6 +369,8 @@ namespace System.Reflection.Emit
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Fields might be removed")]
         public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingFlags) { throw null; }
         public override int GetHashCode() { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Methods might be removed")]
+        protected override System.Reflection.MethodInfo? GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, System.Reflection.CallingConventions callConvention, System.Type[]? types, System.Reflection.ParameterModifier[]? modifiers) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Methods might be removed")]
         public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingFlags) { throw null; }
         public override void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { throw null; }
@@ -450,7 +451,6 @@ namespace System.Reflection.Emit
         public override bool IsSecurityTransparent { get { throw null; } }
         public override bool IsSZArray { get { throw null; } }
         public override bool IsTypeDefinition { get { throw null; } }
-        public override bool IsVariableBoundArray { get { throw null; } }
         public override int MetadataToken { get { throw null; } }
         public override System.Reflection.Module Module { get { throw null; } }
         public override string Name { get { throw null; } }
@@ -541,6 +541,7 @@ namespace System.Reflection.Emit
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
         public override object? InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object? target, object?[]? args, System.Reflection.ParameterModifier[]? modifiers, System.Globalization.CultureInfo? culture, string[]? namedParameters) { throw null; }
         protected override bool IsArrayImpl() { throw null; }
+        public override bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Reflection.TypeInfo? typeInfo) { throw null; }
         public override bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Type? c) { throw null; }
         protected override bool IsByRefImpl() { throw null; }
         protected override bool IsCOMObjectImpl() { throw null; }

--- a/src/libraries/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.txt
@@ -2,16 +2,9 @@ Compat issues with assembly System.Reflection.Emit:
 MembersMustExist : Member 'public System.Reflection.Emit.ModuleBuilder System.Reflection.Emit.AssemblyBuilder.DefineDynamicModule(System.String, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Reflection.Module System.Reflection.Emit.ConstructorBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String System.Reflection.Emit.ConstructorBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
-CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.EnumBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
-MembersMustExist : Member 'public System.Type System.Reflection.Emit.EnumBuilder.CreateType()' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.Boolean System.Reflection.Emit.EnumBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
-CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.GenericTypeParameterBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
-MembersMustExist : Member 'public System.Boolean System.Reflection.Emit.GenericTypeParameterBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Reflection.Module System.Reflection.Emit.MethodBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String System.Reflection.Emit.MethodBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Diagnostics.SymbolStore.ISymbolDocumentWriter System.Reflection.Emit.ModuleBuilder.DefineDocument(System.String, System.Guid, System.Guid, System.Guid)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected System.ModuleHandle System.Reflection.Emit.ModuleBuilder.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean System.Reflection.Emit.ModuleBuilder.IsTransient()' does not exist in the reference but it does exist in the implementation.
-CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.TypeBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
-MembersMustExist : Member 'public System.Boolean System.Reflection.Emit.TypeBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
-Total Issues: 15
+Total Issues: 8

--- a/src/libraries/System.Reflection.Emit/tests/EnumBuilder/EnumBuilder.Methods.Tests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/EnumBuilder/EnumBuilder.Methods.Tests.cs
@@ -11,6 +11,15 @@ namespace System.Reflection.Emit.Tests
     {
         public static IEnumerable<object[]> DefineLiteral_TestData()
         {
+            foreach (object[] coreData in DefineLiteralTestDataCore())
+            {
+                yield return coreData.Concat(new object[] { true }).ToArray();
+                yield return coreData.Concat(new object[] { false }).ToArray();
+            }
+        }
+
+        private static IEnumerable<object[]> DefineLiteralTestDataCore()
+        {
             yield return new object[] { typeof(byte), (byte)0 };
             yield return new object[] { typeof(byte), (byte)1 };
 
@@ -51,7 +60,7 @@ namespace System.Reflection.Emit.Tests
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2389", TestRuntimes.Mono)]
         [MemberData(nameof(DefineLiteral_TestData))]
-        public void DefineLiteral(Type underlyingType, object literalValue)
+        public void DefineLiteral(Type underlyingType, object literalValue, bool useCreateTypeInfo)
         {
             EnumBuilder enumBuilder = Helpers.DynamicEnum(TypeAttributes.Public, underlyingType);
             FieldBuilder literal = enumBuilder.DefineLiteral("FieldOne", literalValue);
@@ -61,7 +70,10 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal, literal.Attributes);
             Assert.Equal(enumBuilder.AsType(), literal.FieldType);
 
-            Type createdEnum = enumBuilder.CreateTypeInfo().AsType();
+            Type createdEnum = useCreateTypeInfo ?
+                enumBuilder.CreateTypeInfo().AsType() :
+                enumBuilder.CreateType();
+
             FieldInfo createdLiteral = createdEnum.GetField("FieldOne");
             Assert.Equal(createdEnum, createdLiteral.FieldType);
 
@@ -123,17 +135,27 @@ namespace System.Reflection.Emit.Tests
 
         public static IEnumerable<object[]> DefineLiteral_InvalidLiteralValue_ThrowsTypeLoadExceptionOnCreation_TestData()
         {
-            yield return new object[] { typeof(DateTime), DateTime.Now };
-            yield return new object[] { typeof(string), "" }; ;
+            yield return new object[] { typeof(DateTime), DateTime.Now, true };
+            yield return new object[] { typeof(DateTime), DateTime.Now, false };
+
+            yield return new object[] { typeof(string), "", true };
+            yield return new object[] { typeof(string), "", false };
         }
 
         [Theory]
         [MemberData(nameof(DefineLiteral_InvalidLiteralValue_ThrowsTypeLoadExceptionOnCreation_TestData))]
-        public void DefineLiteral_InvalidLiteralValue_ThrowsTypeLoadExceptionOnCreation(Type underlyingType, object literalValue)
+        public void DefineLiteral_InvalidLiteralValue_ThrowsTypeLoadExceptionOnCreation(Type underlyingType, object literalValue, bool useCreateTypeInfo)
         {
             EnumBuilder enumBuilder = Helpers.DynamicEnum(TypeAttributes.Public, underlyingType);
             FieldBuilder literal = enumBuilder.DefineLiteral("LiteralName", literalValue);
-            Assert.Throws<TypeLoadException>(() => enumBuilder.CreateTypeInfo());
+            if (useCreateTypeInfo)
+            {
+                Assert.Throws<TypeLoadException>(() => enumBuilder.CreateTypeInfo());
+            }
+            else
+            {
+                Assert.Throws<TypeLoadException>(() => enumBuilder.CreateType());
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fix #46681

I also sync'd the ref source with the implementation w.r.t. override members. This makes it easier going forward for people using GenerateReferenceAssemblySource to generate this file. Less manual fix ups.