### PR TITLE
Apple Silicon coreclr runtime tests

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -81,6 +81,21 @@ jobs:
       - eng/pipelines/coreclr/*
       - eng/pipelines/mono/*
       - eng/pipelines/libraries/*
+    # We have limited Apple Silicon testing capacity
+    # We want PR testing on a narrower set of changes
+    # Specifically runtime directories which are higher risk of
+    # introducing a platform specific regression
+    - subset: coreclr_AppleSilicon
+      include:
+      - src/coreclr/dlls/*
+      - src/coreclr/gc/*
+      - src/coreclr/gcinfo/*
+      - src/coreclr/inc/*
+      - src/coreclr/jit/*
+      - src/coreclr/pal/*
+      - src/coreclr/vm/*
+      exclude:
+      - *
 
     - ${{ if ne(parameters.extraSubsets, '') }}:
       - ${{ parameters.extraSubsets }}

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -95,7 +95,7 @@ jobs:
       - src/coreclr/pal/*
       - src/coreclr/vm/*
       exclude:
-      - *
+      - '*'
 
     - ${{ if ne(parameters.extraSubsets, '') }}:
       - ${{ parameters.extraSubsets }}

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -97,7 +97,7 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'OSX_arm64') }}:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'ci', 'libraries')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
         - OSX.1100.ARM64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - OSX.1100.ARM64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -792,6 +792,22 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_arm64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      condition: >-
+        or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
+          eq(variables['isFullMatrix'], true))
+
 #
 # Mono Test builds with CoreCLR runtime tests using live libraries debug build
 # Only when Mono is changed


### PR DESCRIPTION
Create SetPathVars_coreclr_AppleSilicon for enabling limited PR runtime testing

Enable coreclr runtime tests on Apple Silicon for isFullMatrix & SetPathVars_coreclr_AppleSilicon.containsChange

- I think the tests are pretty stable, I have disable a lot of unstable tests >1000 after collecting all the failures for 100 runs.
- I am hoping we have enough Apple Silicon capacity for this limited set of paths.  
  - We are not saturating these queues as only rolling and scheduled builds are enabled.
  - There were about 30 PRs to these paths in the last 10 days
  - Assuming 10 runs per PR, seems like we may have sufficient capacity
  - I will watch the queues once this merges.
