### PR TITLE
[AndroidCrypto] Check if DSA impl is disposed before setting key size.

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
@@ -45,10 +45,11 @@ namespace System.Security.Cryptography
                         return;
                     }
 
+                    ThrowIfDisposed();
+
                     // Set the KeySize before FreeKey so that an invalid value doesn't throw away the key
                     base.KeySize = value;
 
-                    ThrowIfDisposed();
                     FreeKey();
                     _key = new Lazy<SafeDsaHandle>(GenerateKey);
                 }


### PR DESCRIPTION
Fixes the UseAfterDispose DSA test failures.