### PR TITLE
[interp] Stop generating code in the cbb if the inlined method always throws

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4267,7 +4267,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		if (in_offset == bb->end)
 			bb = bb->next;
 
-		if (bb->dead) {
+		if (bb->dead || td->cbb->dead) {
 			int op_size = mono_opcode_size (td->ip, end);
 			g_assert (op_size > 0); /* The BB formation pass must catch all bad ops */
 
@@ -7195,6 +7195,10 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				memcpy (td->stack, exit_bb->stack_state, exit_bb->stack_height * sizeof(td->stack [0]));
 			td->sp = td->stack + exit_bb->stack_height;
 		}
+		// If exit_bb is not reached by any other bb in this method, just mark it as dead so the
+		// method that does the inlining no longer generates code for the following IL opcodes.
+		if (exit_bb->in_count == 0)
+			exit_bb->dead = TRUE;
 	}
 
 	if (sym_seq_points) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49205