### PR TITLE
[AndroidCrypto] Avoid printing JNI exceptions in cases where they are expected

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -331,7 +331,7 @@ error:
     {
         // Destroy the private key data.
         (*env)->CallVoidMethod(env, loc[privateKey], g_destroy);
-        TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
+        (void)TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
     }
 
 cleanup:

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -331,7 +331,7 @@ error:
     {
         // Destroy the private key data.
         (*env)->CallVoidMethod(env, loc[privateKey], g_destroy);
-        CheckJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
+        TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
     }
 
 cleanup:

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
@@ -49,7 +49,7 @@ void AndroidCryptoNative_EcKeyDestroy(EC_KEY* r)
                 {
                     (*env)->CallVoidMethod(env, privateKey, g_destroy);
                     ReleaseLRef(env, privateKey);
-                    CheckJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
+                    TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
                 }
             }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
@@ -49,7 +49,7 @@ void AndroidCryptoNative_EcKeyDestroy(EC_KEY* r)
                 {
                     (*env)->CallVoidMethod(env, privateKey, g_destroy);
                     ReleaseLRef(env, privateKey);
-                    TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
+                    (void)TryClearJNIExceptions(env); // The destroy call might throw an exception. Clear the exception state.
                 }
             }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -371,6 +371,17 @@ bool CheckJNIExceptions(JNIEnv* env)
     return false;
 }
 
+bool TryClearJNIExceptions(JNIEnv* env)
+{
+    if ((*env)->ExceptionCheck(env))
+    {
+        (*env)->ExceptionClear(env);
+        return true;
+    }
+
+    return false;
+}
+
 void AssertOnJNIExceptions(JNIEnv* env)
 {
     assert(!CheckJNIExceptions(env));
@@ -580,7 +591,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_DSAPublicKeySpecClass =              GetClassGRef(env, "java/security/spec/DSAPublicKeySpec");
     g_DSAPublicKeySpecCtor =               GetMethod(env, false, g_DSAPublicKeySpecClass, "<init>", "(Ljava/math/BigInteger;Ljava/math/BigInteger;Ljava/math/BigInteger;Ljava/math/BigInteger;)V");
     g_DSAPublicKeySpecGetY =               GetMethod(env, false, g_DSAPublicKeySpecClass, "getY", "()Ljava/math/BigInteger;");
-    g_DSAPublicKeySpecGetP =               GetMethod(env, false, g_DSAPublicKeySpecClass, "getP", "()Ljava/math/BigInteger;"); 
+    g_DSAPublicKeySpecGetP =               GetMethod(env, false, g_DSAPublicKeySpecClass, "getP", "()Ljava/math/BigInteger;");
     g_DSAPublicKeySpecGetQ =               GetMethod(env, false, g_DSAPublicKeySpecClass, "getQ", "()Ljava/math/BigInteger;");
     g_DSAPublicKeySpecGetG =               GetMethod(env, false, g_DSAPublicKeySpecClass, "getG", "()Ljava/math/BigInteger;");
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -341,8 +341,16 @@ jobject AddGRef(JNIEnv *env, jobject gref);
 void ReleaseGRef(JNIEnv *env, jobject gref);
 void ReleaseLRef(JNIEnv *env, jobject lref);
 jclass GetClassGRef(JNIEnv *env, const char* name);
+
+// Print and clear any JNI exceptions. Returns true if there was an exception, false otherwise.
 bool CheckJNIExceptions(JNIEnv* env);
+
+// Clear any JNI exceptions without printing them. Returns true if there was an exception, false otherwise.
+bool TryClearJNIExceptions(JNIEnv* env);
+
+// Assert on any JNI exceptions. Prints the exception before asserting.
 void AssertOnJNIExceptions(JNIEnv* env);
+
 jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);
 jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
@@ -225,7 +225,7 @@ PAL_X509ContentType AndroidCryptoNative_X509GetContentType(const uint8_t* buf, i
     // CertPath certPath = certFactory.generateCertPath(stream, "PKCS7");
     loc[pkcs7Type] = JSTRING("PKCS7");
     loc[certPath] = (*env)->CallObjectMethod(env, loc[certFactory], g_CertFactoryGenerateCertPathFromStream, loc[stream], loc[pkcs7Type]);
-    if (!CheckJNIExceptions(env))
+    if (!TryClearJNIExceptions(env))
     {
         ret = PAL_Pkcs7;
         goto cleanup;
@@ -235,7 +235,7 @@ PAL_X509ContentType AndroidCryptoNative_X509GetContentType(const uint8_t* buf, i
     // Certificate cert = certFactory.generateCertificate(stream);
     (*env)->CallVoidMethod(env, loc[stream], g_ByteArrayInputStreamReset);
     loc[cert] = (*env)->CallObjectMethod(env, loc[certFactory], g_CertFactoryGenerateCertificate, loc[stream]);
-    if (!CheckJNIExceptions(env))
+    if (!TryClearJNIExceptions(env))
     {
         ret = PAL_Certificate;
         goto cleanup;


### PR DESCRIPTION
`AndroidCryptoNative_X509GetContentType` relies on errors to determine what a byte array represents. Avoid the noise of printing the exceptions in this case.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs