### PR TITLE
Fix pgo ci bugs

### DIFF
--- a/src/coreclr/tools/Common/CommandLine/ArgumentSyntax.cs
+++ b/src/coreclr/tools/Common/CommandLine/ArgumentSyntax.cs
@@ -428,9 +428,24 @@ namespace Internal.CommandLine
             return GetParameters(ActiveCommand);
         }
 
+        private static int ConsoleWindowWidth()
+        {
+            // Console.WindowWidth will throw an exception if the output is redirected in some cases
+            // This try/catch routine is probably excessive, but it will definitely cover all the cases
+            try
+            {
+                if (!Console.IsOutputRedirected)
+                    return Console.WindowWidth;
+            }
+            catch
+            {
+            }
+            return 100;
+        }
+
         public string GetHelpText()
         {
-            return GetHelpText(Console.WindowWidth - 2);
+            return GetHelpText(ConsoleWindowWidth() - 2);
         }
 
         public string GetHelpText(int maxWidth)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
@@ -94,10 +94,14 @@ namespace ILCompiler
                         }
                     }
 
-                    var mergedSchemaData = data.SchemaData;
-                    if (mergedSchemaData == null)
+                    PgoSchemaElem[] mergedSchemaData;
+                    if (data.SchemaData == null)
                     {
                         mergedSchemaData = dataToMerge.SchemaData;
+                    }
+                    else if (dataToMerge.SchemaData == null)
+                    {
+                        mergedSchemaData = data.SchemaData;
                     }
                     else
                     {

--- a/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
@@ -25,8 +25,18 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         private readonly ModuleLoadLogger _moduleLoadLogger;
         private int _clrInstanceID;
 
+        private readonly Dictionary<string,string> _normalizedFilePathToFilePath = new Dictionary<string,string> (StringComparer.OrdinalIgnoreCase);
+
         public TraceTypeSystemContext(PgoTraceProcess traceProcess, int clrInstanceID, Logger logger)
         {
+            foreach (var traceData in traceProcess.TraceProcess.EventsInProcess.ByEventType<ModuleLoadUnloadTraceData>())
+            {
+                if (traceData.ModuleILPath != null)
+                {
+                    _normalizedFilePathToFilePath[traceData.ModuleILPath] = traceData.ModuleILPath;
+                }
+            }
+
             _pgoTraceProcess = traceProcess;
             _clrInstanceID = clrInstanceID;
             _moduleLoadLogger = new ModuleLoadLogger(logger);
@@ -132,7 +142,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                 if (PgoTraceProcess.CompareModuleAgainstSimpleName(simpleName, managedModule))
                 {
-                    filePath = PgoTraceProcess.ComputeFilePathOnDiskForModule(managedModule);
+                    string filePathTemp = PgoTraceProcess.ComputeFilePathOnDiskForModule(managedModule);
+
+                    // This path may be normalized
+                    if (File.Exists(filePathTemp) || !_normalizedFilePathToFilePath.TryGetValue(filePathTemp, out filePath))
+                        filePath = filePathTemp;
                     break;
                 }
             }


### PR DESCRIPTION
For use in CI dotnet-pgo has found more issues
- Our command line parser may throw from the GetHelpText function. The fix is to catch that throw, and even avoid the throw in the first place by checking for a redirected console.
- The TraceEvent library normalizes the strings of filenames used to represent IL files in the constructor for TraceModuleFile. This is problematic on cases sensitive file systems such as a typical Linux install. Workaround the issue by creating a lookup table back to the original file using non-normalized data.