### PR TITLE
Enable CheckDownloadedFiles on DownloadBuildArtifacts task

### DIFF
--- a/eng/pipelines/common/download-artifact-step.yml
+++ b/eng/pipelines/common/download-artifact-step.yml
@@ -14,6 +14,7 @@ steps:
       downloadType: single
       downloadPath: '$(Build.SourcesDirectory)/__download__'
       artifactName: '${{ parameters.artifactName }}'
+      checkDownloadedFiles: true
 
   # Unzip artifact
   - task: ExtractFiles@1

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -72,6 +72,7 @@ jobs:
       inputs:
         artifactName: $(buildCrossDacArtifactName)
         downloadPath: $(crossDacArtifactPath)
+        checkDownloadedFiles: true
 
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset crossdacpack -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) $(crossDacArgs) -ci
       displayName: Build crossdac packaging

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -43,6 +43,7 @@ jobs:
     inputs:
       artifactName: IntermediateArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+      checkDownloadedFiles: true
 
   - script: >-
       build.cmd -ci


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/32805

This enables the AzDo fix: https://github.com/microsoft/azure-pipelines-tasks/pull/14065

We need this in order for AzDo to check that the downloaded artifact is "good" and if it is not, it will retry.

cc: @MattGal @dotnet/runtime-infrastructure 