### PR TITLE
Increase timeout for thread pool tests

### DIFF
--- a/src/libraries/Common/tests/System/Threading/ThreadTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Threading/ThreadTestHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tests
     public static class ThreadTestHelpers
     {
         public const int ExpectedTimeoutMilliseconds = 50;
-        public const int UnexpectedTimeoutMilliseconds = 1000 * 30;
+        public const int UnexpectedTimeoutMilliseconds = 1000 * 60;
 
         // Wait longer for a thread to time out, so that an unexpected timeout in the thread is more likely to expire first and
         // provide a better stack trace for the failure


### PR DESCRIPTION
Relates to #48236

It isn't possible to say whether the test is hung, or will complete but occasionally needs more than 30 seconds. Let's try increasing the cutoff to see.