### PR TITLE
[mono] Add missing opcodes for r4 to native int conversions

### DIFF
--- a/src/mono/mono/mini/cpu-arm.md
+++ b/src/mono/mono/mini/cpu-arm.md
@@ -227,6 +227,7 @@ rmove: dest:f src1:f len:4
 r4_conv_to_i1: dest:i src1:f len:88
 r4_conv_to_i2: dest:i src1:f len:88
 r4_conv_to_i4: dest:i src1:f len:88
+r4_conv_to_i: dest:i src1:f len:88
 r4_conv_to_u1: dest:i src1:f len:88
 r4_conv_to_u2: dest:i src1:f len:88
 r4_conv_to_u4: dest:i src1:f len:88

--- a/src/mono/mono/mini/cpu-arm64.md
+++ b/src/mono/mono/mini/cpu-arm64.md
@@ -229,6 +229,7 @@ r4_conv_to_u2: dest:i src1:f len:8
 r4_conv_to_i4: dest:i src1:f len:8
 r4_conv_to_u4: dest:i src1:f len:8
 r4_conv_to_i8: dest:l src1:f len:8
+r4_conv_to_i: dest:l src1:f len:8
 r4_conv_to_u8: dest:l src1:f len:8
 r4_conv_to_r4: dest:f src1:f len:4
 r4_conv_to_r8: dest:f src1:f len:4

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -5903,6 +5903,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 2, FALSE);
 			break;
 		case OP_RCONV_TO_I4:
+		case OP_RCONV_TO_I:
 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
 			break;
 		case OP_RCONV_TO_U4:

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -4335,6 +4335,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_fcvtzu_sx (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_I8:
+		case OP_RCONV_TO_I:
 			arm_fcvtzs_sx (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_U8:

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1312,9 +1312,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StructPacking/StructPacking/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Miscellaneous/ThisCall/ThisCallTest/**">
-            <Issue>https://github.com/dotnet/runtime/issues/46820</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/ldind_conv/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46820