### PR TITLE
Include timeout value in Regex cache key

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -110,7 +110,7 @@ namespace System.Text.RegularExpressions
             Regex.ValidatePattern(pattern);
 
             CultureInfo culture = CultureInfo.CurrentCulture;
-            Key key = new Key(pattern, culture.ToString(), RegexOptions.None, hasTimeout: false);
+            Key key = new Key(pattern, culture.ToString(), RegexOptions.None, Regex.s_defaultMatchTimeout);
 
             if (!TryGet(key, out Regex? regex))
             {
@@ -128,7 +128,7 @@ namespace System.Text.RegularExpressions
             Regex.ValidateMatchTimeout(matchTimeout);
 
             CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
-            Key key = new Key(pattern, culture.ToString(), options, matchTimeout != Regex.InfiniteMatchTimeout);
+            Key key = new Key(pattern, culture.ToString(), options, matchTimeout);
 
             if (!TryGet(key, out Regex? regex))
             {
@@ -265,9 +265,9 @@ namespace System.Text.RegularExpressions
             private readonly string _pattern;
             private readonly string _culture;
             private readonly RegexOptions _options;
-            private readonly bool _hasTimeout;
+            private readonly TimeSpan _matchTimeout;
 
-            public Key(string pattern, string culture, RegexOptions options, bool hasTimeout)
+            public Key(string pattern, string culture, RegexOptions options, TimeSpan matchTimeout)
             {
                 Debug.Assert(pattern != null, "Pattern must be provided");
                 Debug.Assert(culture != null, "Culture must be provided");
@@ -275,7 +275,7 @@ namespace System.Text.RegularExpressions
                 _pattern = pattern;
                 _culture = culture;
                 _options = options;
-                _hasTimeout = hasTimeout;
+                _matchTimeout = matchTimeout;
             }
 
             public override bool Equals([NotNullWhen(true)] object? obj) =>
@@ -285,7 +285,7 @@ namespace System.Text.RegularExpressions
                 _pattern.Equals(other._pattern) &&
                 _culture.Equals(other._culture) &&
                 _options == other._options &&
-                _hasTimeout == other._hasTimeout;
+                _matchTimeout == other._matchTimeout;
 
             public static bool operator ==(Key left, Key right) =>
                 left.Equals(right);


### PR DESCRIPTION
Static Regex methods use a cache of recently used regexes.  We currently include in the key for that cache whether a timeout value was specified, since whether there's a timeout can impact how the regex is built, but we don't currently include the actual value of the timeout.  This leads to oddities where if the same pattern, culture, and options are used with a static regex method and one non-infinite timeout, and then those exact same values are used with a different non-infinite timeout, and then original data was still in the cache, we'll end up using the previous timeout value rather than the new timeout value.  The fix is just to include the timeout itself in the key.

cc: @pgovind, @tannergooding, @eerhardt, @danmoseley