### PR TITLE
Fix incomplete dumps generated by createdump

### DIFF
--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -203,23 +203,23 @@ DumpWriter::WriteDump()
         // Only write the regions that are backed by memory
         if (memoryRegion.IsBackedByMemory())
         {
-            uint32_t size = memoryRegion.Size();
+            uint64_t size = memoryRegion.Size();
             uint64_t address = memoryRegion.StartAddress();
             total += size;
 
             while (size > 0)
             {
-                uint32_t bytesToRead = std::min(size, (uint32_t)sizeof(m_tempBuffer));
+                size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
                 size_t read = 0;
 
                 if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
-                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08x) FAILED\n", address, bytesToRead);
+                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08zx) FAILED\n", address, bytesToRead);
                     return false;
                 }
 
                 // This can happen if the target process dies before createdump is finished
                 if (read == 0) {
-                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08x) returned 0 bytes read\n", address, bytesToRead);
+                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08zx) returned 0 bytes read\n", address, bytesToRead);
                     return false;
                 }
 

--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -203,8 +203,8 @@ DumpWriter::WriteDump()
         // Only write the regions that are backed by memory
         if (memoryRegion.IsBackedByMemory())
         {
-            uint64_t size = memoryRegion.Size();
             uint64_t address = memoryRegion.StartAddress();
+            size_t size = memoryRegion.Size();
             total += size;
 
             while (size > 0)


### PR DESCRIPTION
There are memory regions > 4GB in size that overflowed a 32bit size value.  Changed to 64bit.

Fixes issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1277488?src=WorkItemMention&src-action=artifact_link

This also may be the cause of issue https://github.com/dotnet/diagnostics/issues/1780