### PR TITLE
Skip compilation of simple methods that just throw in crossgen2

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs
@@ -33,6 +33,23 @@ namespace Internal.IL
                 && s_opcodeSizes[(int)opcode] != Invalid;
         }
 
+        public static bool IsBranch(this ILOpcode opcode)
+        {
+            if (opcode >= ILOpcode.br && opcode <= ILOpcode.blt_un)
+                return true;
+
+            if (opcode >= ILOpcode.br_s && opcode <= ILOpcode.blt_un_s)
+                return true;
+
+            if (opcode == ILOpcode.leave_s)
+                return true;
+
+            if (opcode == ILOpcode.leave)
+                return true;
+
+            return false;
+        }
+
         private static readonly byte[] s_opcodeSizes = new byte[]
         {
             1, // nop = 0x00,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -556,7 +556,7 @@ namespace ILCompiler
                             // Create only 1 CorInfoImpl per thread.
                             // This allows SuperPMI to rely on non-reuse of handles in ObjectToHandle
                             CorInfoImpl corInfoImpl = _corInfoImpls.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
-                            corInfoImpl.CompileMethod(methodCodeNodeNeedingCode);
+                            corInfoImpl.CompileMethod(methodCodeNodeNeedingCode, Logger);
                         }
                     }
                     catch (TypeSystemException ex)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -402,7 +402,7 @@ namespace Internal.JitInterface
                     var ilOpcode = reader.ReadILOpcode();
                     if (ilOpcode == ILOpcode.throw_)
                         return true;
-                    if (ilOpcode.IsBranch())
+                    if (ilOpcode.IsBranch() || ilOpcode == ILOpcode.switch_)
                         return false;
                     reader.Skip(ilOpcode);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -388,7 +388,32 @@ namespace Internal.JitInterface
             return false;
         }
 
-        public void CompileMethod(MethodWithGCInfo methodCodeNodeNeedingCode)
+        private bool FunctionJustThrows(MethodIL ilBody)
+        {
+            try
+            {
+                if (ilBody.GetExceptionRegions().Length != 0)
+                    return false;
+
+                ILReader reader = new ILReader(ilBody.GetILBytes());
+
+                while (reader.HasNext)
+                {
+                    var ilOpcode = reader.ReadILOpcode();
+                    if (ilOpcode == ILOpcode.throw_)
+                        return true;
+                    if (ilOpcode.IsBranch())
+                        return false;
+                    reader.Skip(ilOpcode);
+                }
+            }
+            catch
+            { }
+
+            return false;
+        }
+
+        public void CompileMethod(MethodWithGCInfo methodCodeNodeNeedingCode, Logger logger)
         {
             bool codeGotPublished = false;
             _methodCodeNode = methodCodeNodeNeedingCode;
@@ -398,10 +423,19 @@ namespace Internal.JitInterface
                 if (!ShouldSkipCompilation(MethodBeingCompiled) && !MethodSignatureIsUnstable(MethodBeingCompiled.Signature, out var _))
                 {
                     MethodIL methodIL = _compilation.GetMethodIL(MethodBeingCompiled);
+
                     if (methodIL != null)
                     {
-                        CompileMethodInternal(methodCodeNodeNeedingCode, methodIL);
-                        codeGotPublished = true;
+                        if (!FunctionJustThrows(methodIL))
+                        {
+                            CompileMethodInternal(methodCodeNodeNeedingCode, methodIL);
+                            codeGotPublished = true;
+                        }
+                        else
+                        {
+                            if (logger.IsVerbose)
+                                logger.Writer.WriteLine($"Warning: Method `{MethodBeingCompiled}` was not compiled because it always throws an exception");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Significant savings when compiling System.Private.CoreLib. In particular, there are *many* intrinsic functions that we can now avoid compilation of
  - X64 build drops about 3,000 functions from compilation