### PR TITLE
Remove release build cron triggers from jitstress jobs

### DIFF
--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -7,12 +7,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 4 * * *"
-  displayName: Daily (if changes) at 8:00 PM (UTC-8:00)
-  branches:
-    include:
-    - release/*.*
-  always: false
 
 jobs:
 

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -7,12 +7,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 7 * * *"
-  displayName: Daily (if changes) at 11:00 PM (UTC-8:00)
-  branches:
-    include:
-    - release/*.*
-  always: false
 
 jobs:
 


### PR DESCRIPTION
We need to make per-preview decisions about when and how
frequently to run non-baseline jobs. We don't want the
existing configuration to automatically flow to new previews.