### PR TITLE
XmlDocument: save BOM-less UTF-8 files by default

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
@@ -1378,7 +1378,9 @@ namespace System.Xml
                     string value = Declaration.Encoding;
                     if (value.Length > 0)
                     {
-                        return System.Text.Encoding.GetEncoding(value);
+                        return string.Equals(value, "utf-8", StringComparison.OrdinalIgnoreCase) ?
+                                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) :
+                                    System.Text.Encoding.GetEncoding(value);
                     }
                 }
                 return null;

--- a/src/libraries/System.Private.Xml/tests/XmlDocument/System.Xml.XmlDocument.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlDocument/System.Xml.XmlDocument.Tests.csproj
@@ -6,6 +6,7 @@
     <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs"
              Link="Common\System\ShouldNotBeInvokedException.cs" />
     <Compile Include="XmlDocumentTests\LoadTests.cs" />
+    <Compile Include="XmlDocumentTests\SaveTests.cs" />
     <Compile Include="XmlAttributeCollectionTests\AppendTests.cs" />
     <Compile Include="XmlAttributeCollectionTests\CollectionInterfaceTests.cs" />
     <Compile Include="XmlAttributeCollectionTests\CopyToTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
@@ -7,61 +7,53 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
-  public class SaveTests
-  {
-    public static readonly byte[] utf8BomBytes = new byte[] { 0xef, 0xbb, 0xbf };
-
-    [Fact]
-    public void SaveDocumentToFilePath()
+    public class SaveTests
     {
-      var xmlDocument = new XmlDocument();
-      xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", "UTF-8", null));
-      xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
+        public static readonly byte[] utf8BomBytes = Encoding.UTF8.GetPreamble();
 
-      var tmpFile = Path.GetTempFileName();
-      try
-      {
-        // Let .Save() infer the encoding from the declaration.
-        xmlDocument.Save(tmpFile);
-
-        var bytes = File.ReadAllBytes(tmpFile);
-        Assert.False(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should create BOM-less UTF-8 files by default.");
-      }
-      finally
-      {
-        File.Delete(tmpFile);
-      }
-    }
-
-    [Fact]
-    public void SaveDocumentViaWriter()
-    {
-      var xmlDocument = new XmlDocument();
-      xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", null, null));
-      xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
-
-      XmlWriterSettings settings = new XmlWriterSettings();
-      // Set the encoding explicitly, to UTF-8 with BOM.
-      settings.Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
-
-      var tmpFile = Path.GetTempFileName();
-      try
-      {
-        using (XmlWriter writer = XmlWriter.Create(tmpFile, settings))
+        [Fact]
+        public void SaveDocumentToFilePath()
         {
-          xmlDocument.Save(writer);
+            var xmlDocument = new XmlDocument();
+            xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", "UTF-8", null));
+            xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
+
+            var tmpFile = Path.GetTempFileName();
+            try
+            {
+                // Let .Save() infer the encoding from the declaration.
+                xmlDocument.Save(tmpFile);
+
+                var bytes = File.ReadAllBytes(tmpFile);
+                Assert.False(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should create BOM-less UTF-8 files by default.");
+            }
+            finally
+            {
+                File.Delete(tmpFile);
+            }
         }
 
-        var bytes = File.ReadAllBytes(tmpFile);
-        Assert.True(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should respect an XmlWriter's encoding.");
+        [Fact]
+        public void SaveDocumentViaWriter()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", null, null));
+            xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
 
-      }
-      finally
-      {
-        File.Delete(tmpFile);
-      }
+            XmlWriterSettings settings = new XmlWriterSettings();
+            // Set the encoding explicitly, to UTF-8 with BOM.
+            settings.Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
 
+            using (var ms = new MemoryStream())
+            {
+                using (XmlWriter writer = XmlWriter.Create(ms, settings))
+                {
+                    xmlDocument.Save(writer);
+                }
+
+                var bytes = ms.GetBuffer();
+                Assert.True(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should respect an XmlWriter's encoding.");
+            }
+        }
     }
-
-  }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace System.Xml.Tests
+{
+  public class SaveTests
+  {
+    public static readonly byte[] utf8BomBytes = new byte[] { 0xef, 0xbb, 0xbf };
+
+    [Fact]
+    public void SaveDocumentToFilePath()
+    {
+      var xmlDocument = new XmlDocument();
+      xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", "UTF-8", null));
+      xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
+
+      var tmpFile = Path.GetTempFileName();
+      try
+      {
+        // Let .Save() infer the encoding from the declaration.
+        xmlDocument.Save(tmpFile);
+
+        var bytes = File.ReadAllBytes(tmpFile);
+        Assert.False(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should create BOM-less UTF-8 files by default.");
+      }
+      finally
+      {
+        File.Delete(tmpFile);
+      }
+    }
+
+    [Fact]
+    public void SaveDocumentViaWriter()
+    {
+      var xmlDocument = new XmlDocument();
+      xmlDocument.AppendChild(xmlDocument.CreateXmlDeclaration("1.0", null, null));
+      xmlDocument.AppendChild(xmlDocument.CreateElement("Foo"));
+
+      XmlWriterSettings settings = new XmlWriterSettings();
+      // Set the encoding explicitly, to UTF-8 with BOM.
+      settings.Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+      var tmpFile = Path.GetTempFileName();
+      try
+      {
+        using (XmlWriter writer = XmlWriter.Create(tmpFile, settings))
+        {
+          xmlDocument.Save(writer);
+        }
+
+        var bytes = File.ReadAllBytes(tmpFile);
+        Assert.True(bytes[0] == utf8BomBytes[0] && bytes[1] == utf8BomBytes[1] && bytes[2] == utf8BomBytes[2], ".Save() should respect an XmlWriter's encoding.");
+
+      }
+      finally
+      {
+        File.Delete(tmpFile);
+      }
+
+    }
+
+  }
+}

--- a/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlDocument/XmlDocumentTests/SaveTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.IO;
 using System.Text;
 using Xunit;


### PR DESCRIPTION

Fix #28218