### PR TITLE
[AndroidCrypto] Support a zero-length salt for HMACs.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -29,8 +29,21 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
     else
         return FAIL;
 
-    jbyteArray keyBytes = (*env)->NewByteArray(env, keyLen);
-    (*env)->SetByteArrayRegion(env, keyBytes, 0, keyLen, (jbyte*)key);
+    jbyteArray keyBytes;
+
+    if (key && keyLen > 0)
+    {
+        keyBytes = (*env)->NewByteArray(env, keyLen);
+        (*env)->SetByteArrayRegion(env, keyBytes, 0, keyLen, (jbyte*)key);
+    }
+    else
+    {
+        // Java does not support zero-length byte arrays in the SecretKeySpec type,
+        // so instead create an empty 1-byte length byte array that's initalized to 0.
+        // the HMAC algorithm pads keys with zeros until the key is block-length,
+        // so this effectively creates the same key as if it were a zero byte-length key.
+        keyBytes = (*env)->NewByteArray(env, 1);
+    }
     jobject sksObj = (*env)->NewObject(env, g_sksClass, g_sksCtor, keyBytes, macName);
     if (CheckJNIExceptions(env))
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -44,6 +44,7 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
         // so this effectively creates the same key as if it were a zero byte-length key.
         keyBytes = (*env)->NewByteArray(env, 1);
     }
+
     jobject sksObj = (*env)->NewObject(env, g_sksClass, g_sksCtor, keyBytes, macName);
     if (CheckJNIExceptions(env))
     {


### PR DESCRIPTION
Java does not support zero-length arrays in the SecretKeySpec constructor, so instead use a zero-initialized one-byte array as the key when zero bytes are provided.

This fixes the failing HKDF tests, so about 40ish more tests pass with this fix.