### PR TITLE
Superpmi collection pipeline improvements

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -152,7 +152,6 @@ jobs:
     - windows_x64
     - windows_x86
     - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -42,101 +42,101 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: tests
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: tests
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
-#     # - Linux_arm
-#     # - Linux_arm64
-#     # - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen2
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
+    # - Linux_arm
+    # - Linux_arm64
+    # - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen2
+      collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -148,11 +148,11 @@ jobs:
     #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
     # - Linux_arm
     # - Linux_arm64
-    # - Linux_x64
+    - Linux_x64
     - windows_x64
-    # - windows_x86
-    # - windows_arm64
-    # - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -42,101 +42,101 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: tests
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: tests
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
-    # - Linux_arm
-    # - Linux_arm64
-    # - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen2
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
+#     # - Linux_arm
+#     # - Linux_arm64
+#     # - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen2
+#       collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -42,101 +42,101 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: tests
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: tests
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
-    # - Linux_arm
-    # - Linux_arm64
-    # - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen2
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
+#     # - Linux_arm
+#     # - Linux_arm64
+#     # - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen2
+#       collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -148,11 +148,11 @@ jobs:
     #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
     # - Linux_arm
     # - Linux_arm64
-    - Linux_x64
+    # - Linux_x64
     - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    # - windows_x86
+    # - windows_arm64
+    # - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -42,101 +42,101 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: tests
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: tests
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
-#     # - Linux_arm
-#     # - Linux_arm64
-#     # - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen2
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
+    # - Linux_arm
+    # - Linux_arm64
+    # - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen2
+      collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -76,7 +76,7 @@ jobs:
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)\artifacts\helixresults\'
       - name: MergedMchFileLocation
-        value: '$(Build.SourcesDirectory)\artifacts\'
+        value: '$(Build.SourcesDirectory)\artifacts\spmi_collection'
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'python3'
@@ -87,7 +87,7 @@ jobs:
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)/artifacts/helixresults/'
       - name: MergedMchFileLocation
-        value: '$(Build.SourcesDirectory)/artifacts/'
+        value: '$(Build.SourcesDirectory)/artifacts/spmi_collection'
     - ${{ if eq(parameters.collectionName, 'libraries') }}:
       - name: InputDirectory
         value: '$(Core_Root_Dir)'
@@ -132,23 +132,42 @@ jobs:
         CollectionType: '$(CollectionType)'
         CollectionName: '$(CollectionName)'
 
-    - task: PublishPipelineArtifact@1
-      displayName: Publish SuperPMI collection
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/artifacts/helixresults
-        artifactName: 'SuperPMI_Result_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}'
-      continueOnError: true # continue to next step of merging with whatever partition data we gathered. 
-      condition: always()   # Always publish whatever we collected.
+    # Create directories and ensure crossgen is executable
+    - ${{ if ne(parameters.osGroup, 'windows') }}:
+      - script: |
+          mkdir -p $(MergedMchFileLocation)
+        displayName: Create directory for merged collection
+    - ${{ if eq(parameters.osGroup, 'windows') }}:
+      - script: |
+          mkdir $(MergedMchFileLocation)
+        displayName: Create directories
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
       displayName: ${{ format('Merge {0}-{1} SuperPMI collections', parameters.collectionName, parameters.collectionType) }}
 
-    # For now, we won't upload merged collection as an artifact.
+    - template: /eng/pipelines/common/upload-artifact-step.yml
+      parameters:
+        rootFolder: $(MergedMchFileLocation)
+        includeRootFolder: false
+        archiveType: $(archiveType)
+        tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
+        artifactName: 'SuperPMI_Collection_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
+        displayName: ${{ format('Upload artifacts SuperPMI {0}-{1} collection', parameters.collectionName, parameters.collectionType) }}
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py upload -log_level DEBUG -arch $(archType) -build_type $(buildConfig) -mch_files $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch -core_root $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).x64.$(buildConfigUpper)
       displayName: ${{ format('Upload SuperPMI {0}-{1} collection to Azure Storage', parameters.collectionName, parameters.collectionType) }}
       env:
         CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline
+
+  # #TODO: superpmi logs as well
+  #   - task: PublishPipelineArtifact@1
+  #     displayName: Publish SuperPMI collection
+  #     inputs:
+  #       targetPath: $(Build.SourcesDirectory)/artifacts/helixresults
+  #       artifactName: 'SuperPMI_Result_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}'
+  #     continueOnError: true # continue to next step of merging with whatever partition data we gathered. 
+  #     condition: always()   # Always publish whatever we collected.
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Logs

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -75,6 +75,8 @@ jobs:
         value: '$(Build.SourcesDirectory)\artifacts\tests\coreclr\${{ parameters.osGroup }}.${{ parameters.archType }}.${{ parameters.buildConfig }}\Tests\Core_Root'
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)\artifacts\helixresults\'
+      - name: MergedMchFileLocation
+        value: '$(Build.SourcesDirectory)\artifacts\'
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'python3'
@@ -84,6 +86,8 @@ jobs:
         value: '$(Build.SourcesDirectory)/artifacts/tests/coreclr/${{ parameters.osGroup }}.${{ parameters.archType }}.$(buildConfigUpper)/Tests/Core_Root'
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)/artifacts/helixresults/'
+      - name: MergedMchFileLocation
+        value: '$(Build.SourcesDirectory)/artifacts/'
     - ${{ if eq(parameters.collectionName, 'libraries') }}:
       - name: InputDirectory
         value: '$(Core_Root_Dir)'
@@ -133,27 +137,22 @@ jobs:
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/helixresults
         artifactName: 'SuperPMI_Result_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}'
-      continueOnError: true
-      condition: always()
+      continueOnError: true # continue to next step of merging with whatever partition data we gathered. 
+      condition: always()   # Always publish whatever we collected.
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
       displayName: ${{ format('Merge {0}-{1} SuperPMI collections', parameters.collectionName, parameters.collectionType) }}
-      continueOnError: true
-      condition: always()
 
     # For now, we won't upload merged collection as an artifact.
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py upload -log_level DEBUG -arch $(archType) -build_type $(buildConfig) -mch_files $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch -core_root $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).x64.$(buildConfigUpper)
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py upload -log_level DEBUG -arch $(archType) -build_type $(buildConfig) -mch_files $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch -core_root $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).x64.$(buildConfigUpper)
       displayName: ${{ format('Upload SuperPMI {0}-{1} collection to Azure Storage', parameters.collectionName, parameters.collectionType) }}
       env:
         CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline
-      continueOnError: true
-      condition: always()
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
         artifactName: 'SuperPMI_Logs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
-      continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -77,6 +77,8 @@ jobs:
         value: '$(Build.SourcesDirectory)\artifacts\helixresults\'
       - name: MergedMchFileLocation
         value: '$(Build.SourcesDirectory)\artifacts\spmi_collection\'
+      - name: SpmiLogsLocation
+        value: '$(Build.SourcesDirectory)\artifacts\spmi_logs\'
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'python3'
@@ -88,6 +90,8 @@ jobs:
         value: '$(Build.SourcesDirectory)/artifacts/helixresults/'
       - name: MergedMchFileLocation
         value: '$(Build.SourcesDirectory)/artifacts/spmi_collection/'
+      - name: SpmiLogsLocation
+        value: '$(Build.SourcesDirectory)/artifacts/spmi_logs/'
     - ${{ if eq(parameters.collectionName, 'libraries') }}:
       - name: InputDirectory
         value: '$(Core_Root_Dir)'
@@ -136,10 +140,12 @@ jobs:
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - script: |
           mkdir -p $(MergedMchFileLocation)
+          mkdir -p $(SpmiLogsLocation)
         displayName: Create directory for merged collection
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - script: |
           mkdir $(MergedMchFileLocation)
+          mkdir $(SpmiLogsLocation)
         displayName: Create directories
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
@@ -160,18 +166,28 @@ jobs:
       env:
         CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline
 
-  # #TODO: superpmi logs as well
-  #   - task: PublishPipelineArtifact@1
-  #     displayName: Publish SuperPMI collection
-  #     inputs:
-  #       targetPath: $(Build.SourcesDirectory)/artifacts/helixresults
-  #       artifactName: 'SuperPMI_Result_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}'
-  #     continueOnError: true # continue to next step of merging with whatever partition data we gathered. 
-  #     condition: always()   # Always publish whatever we collected.
+    - task: CopyFiles@2
+      displayName: Copying superpmi.log of all partitions
+      inputs:
+        sourceFolder: '$(MchFilesLocation)'
+        contents: '**/$(CollectionName).$(CollectionType)*.log'
+        targetFolder: '$(SpmiLogsLocation)'
+      condition: always()
+
+    - template: /eng/pipelines/common/upload-artifact-step.yml
+      parameters:
+        rootFolder: $(SpmiLogsLocation)
+        includeRootFolder: false
+        archiveType: $(archiveType)
+        tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
+        artifactName: 'SuperPMI_Logs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
+        displayName: ${{ format('Upload SuperPMI logs {0}-{1} collection', parameters.collectionName, parameters.collectionType) }}
+      condition: always()
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'SuperPMI_Logs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
+        artifactName: 'SuperPMI_BuildLogs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
       condition: always()

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -76,7 +76,7 @@ jobs:
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)\artifacts\helixresults\'
       - name: MergedMchFileLocation
-        value: '$(Build.SourcesDirectory)\artifacts\spmi_collection'
+        value: '$(Build.SourcesDirectory)\artifacts\spmi_collection\'
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'python3'
@@ -87,7 +87,7 @@ jobs:
       - name: MchFilesLocation
         value: '$(Build.SourcesDirectory)/artifacts/helixresults/'
       - name: MergedMchFileLocation
-        value: '$(Build.SourcesDirectory)/artifacts/spmi_collection'
+        value: '$(Build.SourcesDirectory)/artifacts/spmi_collection/'
     - ${{ if eq(parameters.collectionName, 'libraries') }}:
       - name: InputDirectory
         value: '$(Core_Root_Dir)'

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -174,19 +174,15 @@ jobs:
         targetFolder: '$(SpmiLogsLocation)'
       condition: always()
 
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(SpmiLogsLocation)
-        includeRootFolder: false
-        archiveType: $(archiveType)
-        tarCompression: $(tarCompression)
-        archiveExtension: $(archiveExtension)
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Superpmi logs
+      inputs:
+        targetPath: $(SpmiLogsLocation)
         artifactName: 'SuperPMI_Logs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'
-        displayName: ${{ format('Upload SuperPMI logs {0}-{1} collection', parameters.collectionName, parameters.collectionType) }}
       condition: always()
 
     - task: PublishPipelineArtifact@1
-      displayName: Publish Logs
+      displayName: Publish SuperPMI build logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
         artifactName: 'SuperPMI_BuildLogs_$(CollectionName)_$(CollectionType)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.runtimeType }}_${{ parameters.codeGenType }}_${{ parameters.runKind }}'

--- a/src/coreclr/ToolBox/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbmerge.cpp
@@ -575,6 +575,12 @@ CLEAN_UP:
             LogError("Failed to delete file after MCS /merge failed. GetLastError()=%u", GetLastError());
         }
     }
+    else
+    {
+        // if no files found to merge, then there was some problem.
+        LogError("No files found to merge.");
+        result = (totalSize == 0) ? 1 : 0;
+    }
     delete[] nameOfOutputFileAsWchar;
 
     return result;

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,11 +43,11 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 29bba306-6814-4154-8f53-782a7d65aa88 */
-    0x29bba306,
-    0x6814,
-    0x4154,
-    {0x8f, 0x53, 0x78, 0x2a, 0x7d, 0x65, 0xaa, 0x88}
+constexpr GUID JITEEVersionIdentifier = { /* 73d20c3a-75a9-4eea-a952-60419d67b6a6 */
+    0x73d20c3a,
+    0x75a9,
+    0x4eea,
+    {0xa9, 0x52, 0x60, 0x41, 0x9d, 0x67, 0xb6, 0xa6}
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,11 +43,11 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 73d20c3a-75a9-4eea-a952-60419d67b6a6 */
-    0x73d20c3a,
-    0x75a9,
-    0x4eea,
-    {0xa9, 0x52, 0x60, 0x41, 0x9d, 0x67, 0xb6, 0xa6}
+constexpr GUID JITEEVersionIdentifier = { /* 29bba306-6814-4154-8f53-782a7d65aa88 */
+    0x29bba306,
+    0x6814,
+    0x4154,
+    {0x8f, 0x53, 0x78, 0x2a, 0x7d, 0x65, 0xaa, 0x88}
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -157,8 +157,10 @@ def build_and_run(coreclr_args, output_mch_name):
          "--framework", "net6.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
          "-o", artifacts_directory], _exit_on_fail=True)
 
+    # Disable ReadyToRun so we always JIT R2R methods and collect them
     collection_command = f"{dotnet_exe} {benchmarks_dll}  --filter \"*\" --corerun {path.join(core_root, corerun_exe)} --partition-count {partition_count} " \
                          f"--partition-index {partition_index} --envVars COMPlus_JitName:{shim_name} " \
+                         "--envVars COMPlus_ZapDisable:1 --envVars COMPlus_ReadyToRun:0" \
                          "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart"
 
     # Generate the execution script in Temp location
@@ -170,16 +172,10 @@ def build_and_run(coreclr_args, output_mch_name):
         if is_windows:
             contents.append("set JitName=%COMPlus_JitName%")
             contents.append("set COMPlus_JitName=")
-            # Disable ReadyToRun so we always JIT R2R methods and collect them
-            contents.append("set COMPlus_ZapDisable=1")
-            contents.append("set COMPlus_ReadyToRun=0")
         else:
             contents.append("#!/bin/bash")
             contents.append("export JitName=$COMPlus_JitName")
             contents.append("unset COMPlus_JitName")
-            # Disable ReadyToRun so we always JIT R2R methods and collect them
-            contents.append("export COMPlus_ZapDisable=1")
-            contents.append("export COMPlus_ReadyToRun=0")
         contents.append(f"pushd {performance_directory}")
         contents.append(collection_command)
 

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -160,7 +160,7 @@ def build_and_run(coreclr_args, output_mch_name):
     # Disable ReadyToRun so we always JIT R2R methods and collect them
     collection_command = f"{dotnet_exe} {benchmarks_dll}  --filter \"*\" --corerun {path.join(core_root, corerun_exe)} --partition-count {partition_count} " \
                          f"--partition-index {partition_index} --envVars COMPlus_JitName:{shim_name} " \
-                         "--envVars COMPlus_ZapDisable:1 --envVars COMPlus_ReadyToRun:0" \
+                         " COMPlus_ZapDisable:1 COMPlus_ReadyToRun:0" \
                          "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart"
 
     # Generate the execution script in Temp location

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -160,7 +160,7 @@ def build_and_run(coreclr_args, output_mch_name):
     # Disable ReadyToRun so we always JIT R2R methods and collect them
     collection_command = f"{dotnet_exe} {benchmarks_dll}  --filter \"*\" --corerun {path.join(core_root, corerun_exe)} --partition-count {partition_count} " \
                          f"--partition-index {partition_index} --envVars COMPlus_JitName:{shim_name} " \
-                         " COMPlus_ZapDisable:1 COMPlus_ReadyToRun:0" \
+                         " COMPlus_ZapDisable:1  COMPlus_ReadyToRun:0 " \
                          "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart"
 
     # Generate the execution script in Temp location

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -170,10 +170,16 @@ def build_and_run(coreclr_args, output_mch_name):
         if is_windows:
             contents.append("set JitName=%COMPlus_JitName%")
             contents.append("set COMPlus_JitName=")
+            # Disable ReadyToRun so we always JIT R2R methods and collect them
+            contents.append("set COMPlus_ZapDisable=1")
+            contents.append("set COMPlus_ReadyToRun=0")
         else:
             contents.append("#!/bin/bash")
             contents.append("export JitName=$COMPlus_JitName")
             contents.append("unset COMPlus_JitName")
+            # Disable ReadyToRun so we always JIT R2R methods and collect them
+            contents.append("export COMPlus_ZapDisable=1")
+            contents.append("export COMPlus_ReadyToRun=0")
         contents.append(f"pushd {performance_directory}")
         contents.append(collection_command)
 
@@ -190,8 +196,6 @@ def build_and_run(coreclr_args, output_mch_name):
 
         run_command([
             python_path, path.join(superpmi_directory, "superpmi.py"), "collect", "-core_root", core_root,
-            # Disable ReadyToRun so we always JIT R2R methods and collect them
-            "--use_zapdisable",
             "-output_mch_path", output_mch_name, "-log_file", log_file, "-log_level", "debug",
             script_name], _exit_on_fail=True)
 


### PR DESCRIPTION
- Fail the job if `merge-mch` fails
- Upload single merged `.mch` zipped file to azure artifacts. This will save lot of space on azure artifacts because earlier we used to upload `.mch ` files as it is.
- Upload superpmi.log files from all the partitions separately
- Use `--zap_disable` for `CoreRun.exe` instead of `dotnet.exe` during benchmark collection.