### PR TITLE
[macOS-arm64] Disable failing libraries tests

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportCollectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportCollectionTests.cs
@@ -142,6 +142,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/31792", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49365", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
         [Trait("Type", "Integration")]
         public void ImportCollectionsFromContainerOnly()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -735,6 +735,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49107", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
         public void TestVirtualMemorySize64()
         {
             CreateDefaultProcess();

--- a/src/libraries/System.DirectoryServices.Protocols/tests/AsqRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/AsqRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class AsqRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConversionExceptionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConversionExceptionTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class BerConversionExceptionTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class BerConverterTests
     {
         public static IEnumerable<object[]> Encode_TestData()

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class DirSyncRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class DirectoryControlTests
     {
         [Theory]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public partial class DirectoryServicesProtocolsTests
     {
         internal static bool IsLdapConfigurationExist => LdapConfiguration.Configuration != null;

--- a/src/libraries/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class ExtendedDNControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class PageResultRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class QuotaControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class SearchOptionsControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/SecurityDescriptorFlagControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/SecurityDescriptorFlagControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class SecurityDescriptorFlagControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class VerifyNameControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class VlvRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-FreeBSD</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -11,6 +11,7 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedFile.CreateNew.
     /// </summary>
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedFileTests_CreateNew : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -11,6 +11,7 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedViewAccessor.
     /// </summary>
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedViewAccessorTests : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -11,6 +11,7 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedViewStream.
     /// </summary>
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedViewStreamTests : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
@@ -5,7 +5,6 @@ using System.IO.Tests;
 using System.Threading.Tasks;
 using Xunit;
 
-
 namespace System.IO.MemoryMappedFiles.Tests
 {
     public abstract class MemoryMappedViewStreamConformanceTests : StandaloneStreamConformanceTests

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
@@ -5,6 +5,7 @@ using System.IO.Tests;
 using System.Threading.Tasks;
 using Xunit;
 
+
 namespace System.IO.MemoryMappedFiles.Tests
 {
     public abstract class MemoryMappedViewStreamConformanceTests : StandaloneStreamConformanceTests
@@ -45,6 +46,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         }
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class AnonymousMemoryMappedViewStreamConformanceTests : MemoryMappedViewStreamConformanceTests
     {
         protected override MemoryMappedFile CreateFile(int length) =>

--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -5,6 +5,9 @@
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <AssembliesBeingTested Include="Microsoft.CSharp" />

--- a/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -3,6 +3,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericVectorTests.cs" />

--- a/src/libraries/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
+++ b/src/libraries/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
@@ -5,6 +5,9 @@
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Fakes\FakeUri.cs" />

--- a/src/libraries/System.Private.Xml/tests/Misc/System.Xml.Misc.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Misc/System.Xml.Misc.Tests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <RootNamespace>XmlMiscTests</RootNamespace>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="XmlUrlResolverTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49365", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public partial class TCEOFHandling
     {
         private static NewLineHandling[] s_nlHandlingMembers = { NewLineHandling.Entitize, NewLineHandling.Replace, NewLineHandling.None };

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/ErrorCondition.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/ErrorCondition.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49365", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public partial class TCErrorConditionWriter// : XmlWriterTestCaseBase
     {
         public static string file = "writerErr.out";

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/WriteEndDocumentOnCloseTest.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/WriteEndDocumentOnCloseTest.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49365", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public partial class TCWriteEndDocumentOnCloseTest
     {
         [Theory]

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Errata4.cs" />

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -6,6 +6,9 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\EnumTypes.cs"

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -5,6 +5,9 @@
          TODO: [AndroidCrypto] Remove ANDROID_OPENSSL_AAR check once Android native crypto is complete -->
     <UseAndroidCrypto Condition="'$(TargetsAndroid)' == 'true' and '$(ANDROID_OPENSSL_AAR)' == ''">true</UseAndroidCrypto>
     <UseAppleCrypto Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</UseAppleCrypto>
+    <!-- ActiveIssue Apple Silicon No usable version of libssl was found
+        https://github.com/dotnet/runtime/issues/49083 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <!-- ActiveIssue Apple Silicon No usable version of libssl was found
+        https://github.com/dotnet/runtime/issues/49083 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -4,6 +4,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Suppress warning 'JsonSerializerOptions.IgnoreNullValues' is obsolete. -->
     <NoWarn>CS0618</NoWarn>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -4,6 +4,9 @@
     <!-- xUnit2008 is about regexes and isn't appropriate in the test project for regexes -->
     <NoWarn>$(NoWarn);xUnit2008</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent);net48</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttRegexTests.cs" />

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!-- ActiveIssue XUnit crashes on Apple Silicon
+        https://github.com/dotnet/runtime/issues/49110 -->
+    <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />


### PR DESCRIPTION
I was able to get one clean Libraries `all` test on Apple Silicon run in CI with these disabled. Will run a few more times to try to get more intermittent failures.