### PR TITLE
[wasm] Turn off canonization of NaNs. It doesn't seem to be needed, a…

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -4877,11 +4877,12 @@ emit_handler_start (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef builder
 	bblocks [bb->block_num].bblock = target_bb;
 }
 
-//Wasm requires us to canonicalize NaNs.
 static LLVMValueRef
 get_double_const (MonoCompile *cfg, double val)
 {
-#ifdef TARGET_WASM
+	//#ifdef TARGET_WASM
+#if 0
+	//Wasm requires us to canonicalize NaNs.
 	if (mono_isnan (val))
 		*(gint64 *)&val = 0x7FF8000000000000ll;
 #endif
@@ -4891,7 +4892,8 @@ get_double_const (MonoCompile *cfg, double val)
 static LLVMValueRef
 get_float_const (MonoCompile *cfg, float val)
 {
-#ifdef TARGET_WASM
+	//#ifdef TARGET_WASM
+#if 0
 	if (mono_isnan (val))
 		*(int *)&val = 0x7FC00000;
 #endif


### PR DESCRIPTION
…nd it causes test failures.

Fixes https://github.com/dotnet/runtime/issues/49245.