### PR TITLE
[metadata_update] Fix bounds check error

### DIFF
--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -973,6 +973,7 @@ mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_i
 gboolean
 mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int token_index);
 
+/* token_index is 1-based */
 static inline gboolean
 mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_index)
 {

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1000,7 +1000,10 @@ mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int to
 	GList *list = image->delta_image;
 	MonoImage *dmeta;
 	MonoTableInfo *table;
+	/* result row, 0-based */
 	int ridx;
+
+	int original_token = mono_metadata_make_token (table_index, token_index);
 
 	uint32_t exposed_gen = mono_metadata_update_get_thread_generation ();
 	do {
@@ -1011,7 +1014,8 @@ mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int to
 			return TRUE;
 		list = list->next;
 		table = &dmeta->tables [table_index];
-		ridx = mono_image_relative_delta_index (dmeta, mono_metadata_make_token (table_index, token_index + 1)) - 1;
+		/* mono_image_relative_delta_index returns a 1-based index */
+		ridx = mono_image_relative_delta_index (dmeta, original_token) - 1;
 	} while (ridx < 0 || ridx >= table->rows);
 
 	return FALSE;
@@ -4779,7 +4783,7 @@ mono_metadata_parse_mh_full (MonoImage *m, MonoGenericContainer *container, cons
 
 	if (local_var_sig_tok) {
 		int idx = mono_metadata_token_index (local_var_sig_tok) - 1;
-		if (mono_metadata_table_bounds_check (m, MONO_TABLE_STANDALONESIG, idx)) {
+		if (mono_metadata_table_bounds_check (m, MONO_TABLE_STANDALONESIG, idx + 1)) {
 			mono_error_set_bad_image (error, m, "Invalid method header local vars signature token 0x%08x", idx);
 			goto fail;
 		}


### PR DESCRIPTION
The issue is that the STANDALONESIG bounds check was using a 0-based index, and `mono_metadata_bounds_check_slow` was compensating by adding 1.

But that made another call to the bounds check fail: in `mono_class_from_typeref_checked` we passed a 1-based index.  So in the case where a TypeRef was using the last AssemblyRef in a delta, the bound check would fail.

Fixes https://github.com/dotnet/runtime/issues/49227