### PR TITLE
Resolving ILLink warnings on System.Private.Xml (Part 1)

### DIFF
--- a/src/libraries/System.Private.Xml/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Private.Xml/src/ILLink/ILLink.Suppressions.xml
@@ -141,12 +141,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.XslCompiledTransform.Load(System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2072</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Xml.Serialization.ReflectionXmlSerializationReader.WriteNullableMethod(System.Xml.Serialization.NullableMapping,System.Boolean,System.String)</property>
@@ -168,12 +162,6 @@
       <argument>IL2072</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Xml.Serialization.XmlSerializationILGen.GenerateTypedSerializer(System.String,System.String,System.Xml.Serialization.XmlMapping,System.Xml.Serialization.CodeIdentifiers,System.String,System.String,System.String)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2072</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.XsltOld.Processor.#ctor(System.Xml.XPath.XPathNavigator,System.Xml.Xsl.XsltArgumentList,System.Xml.XmlResolver,System.Xml.Xsl.XsltOld.Stylesheet,System.Collections.Generic.List{System.Xml.Xsl.XsltOld.TheQuery},System.Xml.Xsl.XsltOld.RootAction,System.Xml.Xsl.XsltOld.Debugger.IXsltDebugger)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -315,18 +303,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.IlGen.XmlILModule.BakeMethods</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.XsltOld.XsltCompileContext.GetExtentionMethod(System.String,System.String,System.Xml.XPath.XPathResultType[],System.Object@)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2077</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Xml.Serialization.SerializableMapping.RetrieveSerializableSchema</property>
@@ -348,6 +324,12 @@
       <argument>IL2067</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Xml.Xsl.Runtime.XmlExtensionFunctionTable.Bind(System.String,System.String,System.Int32,System.Type,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Xml.Xsl.XsltOld.XsltCompileContext.GetExtentionMethod(System.String,System.String,System.Xml.XPath.XPathResultType[],System.Object@)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.Xml/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Private.Xml/src/ILLink/ILLink.Suppressions.xml
@@ -143,12 +143,6 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.Runtime.EarlyBoundInfo.#ctor(System.String,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Xml.Xsl.XslCompiledTransform.Load(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -345,15 +339,15 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2080</argument>
+      <argument>IL2067</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.Runtime.XmlExtensionFunction.Bind</property>
+      <property name="Target">M:System.Xml.Xsl.Runtime.XmlExtensionFunction.#ctor(System.String,System.String,System.Int32,System.Type,System.Reflection.BindingFlags)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2080</argument>
+      <argument>IL2067</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Xml.Xsl.Runtime.XmlExtensionFunction.CanBind</property>
+      <property name="Target">M:System.Xml.Xsl.Runtime.XmlExtensionFunctionTable.Bind(System.String,System.String,System.Int32,System.Type,System.Reflection.BindingFlags)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/StaticDataManager.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/StaticDataManager.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Xml.Xsl.Qil;
 using System.Xml.Xsl.Runtime;
@@ -172,7 +173,7 @@ namespace System.Xml.Xsl.IlGen
         /// Add early bound information to a list that is used by this query.  Return the index of
         /// the early bound information in the list.
         /// </summary>
-        public int DeclareEarlyBound(string namespaceUri, Type ebType)
+        public int DeclareEarlyBound(string namespaceUri, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type ebType)
         {
             if (_earlyInfo == null)
                 _earlyInfo = new UniqueList<EarlyBoundInfo>();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
@@ -3600,7 +3600,7 @@ namespace System.Xml.Xsl.IlGen
         /// <summary>
         /// Generate code for QilNodeType.XsltInvokeEarlyBound.
         /// </summary>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:MissingRequiresUnreferencedCodeAttribute",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:RequiresUnreferencedCode",
             Justification = "Supressing warning about not having the RequiresUnreferencedCode attribute since we added " +
             "the attribute to this subclass' constructor. This allows us to not have to annotate the whole QilNode hirerarchy.")]
         protected override QilNode VisitXsltInvokeEarlyBound(QilInvokeEarlyBound ndInvoke)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
@@ -35,6 +35,9 @@ namespace System.Xml.Xsl.IlGen
         private IteratorDescriptor? _iterNested;
         private int _indexId;
 
+        [RequiresUnreferencedCode("Method VisitXsltInvokeEarlyBound will require code that cannot be statically analyzed.")]
+        public XmlILVisitor()
+        { }
 
         //-----------------------------------------------
         // Entry
@@ -3597,6 +3600,9 @@ namespace System.Xml.Xsl.IlGen
         /// <summary>
         /// Generate code for QilNodeType.XsltInvokeEarlyBound.
         /// </summary>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:MissingRequiresUnreferencedCodeAttribute",
+            Justification = "Supressing warning about not having the RequiresUnreferencedCode attribute since we added " +
+            "the attribute to this subclass' constructor. This allows us to not have to annotate the whole QilNode hirerarchy.")]
         protected override QilNode VisitXsltInvokeEarlyBound(QilInvokeEarlyBound ndInvoke)
         {
             QilName ndName = ndInvoke.Name;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace System.Xml.Xsl.Runtime
@@ -14,13 +15,16 @@ namespace System.Xml.Xsl.Runtime
     {
         private readonly string _namespaceUri;            // Namespace Uri mapped to these early bound functions
         private readonly ConstructorInfo _constrInfo;     // Constructor for the early bound function object
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        private readonly Type _ebType;
 
-        public EarlyBoundInfo(string namespaceUri, Type ebType)
+        public EarlyBoundInfo(string namespaceUri, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type ebType)
         {
             Debug.Assert(namespaceUri != null && ebType != null);
 
             // Get the default constructor
             _namespaceUri = namespaceUri;
+            _ebType = ebType;
             _constrInfo = ebType.GetConstructor(Type.EmptyTypes);
             Debug.Assert(_constrInfo != null, "The early bound object type " + ebType.FullName + " must have a public default constructor");
         }
@@ -33,7 +37,11 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return the Clr Type of the early bound object.
         /// </summary>
-        public Type EarlyBoundType { get { return _constrInfo.DeclaringType; } }
+        [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type EarlyBoundType
+        {
+            get { return _ebType; }
+        }
 
         /// <summary>
         /// Create an instance of the early bound object.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
@@ -37,7 +37,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return the Clr Type of the early bound object.
         /// </summary>
-        [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         public Type EarlyBoundType
         {
             get { return _ebType; }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
@@ -9,6 +9,7 @@ using System.Xml.Schema;
 using System.Reflection;
 using System.Globalization;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml.Xsl.Runtime
 {
@@ -57,6 +58,7 @@ namespace System.Xml.Xsl.Runtime
         private string _namespaceUri;                // Extension object identifier
         private string _name;                        // Name of this method
         private int _numArgs;                        // Argument count
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         private Type _objectType;                    // Type of the object which will be searched for matching methods
         private BindingFlags _flags;                 // Modifiers that were used to search for a matching signature
         private int _hashCode;                       // Pre-computed hashcode
@@ -95,7 +97,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Initialize, but do not bind.
         /// </summary>
-        public void Init(string name, string namespaceUri, int numArgs, Type objectType, BindingFlags flags)
+        public void Init(string name, string namespaceUri, int numArgs, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicMethods)] Type objectType, BindingFlags flags)
         {
             _name = name;
             _namespaceUri = namespaceUri;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
@@ -4,6 +4,7 @@
 #nullable disable
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml.Xsl.IlGen;
 using System.Xml.Xsl.Qil;
@@ -35,6 +36,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Constructor.
         /// </summary>
+        [RequiresUnreferencedCode("This method will create a copy that uses earlybound types which cannot be statically analyzed.")]
         public XmlQueryStaticData(XmlWriterSettings defaultWriterSettings, IList<WhitespaceRule> whitespaceRules, StaticDataManager staticData)
         {
             Debug.Assert(defaultWriterSettings != null && staticData != null);
@@ -70,6 +72,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Deserialize XmlQueryStaticData object from a byte array.
         /// </summary>
+        [RequiresUnreferencedCode("This method will create EarlyBoundInfo from passed in ebTypes array which cannot be statically analyzed.")]
         public XmlQueryStaticData(byte[] data, Type[] ebTypes)
         {
             MemoryStream dataStream = new MemoryStream(data, /*writable:*/false);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -70,7 +70,10 @@ namespace System.Xml.Xsl
         // SxS Note: The way the trace file names are created (hardcoded) is NOT SxS safe. However the files are
         // created only for internal tracing purposes. In addition XmlILTrace class is not compiled into retail
         // builds. As a result it is fine to suppress the FxCop SxS warning.
-        [RequiresUnreferencedCode("This method will use the XmlILVisitor which will use types that cannot be statically analyzed.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:MissingRequiresUnreferencedCode",
+            Justification = "This method will generate the IL methods using RefEmit at runtime, which will then try to call them " +
+            "using methods that are annotated as RequiresUnreferencedCode. In this case, these uses can be suppressed as the " +
+            "linker won't be able to trim any IL that gets generated at runtime.")]
         public XmlILCommand? Generate(QilExpression query, TypeBuilder? typeBldr)
         {
             _qil = query;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -70,10 +70,10 @@ namespace System.Xml.Xsl
         // SxS Note: The way the trace file names are created (hardcoded) is NOT SxS safe. However the files are
         // created only for internal tracing purposes. In addition XmlILTrace class is not compiled into retail
         // builds. As a result it is fine to suppress the FxCop SxS warning.
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:MissingRequiresUnreferencedCode",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "This method will generate the IL methods using RefEmit at runtime, which will then try to call them " +
             "using methods that are annotated as RequiresUnreferencedCode. In this case, these uses can be suppressed as the " +
-            "linker won't be able to trim any IL that gets generated at runtime.")]
+            "trimmer won't be able to trim any IL that gets generated at runtime.")]
         public XmlILCommand? Generate(QilExpression query, TypeBuilder? typeBldr)
         {
             _qil = query;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -70,6 +70,7 @@ namespace System.Xml.Xsl
         // SxS Note: The way the trace file names are created (hardcoded) is NOT SxS safe. However the files are
         // created only for internal tracing purposes. In addition XmlILTrace class is not compiled into retail
         // builds. As a result it is fine to suppress the FxCop SxS warning.
+        [RequiresUnreferencedCode("This method will use the XmlILVisitor which will use types that cannot be statically analyzed.")]
         public XmlILCommand? Generate(QilExpression query, TypeBuilder? typeBldr)
         {
             _qil = query;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
@@ -196,13 +196,14 @@ namespace System.Xml.Xsl.Xslt
             }
 
             // Create list of all early bound objects
-            Dictionary<string, Type?> scriptClasses = compiler.Scripts.ScriptClasses;
+            Scripts.LinkerSafeDictionary scriptClasses = compiler.Scripts.ScriptClasses;
             List<EarlyBoundInfo> ebTypes = new List<EarlyBoundInfo>(scriptClasses.Count);
-            foreach (KeyValuePair<string, Type?> pair in scriptClasses)
+            foreach (string key in scriptClasses.Keys)
             {
-                if (pair.Value != null)
+                Type? value = scriptClasses[key];
+                if (value != null)
                 {
-                    ebTypes.Add(new EarlyBoundInfo(pair.Key, pair.Value));
+                    ebTypes.Add(new EarlyBoundInfo(key, value));
                 }
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
@@ -196,7 +196,7 @@ namespace System.Xml.Xsl.Xslt
             }
 
             // Create list of all early bound objects
-            Scripts.LinkerSafeDictionary scriptClasses = compiler.Scripts.ScriptClasses;
+            Scripts.TrimSafeDictionary scriptClasses = compiler.Scripts.ScriptClasses;
             List<EarlyBoundInfo> ebTypes = new List<EarlyBoundInfo>(scriptClasses.Count);
             foreach (string key in scriptClasses.Keys)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
@@ -4,7 +4,9 @@
 // <spec>http://devdiv/Documents/Whidbey/CLR/CurrentSpecs/BCL/CodeDom%20Activation.doc</spec>
 //------------------------------------------------------------------------------
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Xsl.Runtime;
 
 namespace System.Xml.Xsl.Xslt
@@ -12,7 +14,7 @@ namespace System.Xml.Xsl.Xslt
     internal class Scripts
     {
         private readonly Compiler _compiler;
-        private readonly Dictionary<string, Type?> _nsToType = new Dictionary<string, Type?>();
+        private readonly LinkerSafeDictionary _nsToType = new LinkerSafeDictionary();
         private readonly XmlExtensionFunctionTable _extFuncs = new XmlExtensionFunctionTable();
 
         public Scripts(Compiler compiler)
@@ -20,7 +22,7 @@ namespace System.Xml.Xsl.Xslt
             _compiler = compiler;
         }
 
-        public Dictionary<string, Type?> ScriptClasses
+        public LinkerSafeDictionary ScriptClasses
         {
             get { return _nsToType; }
         }
@@ -40,6 +42,45 @@ namespace System.Xml.Xsl.Xslt
                 }
             }
             return null;
+        }
+
+        internal class LinkerSafeDictionary : IDictionary<string, Type?>
+        {
+            private readonly Dictionary<string, Type?> _backingDictionary = new Dictionary<string, Type?>();
+
+            public Type? this[string key]
+            {
+                [UnconditionalSuppressMessage("TrimAnalysis", "IL2093:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
+                [UnconditionalSuppressMessage("TrimAnalysis", "IL2073:MissingDynamicallyAccessedMembers",
+                    Justification = "The getter of the dictionary is not annotated to preserve the constructor, but the sources that are adding the items to " +
+                    "the dictionary are annotated so we can supress the message as we know the constructor will be preserved.")]
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+                get => ((IDictionary<string, Type?>)_backingDictionary)[key];
+                [UnconditionalSuppressMessage("TrimAnalysis", "IL2092:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
+                [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+                set => ((IDictionary<string, Type?>)_backingDictionary)[key] = value;
+            }
+
+            public ICollection<string> Keys => ((IDictionary<string, Type?>)_backingDictionary).Keys;
+
+            public ICollection<Type?> Values => ((IDictionary<string, Type?>)_backingDictionary).Values;
+
+            public int Count => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Count;
+
+            public bool IsReadOnly => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).IsReadOnly;
+
+            [UnconditionalSuppressMessage("TrimAnalysis", "IL2092:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
+            public void Add(string key, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? value) => ((IDictionary<string, Type?>)_backingDictionary).Add(key, value);
+            public void Add(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Add(item);
+            public void Clear() => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Clear();
+            public bool Contains(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Contains(item);
+            public bool ContainsKey(string key) => ((IDictionary<string, Type?>)_backingDictionary).ContainsKey(key);
+            public void CopyTo(KeyValuePair<string, Type?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).CopyTo(array, arrayIndex);
+            public IEnumerator<KeyValuePair<string, Type?>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, Type?>>)_backingDictionary).GetEnumerator();
+            public bool Remove(string key) => ((IDictionary<string, Type?>)_backingDictionary).Remove(key);
+            public bool Remove(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Remove(item);
+            public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type? value) => ((IDictionary<string, Type?>)_backingDictionary).TryGetValue(key, out value);
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_backingDictionary).GetEnumerator();
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
@@ -14,7 +14,7 @@ namespace System.Xml.Xsl.Xslt
     internal class Scripts
     {
         private readonly Compiler _compiler;
-        private readonly LinkerSafeDictionary _nsToType = new LinkerSafeDictionary();
+        private readonly TrimSafeDictionary _nsToType = new TrimSafeDictionary();
         private readonly XmlExtensionFunctionTable _extFuncs = new XmlExtensionFunctionTable();
 
         public Scripts(Compiler compiler)
@@ -22,7 +22,7 @@ namespace System.Xml.Xsl.Xslt
             _compiler = compiler;
         }
 
-        public LinkerSafeDictionary ScriptClasses
+        public TrimSafeDictionary ScriptClasses
         {
             get { return _nsToType; }
         }
@@ -44,43 +44,28 @@ namespace System.Xml.Xsl.Xslt
             return null;
         }
 
-        internal class LinkerSafeDictionary : IDictionary<string, Type?>
+        internal class TrimSafeDictionary
         {
             private readonly Dictionary<string, Type?> _backingDictionary = new Dictionary<string, Type?>();
 
             public Type? this[string key]
             {
-                [UnconditionalSuppressMessage("TrimAnalysis", "IL2093:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
                 [UnconditionalSuppressMessage("TrimAnalysis", "IL2073:MissingDynamicallyAccessedMembers",
                     Justification = "The getter of the dictionary is not annotated to preserve the constructor, but the sources that are adding the items to " +
                     "the dictionary are annotated so we can supress the message as we know the constructor will be preserved.")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
                 get => ((IDictionary<string, Type?>)_backingDictionary)[key];
-                [UnconditionalSuppressMessage("TrimAnalysis", "IL2092:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
                 set => ((IDictionary<string, Type?>)_backingDictionary)[key] = value;
             }
 
             public ICollection<string> Keys => ((IDictionary<string, Type?>)_backingDictionary).Keys;
 
-            public ICollection<Type?> Values => ((IDictionary<string, Type?>)_backingDictionary).Values;
-
             public int Count => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Count;
 
-            public bool IsReadOnly => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).IsReadOnly;
-
-            [UnconditionalSuppressMessage("TrimAnalysis", "IL2092:MissingAttributeOnBaseClass", Justification = "This implementation of IDictionary must have extra annotation attributes in order to be trim safe")]
-            public void Add(string key, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? value) => ((IDictionary<string, Type?>)_backingDictionary).Add(key, value);
-            public void Add(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Add(item);
-            public void Clear() => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Clear();
-            public bool Contains(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Contains(item);
             public bool ContainsKey(string key) => ((IDictionary<string, Type?>)_backingDictionary).ContainsKey(key);
-            public void CopyTo(KeyValuePair<string, Type?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).CopyTo(array, arrayIndex);
-            public IEnumerator<KeyValuePair<string, Type?>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, Type?>>)_backingDictionary).GetEnumerator();
-            public bool Remove(string key) => ((IDictionary<string, Type?>)_backingDictionary).Remove(key);
-            public bool Remove(KeyValuePair<string, Type?> item) => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Remove(item);
+
             public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type? value) => ((IDictionary<string, Type?>)_backingDictionary).TryGetValue(key, out value);
-            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_backingDictionary).GetEnumerator();
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
@@ -54,18 +54,18 @@ namespace System.Xml.Xsl.Xslt
                     Justification = "The getter of the dictionary is not annotated to preserve the constructor, but the sources that are adding the items to " +
                     "the dictionary are annotated so we can supress the message as we know the constructor will be preserved.")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-                get => ((IDictionary<string, Type?>)_backingDictionary)[key];
+                get => _backingDictionary[key];
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-                set => ((IDictionary<string, Type?>)_backingDictionary)[key] = value;
+                set => _backingDictionary[key] = value;
             }
 
-            public ICollection<string> Keys => ((IDictionary<string, Type?>)_backingDictionary).Keys;
+            public ICollection<string> Keys => _backingDictionary.Keys;
 
-            public int Count => ((ICollection<KeyValuePair<string, Type?>>)_backingDictionary).Count;
+            public int Count => _backingDictionary.Count;
 
-            public bool ContainsKey(string key) => ((IDictionary<string, Type?>)_backingDictionary).ContainsKey(key);
+            public bool ContainsKey(string key) => _backingDictionary.ContainsKey(key);
 
-            public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type? value) => ((IDictionary<string, Type?>)_backingDictionary).TryGetValue(key, out value);
+            public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type? value) => _backingDictionary.TryGetValue(key, out value);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Processor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Processor.cs
@@ -371,15 +371,10 @@ namespace System.Xml.Xsl.XsltOld
 
             _scriptExtensions = new Hashtable(_stylesheet.ScriptObjectTypes.Count);
             {
-                foreach (DictionaryEntry entry in _stylesheet.ScriptObjectTypes)
+                // Scripts are not supported on stylesheets
+                if (_stylesheet.ScriptObjectTypes.Count > 0)
                 {
-                    string namespaceUri = (string)entry.Key;
-                    if (GetExtensionObject(namespaceUri) != null)
-                    {
-                        throw XsltException.Create(SR.Xslt_ScriptDub, namespaceUri);
-                    }
-                    _scriptExtensions.Add(namespaceUri, Activator.CreateInstance((Type)entry.Value!,
-                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, null, null));
+                    throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported);
                 }
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -238,7 +238,7 @@ namespace System.Xml.Xsl
                 throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), nameof(compiledStylesheet));
         }
 
-        [RequiresUnreferencedCode("This method will call into constructors of the earlyBoundTypes array which cannot be statically analized.")]
+        [RequiresUnreferencedCode("This method will call into constructors of the earlyBoundTypes array which cannot be statically analyzed.")]
         public void Load(MethodInfo executeMethod, byte[] queryData, Type[]? earlyBoundTypes)
         {
             Reset();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -89,7 +89,6 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(XmlReader stylesheet)
         {
             Reset();
@@ -98,7 +97,6 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(XmlReader stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
@@ -107,7 +105,6 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(IXPathNavigable stylesheet)
         {
             Reset();
@@ -116,14 +113,12 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(IXPathNavigable stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
             LoadInternal(stylesheet, settings, stylesheetResolver);
         }
 
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(string stylesheetUri)
         {
             Reset();
@@ -134,7 +129,6 @@ namespace System.Xml.Xsl
             LoadInternal(stylesheetUri, XsltSettings.Default, CreateDefaultResolver());
         }
 
-        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(string stylesheetUri, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
@@ -145,7 +139,6 @@ namespace System.Xml.Xsl
             LoadInternal(stylesheetUri, settings, stylesheetResolver);
         }
 
-        [RequiresUnreferencedCode("This method calles CompileQilToMsil method which might use types that cannot be statically analyzed.")]
         private CompilerErrorCollection LoadInternal(object stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             if (stylesheet == null)
@@ -191,7 +184,6 @@ namespace System.Xml.Xsl
             return null;
         }
 
-        [RequiresUnreferencedCode("This method calls XmlILGenerator.Generate which might require types that cannot be statically analyzed.")]
         private void CompileQilToMsil(XsltSettings settings)
         {
             _command = new XmlILGenerator().Generate(_qil!, /*typeBuilder:*/null)!;
@@ -202,7 +194,7 @@ namespace System.Xml.Xsl
         //------------------------------------------------
         // Load compiled stylesheet from a Type
         //------------------------------------------------
-        [RequiresUnreferencedCode("This method uses the types that are grabbed from the compileStylesheet which cannot be statically analyzed.")]
+        [RequiresUnreferencedCode("This method will get fields and types from the assembly of the passed in compiledStylesheet and call their constructors which cannot be statically analyzed")]
         public void Load(Type compiledStylesheet)
         {
             Reset();
@@ -246,7 +238,7 @@ namespace System.Xml.Xsl
                 throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), nameof(compiledStylesheet));
         }
 
-        [RequiresUnreferencedCode("This method uses the constructors of the passed in earlyBoundTypes which cannot be statically analyzed.")]
+        [RequiresUnreferencedCode("This method will call into constructors of the earlyBoundTypes array which cannot be statically analized.")]
         public void Load(MethodInfo executeMethod, byte[] queryData, Type[]? earlyBoundTypes)
         {
             Reset();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -89,6 +89,7 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(XmlReader stylesheet)
         {
             Reset();
@@ -97,6 +98,7 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(XmlReader stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
@@ -105,6 +107,7 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(IXPathNavigable stylesheet)
         {
             Reset();
@@ -113,12 +116,14 @@ namespace System.Xml.Xsl
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(IXPathNavigable stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
             LoadInternal(stylesheet, settings, stylesheetResolver);
         }
 
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(string stylesheetUri)
         {
             Reset();
@@ -129,6 +134,7 @@ namespace System.Xml.Xsl
             LoadInternal(stylesheetUri, XsltSettings.Default, CreateDefaultResolver());
         }
 
+        [RequiresUnreferencedCode("This method requires a call to LoadInternal which might use types that cannot be statically analyzed.")]
         public void Load(string stylesheetUri, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             Reset();
@@ -139,6 +145,7 @@ namespace System.Xml.Xsl
             LoadInternal(stylesheetUri, settings, stylesheetResolver);
         }
 
+        [RequiresUnreferencedCode("This method calles CompileQilToMsil method which might use types that cannot be statically analyzed.")]
         private CompilerErrorCollection LoadInternal(object stylesheet, XsltSettings? settings, XmlResolver? stylesheetResolver)
         {
             if (stylesheet == null)
@@ -184,6 +191,7 @@ namespace System.Xml.Xsl
             return null;
         }
 
+        [RequiresUnreferencedCode("This method calls XmlILGenerator.Generate which might require types that cannot be statically analyzed.")]
         private void CompileQilToMsil(XsltSettings settings)
         {
             _command = new XmlILGenerator().Generate(_qil!, /*typeBuilder:*/null)!;
@@ -194,7 +202,7 @@ namespace System.Xml.Xsl
         //------------------------------------------------
         // Load compiled stylesheet from a Type
         //------------------------------------------------
-
+        [RequiresUnreferencedCode("This method uses the types that are grabbed from the compileStylesheet which cannot be statically analyzed.")]
         public void Load(Type compiledStylesheet)
         {
             Reset();
@@ -238,6 +246,7 @@ namespace System.Xml.Xsl
                 throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), nameof(compiledStylesheet));
         }
 
+        [RequiresUnreferencedCode("This method uses the constructors of the passed in earlyBoundTypes which cannot be statically analyzed.")]
         public void Load(MethodInfo executeMethod, byte[] queryData, Type[]? earlyBoundTypes)
         {
             Reset();

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -871,6 +871,34 @@ namespace System.Xml.Tests
             _output.WriteLine("Did not throw compile exception for stylesheet");
             Assert.True(false);
         }
+
+        [Fact]
+        public void XslTransformThrowsPNSEWhenUsingScripts()
+        {
+            using StringReader xslFile = new StringReader(
+        @"<xsl:stylesheet version=""1.0"" xmlns:xsl=""http://www.w3.org/1999/XSL/Transform""
+  xmlns:msxsl=""urn:schemas-microsoft-com:xslt""
+  xmlns:user=""urn:my-scripts"">
+  <msxsl:script language=""C#"" implements-prefix=""user"">
+    <![CDATA[
+  public double modifyPrice(double price){
+    price*=0.9;
+    return price;
+  }
+  ]]>
+  </msxsl:script>
+  <xsl:template match=""Root"">
+    <Root xmlns="""">
+      <Price><xsl:value-of select=""user:modifyPrice(Price)""/></Price>
+    </Root>
+  </xsl:template>
+</xsl:stylesheet>");
+
+            using XmlReader reader = XmlReader.Create(xslFile); 
+            XslTransform xslt = new XslTransform();
+            XsltCompileException compilationException = Assert.Throws<XsltCompileException>(() => xslt.Load(reader));
+            Assert.True(compilationException.InnerException != null && compilationException.InnerException is PlatformNotSupportedException);
+        }
     }
 
     /**************************************************************************/

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -2787,9 +2787,11 @@ namespace System.Xml.Xsl
         public XslCompiledTransform() { }
         public XslCompiledTransform(bool enableDebug) { }
         public System.Xml.XmlWriterSettings? OutputSettings { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("This method will call into constructors of the earlyBoundTypes array which cannot be statically analized.")]
         public void Load(System.Reflection.MethodInfo executeMethod, byte[] queryData, System.Type[]? earlyBoundTypes) { }
         public void Load(string stylesheetUri) { }
         public void Load(string stylesheetUri, System.Xml.Xsl.XsltSettings? settings, System.Xml.XmlResolver? stylesheetResolver) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("This method will get fields and types from the assembly of the passed in compiledStylesheet and call their constructors which cannot be statically analyzed")]
         public void Load(System.Type compiledStylesheet) { }
         public void Load(System.Xml.XmlReader stylesheet) { }
         public void Load(System.Xml.XmlReader stylesheet, System.Xml.Xsl.XsltSettings? settings, System.Xml.XmlResolver? stylesheetResolver) { }

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -2787,7 +2787,7 @@ namespace System.Xml.Xsl
         public XslCompiledTransform() { }
         public XslCompiledTransform(bool enableDebug) { }
         public System.Xml.XmlWriterSettings? OutputSettings { get { throw null; } }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("This method will call into constructors of the earlyBoundTypes array which cannot be statically analized.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("This method will call into constructors of the earlyBoundTypes array which cannot be statically analyzed.")]
         public void Load(System.Reflection.MethodInfo executeMethod, byte[] queryData, System.Type[]? earlyBoundTypes) { }
         public void Load(string stylesheetUri) { }
         public void Load(string stylesheetUri, System.Xml.Xsl.XsltSettings? settings, System.Xml.XmlResolver? stylesheetResolver) { }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/45623

cc: @eerhardt @krwq

This is the first part of resolving the System.Private.Xml linker warnings, which for now involves most of the XslCompiledTransform ones.
