### PR TITLE
Fix null reference in pgo data merging

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
@@ -94,10 +94,14 @@ namespace ILCompiler
                         }
                     }
 
-                    var mergedSchemaData = data.SchemaData;
-                    if (mergedSchemaData == null)
+                    PgoSchemaElem[] mergedSchemaData;
+                    if (data.SchemaData == null)
                     {
                         mergedSchemaData = dataToMerge.SchemaData;
+                    }
+                    else if (dataToMerge.SchemaData == null)
+                    {
+                        mergedSchemaData = data.SchemaData;
                     }
                     else
                     {


### PR DESCRIPTION
Profile schema data can be null, handle both cases correctly in merge algorithm