### PR TITLE
Fix marshaling in HostFXR API test

### DIFF
--- a/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
@@ -24,27 +24,27 @@ namespace HostApiInvokerApp
                 global_json_path = 1,
             }
 
-            [StructLayout(LayoutKind.Sequential, CharSet = Utils.OSCharSet)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_sdk_info
             {
-                internal int size;
+                internal UIntPtr size;
                 internal string version;
                 internal string path;
             }
 
-            [StructLayout(LayoutKind.Sequential, CharSet = Utils.OSCharSet)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_framework_info
             {
-                internal int size;
+                internal UIntPtr size;
                 internal string name;
                 internal string version;
                 internal string path;
             }
 
-            [StructLayout(LayoutKind.Sequential, CharSet = Utils.OSCharSet)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_info
             {
-                internal int size;
+                internal UIntPtr size;
 
                 internal string hostfxr_version;
                 internal string hostfxr_commit_hash;
@@ -56,43 +56,43 @@ namespace HostApiInvokerApp
                 internal IntPtr frameworks;
             }
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void hostfxr_resolve_sdk2_result_fn(
                 hostfxr_resolve_sdk2_result_key_t key,
                 string value);
 
-            [DllImport(nameof(hostfxr), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostfxr), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern int hostfxr_resolve_sdk2(
                 string exe_dir,
                 string working_dir,
                 hostfxr_resolve_sdk2_flags_t flags,
                 hostfxr_resolve_sdk2_result_fn result);
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void hostfxr_get_available_sdks_result_fn(
                 int sdk_count,
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
                 string[] sdk_dirs);
 
-            [DllImport(nameof(hostfxr), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostfxr), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern int hostfxr_get_available_sdks(
                 string exe_dir,
                 hostfxr_get_available_sdks_result_fn result);
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void hostfxr_error_writer_fn(
                 string message);
 
-            [DllImport(nameof(hostfxr), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostfxr), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr hostfxr_set_error_writer(
                 hostfxr_error_writer_fn error_writer);
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void hostfxr_get_dotnet_environment_info_result_fn(
                  IntPtr info,
                  IntPtr result_context);
 
-            [DllImport(nameof(hostfxr), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostfxr), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern int hostfxr_get_dotnet_environment_info(
                 string dotnet_root,
                 IntPtr reserved,
@@ -209,17 +209,20 @@ namespace HostApiInvokerApp
 
                 hostfxr_version = environment_info.hostfxr_version;
                 hostfxr_commit_hash = environment_info.hostfxr_commit_hash;
-                    
+
                 int env_info_size = Marshal.SizeOf(environment_info);
-                if (env_info_size != environment_info.size)
+
+                if ((IntPtr.Size == 4 && (env_info_size != (uint)environment_info.size)) ||
+                    ((ulong)env_info_size != (ulong)environment_info.size))
                     throw new Exception($"Size field value of hostfxr_dotnet_environment_info struct is {environment_info.size} but {env_info_size} was expected.");
-                    
+
                 for (int i = 0; i < environment_info.sdk_count; i++)
                 {
                     IntPtr pSdkInfo = new IntPtr(environment_info.sdks.ToInt64() + (i * Marshal.SizeOf<hostfxr.hostfxr_dotnet_environment_sdk_info>()));
                     sdks.Add(Marshal.PtrToStructure<hostfxr.hostfxr_dotnet_environment_sdk_info>(pSdkInfo));
 
-                    if (Marshal.SizeOf(sdks[i]) != sdks[i].size)
+                    if (((IntPtr.Size == 4) && (Marshal.SizeOf(sdks[i]) != (uint)sdks[i].size)) ||
+                        ((ulong)Marshal.SizeOf(sdks[i]) != (ulong)sdks[i].size))
                         throw new Exception($"Size field value of hostfxr_dotnet_environment_sdk_info struct is {sdks[i].size} but {Marshal.SizeOf(sdks[i])} was expected.");
                 }
 
@@ -228,7 +231,8 @@ namespace HostApiInvokerApp
                     IntPtr pFrameworkInfo = new IntPtr(environment_info.frameworks.ToInt64() + (i * Marshal.SizeOf<hostfxr.hostfxr_dotnet_environment_framework_info>()));
                     frameworks.Add(Marshal.PtrToStructure<hostfxr.hostfxr_dotnet_environment_framework_info>(pFrameworkInfo));
 
-                    if (Marshal.SizeOf(frameworks[i]) != frameworks[i].size)
+                    if (((IntPtr.Size == 4) && (Marshal.SizeOf(frameworks[i]) != (uint)frameworks[i].size)) ||
+                        ((ulong)Marshal.SizeOf(frameworks[i]) != (ulong)frameworks[i].size))
                         throw new Exception($"Size field value of hostfxr_dotnet_environment_framework_info struct is {frameworks[i].size} but {Marshal.SizeOf(frameworks[i])} was expected.");
                 }
 

--- a/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
@@ -27,7 +27,8 @@ namespace HostApiInvokerApp
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_sdk_info
             {
-                internal UIntPtr size;
+                internal nuint size;
+
                 internal string version;
                 internal string path;
             }
@@ -35,7 +36,8 @@ namespace HostApiInvokerApp
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_framework_info
             {
-                internal UIntPtr size;
+                internal nuint size;
+
                 internal string name;
                 internal string version;
                 internal string path;
@@ -44,15 +46,15 @@ namespace HostApiInvokerApp
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
             internal struct hostfxr_dotnet_environment_info
             {
-                internal UIntPtr size;
+                internal nuint size;
 
                 internal string hostfxr_version;
                 internal string hostfxr_commit_hash;
 
-                internal int sdk_count;
+                internal nuint sdk_count;
                 internal IntPtr sdks;
 
-                internal int framework_count;
+                internal nuint framework_count;
                 internal IntPtr frameworks;
             }
 
@@ -212,27 +214,24 @@ namespace HostApiInvokerApp
 
                 int env_info_size = Marshal.SizeOf(environment_info);
 
-                if ((IntPtr.Size == 4 && (env_info_size != (uint)environment_info.size)) ||
-                    ((ulong)env_info_size != (ulong)environment_info.size))
+                if ((nuint)env_info_size != environment_info.size)
                     throw new Exception($"Size field value of hostfxr_dotnet_environment_info struct is {environment_info.size} but {env_info_size} was expected.");
 
-                for (int i = 0; i < environment_info.sdk_count; i++)
+                for (int i = 0; i < (int)environment_info.sdk_count; i++)
                 {
                     IntPtr pSdkInfo = new IntPtr(environment_info.sdks.ToInt64() + (i * Marshal.SizeOf<hostfxr.hostfxr_dotnet_environment_sdk_info>()));
                     sdks.Add(Marshal.PtrToStructure<hostfxr.hostfxr_dotnet_environment_sdk_info>(pSdkInfo));
 
-                    if (((IntPtr.Size == 4) && (Marshal.SizeOf(sdks[i]) != (uint)sdks[i].size)) ||
-                        ((ulong)Marshal.SizeOf(sdks[i]) != (ulong)sdks[i].size))
+                    if ((nuint)Marshal.SizeOf(sdks[i]) != sdks[i].size)
                         throw new Exception($"Size field value of hostfxr_dotnet_environment_sdk_info struct is {sdks[i].size} but {Marshal.SizeOf(sdks[i])} was expected.");
                 }
 
-                for (int i = 0; i < environment_info.framework_count; i++)
+                for (int i = 0; i < (int)environment_info.framework_count; i++)
                 {
                     IntPtr pFrameworkInfo = new IntPtr(environment_info.frameworks.ToInt64() + (i * Marshal.SizeOf<hostfxr.hostfxr_dotnet_environment_framework_info>()));
                     frameworks.Add(Marshal.PtrToStructure<hostfxr.hostfxr_dotnet_environment_framework_info>(pFrameworkInfo));
 
-                    if (((IntPtr.Size == 4) && (Marshal.SizeOf(frameworks[i]) != (uint)frameworks[i].size)) ||
-                        ((ulong)Marshal.SizeOf(frameworks[i]) != (ulong)frameworks[i].size))
+                    if ((nuint)Marshal.SizeOf(frameworks[i]) != frameworks[i].size)
                         throw new Exception($"Size field value of hostfxr_dotnet_environment_framework_info struct is {frameworks[i].size} but {Marshal.SizeOf(frameworks[i])} was expected.");
                 }
 

--- a/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
+++ b/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
@@ -15,22 +15,22 @@ namespace HostApiInvokerApp
     {
         internal static class hostpolicy
         {
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void corehost_resolve_component_dependencies_result_fn(
                 string assembly_paths,
                 string native_search_paths,
                 string resource_search_paths);
 
-            [DllImport(nameof(hostpolicy), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostpolicy), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern int corehost_resolve_component_dependencies(
                 string component_main_assembly_path, 
                 corehost_resolve_component_dependencies_result_fn result);
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
             internal delegate void corehost_error_writer_fn(
                 string message);
 
-            [DllImport(nameof(hostpolicy), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(nameof(hostpolicy), CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr corehost_set_error_writer(
                 corehost_error_writer_fn error_writer);
         }

--- a/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/Utils.cs
+++ b/src/installer/tests/Assets/TestProjects/HostApiInvokerApp/Utils.cs
@@ -11,12 +11,6 @@ namespace HostApiInvokerApp
     public static class Utils
     {
 #if WINDOWS
-       public const CharSet OSCharSet = CharSet.Unicode;
-#else
-       public const CharSet OSCharSet = CharSet.Ansi; // actually UTF8 on Unix
-#endif
-
-#if WINDOWS
         internal static class kernel32
         {
             [DllImport(nameof(kernel32), CharSet = CharSet.Auto, BestFitMapping = false, SetLastError = true)]


### PR DESCRIPTION
We currently marshal size fields (which are of `size_t` type in native code) as `int`, which is always a 32-bit integer, whereas `size_t` will change its bitness depending on the architecture (it's a little strange that tests pass in every architecture anyway?) Regardless, the correct thing to do here seems to marshal as `UIntPtr` and decide whether to cast it to `uint` or `ulong` depending upon the architecture of the running machine.