### PR TITLE
Backport "Fix incomplete dumps generated by createdump (#49468)"

### DIFF
--- a/src/coreclr/src/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/src/debug/createdump/createdumpunix.cpp
@@ -45,6 +45,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     }
     if (!dumpWriter.WriteDump())
     {
+        fprintf(stderr, "Writing dump FAILED\n");
         goto exit;
     }
     result = true;

--- a/src/coreclr/src/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/src/debug/createdump/dumpwriter.cpp
@@ -203,24 +203,24 @@ DumpWriter::WriteDump()
         // Only write the regions that are backed by memory
         if (memoryRegion.IsBackedByMemory())
         {
-            uint32_t size = memoryRegion.Size();
             uint64_t address = memoryRegion.StartAddress();
+            size_t size = memoryRegion.Size();
             total += size;
 
             while (size > 0)
             {
-                uint32_t bytesToRead = std::min(size, (uint32_t)sizeof(m_tempBuffer));
+                size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
                 size_t read = 0;
 
                 if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
-                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08x) FAILED\n", address, bytesToRead);
+                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08zx) FAILED\n", address, bytesToRead);
                     return false;
                 }
 
                 // This can happen if the target process dies before createdump is finished
                 if (read == 0) {
-                    TRACE("ReadProcessMemory(%" PRIA PRIx64 ", %08x) return 0 bytes read\n", address, bytesToRead);
-                    break;
+                    fprintf(stderr, "ReadProcessMemory(%" PRIA PRIx64 ", %08zx) returned 0 bytes read\n", address, bytesToRead);
+                    return false;
                 }
 
                 if (!WriteData(m_tempBuffer, read)) {


### PR DESCRIPTION
# Customer Impact

Incomplete core dumps on Linux are being generated by createdump (via dotnet-dump or unhandled exception env var triggers) causing SOS commands to fail. Multiple customers have reported this problem in 3.1 and 5.0 when their GC heaps have grown larger than 4GB.  

# Regression?

No. The bug has been in createdump from the beginning. 

# Risk (see taxonomy)

Low.

# Is there a packaging impact?

No.

# Full description

The core dump generated for a app that has large GC heaps (>4GB) are don't contain all the memory needed in process. This is because of a 32bit size value overflow; changed to size_t.

Issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1277488?src=WorkItemMention&src-action=artifact_link
Issue: https://github.com/dotnet/diagnostics/issues/1780