### PR TITLE
Reduce EventParameterInfo[] allocations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -172,6 +172,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Reflection;
 using System.Resources;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -2206,7 +2207,7 @@ namespace System.Diagnostics.Tracing
                                     string eventName = "EventSourceMessage";
                                     EventParameterInfo paramInfo = default(EventParameterInfo);
                                     paramInfo.SetInfo("message", typeof(string));
-                                    byte[]? metadata = EventPipeMetadataGenerator.Instance.GenerateMetadata(0, eventName, keywords, (uint)level, 0, EventOpcode.Info, new EventParameterInfo[] { paramInfo });
+                                    byte[]? metadata = EventPipeMetadataGenerator.Instance.GenerateMetadata(0, eventName, keywords, (uint)level, 0, EventOpcode.Info, MemoryMarshal.CreateReadOnlySpan(ref paramInfo, 1));
                                     uint metadataLength = (metadata != null) ? (uint)metadata.Length : 0;
 
                                     fixed (byte* pMetadata = metadata)


### PR DESCRIPTION
From https://themesof.net/ startup

Alas can't stackalloc a struct with object refs

Before

![image](https://user-images.githubusercontent.com/1142958/110484796-e8b3e500-80e2-11eb-8f9c-eef00f8740db.png)

After

![image](https://user-images.githubusercontent.com/1142958/110533174-9dff9080-8115-11eb-9e7e-7692ec0f9ecf.png)


