### PR TITLE
Remove DynamicDependency workaround

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
@@ -83,13 +83,6 @@ namespace System.Diagnostics
         // done by GetStackFramesInternal (on Windows for old PDB format).
         //
 
-        // TODO: Remove these DynamicDependencyAttributes when https://github.com/mono/linker/issues/943 is fixed.
-        // This is necessary because linker can't add new assemblies to the closure when recognizing Type.GetType
-        // so the code below is actually recognized by linker, but fails to resolve the type since the System.Diagnostics.StackTrace
-        // is not always part of the closure linker works on.
-        // DynamicDependencyAttribute on the other hand can pull in additional assemblies.
-        [DynamicDependency("GetSourceLineInfo", "System.Diagnostics.StackTraceSymbols", "System.Diagnostics.StackTrace")]
-        [DynamicDependency("#ctor()", "System.Diagnostics.StackTraceSymbols", "System.Diagnostics.StackTrace")]
         internal void InitializeSourceInfo(int iSkip, bool fNeedFileInfo, Exception? exception)
         {
             StackTrace.GetStackFramesInternal(this, iSkip, fNeedFileInfo, exception);

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -399,11 +399,6 @@ namespace System
             return oh?.Unwrap();
         }
 
-        // TODO: Remove these DynamicDependencyAttributes when https://github.com/mono/linker/issues/943 is fixed.
-        [DynamicDependency("GetDefaultInstance", "System.Security.Principal.GenericPrincipal", "System.Security.Claims")]
-#if TARGET_WINDOWS
-        [DynamicDependency("GetDefaultInstance", "System.Security.Principal.WindowsPrincipal", "System.Security.Principal.Windows")]
-#endif
         internal IPrincipal? GetThreadPrincipal()
         {
             IPrincipal? principal = _defaultPrincipal;

--- a/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -27,8 +27,6 @@ namespace System.ComponentModel
         /// class, converting the specified value to the specified type, and using the U.S. English
         /// culture as the translation context.
         /// </summary>
-        // TODO: https://github.com/mono/linker/issues/943
-        [DynamicDependency("ConvertFromInvariantString", "System.ComponentModel.TypeConverter", "System.ComponentModel.TypeConverter")]
         public DefaultValueAttribute(Type type, string? value)
         {
             // The null check and try/catch here are because attributes should never throw exceptions.

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceSet.cs
@@ -105,8 +105,6 @@ namespace System.Resources
         // Returns the preferred IResourceWriter class for this kind of ResourceSet.
         // Subclasses of ResourceSet using their own Readers &; should override
         // GetDefaultReader and GetDefaultWriter.
-        // TODO: https://github.com/mono/linker/issues/943
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, "System.Resources.ResourceWriter", "System.Resources.Writer")]
         public virtual Type GetDefaultWriter()
         {
             return Type.GetType("System.Resources.ResourceWriter, System.Resources.Writer", throwOnError: true)!;


### PR DESCRIPTION
The linker no longer needs these DynamicDependency attributes because it
can resolve the assemblies when it sees the strings passed to GetType.