### PR TITLE
[mono][mbr] Implement DOTNET_MODIFIABLE_ASSEMBLIES support

### DIFF
--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -13,6 +13,7 @@
 #ifdef ENABLE_METADATA_UPDATE
 
 #include <glib.h>
+#include "mono/metadata/assembly-internals.h"
 #include "mono/metadata/metadata-internals.h"
 #include "mono/metadata/metadata-update.h"
 #include "mono/metadata/object-internals.h"
@@ -110,8 +111,9 @@ mono_metadata_update_no_inline (MonoMethod *caller, MonoMethod *callee)
 {
 	if (!mono_metadata_update_enabled (NULL))
 		return FALSE;
-	/* FIXME: check the debugger bits on the MonoAssembly of the caller and callee */
-	return TRUE;
+	MonoAssembly *caller_assm = m_class_get_image(caller->klass)->assembly;
+	MonoAssembly *callee_assm = m_class_get_image(callee->klass)->assembly;
+	return mono_assembly_is_jit_optimizer_disabled (caller_assm) || mono_assembly_is_jit_optimizer_disabled (callee_assm);
 }
 
 static void

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -11,6 +11,19 @@
 
 #ifdef ENABLE_METADATA_UPDATE
 
+enum MonoModifiableAssemblies {
+	/* modifiable assemblies are disabled */
+	MONO_MODIFIABLE_ASSM_NONE = 0,
+	/* assemblies with the Debug flag are modifiable */
+	MONO_MODIFIABLE_ASSM_DEBUG = 1,
+};
+
+gboolean
+mono_metadata_update_enabled (int *modifiable_assemblies_out);
+
+gboolean
+mono_metadata_update_no_inline (MonoMethod *caller, MonoMethod *callee);
+
 void
 mono_metadata_update_init (void);
 

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -57,6 +57,21 @@ mono_metadata_update_cleanup_on_close (MonoImage *base_image);
 MonoImage *
 mono_table_info_get_base_image (const MonoTableInfo *t);
 
+#else /* ENABLE_METADATA_UPDATE */
+
+static inline gboolean
+mono_metadata_update_enabled (int *modifiable_assemblies_out)
+{
+        if (modifiable_assemblies_out)
+                *modifiable_assemblies_out = 0;
+        return FALSE;
+}
+
+static inline gboolean
+mono_metadata_update_no_inline (MonoMethod *caller, MonoMethod *callee)
+{
+        return FALSE;
+}
 
 #endif /* ENABLE_METADATA_UPDATE */
 

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7230,8 +7230,6 @@ copy_imethod_for_frame (InterpFrame *frame)
 static void
 interp_metadata_update_init (MonoError *error)
 {
-	if ((mono_interp_opt & INTERP_OPT_INLINE) != 0)
-		mono_error_set_execution_engine (error, "Interpreter inlining must be turned off for metadata updates");
 }
 
 #ifdef ENABLE_METADATA_UPDATE

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2633,6 +2633,16 @@ interp_icall_op_for_sig (MonoMethodSignature *sig)
 #define INLINE_DEPTH_LIMIT 10
 
 static gboolean
+is_metadata_update_disabled (void)
+{
+	static gboolean disabled = FALSE;
+	if (disabled)
+		return disabled;
+	disabled = !mono_metadata_update_enabled (NULL);
+	return disabled;
+}
+
+static gboolean
 interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodSignature *csignature)
 {
 	MonoMethodHeaderSummary header;
@@ -2684,6 +2694,9 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 		return FALSE;
 
 	if (td->prof_coverage)
+		return FALSE;
+
+	if (!is_metadata_update_disabled () && mono_metadata_update_no_inline (td->method, method))
 		return FALSE;
 
 	if (g_list_find (td->dont_inline, method))

--- a/src/mono/sample/mbr/DeltaHelper.targets
+++ b/src/mono/sample/mbr/DeltaHelper.targets
@@ -12,6 +12,7 @@
 	         What other properties do  I need to pass? Maybe hotreload-delta-gen should just expose an MSBuild task so we can pass everything -->
       <HotreloadDeltaGenArgs Condition="'$(Configuration)' != ''">$(HotreloadDeltaGenArgs) -p:Configuration=$(Configuration)</HotreloadDeltaGenArgs>
       <HotreloadDeltaGenArgs Condition="'$(RuntimeIdentifier)' != ''">$(HotreloadDeltaGenArgs) -p:RuntimeIdentifier=$(RuntimeIdentifier)</HotreloadDeltaGenArgs>
+      <HotreloadDeltaGenArgs Condition="'$(BuiltRuntimeConfiguration)' != ''">$(HotreloadDeltaGenArgs) -p:BuiltRuntimeConfiguration=$(BuiltRuntimeConfiguration)</HotreloadDeltaGenArgs>
       <HotreloadDeltaGenArgs>$(HotreloadDeltaGenArgs) -script:$(DeltaScript)</HotreloadDeltaGenArgs>
     </PropertyGroup>
     <Exec Command="$(HotreloadDeltaGenFullPath) $(HotreloadDeltaGenArgs)"/>

--- a/src/mono/sample/mbr/browser/runtime.js
+++ b/src/mono/sample/mbr/browser/runtime.js
@@ -7,7 +7,7 @@ var Module = {
             App.init ();
         };
         config.environment_variables = {
-            "MONO_METADATA_UPDATE": "1"
+            "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
         };
         config.fetch_file_cb = function (asset) {
             return fetch (asset, { credentials: 'same-origin' });

--- a/src/mono/sample/mbr/console/ConsoleDelta.csproj
+++ b/src/mono/sample/mbr/console/ConsoleDelta.csproj
@@ -25,7 +25,7 @@
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.$(RuntimeIdentifier)\$(Configuration)</PackageDirectory>
+        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.$(RuntimeIdentifier)\$(BuiltRuntimeConfiguration)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />

--- a/src/mono/sample/mbr/console/Makefile
+++ b/src/mono/sample/mbr/console/Makefile
@@ -2,7 +2,10 @@ TOP=../../../../../
 DOTNET:=$(TOP)./dotnet.sh
 DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 
-CONFIG ?=Release
+# How to build the project.  For hot reload this must be Debug
+CONFIG ?=Debug
+# How was dotnet/runtime built? should be the same as build.sh -c option
+BUILT_RUNTIME_CONFIG ?= Release
 MONO_ARCH=x64
 
 OS := $(shell uname -s)
@@ -15,7 +18,7 @@ endif
 MONO_ENV_OPTIONS = --interp
 
 publish:
-	$(DOTNET) publish -c $(CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
+	$(DOTNET) publish -c $(CONFIG) -r $(TARGET_OS)-$(MONO_ARCH) -p:BuiltRuntimeConfiguration=$(BUILT_RUNTIME_CONFIG)
 
 run: publish
 	COMPlus_DebugWriteToStdErr=1 \

--- a/src/mono/sample/mbr/console/Makefile
+++ b/src/mono/sample/mbr/console/Makefile
@@ -12,7 +12,7 @@ else
 	TARGET_OS=linux
 endif
 
-MONO_ENV_OPTIONS ?=--interp=-inline
+MONO_ENV_OPTIONS = --interp
 
 publish:
 	$(DOTNET) publish -c $(CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
@@ -20,6 +20,7 @@ publish:
 run: publish
 	COMPlus_DebugWriteToStdErr=1 \
 	MONO_ENV_OPTIONS="$(MONO_ENV_OPTIONS)" \
+	DOTNET_MODIFIABLE_ASSEMBLIES=debug \
 	$(TOP)artifacts/bin/ConsoleDelta/$(MONO_ARCH)/$(CONFIG)/$(TARGET_OS)-$(MONO_ARCH)/publish/ConsoleDelta
 
 clean:

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -514,12 +514,6 @@ mono_wasm_load_runtime (const char *unused, int debug_level)
 #else
 	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
 
-#ifdef ENABLE_METADATA_UPDATE
-	if (monoeg_g_hasenv ("MONO_METADATA_UPDATE")) {
-		interp_opts = "-inline";
-	}
-#endif
-
 	/*
 	 * debug_level > 0 enables debugging and sets the debug log level to debug_level
 	 * debug_level == 0 disables debugging and enables interpreter optimizations


### PR DESCRIPTION
Implements https://github.com/dotnet/runtime/issues/47274 for Mono.

1. `DOTNET_MODIFIABLE_ASSEMBLIES` envirnonment variable must be set to `debug` for hot reload to be enabled (in addition to the interpreter being enabled)
2. Assemblies must be compiled in Debug mode - we check `DebuggableAttribute` for the `DisableOptimizations` bit.  If an assembly doesn't have the bit set, it can't be reloaded.
3. In the interpreter - don't try to inline when hot reload is enabled and the caller or callee has the DisableOptimizations bit set.

/cc @vargaz @BrzVlad @mikem8361 