### PR TITLE
Undo the `Const < (uint)span.Length` hacks in the BCL

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
@@ -41,7 +41,7 @@ namespace System.Buffers.Text
                     return true;
                 }
 
-                if (4 < (uint)source.Length)
+                if (source.Length > 4)
                 {
                     if (dw == 0x534c4146 /* 'SLAF' */ && (source[4] & ~0x20) == 'E')
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -1208,9 +1208,7 @@ namespace System
         //   Tue, 03 Jan 2017 08:08:05 GMT
         private static bool TryFormatR(DateTime dateTime, TimeSpan offset, Span<char> destination, out int charsWritten)
         {
-            // Writing the check in this fashion elides all bounds checks on 'destination'
-            // for the remainder of the method.
-            if (28 >= (uint)destination.Length)
+            if (destination.Length <= 28)
             {
                 charsWritten = 0;
                 return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
@@ -134,7 +134,7 @@ namespace System.Text
             {
                 firstChar = chars[0];
 
-                if (1 < (uint)chars.Length)
+                if (chars.Length > 1)
                 {
                     secondChar = chars[1];
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -316,7 +316,7 @@ namespace System.Text
                 // Let's optimistically assume for now it's a high surrogate and hope
                 // that combining it with the next char yields useful results.
 
-                if (1 < (uint)source.Length)
+                if (source.Length > 1)
                 {
                     char secondChar = source[1];
                     if (TryCreate(firstChar, secondChar, out result))
@@ -817,7 +817,7 @@ namespace System.Text
 
                 // Treat 'returnValue' as the high surrogate.
 
-                if (1 >= (uint)input.Length)
+                if (input.Length <= 1)
                 {
                     return -1; // not an argument exception - just a "bad data" failure
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
@@ -102,7 +102,7 @@ namespace System.Text.Unicode
 
                     destination = destination.Slice((int)(pOutputBufferRemaining - (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(destination))));
 
-                    if (2 >= (uint)destination.Length)
+                    if (destination.Length <= 2)
                     {
                         operationStatus = OperationStatus.DestinationTooSmall;
                         break;


### PR DESCRIPTION
With #40180 having been merged for some time (many thanks to @nathan-moore!), the `if (Const < (uint)span.Length)` pattern and its permutations can now be get rid of in the BCL. A quick regex search found the following places:
```
System.Private.CoreLib\src\System\Buffers\Text\Utf8Parser\Utf8Parser.Boolean.cs:44:    if (4 < (uint)source.Length)
System.Private.CoreLib\src\System\Text\Unicode\Utf8.cs:105:                            if (2 >= (uint)destination.Length)
System.Private.CoreLib\src\System\Text\EncoderFallback.cs:137:                         if (1 < (uint)chars.Length)
System.Private.CoreLib\src\System\Text\Rune.cs:319:                                    if (1 < (uint)source.Length)
System.Private.CoreLib\src\System\Text\Rune.cs:820:                                    if (1 >= (uint)input.Length)
```

I have manually verified that the codegen for them and the equivalent "natural" versions is the same on the main branch (even without the casts).

cc @GrabYourPitchforks

Do we know of any other places that may have similar things lying around?