### PR TITLE
Push Evidence down to System.Security.AccessControl

### DIFF
--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
@@ -536,38 +536,38 @@ namespace System.Security.Policy
     public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
     {
         public Evidence() { }
-        [System.ObsoleteAttribute]
+        [Obsolete("This constructor is obsolete. Please use the constructor which takes arrays of EvidenceBase instead.")]
         public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
         public Evidence(System.Security.Policy.Evidence evidence) { }
         public Evidence(System.Security.Policy.EvidenceBase[] hostEvidence, System.Security.Policy.EvidenceBase[] assemblyEvidence) { }
-        [System.ObsoleteAttribute]
+        [Obsolete("Evidence should not be treated as an ICollection. Please use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
         public int Count { get { throw null; } }
         public bool IsReadOnly { get { throw null; } }
         public bool IsSynchronized { get { throw null; } }
         public bool Locked { get { throw null; } set { } }
         public object SyncRoot { get { throw null; } }
-        [System.ObsoleteAttribute]
+        [Obsolete("This method is obsolete. Please use AddAssemblyEvidence instead.")]
         public void AddAssembly(object id) { }
         public void AddAssemblyEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
-        [System.ObsoleteAttribute]
+        [Obsolete("This method is obsolete. Please use AddHostEvidence instead.")]
         public void AddHost(object id) { }
         public void AddHostEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
         public void Clear() { }
-        public System.Security.Policy.Evidence Clone() { throw null; }
-        [System.ObsoleteAttribute]
+        public System.Security.Policy.Evidence? Clone() { throw null; }
+        [Obsolete("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(System.Array array, int index) { }
         public System.Collections.IEnumerator GetAssemblyEnumerator() { throw null; }
-        public T GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
-        [System.ObsoleteAttribute]
+        public T? GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }        
+        [Obsolete("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public System.Collections.IEnumerator GetHostEnumerator() { throw null; }
-        public T GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
+        public T? GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
         public void Merge(System.Security.Policy.Evidence evidence) { }
         public void RemoveType(System.Type t) { }
     }
     public abstract partial class EvidenceBase
     {
         protected EvidenceBase() { }
-        public virtual System.Security.Policy.EvidenceBase Clone() { throw null; }
+        public virtual System.Security.Policy.EvidenceBase? Clone() { throw null; }
     }
 }

--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
@@ -530,3 +530,44 @@ namespace System.Security.AccessControl
         public void SetAudit(System.Security.Principal.SecurityIdentifier sid, System.Security.AccessControl.ObjectAuditRule rule) { }
     }
 }
+
+namespace System.Security.Policy
+{
+    public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public Evidence() { }
+        [System.ObsoleteAttribute]
+        public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
+        public Evidence(System.Security.Policy.Evidence evidence) { }
+        public Evidence(System.Security.Policy.EvidenceBase[] hostEvidence, System.Security.Policy.EvidenceBase[] assemblyEvidence) { }
+        [System.ObsoleteAttribute]
+        public int Count { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public bool Locked { get { throw null; } set { } }
+        public object SyncRoot { get { throw null; } }
+        [System.ObsoleteAttribute]
+        public void AddAssembly(object id) { }
+        public void AddAssemblyEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
+        [System.ObsoleteAttribute]
+        public void AddHost(object id) { }
+        public void AddHostEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
+        public void Clear() { }
+        public System.Security.Policy.Evidence Clone() { throw null; }
+        [System.ObsoleteAttribute]
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IEnumerator GetAssemblyEnumerator() { throw null; }
+        public T GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
+        [System.ObsoleteAttribute]
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public System.Collections.IEnumerator GetHostEnumerator() { throw null; }
+        public T GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
+        public void Merge(System.Security.Policy.Evidence evidence) { }
+        public void RemoveType(System.Type t) { }
+    }
+    public abstract partial class EvidenceBase
+    {
+        protected EvidenceBase() { }
+        public virtual System.Security.Policy.EvidenceBase Clone() { throw null; }
+    }
+}

--- a/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -24,6 +24,8 @@
     <Compile Include="System\Security\AccessControl\Rules.cs" />
     <Compile Include="System\Security\AccessControl\Win32.cs" />
     <Compile Include="System\Security\Principal\Win32.cs" />
+    <Compile Include="System\Security\Policy\Evidence.cs" />
+    <Compile Include="System\Security\Policy\EvidenceBase.cs" />
     <!-- PInvoke sources -->
     <Compile Include="$(CommonPath)System\NotImplemented.cs"
              Link="Common\System\NotImplemented.cs" />

--- a/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
@@ -22,12 +22,12 @@ namespace System.Security.Policy
         public void AddAssembly(object id) { }
         public void AddAssemblyEvidence<T>(T evidence) where T : EvidenceBase { }
         public void AddHostEvidence<T>(T evidence) where T : EvidenceBase { }
-        public T GetAssemblyEvidence<T>() where T : EvidenceBase { return default(T); }
-        public T GetHostEvidence<T>() where T : EvidenceBase { return default(T); }
+        public T? GetAssemblyEvidence<T>() where T : EvidenceBase { return default(T); }
+        public T? GetHostEvidence<T>() where T : EvidenceBase { return default(T); }
         [Obsolete("This method is obsolete. Please use AddHostEvidence instead.")]
         public void AddHost(object id) { }
         public void Clear() { }
-        public Evidence Clone() { return default(Evidence); }
+        public Evidence? Clone() { return default(Evidence); }
         [Obsolete("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(Array array, int index) { }
         public IEnumerator GetAssemblyEnumerator() { return Array.Empty<object>().GetEnumerator(); }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/Policy/EvidenceBase.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/Policy/EvidenceBase.cs
@@ -6,6 +6,6 @@ namespace System.Security.Policy
     public abstract partial class EvidenceBase
     {
         protected EvidenceBase() { }
-        public virtual EvidenceBase Clone() { return default(EvidenceBase); }
+        public virtual EvidenceBase? Clone() { return default(EvidenceBase); }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -7,7 +7,7 @@
     <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <ProjectReference Include="..\..\System.Security.Permissions\ref\System.Security.Permissions.csproj" />
+    <ProjectReference Include="..\..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="System.Security" />

--- a/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -91,7 +91,7 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\src\System.Security.Permissions.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="System.Security" />

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
@@ -13,6 +13,8 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.SecurityAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.SecurityPermissionAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.SecurityPermissionFlag))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Policy.Evidence))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Policy.EvidenceBase))]
 #if NETCOREAPP
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.IStackWalk))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.PermissionSet))]

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1942,43 +1942,6 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-    public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
-    {
-        public Evidence() { }
-        [System.ObsoleteAttribute]
-        public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
-        public Evidence(System.Security.Policy.Evidence evidence) { }
-        public Evidence(System.Security.Policy.EvidenceBase[] hostEvidence, System.Security.Policy.EvidenceBase[] assemblyEvidence) { }
-        [System.ObsoleteAttribute]
-        public int Count { get { throw null; } }
-        public bool IsReadOnly { get { throw null; } }
-        public bool IsSynchronized { get { throw null; } }
-        public bool Locked { get { throw null; } set { } }
-        public object SyncRoot { get { throw null; } }
-        [System.ObsoleteAttribute]
-        public void AddAssembly(object id) { }
-        public void AddAssemblyEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
-        [System.ObsoleteAttribute]
-        public void AddHost(object id) { }
-        public void AddHostEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
-        public void Clear() { }
-        public System.Security.Policy.Evidence Clone() { throw null; }
-        [System.ObsoleteAttribute]
-        public void CopyTo(System.Array array, int index) { }
-        public System.Collections.IEnumerator GetAssemblyEnumerator() { throw null; }
-        public T GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
-        [System.ObsoleteAttribute]
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.IEnumerator GetHostEnumerator() { throw null; }
-        public T GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
-        public void Merge(System.Security.Policy.Evidence evidence) { }
-        public void RemoveType(System.Type t) { }
-    }
-    public abstract partial class EvidenceBase
-    {
-        protected EvidenceBase() { }
-        public virtual System.Security.Policy.EvidenceBase Clone() { throw null; }
-    }
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif

--- a/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -135,8 +135,6 @@
     <Compile Include="System\Security\Policy\ApplicationVersionMatch.cs" />
     <Compile Include="System\Security\Policy\CodeConnectAccess.cs" />
     <Compile Include="System\Security\Policy\CodeGroup.cs" />
-    <Compile Include="System\Security\Policy\Evidence.cs" />
-    <Compile Include="System\Security\Policy\EvidenceBase.cs" />
     <Compile Include="System\Security\Policy\FileCodeGroup.cs" />
     <Compile Include="System\Security\Policy\FirstMatchCodeGroup.cs" />
     <Compile Include="System\Security\Policy\GacInstalled.cs" />


### PR DESCRIPTION
This can avoid the dependency
  System.Security.Cryptography.Xml > System.Security.Permissions (and a slew of other dependencies due to this)

Contributes to https://github.com/dotnet/runtime/issues/42645