### PR TITLE
[AndroidCrypto] Fix remaining Algorithms test failures.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Dsa.Tests
 
         private static void UseAfterDispose(bool importKey)
         {
-            DSA key = importKey ? DSAFactory.Create(DSATestData.GetDSA1024Params()) : DSAFactory.Create(512);
+            DSA key = importKey ? DSAFactory.Create(DSATestData.GetDSA1024Params()) : DSAFactory.Create(1024);
 
             byte[] pkcs8Private;
             byte[] pkcs8EncryptedPrivate;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
@@ -134,7 +134,7 @@ AMSdNgiG5wSTamZ44ROdJreBn36QBEEEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg
 AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
 /2jPwhpHKz8E19aFG/Y0ny19WzRSs4o=",
                 EccTestData.GetNistP256ReferenceKeyExplicit(),
-                SupportsExplicitCurves);
+                SupportsExplicitCurves && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ hjy6jYfLa1BCJhvq+WbNc7zEb2MfXVhnImaG+XTqXI0c",
 MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEBBBswGQIBAQQUxdlEVH3hFdsliNxv
 3ro7Rz6cTZY=",
                 EccTestData.BrainpoolP160r1Key1,
-                SupportsBrainpool);
+                SupportsBrainpool && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ heDtThcoFBJUsNhEHrc=",
                     HashAlgorithmName.SHA384,
                     4096),
                 EccTestData.BrainpoolP160r1Key1,
-                SupportsBrainpool);
+                SupportsBrainpool && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -204,7 +204,7 @@ heDtThcoFBJUsNhEHrc=",
             ReadWriteBase64ECPrivateKey(
                 "MCMCAQEEFQPBmVrfrowFGNwT3+YwS7AQF+akEqAHBgUrgQQAAQ==",
                 EccTestData.Sect163k1Key1,
-                SupportsSect163k1 && CanDeriveNewPublicKey);
+                SupportsSect163k1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -215,7 +215,7 @@ heDtThcoFBJUsNhEHrc=",
 MDMCAQAwEAYHKoZIzj0CAQYFK4EEAAEEHDAaAgEBBBUDwZla366MBRjcE9/mMEuw
 EBfmpBI=",
                 EccTestData.Sect163k1Key1,
-                SupportsSect163k1);
+                SupportsSect163k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -229,7 +229,7 @@ AAAAAAABBBUAAAAAAAAAAAAAAAAAAAAAAAAAAAEEKwQC/hPAU3u8EayqB9eT3k5t
 XlyU7ugCiQcPsF04/1gyHy6ABTbVOMzao9kCFQQAAAAAAAAAAAACAQii4MwNmfil
 7wIBAg==",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1 && CanDeriveNewPublicKey);
+                SupportsSect163k1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -243,7 +243,7 @@ AAAAAAAAAAAAAAAAAAABBCsEAv4TwFN7vBGsqgfXk95ObV5clO7oAokHD7BdOP9Y
 Mh8ugAU21TjM2qPZAhUEAAAAAAAAAAAAAgEIouDMDZn4pe8CAQIEHDAaAgEBBBUD
 wZla366MBRjcE9/mMEuwEBfmpBI=",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -261,7 +261,7 @@ DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEENKfCUCiZgnSk3NJ1fYNsfsEQEiv
                     HashAlgorithmName.SHA256,
                     7),
                 EccTestData.Sect163k1Key1,
-                SupportsSect163k1);
+                SupportsSect163k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -282,7 +282,7 @@ RVA9DXUNz5+yUlfGzgErHYGwRLaLCACU6+WAC34Kkyk=",
                     HashAlgorithmName.SHA256,
                     7),
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -307,7 +307,7 @@ yJQ13lJCBBUAyVF9BtUkDTz/OMdLILbNTW+d1NkDFQDSwPsVdghg3vHu9NaW5naH
 VhUXVAQrBAevaZiVRhA9eTKfzD10iA8zu+gDywHsIyEbWWat6h0/h/fqWEiu8LfK
 nwIVBAAAAAAAAAAAAAHmD8iCHMdNrq/BAgEC",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1 && CanDeriveNewPublicKey);
+                SupportsC2pnb163v1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -321,7 +321,7 @@ JA08/zjHSyC2zU1vndTZAxUA0sD7FXYIYN7x7vTWluZ2h1YVF1QEKwQHr2mYlUYQ
 PXkyn8w9dIgPM7voA8sB7CMhG1lmreodP4f36lhIrvC3yp8CFQQAAAAAAAAAAAAB
 5g/IghzHTa6vwQIBAgQcMBoCAQEEFQD00koUBxIvRFlnvh2TwAk6ZTZ5hg==",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -342,7 +342,7 @@ AerBJbccwFJfDAXP+eW3qWtaMgulL0gUYZQ7FcXH+z5CAWwdarLOCDZGqvQFtZ16",
                     HashAlgorithmName.SHA256,
                     7),
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -353,7 +353,7 @@ AerBJbccwFJfDAXP+eW3qWtaMgulL0gUYZQ7FcXH+z5CAWwdarLOCDZGqvQFtZ16",
 MEICAQAwEAYHKoZIzj0CAQYFK4EEABAEKzApAgEBBCQAtPGuHn/c1LDoIFPAipCI
 UrJiMebAFnD8xsPqLF0/7UDt8Dc=",
                 EccTestData.Sect283k1Key1,
-                SupportsSect283k1);
+                SupportsSect283k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -371,7 +371,7 @@ vW82QOEXDhi1gO24nhx2gUeqVTHjhFq14blAu5l5",
                     HashAlgorithmName.SHA384,
                     4096),
                 EccTestData.Sect283k1Key1,
-                SupportsSect283k1);
+                SupportsSect283k1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -391,7 +391,7 @@ vW82QOEXDhi1gO24nhx2gUeqVTHjhFq14blAu5l5",
 MDYCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAAEEHDAaAgEBBBUA9NJKFAcSL0RZZ74d
 k8AJOmU2eYY=",
                 EccTestData.C2pnb163v1Key1,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1 && CanDeriveNewPublicKey);
         }
 
         [Fact]
@@ -409,7 +409,7 @@ DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEEKWBssmLHI618uBvF0PA4VoEQIDy
                     HashAlgorithmName.SHA512,
                     1024),
                 EccTestData.C2pnb163v1Key1,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1 && CanDeriveNewPublicKey);
         }
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -33,8 +33,9 @@ namespace System.Security.Cryptography.Tests
         public static bool SupportsC2pnb163v1 { get; } = IsCurveSupported(EccTestData.C2pnb163v1Key1.Curve.Oid);
 
         // Some platforms support explicitly specifying these curves, but do not support specifying them by name.
-        public static bool SupportsSect163k1Explicit { get; } = SupportsSect163k1 || SupportsExplicitCurves;
-        public static bool SupportsC2pnb163v1Explicit { get; } = SupportsC2pnb163v1 || SupportsExplicitCurves;
+        public static bool ExplicitNamedSameSupport { get; } = !PlatformDetection.IsAndroid;
+        public static bool SupportsSect163k1Explicit { get; } = SupportsSect163k1 || (!ExplicitNamedSameSupport && SupportsExplicitCurves);
+        public static bool SupportsC2pnb163v1Explicit { get; } = SupportsC2pnb163v1 || (!ExplicitNamedSameSupport && SupportsExplicitCurves);
 
         private static bool IsCurveSupported(Oid oid)
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -20,17 +20,21 @@ namespace System.Security.Cryptography.Tests
         protected abstract void Exercise(T key);
         protected virtual Func<T, byte[]> PublicKeyWriteArrayFunc { get; } = null;
         protected virtual WriteKeyToSpanFunc PublicKeyWriteSpanFunc { get; } = null;
+        
+        // This would need to be virtualized if there was ever a platform that
+        // allowed explicit in ECDH or ECDSA but not the other.
+        public static bool SupportsExplicitCurves { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupported;
+
+        public static bool CanDeriveNewPublicKey { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
 
         public static bool SupportsBrainpool { get; } = IsCurveSupported(ECCurve.NamedCurves.brainpoolP160r1.Oid);
         public static bool SupportsSect163k1 { get; } = IsCurveSupported(EccTestData.Sect163k1Key1.Curve.Oid);
         public static bool SupportsSect283k1 { get; } = IsCurveSupported(EccTestData.Sect283k1Key1.Curve.Oid);
         public static bool SupportsC2pnb163v1 { get; } = IsCurveSupported(EccTestData.C2pnb163v1Key1.Curve.Oid);
 
-        // This would need to be virtualized if there was ever a platform that
-        // allowed explicit in ECDH or ECDSA but not the other.
-        public static bool SupportsExplicitCurves { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupported;
-
-        public static bool CanDeriveNewPublicKey { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
+        // Some platforms support explicitly specifying these curves, but do not support specifying them by name.
+        public static bool SupportsSect163k1Explicit { get; } = SupportsSect163k1 || SupportsExplicitCurves;
+        public static bool SupportsC2pnb163v1Explicit { get; } = SupportsC2pnb163v1 || SupportsExplicitCurves;
 
         private static bool IsCurveSupported(Oid oid)
         {
@@ -421,7 +425,7 @@ B9eT3k5tXlyU7ugCiQcPsF04/1gyHy6ABTbVOMzao9kCFQQAAAAAAAAAAAACAQii
 4MwNmfil7wIBAqEuAywABAYXnjcZzIElQ1/mRYnV/KbcGIdVHQeI/rti/8kkjYs5
 iv4+C1w8ArP+Nw==",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit);
         }
 
         [Fact]
@@ -435,7 +439,7 @@ Bw+wXTj/WDIfLoAFNtU4zNqj2QIVBAAAAAAAAAAAAAIBCKLgzA2Z+KXvAgECBEww
 SgIBAQQVA8GZWt+ujAUY3BPf5jBLsBAX5qQSoS4DLAAEBheeNxnMgSVDX+ZFidX8
 ptwYh1UdB4j+u2L/ySSNizmK/j4LXDwCs/43",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit);
         }
 
         [Fact]
@@ -455,7 +459,7 @@ z2NFvWcpK0Fh9fCVGuXV9sjJ5qE=",
                     HashAlgorithmName.SHA256,
                     12),
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit);
         }
 
         [Fact]
@@ -468,7 +472,7 @@ MAkCAQMCAQYCAQcwBgQBAQQBAQQrBAL+E8BTe7wRrKoH15PeTm1eXJTu6AKJBw+w
 XTj/WDIfLoAFNtU4zNqj2QIVBAAAAAAAAAAAAAIBCKLgzA2Z+KXvAgECAywABAYX
 njcZzIElQ1/mRYnV/KbcGIdVHQeI/rti/8kkjYs5iv4+C1w8ArP+Nw==",
                 EccTestData.Sect163k1Key1Explicit,
-                SupportsSect163k1);
+                SupportsSect163k1Explicit);
         }
 
         [Fact]
@@ -589,7 +593,7 @@ VhUXVAQrBAevaZiVRhA9eTKfzD10iA8zu+gDywHsIyEbWWat6h0/h/fqWEiu8LfK
 nwIVBAAAAAAAAAAAAAHmD8iCHMdNrq/BAgECoS4DLAAEAhEnLxxVgkJoiOkb1pJX
 dJQjIkiqBCcIMPehAJrWcKiN6SvVkkjMgTtF",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit);
         }
 
         [Fact]
@@ -604,7 +608,7 @@ PXkyn8w9dIgPM7voA8sB7CMhG1lmreodP4f36lhIrvC3yp8CFQQAAAAAAAAAAAAB
 5g/IghzHTa6vwQIBAgRMMEoCAQEEFQD00koUBxIvRFlnvh2TwAk6ZTZ5hqEuAywA
 BAIRJy8cVYJCaIjpG9aSV3SUIyJIqgQnCDD3oQCa1nCojekr1ZJIzIE7RQ==",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit);
         }
 
         [Fact]
@@ -625,7 +629,7 @@ wxcZ+wOsnebIwy4ftKL+klh5EXv/9S5sCjC8g8J2cA6GmcZbiQ==",
                     HashAlgorithmName.SHA512,
                     1024),
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit);
         }
 
         [Fact]
@@ -640,7 +644,7 @@ zD10iA8zu+gDywHsIyEbWWat6h0/h/fqWEiu8LfKnwIVBAAAAAAAAAAAAAHmD8iC
 HMdNrq/BAgECAywABAIRJy8cVYJCaIjpG9aSV3SUIyJIqgQnCDD3oQCa1nCojekr
 1ZJIzIE7RQ==",
                 EccTestData.C2pnb163v1Key1Explicit,
-                SupportsC2pnb163v1);
+                SupportsC2pnb163v1Explicit);
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
@@ -154,6 +154,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Android)] // Android does not validate curve parameters
         public static void TestExplicitImportValidationNegative()
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -188,6 +188,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [ConditionalFact(nameof(ECExplicitCurvesSupported))]
+        [PlatformSpecific(~TestPlatforms.Android)] // Android does not validate curve parameters
         public static void TestExplicitImportValidationNegative()
         {
             unchecked

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -1341,6 +1341,7 @@ zM=
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/29515", TestPlatforms.OSX)]
+        [PlatformSpecific(~TestPlatforms.Android)]
         public static void FromNonsenseXml()
         {
             // This is DiminishedDPParameters XML, but with a P that is way too long.

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -1340,8 +1340,7 @@ zM=
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29515", TestPlatforms.OSX)]
-        [PlatformSpecific(~TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/29515", TestPlatforms.OSX | TestPlatforms.Android)]
         public static void FromNonsenseXml()
         {
             // This is DiminishedDPParameters XML, but with a P that is way too long.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -340,6 +340,8 @@ cleanup:
     return ToGRef(env, keyPair);
 }
 
+#define CURVE_NOT_SUPPORTED -1
+
 int32_t AndroidCryptoNative_EcKeyCreateByKeyParameters(EC_KEY** key,
                                                 const char* oid,
                                                 uint8_t* qx,
@@ -364,7 +366,7 @@ int32_t AndroidCryptoNative_EcKeyCreateByKeyParameters(EC_KEY** key,
     *key = AndroidCryptoNative_EcKeyCreateByOid(oid);
     if (*key == NULL)
     {
-        return FAIL;
+        return CURVE_NOT_SUPPORTED;
     }
 
     // Release the reference to the generated key pair. We're going to make our own with the explicit keys.

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
@@ -13,8 +13,22 @@ namespace System.Security.Cryptography.Algorithms.Tests
         public static bool SupportsFips186_3 => DSAFactory.SupportsFips186_3;
 
         [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [PlatformSpecific(~TestPlatforms.Android)] // Android only supports key sizes that are a multiple of 1024
         [InlineData(512)]
         [InlineData(960)]
+        public static void CreateWithKeysize_SmallKeys(int keySizeInBits)
+        {
+            using (DSA dsa = DSA.Create(keySizeInBits))
+            {
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+
+                DSAParameters parameters = dsa.ExportParameters(false);
+                Assert.Equal(keySizeInBits, parameters.Y.Length << 3);
+                Assert.Equal(keySizeInBits, dsa.KeySize);
+            }
+        }
+
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
         [InlineData(1024)]
         public static void CreateWithKeysize(int keySizeInBits)
         {


### PR DESCRIPTION
Product fixes:

- Return a different error code for curve-not-supported to correctly throw PNSE.

Test fixes:

- Allow platforms that support explicit curves to indicate they support a particular curve when parameters are supplied explicitly but not by name
- Split the DSA tests by key size for easy disabling on Android.
- Disable a few tests that won't pass on Android (some of which are disabled on other platforms).

