### PR TITLE
Update SDK's target version to 6.0 Preview 2

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -18,14 +18,4 @@
     <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
   </ItemGroup>
 
-  <!-- Mega hack to remove Newtonsoft.Json dependency which doesn't unify during runtime with the dependency in the SDK and causes MissingMethodExceptions. -->
-  <Target Name="RemovePackagingContentForMSBuildALC"
-          AfterTargets="Restore">
-    <PropertyGroup>
-      <_BuildTasksPackagingNewtonsoftDependency>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\tools\netcoreapp3.1\Newtonsoft.Json.dll</_BuildTasksPackagingNewtonsoftDependency>
-    </PropertyGroup>
-
-    <Delete Files="$(_BuildTasksPackagingNewtonsoftDependency)" Condition="Exists('$(_BuildTasksPackagingNewtonsoftDependency)')" />
-  </Target>
-
 </Project>

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.2.21118.7"
+    "dotnet": "6.0.100-preview.2.21155.3"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -307,12 +307,4 @@
     <Message Condition="'$(TestPackages)' != 'true'" Importance="High" Text="Build TargetFramework: $(BuildTargetFramework)" />
     <Message Condition="'$(TestPackages)' == 'true'" Importance="High" Text="Doing Package Testing" />
   </Target>
-  
-  <!-- TODO: Remove after https://github.com/dotnet/arcade/pull/6975 is merged. -->
-  <Target Name="UpdateDotNetCliVersionForMobile"
-          BeforeTargets="AddDotNetSdk">
-    <PropertyGroup>
-      <DotNetCliVersion Condition="'$(DotNetCliPackageType)' == 'aspnetcore-runtime'">6.0.0-preview.1.21103.6</DotNetCliVersion>
-    </PropertyGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Not updating the minimum required version as that's considered a breaking change that needs to go through the monthly infra rollout.