### PR TITLE
`Libraries.AppleCryptoNative` constant should not have .dylib extension

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         internal const string Odbc32 = "libodbc.2.dylib";
         internal const string OpenLdap = "libldap.dylib";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
-        internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple.dylib";
+        internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple";
         internal const string MsQuic = "libmsquic.dylib";
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/48801

In other cases with embeddable libraries we do not include .dylib. As a result both static and dynamic versions of the lib can be used. 

Example:
```cs
        internal const string NetSecurityNative = "libSystem.Net.Security.Native";
        internal const string CryptoNative = "libSystem.Security.Cryptography.Native.OpenSsl";
```
Having .dylib forces use of a dynamic library, which breaks singlefile scenarios.
