### PR TITLE
Enable crossgen2 SuperPMI for Linux

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -123,10 +123,9 @@ jobs:
     platforms:
     # Linux tests are built on the OSX machines.
     # - OSX_x64
-    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
-    # - Linux_arm
-    # - Linux_arm64
-    # - Linux_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
     - windows_x64
     - windows_x86
     - windows_arm64

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1710,6 +1710,13 @@ void interceptor_ICJI::getCallInfo(
     param.flags                     = flags;
     param.pResult                   = pResult;
 
+#ifdef HOST_UNIX
+    // We don't seem to be able to capture the exception code in PAL exceptions when thrown
+    // from crossgen2. So assume there will be some error, then set it to zero (no error)
+    // if the `getCallInfo` call doesn't throw.
+    param.exceptionCode = 1;
+#endif // HOST_UNIX
+
     PAL_TRY(Param*, pOuterParam, &param)
     {
         PAL_TRY(Param*, pParam, pOuterParam)
@@ -1717,6 +1724,9 @@ void interceptor_ICJI::getCallInfo(
             pParam->pThis->mc->cr->AddCall("getCallInfo");
             pParam->pThis->original_ICorJitInfo->getCallInfo(pParam->pResolvedToken, pParam->pConstrainedResolvedToken,
                                                              pParam->callerHandle, pParam->flags, pParam->pResult);
+#ifdef HOST_UNIX
+            pParam->exceptionCode = 0;
+#endif // HOST_UNIX
         }
         PAL_EXCEPT_FILTER(FilterSuperPMIExceptions_CaptureExceptionAndContinue)
         {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -27,6 +27,7 @@ WCHAR*         g_DefaultRealJitPath = nullptr;
 MethodContext* g_globalContext      = nullptr;
 WCHAR*         g_debugRecStr        = nullptr;
 WCHAR*         g_debugRepStr        = nullptr;
+bool           g_initialized        = false;
 
 void SetDefaultPaths()
 {
@@ -102,6 +103,28 @@ void SetDebugVariables()
     }
 }
 
+void InitializeShim()
+{
+    if (g_initialized)
+    {
+        return;
+    }
+
+#ifdef HOST_UNIX
+    if (0 != PAL_InitializeDLL())
+    {
+        fprintf(stderr, "Error: Fail to PAL_InitializeDLL\n");
+        exit(1);
+    }
+#endif // HOST_UNIX
+
+    Logger::Initialize();
+    SetLogFilePath();
+    Logger::OpenLogFile(g_logFilePath);
+
+    g_initialized = true;
+}
+
 extern "C"
 #ifdef HOST_UNIX
     DLLEXPORT // For Win32 PAL LoadLibrary emulation
@@ -112,17 +135,7 @@ extern "C"
     switch (ul_reason_for_call)
     {
         case DLL_PROCESS_ATTACH:
-#ifdef HOST_UNIX
-            if (0 != PAL_InitializeDLL())
-            {
-                fprintf(stderr, "Error: Fail to PAL_InitializeDLL\n");
-                exit(1);
-            }
-#endif // HOST_UNIX
-
-            Logger::Initialize();
-            SetLogFilePath();
-            Logger::OpenLogFile(g_logFilePath);
+            InitializeShim();
             break;
 
         case DLL_PROCESS_DETACH:
@@ -142,6 +155,9 @@ extern "C"
 
 extern "C" DLLEXPORT void __stdcall jitStartup(ICorJitHost* host)
 {
+    // crossgen2 doesn't invoke DllMain, so optionally do initialization work here.
+    InitializeShim();
+
     SetDefaultPaths();
     SetLibName();
     SetDebugVariables();

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -155,7 +155,7 @@ extern "C"
 
 extern "C" DLLEXPORT void __stdcall jitStartup(ICorJitHost* host)
 {
-    // crossgen2 doesn't invoke DllMain, so optionally do initialization work here.
+    // crossgen2 doesn't invoke DllMain on Linux/Mac (under PAL), so optionally do initialization work here.
     InitializeShim();
 
     SetDefaultPaths();


### PR DESCRIPTION
Fix SuperPMI on Linux for crossgen2                                                  
                                                                                     
1. crossgen2 doesn't call DllMain (https://github.com/dotnet/runtime/issues/49525),  
so add a call to initialize the PAL and other things in jitStartup() (the JIT does   
it this way already). Note that crossgen2 doesn't call DllMain for shutdown, either, 
so we won't properly shut down the logger. Normally, however, we don't use the logger
during collections.                                                                  
1.1. I only changed the collector, not the other two shims (which aren't used).      
2. We don't seem to be able to get the correct exception code for exceptions thrown  
from crossgen2. So, as a workaround, instead of assuming we're going to succeed,     
assume we're going to fail with a non-zero exception code, and then set it to zero   
if no exception was thrown. This only applies to the `getCallInfo` API.              

Finally, add crossgen2 collections for Linux platforms.
