### PR TITLE
Add checks to prevent silent bad codegen from VN optimizations.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10266,7 +10266,7 @@ public:
         {
             // Create a CompAllocator that labels sub-structure with CMK_FieldSeqStore, and use that for allocation.
             CompAllocator ialloc(getAllocator(CMK_FieldSeqStore));
-            compRoot->m_fieldSeqStore = new (ialloc) FieldSeqStore(ialloc);
+            compRoot->m_fieldSeqStore = new (ialloc) FieldSeqStore(compRoot, ialloc);
         }
         return compRoot->m_fieldSeqStore;
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11201,7 +11201,7 @@ void Compiler::gtDispFieldSeq(FieldSeqNode* pfsn)
         }
         else
         {
-            printf("%s", eeGetFieldName(fldHnd));
+            printf("%s, %#x", eeGetFieldName(fldHnd), dspPtr(fldHnd));
         }
         pfsn = pfsn->m_next;
         if (pfsn != nullptr)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18879,6 +18879,11 @@ bool FieldSeqNode::CheckFldBelongsToCls(Compiler* comp, CORINFO_CLASS_HANDLE cls
     {
         return false;
     }
+    if (IsPseudoField())
+    {
+        // Not sure about it.
+        return true;
+    }
     CORINFO_CLASS_HANDLE realClsHnd = comp->info.compCompHnd->getFieldClass(m_fieldHnd);
     if (realClsHnd != clsHnd)
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -266,6 +266,8 @@ struct FieldSeqNode
         return tail;
     }
 
+    bool CheckFldBelongsToCls(Compiler* comp, CORINFO_CLASS_HANDLE clsHnd) const;
+
     // Make sure this provides methods that allow it to be used as a KeyFuncs type in SimplerHash.
     static int GetHashCode(FieldSeqNode fsn)
     {
@@ -284,6 +286,7 @@ class FieldSeqStore
 {
     typedef JitHashTable<FieldSeqNode, /*KeyFuncs*/ FieldSeqNode, FieldSeqNode*> FieldSeqNodeCanonMap;
 
+    Compiler*             m_compiler;
     CompAllocator         m_alloc;
     FieldSeqNodeCanonMap* m_canonMap;
 
@@ -294,7 +297,7 @@ class FieldSeqStore
     static int ConstantIndexPseudoFieldStruct;
 
 public:
-    FieldSeqStore(CompAllocator alloc);
+    FieldSeqStore(Compiler* comp, CompAllocator alloc);
 
     // Returns the (canonical in the store) singleton field sequence for the given handle.
     FieldSeqNode* CreateSingleton(CORINFO_FIELD_HANDLE fieldHnd);
@@ -3433,10 +3436,7 @@ public:
         return m_fieldSeq;
     }
 
-    void SetFieldSeq(FieldSeqNode* fieldSeq)
-    {
-        m_fieldSeq = fieldSeq;
-    }
+    void SetFieldSeq(FieldSeqNode* fieldSeq);
 
 #ifdef TARGET_ARM
     bool IsOffsetMisaligned() const;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -863,7 +863,14 @@ private:
             addr->ChangeOper(GT_LCL_FLD_ADDR);
             addr->AsLclFld()->SetLclNum(val.LclNum());
             addr->AsLclFld()->SetLclOffs(val.Offset());
-            addr->AsLclFld()->SetFieldSeq(val.FieldSeq());
+            if (varTypeIsStruct(varDsc) && val.FieldSeq()->CheckFldBelongsToCls(m_compiler, varDsc->GetStructHnd()))
+            {
+                addr->AsLclFld()->SetFieldSeq(val.FieldSeq());
+            }
+            else
+            {
+                addr->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+            }
         }
         else
         {
@@ -1032,6 +1039,10 @@ private:
             indir->ChangeOper(GT_LCL_FLD);
             indir->AsLclFld()->SetLclNum(val.LclNum());
             indir->AsLclFld()->SetLclOffs(val.Offset());
+            if (fieldSeq != nullptr && !fieldSeq->CheckFldBelongsToCls(m_compiler, varDsc->GetStructHnd()))
+            {
+                fieldSeq = nullptr;
+            }
             indir->AsLclFld()->SetFieldSeq(fieldSeq == nullptr ? FieldSeqStore::NotAField() : fieldSeq);
 
             // Promoted struct vars aren't currently handled here so the created LCL_FLD can't be

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11642,10 +11642,10 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
 
                     FieldSeqNode* curFieldSeq;
 
-                    if (srcClassHnd == dstClassHnd)
+                    if ((srcClassHnd == dstClassHnd) || (dstClassHnd == nullptr))
                     {
                         CORINFO_FIELD_HANDLE fieldHnd =
-                            info.compCompHnd->getFieldInClass(dstClassHnd, srcFieldVarDsc->lvFldOrdinal);
+                            info.compCompHnd->getFieldInClass(srcClassHnd, srcFieldVarDsc->lvFldOrdinal);
                         curFieldSeq = GetFieldSeqStore()->CreateSingleton(fieldHnd);
                     }
                     else
@@ -11734,7 +11734,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
 
                     FieldSeqNode* curFieldSeq;
 
-                    if (srcClassHnd == dstClassHnd)
+                    if ((srcClassHnd == dstClassHnd) || (srcClassHnd == nullptr))
                     {
                         CORINFO_FIELD_HANDLE fieldHnd =
                             info.compCompHnd->getFieldInClass(dstClassHnd, lvaTable[dstFieldLclNum].lvFldOrdinal);
@@ -11766,7 +11766,14 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                                 srcLclVarTree->gtFlags |= GTF_VAR_CAST;
                                 srcLclVarTree->ChangeOper(GT_LCL_FLD);
                                 srcLclVarTree->gtType = destType;
-                                srcLclVarTree->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+                                if (varTypeIsStruct(srcLclVar) && curFieldSeq->CheckFldBelongsToCls(this, srcLclVar->GetStructHnd()))
+                                {
+                                    srcLclVarTree->AsLclFld()->SetFieldSeq(curFieldSeq);
+                                }
+                                else
+                                {
+                                    srcLclVarTree->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+                                }
                                 srcFld = srcLclVarTree;
                                 done   = true;
                             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11766,7 +11766,8 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                                 srcLclVarTree->gtFlags |= GTF_VAR_CAST;
                                 srcLclVarTree->ChangeOper(GT_LCL_FLD);
                                 srcLclVarTree->gtType = destType;
-                                if (varTypeIsStruct(srcLclVar) && curFieldSeq->CheckFldBelongsToCls(this, srcLclVar->GetStructHnd()))
+                                if (varTypeIsStruct(srcLclVar) &&
+                                    curFieldSeq->CheckFldBelongsToCls(this, srcLclVar->GetStructHnd()))
                                 {
                                     srcLclVarTree->AsLclFld()->SetFieldSeq(curFieldSeq);
                                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7757,10 +7757,10 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                         rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, lclVarTree->TypeGet()));
                                     }
 
+                                    lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
                                     if (isEntire)
                                     {
                                         newLhsVNPair = rhsVNPair;
-                                        lclDefSsaNum = lclVarTree->GetSsaNum();
                                     }
                                     else
                                     {
@@ -7769,7 +7769,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                         ValueNumPair oldLhsVNPair = lvaTable[lclVarTree->GetLclNum()]
                                                                         .GetPerSsaData(lclVarTree->GetSsaNum())
                                                                         ->m_vnPair;
-                                        lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
                                         newLhsVNPair =
                                             vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, fieldSeq, rhsVNPair,
                                                                                 lhs->TypeGet(), compCurBB);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3590,6 +3590,7 @@ ValueNum ValueNumStore::VNApplySelectors(ValueNumKind  vnk,
             {
                 printf(", size = %d", structSize);
             }
+            printf(", field hnd is %#x", dspPtr(fldHnd));
             printf("\n");
         }
 #endif
@@ -3737,8 +3738,9 @@ ValueNum ValueNumStore::VNApplySelectorsAssign(
             {
                 const char* modName;
                 const char* fldName = m_pComp->eeGetFieldName(fldHnd, &modName);
-                printf("    VNForHandle(%s) is " FMT_VN ", fieldType is %s\n", fldName, fldHndVN,
-                       varTypeName(fieldType));
+                printf("    VNForHandle(%s) is " FMT_VN, fldName, fldHndVN);
+                printf(", fieldType is %s", varTypeName(fieldType));
+                printf(", field hnd is %#x\n", dspPtr(fldHnd));
             }
 #endif
             ValueNum fseqMap = VNForMapSelect(vnk, fieldType, map, fldHndVN);
@@ -3755,8 +3757,9 @@ ValueNum ValueNumStore::VNApplySelectorsAssign(
                 }
                 const char* modName;
                 const char* fldName = m_pComp->eeGetFieldName(fldHnd, &modName);
-                printf("    VNForHandle(%s) is " FMT_VN ", fieldType is %s\n", fldName, fldHndVN,
-                       varTypeName(fieldType));
+                printf("    VNForHandle(%s) is " FMT_VN, fldName, fldHndVN);
+                printf(", fieldType is %s", varTypeName(fieldType));
+                printf(", field hnd is %#x\n", dspPtr(fldHnd));
             }
 #endif
             elemAfter = VNApplySelectorsAssignTypeCoerce(elem, indType, block);


### PR DESCRIPTION
VN optimizations are known to be a source of silent bad codegen issues, a good part of them happen because it works with maps [CORINFO_CLASS_HANDLE, CORINFO_FIELD_HANDLE] and when it allows us to access a class/struct with a field handle not from this class. Jit does not hit any asserts when it happens, as a result, we can have this:
```
N003 (  7, 11) [000016] -A------R----             *  ASG       float  $41
N002 (  3,  2) [000015] D------N-----             +--*  LCL_VAR   float  V05 tmp4         d:2 $41
N001 (  3,  6) [000014] -------------             \--*  CNS_DBL   float  8.5000000000000000 $41
***
N003 (  7,  9) [000099] -A------R----             |  |  +--*  ASG       float  $41
N002 (  3,  4) [000097] U------N-----             |  |  |  +--*  LCL_FLD   float  V02 tmp1         ud:1->2[+0] Fseq[X] $180
N001 (  3,  2) [000098] -------N-----             |  |  |  \--*  LCL_VAR   float  V05 tmp4         u:2 
***
N003 (  7,  9) [000115] -A------R----             |  |  +--*  ASG       float  $40
N002 (  3,  2) [000113] D------N-----             |  |  |  +--*  LCL_VAR   float  V09 tmp8         d:2 $40
N001 (  3,  4) [000114] -------------             |  |  |  \--*  LCL_FLD   float  V02 tmp1         u:5[+0] Fseq[X] $40
```
The bug here is that `000114`'s VN is $40, when it should be $180. The issue is that we access `V02` in `000097` and `000114` with different FieldHandles, both have names [X] but one is not from that struct type, in the past, it was a silent bad codegen, now it would be an assert when we try to set such FldSeq for a LclVar + dump now shows the actual handle values, so it is clearer from the dump what happens.

### Summary: our new contract for FldSeq on LclVar is that CORINFO_FIELD_HANDLE must belong to LclVar's CORINFO_CLASS_HANDLE, otherwise it has to be `NotAField()`. And each FldSeq list should dereference a field that exists in the previous class handle.

And when we see similar issues but not with LclFld I expect we broader these checks to other nodes that have FldSeq.

There are small asm diffs:
```
x64 crossgen libs
0 (0.00% of base)
0 total methods with Code Size differences (0 improved, 0 regressed), 201134 unchanged.

x64 pmi libs
Total bytes of delta: 125 (0.00% of base)
8 total methods with Code Size differences (2 improved, 6 regressed), 268234 unchanged.

arm64 altjit windows crossgen libs
Total bytes of delta: 0 (0.00% of base)
0 total methods with Code Size differences (0 improved, 0 regressed), 200625 unchanged.

arm64 altjit  windows pmi libs
Total bytes of delta: 172 (0.00% of base)
8 total methods with Code Size differences (2 improved, 6 regressed), 268234 unchanged.

x64 unix altjit windows crossgen libs
Total bytes of delta: 11 (0.00% of base)
1 total method with Code Size differences (0 improved, 1 regressed), 200625 unchanged.

x64 unix altjit windows pmi libs
Total bytes of delta: 162 (0.00% of base)
13 total methods with Code Size differences (3 improved, 10 regressed), 268229 unchanged.
```

### the diffs are falling into two categories:

1. we inline a method that takes a struct and use the struct as another type, 
for example:
```
Importing BB14 (PC=000) of 'Microsoft.CodeAnalysis.CSharp.MemberResolutionResult`1[__Canon][System.__Canon]:get_Member():System.__Canon:this'
    [ 0]   0 (0x000) ldarg.0
    [ 1]   1 (0x001) ldfld 0A00058C
    [ 1]   6 (0x006) ret

    Inlinee Return expression (before normalization)  =>
               [000134] ------------              *  FIELD     ref    _member
               [000132] ------------              \--*  ADDR      byref 
               [000133] -------N----                 \--*  LCL_VAR   struct<Microsoft.CodeAnalysis.CSharp.MemberResolutionResult`1[[Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], 48> V08 loc4
```
our `this` has type
```
Microsoft.CodeAnalysis.CSharp.MemberResolutionResult`1[[Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol, Microsoft.CodeAnalysis.CSharp
```
when we access it with a token for
```
Microsoft.CodeAnalysis.CSharp.MemberResolutionResult`1[__Canon][System.__Canon]
```
in the past we were setting `CORINFO_FIELD_HANDLE` from `Canon` to LclVar with `MethodSymbol` type, it could have led to errors if we accessed it using `CORINFO_FIELD_HANDLE` from `MethodSymbol` at the same time. Like:
```
Init V08 with 0;
V08._member = 1 using MethodSymbol handle;
read V08._member using Canon handle <- here VN would say that V08._member  is equal 0 because it would not see the previous assignment.
```
I believe we have enough deoptimizations in other places to be protected from such behavior, in this case, V08 is marked as address exposed so VN does not do optimizations with it.

2. `getFieldClass` returs an unexpected value for some fields, I hope @davidwrighton could help me to understand such cases better:
```
CORINFO_FIELD_HANDLE: field = 0x000002b59440e928
CORINFO_CLASS_HANDLE: class = 0x000002b59440f650

m_fieldHnd
0x000002b59440e928 {...}
comp->info.compCompHnd->getFieldClass(m_fieldHnd)
0x000002b59440f3a8 {...} <- it says m_fieldHnd belongs to 0x000002b59440f3a8 
clsHnd
0x000002b59440f650 {...}
comp->info.compCompHnd->getFieldInClass(clsHnd, 0)
0x000002b59440e928 {...} <- it says 0x000002b59440e928  contains 0x000002b59440e928 , but why then 0x000002b59440e928 does not belong to it?

comp->info.compCompHnd->getClassName(clsHnd)
0x000002b594416e50 "System.ValueTuple`3[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral,...
comp->info.compCompHnd->getClassName(0x000002b59440f3a8)
0x000002b594415020 "System.ValueTuple`3[__Canon,__Canon,Boolean]"
```


This change improves our consistency for LCL_FLD but leaves many things unchanged:
For example, when we work with raw addresses we set FldSeq without any checks, it allows us to have smaller diffs and raw addresses are not involved in the most dangerous optimizations but could be used for CSE, like:
```
ADD
  LCL_VAR byref V01 <- we spilled an address of some local var, don't know its struct handle, it is just a pointer for us.
  CNST_INT 8 FldSeq someField <- allow any field seq to be here.
```
and if we have `NotAFld` CSE can't match it with the same `ADD` nodes, but if we have a real `FldSeq` it could be done.

And there are some questions that need to be addressed before the merge:
1. the check for `if (IsPseudoField())` is very optimistic, hope @briansull can tell me how they are used and how the check should be improved.
2. compilation time impact, it looks expensive to call `comp->info.compCompHnd->getFieldClass` so often but we need to measure it to know for sure, probably we can save `CORINFO_CLASS_HANDLE` into `FieldSeqNode`, and then we would not need it but use a little extra memory.

