### PR TITLE
Disable cron scheduling of JIT stress jobs in 6.0 preview2

### DIFF
--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -1,19 +1,5 @@
 trigger: none
 
-schedules:
-- cron: "0 4 * * *"
-  displayName: Daily at 8:00 PM (UTC-8:00)
-  branches:
-    include:
-    - master
-  always: true
-- cron: "0 4 * * *"
-  displayName: Daily (if changes) at 8:00 PM (UTC-8:00)
-  branches:
-    include:
-    - release/*.*
-  always: false
-
 jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -1,19 +1,5 @@
 trigger: none
 
-schedules:
-- cron: "0 7 * * *"
-  displayName: Daily at 11:00 PM (UTC-8:00)
-  branches:
-    include:
-    - master
-  always: true
-- cron: "0 7 * * *"
-  displayName: Daily (if changes) at 11:00 PM (UTC-8:00)
-  branches:
-    include:
-    - release/*.*
-  always: false
-
 jobs:
 
 #


### PR DESCRIPTION
We continue to see AzDO pipeline runs in the 6.0 preview
branches (and we don't want to see that, especially if there
are no changes). Remove the scheduling configuration entirely
to prevent this.