### PR TITLE
[mono] Fix the emission of EnumEqualityComparer instances into the co…

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -618,6 +618,15 @@
 		<type fullname="Mono.ValueTuple`3" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`4" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`5" preserve="fields"/>
+		<!-- aot-compiler.c -->
+		<type fullname="Mono.I8Enum" preserve="fields"/>
+		<type fullname="Mono.UI8Enum" preserve="fields"/>
+		<type fullname="Mono.I16Enum" preserve="fields"/>
+		<type fullname="Mono.UI16Enum" preserve="fields"/>
+		<type fullname="Mono.I32Enum" preserve="fields"/>
+		<type fullname="Mono.UI32Enum" preserve="fields"/>
+		<type fullname="Mono.I64Enum" preserve="fields"/>
+		<type fullname="Mono.UI64Enum" preserve="fields"/>
 
 		<type fullname="System.AppContext">
 			<!-- appdomain.c: mono_runtime_install_appctx_properties -->

--- a/src/mono/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
+++ b/src/mono/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
@@ -118,6 +118,38 @@ namespace Mono
         public T5 Item5;
     }
 
+    internal enum I8Enum : byte
+    {
+    }
+
+    internal enum UI8Enum : sbyte
+    {
+    }
+
+    internal enum I16Enum : short
+    {
+    }
+
+    internal enum UI16Enum : ushort
+    {
+    }
+
+    internal enum I32Enum : int
+    {
+    }
+
+    internal enum UI32Enum : uint
+    {
+    }
+
+    internal enum I64Enum : long
+    {
+    }
+
+    internal enum UI64Enum : ulong
+    {
+    }
+
     internal class NullByRefReturnException : Exception
     {
         public NullByRefReturnException()


### PR DESCRIPTION
…rlib AOT image.

Add a few dummy enums to the Mono namespace in corlib, and use them
to create valid EnumEqualityComparer instances. Also make sure the
instances are actually emitted and not replaced by gsharedvt instances.

Fixes https://github.com/dotnet/runtime/issues/49229.