### PR TITLE
Don't include mono-dtrace.h when generating offsets

### DIFF
--- a/src/mono/mono/utils/dtrace.h
+++ b/src/mono/mono/utils/dtrace.h
@@ -10,7 +10,7 @@
 #ifndef __UTILS_DTRACE_H__
 #define __UTILS_DTRACE_H__
 
-#ifdef ENABLE_DTRACE
+#if defined(ENABLE_DTRACE) && !defined(MONO_GENERATING_OFFSETS)
 
 #include <mono/utils/mono-dtrace.h>
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20919,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>offsets-tool can run before mono-dtrace.h is generated which leads to a compiler error about the file missing.
This happened with the mac arm64 sdks build where we didn't disable dtrace like we do for iOS.

It was racy since it depends on whether we already built the target mono before we're building the cross compiler mono.