### PR TITLE
[AndroidCrypto] Update X509Certificates tests to consume test files that don't use RC2

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -29,7 +29,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string certSubject = @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
             string certSubjectObsolete = @"E=pkit@microsoft.com, C=US, S=WA, L=Redmond, O=Microsoft, OU=ITG, CN=Microsoft Corporate Root Authority";
 
-            using (X509Certificate cert = new X509Certificate(Path.Combine("TestData", "microsoft.cer")))
+            using (X509Certificate cert = new X509Certificate(TestFiles.MicrosoftRootCertFile))
             {
                 Assert.Equal(certSubject, cert.Subject);
                 Assert.Equal(certSubject, cert.Issuer);
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             DateTime notBefore = new DateTime(1999, 7, 12, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
             DateTime notAfter = new DateTime(2009, 7, 9, 17, 33, 53, DateTimeKind.Utc).ToLocalTime();
 
-            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.cer")))
+            using (X509Certificate2 cert2 = new X509Certificate2(TestFiles.TestCertFile))
             {
                 Assert.Equal(certName, cert2.IssuerName.Name);
                 Assert.Equal(certName, cert2.SubjectName.Name);
@@ -264,7 +264,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void X509Cert2CreateFromPfxFile()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "DummyTcpServer.pfx")))
+            using (X509Certificate2 cert2 = new X509Certificate2(TestFiles.DummyTcpServerPfxFile))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());
@@ -274,7 +274,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void X509Cert2CreateFromPfxWithPassword()
         {
-            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.pfx"), "test"))
+            using (X509Certificate2 cert2 = new X509Certificate2(TestFiles.ChainPfxFile, TestData.ChainPfxPassword))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());
@@ -286,7 +286,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             Span<char> pw = stackalloc char[] { 't', 'e', 's', 't' };
 
-            using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.pfx"), pw))
+            using (X509Certificate2 cert2 = new X509Certificate2(TestFiles.ChainPfxFile, pw))
             {
                 // OID=RSA Encryption
                 Assert.Equal("1.2.840.113549.1.1.1", cert2.GetKeyAlgorithm());
@@ -296,13 +296,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void X509Certificate2FromPkcs7DerFile()
         {
-            Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7b")));
+            Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestFiles.Pkcs7SingleDerFile));
         }
 
         [Fact]
         public static void X509Certificate2FromPkcs7PemFile()
         {
-            Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7c")));
+            Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestFiles.Pkcs7SinglePemFile));
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -206,8 +206,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [OuterLoop]
         public static void BuildChainExtraStoreUntrustedRoot()
         {
-            using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
+            using (var testCert = new X509Certificate2(TestFiles.ChainPfxFile, TestData.ChainPfxPassword))
+            using (ImportedCollection ic = Cert.Import(TestFiles.ChainPfxFile, TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
             using (var chainHolder = new ChainHolder())
             {
                 X509Certificate2Collection collection = ic.Collection;
@@ -232,7 +232,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void SystemTrustCertificateWithCustomRootTrust(bool addCertificateToCustomRootTrust)
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
-            using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
+            using (var testCert = new X509Certificate2(TestFiles.ChainPfxFile, TestData.ChainPfxPassword))
             using (var chainHolder = new ChainHolder())
             {
                 X509Chain chain = chainHolder.Chain;
@@ -328,7 +328,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void BuildChainWithSystemTrustAndCustomTrustCertificates()
         {
-            using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
+            using (var testCert = new X509Certificate2(TestFiles.ChainPfxFile, TestData.ChainPfxPassword))
             using (var chainHolder = new ChainHolder())
             {
                 X509Chain chain = chainHolder.Chain;
@@ -343,7 +343,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void BuildChainWithCustomRootTrustAndInvalidCustomCertificates()
         {
-            using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
+            using (var testCert = new X509Certificate2(TestFiles.ChainPfxFile, TestData.ChainPfxPassword))
             using (var chainHolder = new ChainHolder())
             {
                 X509Chain chain = chainHolder.Chain;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportX509DerFile()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.cer")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.MsCertificateDerFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(1, collection.Count);
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportX509PemFile()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.pem")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.MsCertificatePemFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(1, collection.Count);
@@ -91,7 +91,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7DerFile_Empty()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7b")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7EmptyDerFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(0, collection.Count);
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7PemFile_Empty()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7c")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7EmptyPemFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(0, collection.Count);
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7DerFile_Single()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7b")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7SingleDerFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(1, collection.Count);
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7PemFile_Single()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7c")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7SinglePemFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(1, collection.Count);
@@ -199,7 +199,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7DerFile_Chain()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7b")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7ChainDerFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(3, collection.Count);
@@ -209,7 +209,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs7PemFile_Chain()
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7c")))
+            using (ImportedCollection ic = Cert.Import(TestFiles.Pkcs7ChainPemFile))
             {
                 X509Certificate2Collection collection = ic.Collection;
                 Assert.Equal(3, collection.Count);
@@ -274,7 +274,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [MemberData(nameof(StorageFlags))]
         public static void ImportPkcs12File_Single(X509KeyStorageFlags keyStorageFlags)
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, keyStorageFlags))
+            using (ImportedCollection ic = Cert.Import(TestFiles.PfxFile, TestData.PfxDataPassword, keyStorageFlags))
             {
                 X509Certificate2Collection cc2 = ic.Collection;
                 int count = cc2.Count;
@@ -291,7 +291,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestData.PfxDataPassword.AsSpan().CopyTo(password.Slice(1));
             password = password.Slice(1, TestData.PfxDataPassword.Length);
 
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), password, keyStorageFlags))
+            using (ImportedCollection ic = Cert.Import(TestFiles.PfxFile, password, keyStorageFlags))
             {
                 X509Certificate2Collection cc2 = ic.Collection;
                 int count = cc2.Count;
@@ -342,7 +342,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [MemberData(nameof(StorageFlags))]
         public static void ImportPkcs12File_Chain(X509KeyStorageFlags keyStorageFlags)
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, keyStorageFlags))
+            using (ImportedCollection ic = Cert.Import(TestFiles.ChainPfxFile, TestData.ChainPfxPassword, keyStorageFlags))
             {
                 X509Certificate2Collection certs = ic.Collection;
                 int count = certs.Count;
@@ -354,7 +354,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [MemberData(nameof(StorageFlags))]
         public static void ImportPkcs12File_Chain_VerifyContents(X509KeyStorageFlags keyStorageFlags)
         {
-            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, keyStorageFlags))
+            using (ImportedCollection ic = Cert.Import(TestFiles.ChainPfxFile, TestData.ChainPfxPassword, keyStorageFlags))
             {
                 X509Certificate2Collection certs = ic.Collection;
                 int count = certs.Count;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -612,7 +612,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, storageFlags))
             {
-                using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, storageFlags))
+                using (ImportedCollection ic = Cert.Import(TestFiles.PfxFile, TestData.PfxDataPassword, storageFlags))
                 {
                     X509Certificate2Collection cc2 = ic.Collection;
                     int count = cc2.Count;
@@ -781,7 +781,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             var collection = new X509Certificate2Collection();
             try
             {
-                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), (string)null, Cert.EphemeralIfPossible);
+                collection.Import(TestFiles.DummyTcpServerPfxFile, (string)null, Cert.EphemeralIfPossible);
                 collection.Import(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible);
                 Assert.Equal(3, collection.Count);
             }
@@ -801,7 +801,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             try
             {
-                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), (string)null, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
+                collection.Import(TestFiles.DummyTcpServerPfxFile, (string)null, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
                 collection.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible);
 
                 // Pre-condition, we have multiple private keys

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
@@ -10,11 +10,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public class ContentTypeTests
     {
         [Theory]
-        [InlineData("My.pfx", X509ContentType.Pkcs12)]
-        [InlineData("My.cer", X509ContentType.Cert)]
+        [MemberData(nameof(GetFileNamesWithType))]
         public static void TestFileContentType(string fileName, X509ContentType contentType)
         {
-            string fullPath = Path.Combine("TestData", fileName);
+            string fullPath = Path.Combine(TestFiles.TestDataFolder, fileName);
             X509ContentType fileType = X509Certificate2.GetCertContentType(fullPath);
             Assert.Equal(contentType, fileType);
         }
@@ -56,6 +55,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 new object[] { "MultiPrivatePfx", TestData.MultiPrivateKeyPfx, X509ContentType.Pkcs12 },
                 new object[] { "ChainPfx", TestData.ChainPfxBytes, X509ContentType.Pkcs12 },
                 new object[] { "ConcatenatedPem", TestData.ConcatenatedPemFile, X509ContentType.Cert }
+            };
+        }
+
+        public static IEnumerable<object[]> GetFileNamesWithType()
+        {
+            return new[]
+            {
+                new object[] { TestFiles.PfxFileName, X509ContentType.Pkcs12 },
+                new object[] { TestFiles.MyCertFileName, X509ContentType.Cert }
             };
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -961,8 +961,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         private static void TestFindByKeyUsage(bool shouldMatch, object matchCriteria)
         {
             using (var noKeyUsages = new X509Certificate2(TestData.MsCertificate))
-            using (var noKeyUsages2 = new X509Certificate2(Path.Combine("TestData", "test.cer")))
-            using (var keyUsages = new X509Certificate2(Path.Combine("TestData", "microsoft.cer")))
+            using (var noKeyUsages2 = new X509Certificate2(TestFiles.TestCertFile))
+            using (var keyUsages = new X509Certificate2(TestFiles.MicrosoftRootCertFile))
             {
                 var coll = new X509Certificate2Collection { noKeyUsages, noKeyUsages2, keyUsages, };
                 X509Certificate2Collection results = coll.Find(X509FindType.FindByKeyUsage, matchCriteria, false);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             // X509Certificate2 can also extract the certificate from a signed file.
 
-            string path = Path.Combine("TestData", "Windows6.1-KB3004361-x64.msu");
+            string path = TestFiles.SignedMsuFile;
             if (!File.Exists(path))
                 throw new Exception(string.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
 
@@ -263,7 +263,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static X509Certificate2 LoadCertificateFromFile()
         {
-            string path = Path.Combine("TestData", "MS.cer");
+            string path = TestFiles.MsCertificateDerFile;
             if (!File.Exists(path))
                 throw new Exception(string.Format("Test infrastructure failure: Expected to find file \"{0}\".", path));
             byte[] data = File.ReadAllBytes(path);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -48,19 +48,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         // Nice, normal serial number.
-        [InlineData("microsoft.cer", "2A98A8770374E7B34195EBE04D9B17F6")]
+        [InlineData(TestFiles.MicrosoftRootCertFileName, "2A98A8770374E7B34195EBE04D9B17F6")]
         // Positive serial number which requires a padding byte to be interpreted positive.
-        [InlineData("test.cer", "00D01E4090000046520000000100000004")]
+        [InlineData(TestFiles.TestCertFileName, "00D01E4090000046520000000100000004")]
         // Negative serial number.
         //   RFC 2459: INTEGER
         //   RFC 3280: INTEGER, MUST be positive.
         //   RFC 5280: INTEGER, MUST be positive, MUST be 20 bytes or less.
         //       Readers SHOULD handle negative values.
         //       (Presumably readers also "should" handle long values created under the previous rules)
-        [InlineData("My.cer", "D5B5BC1C458A558845BFF51CB4DFF31C")]
+        [InlineData(TestFiles.MyCertFileName, "D5B5BC1C458A558845BFF51CB4DFF31C")]
         public static void TestSerialString(string fileName, string expectedSerial)
         {
-            using (var c = new X509Certificate2(Path.Combine("TestData", fileName)))
+            using (var c = new X509Certificate2(Path.Combine(TestFiles.TestDataFolder, fileName)))
             {
                 Assert.Equal(expectedSerial, c.SerialNumber);
             }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="TempFileHolder.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="TestEnvironmentConfiguration.cs" />
+    <Compile Include="TestFiles.cs" />
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X509Certificate2PemTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestFiles.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestFiles.cs
@@ -33,11 +33,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         internal static readonly string Pkcs7SinglePemFile = Path.Combine(TestDataFolder, "singlecert.p7c");
 
         // PKCS#12
-        private static readonly string PfxSuffix = PlatformSupport.IsRC2Supported ? string.Empty : ".noRC2";
+        private static readonly string PfxSuffix = PlatformSupport.IsRC2Supported ? ".pfx" : ".noRC2.pfx";
 
-        internal static readonly string ChainPfxFile = Path.Combine(TestDataFolder, $"test{PfxSuffix}.pfx");
-        internal static readonly string DummyTcpServerPfxFile = Path.Combine(TestDataFolder, $"DummyTcpServer{PfxSuffix}.pfx");
-        internal static readonly string PfxFileName = $"My{PfxSuffix}.pfx";
+        internal static readonly string ChainPfxFile = Path.Combine(TestDataFolder, "test" + PfxSuffix);
+        internal static readonly string DummyTcpServerPfxFile = Path.Combine(TestDataFolder, "DummyTcpServer" + PfxSuffix);
+        internal static readonly string PfxFileName = "My" + PfxSuffix;
         internal static readonly string PfxFile = Path.Combine(TestDataFolder, PfxFileName);
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestFiles.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestFiles.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Test.Cryptography;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    internal static class TestFiles
+    {
+        internal const string TestDataFolder = "TestData";
+
+        // Certs
+        internal static readonly string MsCertificateDerFile = Path.Combine(TestDataFolder, "MS.cer");
+        internal static readonly string MsCertificatePemFile = Path.Combine(TestDataFolder, "MS.pem");
+
+        internal const string MicrosoftRootCertFileName = "microsoft.cer";
+        internal static readonly string MicrosoftRootCertFile = Path.Combine(TestDataFolder, MicrosoftRootCertFileName);
+
+        internal const string MyCertFileName = "My.cer";
+
+        internal static readonly string SignedMsuFile = Path.Combine(TestDataFolder, "Windows6.1-KB3004361-x64.msu");
+
+        internal const string TestCertFileName = "test.cer";
+        internal static readonly string TestCertFile = Path.Combine(TestDataFolder, TestCertFileName);
+
+        // PKCS#7
+        internal static readonly string Pkcs7ChainDerFile = Path.Combine(TestDataFolder, "certchain.p7b");
+        internal static readonly string Pkcs7ChainPemFile = Path.Combine(TestDataFolder, "certchain.p7c");
+        internal static readonly string Pkcs7EmptyDerFile = Path.Combine(TestDataFolder, "empty.p7b");
+        internal static readonly string Pkcs7EmptyPemFile = Path.Combine(TestDataFolder, "empty.p7c");
+        internal static readonly string Pkcs7SingleDerFile = Path.Combine(TestDataFolder, "singlecert.p7b");
+        internal static readonly string Pkcs7SinglePemFile = Path.Combine(TestDataFolder, "singlecert.p7c");
+
+        // PKCS#12
+        private static readonly string PfxSuffix = PlatformSupport.IsRC2Supported ? string.Empty : ".noRC2";
+
+        internal static readonly string ChainPfxFile = Path.Combine(TestDataFolder, $"test{PfxSuffix}.pfx");
+        internal static readonly string DummyTcpServerPfxFile = Path.Combine(TestDataFolder, $"DummyTcpServer{PfxSuffix}.pfx");
+        internal static readonly string PfxFileName = $"My{PfxSuffix}.pfx";
+        internal static readonly string PfxFile = Path.Combine(TestDataFolder, PfxFileName);
+    }
+}


### PR DESCRIPTION
cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs