### PR TITLE
[wasm][debugger] Detect exception/error when calling runtime_invoke

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -555,7 +555,7 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 	ERROR_DECL (error);
 	PRINT_DEBUG_MSG (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
 	
-	exception_on_runtime_invoke = exc;
+	exception_on_runtime_invoke = (MonoObject*)exc;
 
 	if (pause_on_exc == EXCEPTION_MODE_NONE)
 		return;

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -72,6 +72,7 @@ G_END_DECLS
 static void describe_object_properties_for_klass (void *obj, MonoClass *klass, gboolean isAsyncLocalThis, int gpflags);
 static void handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch_ctx, StackFrameInfo *catch_frame);
 static void assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly);
+static MonoObject* mono_runtime_try_invoke_internal (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError* error);
 
 //FIXME move all of those fields to the profiler object
 static gboolean debugger_enabled;
@@ -83,6 +84,7 @@ static GHashTable *objrefs;
 static GHashTable *obj_to_objref;
 static int objref_id = 0;
 static int pause_on_exc = EXCEPTION_MODE_NONE;
+static MonoObject* exception_on_runtime_invoke = NULL;
 
 static const char*
 all_getters_allowed_class_names[] = {
@@ -314,7 +316,7 @@ get_this_async_id (DbgEngineStackFrame *frame)
 		return 0;
 	}
 
-	obj = mono_runtime_try_invoke (method, builder, NULL, &ex, error);
+	obj = mono_runtime_try_invoke_internal (method, builder, NULL, &ex, error);
 	mono_error_assert_ok (error);
 
 	return get_object_id (obj);
@@ -552,6 +554,8 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 {
 	ERROR_DECL (error);
 	PRINT_DEBUG_MSG (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
+	
+	exception_on_runtime_invoke = exc;
 
 	if (pause_on_exc == EXCEPTION_MODE_NONE)
 		return;
@@ -807,7 +811,7 @@ invoke_to_string (const char *class_name, MonoClass *klass, gpointer addr)
 		if (!method)
 			return NULL;
 
-		MonoString *mstr = (MonoString*) mono_runtime_try_invoke (method, addr , NULL, &exc, error);
+		MonoString *mstr = (MonoString*) mono_runtime_try_invoke_internal (method, addr , NULL, &exc, error);
 		if (exc || !is_ok (error)) {
 			PRINT_DEBUG_MSG (1, "Failed to invoke ToString for %s\n", class_name);
 			return NULL;
@@ -1190,15 +1194,33 @@ invoke_and_describe_getter_value (MonoObject *obj, MonoProperty *p)
 
 	MonoMethodSignature *sig = mono_method_signature_internal (p->get);
 
-	res = mono_runtime_try_invoke (p->get, obj, NULL, &exc, error);
+	res = mono_runtime_try_invoke_internal (p->get, obj, NULL, &exc, error);
 	if (!is_ok (error) && exc == NULL)
-		exc = (MonoObject*) mono_error_convert_to_exception (error);
+		exc = (MonoObject *) mono_error_convert_to_exception (error);
 	if (exc)
-		return describe_value (mono_get_object_type (), &exc, GPFLAG_EXPAND_VALUETYPES);
+	{
+		const char *class_name = mono_class_full_name (mono_object_class (exc));
+		char *str = mono_string_to_utf8_checked_internal (((MonoException*)exc)->message, error);
+		mono_error_assert_ok (error); /* FIXME report error */
+		char *msg = g_strdup_printf("%s: %s", class_name, str);
+		mono_wasm_add_typed_value ("string", msg, 0);
+		g_free (msg);
+		return TRUE;
+	}
 	else if (!res || !m_class_is_valuetype (mono_object_class (res)))
 		return describe_value (sig->ret, &res, GPFLAG_EXPAND_VALUETYPES);
 	else
 		return describe_value (sig->ret, mono_object_unbox_internal (res), GPFLAG_EXPAND_VALUETYPES);
+}
+
+static MonoObject* mono_runtime_try_invoke_internal (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError* error)
+{
+	exception_on_runtime_invoke = NULL;
+	MonoObject* res = mono_runtime_try_invoke (method, obj, params, exc, error);
+	if (exception_on_runtime_invoke != NULL)
+		*exc = exception_on_runtime_invoke;
+	exception_on_runtime_invoke = NULL;
+	return res;
 }
 
 static void

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -555,6 +555,7 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 	ERROR_DECL (error);
 	PRINT_DEBUG_MSG (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
 	
+    //normal mono_runtime_try_invoke does not capture the exception and this is a temporary workaround.
 	exception_on_runtime_invoke = (MonoObject*)exc;
 
 	if (pause_on_exc == EXCEPTION_MODE_NONE)

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -1200,8 +1200,9 @@ invoke_and_describe_getter_value (MonoObject *obj, MonoProperty *p)
 	if (exc)
 	{
 		const char *class_name = mono_class_full_name (mono_object_class (exc));
-		char *str = mono_string_to_utf8_checked_internal (((MonoException*)exc)->message, error);
-		mono_error_assert_ok (error); /* FIXME report error */
+		ERROR_DECL (local_error);
+		char *str = mono_string_to_utf8_checked_internal (((MonoException*)exc)->message, local_error);
+		mono_error_assert_ok (local_error); /* FIXME report error */
 		char *msg = g_strdup_printf("%s: %s", class_name, str);
 		mono_wasm_add_typed_value ("string", msg, 0);
 		g_free (msg);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -465,6 +465,17 @@ namespace DebuggerTests
                    ("this.NullIfAIsNotZero.foo", "ReferenceError"));
            });
 
+        [Fact]
+        public async Task EvaluatePropertyThatThrows()
+        => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClassWithProperties", "InstanceMethod", /*line_offset*/1, "InstanceMethod",
+            $"window.setTimeout(function() {{ invoke_static_method_async('[debugger-test] DebuggerTests.EvaluateTestsClassWithProperties:run');}}, 1);",
+            wait_for_event_fn: async (pause_location) =>
+            {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                await EvaluateOnCallFrameAndCheck(id, ("this.PropertyThrowException", TString("System.Exception: error")));
+            });
+
         async Task EvaluateOnCallFrameAndCheck(string call_frame_id, params (string expression, JObject expected)[] args)
         {
             foreach (var arg in args)

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -76,6 +76,7 @@ namespace DebuggerTests
         public DateTime dateTime;
         public DateTime DTProp => dateTime.AddMinutes(10);
         public int IntProp => a + 5;
+        public string PropertyThrowException => throw new Exception("error");
         public string SetOnlyProp { set { a = value.Length; } }
         public EvaluateTestsClassWithProperties NullIfAIsNotZero => a != 1908712 ? null : new EvaluateTestsClassWithProperties(0);
         public EvaluateTestsClassWithProperties NewInstance => new EvaluateTestsClassWithProperties(3);


### PR DESCRIPTION
Related to #49206.
When we call runtime_invoke on wasm the exception always returns NULL and the error returns OK.
This was a problem because we were trying to get value of this new static property in DateTime type:
private static ReadOnlySpan<byte> DaysInMonth365 => new byte[] { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
As we don't know that we were getting an exception, the value that returns to the test was wrong.
The goal of this PR is detect that we got an exception when running runtime_invoke and return the expected value to debugger.
This is a temporary solution, I think the final solution is to fix runtime_invoke to return exception correctly on WASM.
We also need to support it: https://github.com/dotnet/runtime/blob/b3411852caa6a3de8ab9fa27f7860c76ef43e384/src/mono/mono/metadata/object.c#L6298