### PR TITLE
Add clr.iltools subset

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.runtime+clr.jit+clr.alljits+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.runtime+clr.jit+clr.alljits+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
     <DefaultMonoSubsets Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
@@ -70,13 +70,14 @@
     <_subset>+$(_subset.Trim('+'))+</_subset>
 
     <ClrRuntimeBuildSubsets></ClrRuntimeBuildSubsets>
-    <ClrDefaultRuntimeBuildSubsets>ClrRuntimeSubset=true;ClrJitSubset=true</ClrDefaultRuntimeBuildSubsets>
+    <ClrDefaultRuntimeBuildSubsets>ClrRuntimeSubset=true;ClrJitSubset=true;ClrILToolsSubset=true</ClrDefaultRuntimeBuildSubsets>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CoreClr -->
     <SubsetName Include="Clr" Description="The CoreCLR runtime, LinuxDac, CoreLib (+ native), tools and packages." />
     <SubsetName Include="Clr.DacTools" Description="Managed tools that support building a runtime that supports debugging (such as DacTableGen)." />
+    <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools." />
     <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime." />
     <SubsetName Include="Clr.PalTests" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
@@ -162,6 +163,10 @@
 
   <PropertyGroup Condition="$(_subset.Contains('+clr.alljits+'))">
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrAllJitsSubset=true;ClrJitSubset=true</ClrRuntimeBuildSubsets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(_subset.Contains('+clr.iltools+'))">
+    <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrILToolsSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -80,7 +80,9 @@ if(CLR_CMAKE_HOST_UNIX)
     endif()
 
     add_subdirectory(pal)
-    add_subdirectory(hosts)
+    if(CLR_CMAKE_BUILD_SUBSET_RUNTIME)
+        add_subdirectory(hosts)
+    endif(CLR_CMAKE_BUILD_SUBSET_RUNTIME)
 else(CLR_CMAKE_HOST_UNIX)
     if(CLR_CMAKE_TARGET_UNIX)
         add_subdirectory(pal/src/libunwind)
@@ -103,7 +105,9 @@ endif()
 include_directories("pal/prebuilt/inc")
 include_directories("../../artifacts/obj/coreclr")
 
-add_subdirectory(tools/aot/jitinterface)
+if(CLR_CMAKE_BUILD_SUBSET_JIT)
+  add_subdirectory(tools/aot/jitinterface)
+endif(CLR_CMAKE_BUILD_SUBSET_JIT)
 
 # Above projects do not build with these compile options
 # All of the compiler options are specified in file compileoptions.cmake
@@ -206,15 +210,26 @@ if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSI
 endif()
 
 add_subdirectory(utilcode)
-add_subdirectory(gcinfo)
-add_subdirectory(jit)
 add_subdirectory(inc)
 
 if(CLR_CMAKE_HOST_UNIX)
     add_subdirectory(palrt)
 endif(CLR_CMAKE_HOST_UNIX)
 
-add_subdirectory(vm)
+if(CLR_CMAKE_BUILD_SUBSET_ILTOOLS)
+  add_subdirectory(ildasm)
+  add_subdirectory(ilasm)
+endif(CLR_CMAKE_BUILD_SUBSET_ILTOOLS)
+
+if(CLR_CMAKE_BUILD_SUBSET_JIT)
+  add_subdirectory(gcinfo)
+  add_subdirectory(jit)
+  add_subdirectory(vm)
+else(CLR_CMAKE_BUILD_SUBSET_JIT)
+  # The eventing headers are required to build the IL tools and paltests
+  add_subdirectory(vm/eventing)
+endif(CLR_CMAKE_BUILD_SUBSET_JIT)
+
 if (CLR_CMAKE_BUILD_SUBSET_RUNTIME)
   add_subdirectory(md)
   add_subdirectory(debug)
@@ -224,14 +239,17 @@ if (CLR_CMAKE_BUILD_SUBSET_RUNTIME)
   add_subdirectory(ToolBox)
   add_subdirectory(tools)
   add_subdirectory(unwinder)
-  add_subdirectory(ildasm)
-  add_subdirectory(ilasm)
   add_subdirectory(interop)
 
   if(CLR_CMAKE_HOST_WIN32)
     add_subdirectory(hosts)
   endif(CLR_CMAKE_HOST_WIN32)
-else()
+elseif(CLR_CMAKE_BUILD_SUBSET_ILTOOLS)
+  # These parts of the runtime are required to build the IL tools
+  add_subdirectory(md)
+  add_subdirectory(dlls/mscorrc)
+  add_subdirectory(dlls/mscorpe)
+elseif(CLR_CMAKE_BUILD_SUBSET_JIT)
   if(CLR_CMAKE_HOST_UNIX)
     # this is needed to compile the jit on unix platforms.
     # When the runtime subset is compiled, the add_subdirectory(dlls) above

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -86,6 +86,7 @@ set __BuildJit=1
 set __BuildPALTests=0
 set __BuildAllJits=1
 set __BuildRuntime=1
+set __BuildILTools=1
 set __CrossArch=
 set __CrossArch2=
 set __CrossOS=0
@@ -172,6 +173,7 @@ if /i "%1" == "-nopgooptimize"       (set __PgoOptimize=0&set processedArgs=!pro
 if /i "%1" == "-skipjit"             (set __BuildJit=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-skipalljits"         (set __BuildAllJits=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-skipruntime"         (set __BuildRuntime=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "-skipiltools"         (set __BuildILTools=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 REM TODO these are deprecated remove them eventually
 REM don't add more, use the - syntax instead
@@ -422,7 +424,7 @@ if NOT DEFINED PYTHON (
     goto ExitWithError
 )
 
-set __CMakeClrBuildSubsetArgs="-DCLR_CMAKE_BUILD_SUBSET_JIT=%__BuildJit%" "-DCLR_CMAKE_BUILD_SUBSET_ALLJITS=%__BuildAllJits%" "-DCLR_CMAKE_BUILD_SUBSET_RUNTIME=%__BuildRuntime%"
+set __CMakeClrBuildSubsetArgs="-DCLR_CMAKE_BUILD_SUBSET_JIT=%__BuildJit%" "-DCLR_CMAKE_BUILD_SUBSET_ALLJITS=%__BuildAllJits%" "-DCLR_CMAKE_BUILD_SUBSET_RUNTIME=%__BuildRuntime%" "-DCLR_CMAKE_BUILD_SUBSET_ILTOOLS=%__BuildILTools%"
 
 REM =========================================================================================
 REM ===

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -25,6 +25,7 @@ usage_list+=("-staticanalyzer: skip native image generation.")
 usage_list+=("-skipjit: skip building jit.")
 usage_list+=("-skipalljits: skip building crosstargetting jits.")
 usage_list+=("-skipruntime: skip building runtime.")
+usage_list+=("-skipiltools: skip building IL tools.")
 usage_list+=("-paltests: build the pal tests.")
 
 setup_dirs_local()
@@ -137,6 +138,10 @@ handle_arguments_local() {
             __BuildRuntime=0
             ;;
 
+        skipiltools|-skipiltools)
+            __BuildILTools=0
+            ;;
+
         paltests|-paltests)
             __BuildPALTests=1
             ;;
@@ -192,9 +197,11 @@ __UseNinja=0
 __VerboseBuild=0
 __ValidateCrossArg=1
 __CMakeArgs=""
+__BuildJit=1
 __BuildPALTests=0
 __BuildAllJits=1
 __BuildRuntime=1
+__BuildILTools=1
 
 source "$__ProjectRoot"/_build-commons.sh
 
@@ -247,7 +254,7 @@ restore_optdata
 
 # Build the coreclr (native) components.
 __CMakeArgs="-DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_PATH=$__PgoOptDataPath -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize $__CMakeArgs"
-__CMakeArgs="-DCLR_CMAKE_BUILD_SUBSET_JIT=$__BuildJit -DCLR_CMAKE_BUILD_SUBSET_ALLJITS=$__BuildAllJits -DCLR_CMAKE_BUILD_SUBSET_RUNTIME=$__BuildRuntime $__CMakeArgs"
+__CMakeArgs="-DCLR_CMAKE_BUILD_SUBSET_JIT=$__BuildJit -DCLR_CMAKE_BUILD_SUBSET_ALLJITS=$__BuildAllJits -DCLR_CMAKE_BUILD_SUBSET_RUNTIME=$__BuildRuntime $__CMakeArgs -DCLR_CMAKE_BUILD_SUBSET_ILTOOLS=$__BuildILTools"
 __CMakeArgs="-DCLR_CMAKE_BUILD_TESTS=$__BuildPALTests $__CMakeArgs"
 
 if [[ "$__SkipConfigure" == 0 && "$__CodeCoverage" == 1 ]]; then

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -29,6 +29,7 @@
       <_CoreClrBuildArg Condition="'$(Ninja)' == 'true'" Include="-ninja" />
       <_CoreClrBuildArg Condition="'$(ClrRuntimeSubset)' != 'true'" Include="-skipruntime" />
       <_CoreClrBuildArg Condition="'$(ClrJitSubset)' != 'true'" Include="-skipjit" />
+      <_CoreClrBuildArg Condition="'$(ClrILToolsSubset)' != 'true'" Include="-skipiltools" />
       <_CoreClrBuildArg Condition="'$(ClrPalTestsSubset)' == 'true'" Include="-paltests" />
       <_CoreClrBuildArg Condition="'$(ClrAllJitsSubset)' != 'true'" Include="-skipalljits" />
       <_CoreClrBuildArg Condition="'$(PgoInstrument)' == 'true'" Include="-pgoinstrument" />

--- a/src/coreclr/vm/eventing/CMakeLists.txt
+++ b/src/coreclr/vm/eventing/CMakeLists.txt
@@ -37,7 +37,10 @@ set_source_files_properties(${EventingHeaders} PROPERTIES GENERATED TRUE)
 add_custom_target(eventing_headers DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/eventing_headers.timestamp)
 add_dependencies(eventing_headers eventprovider)
 
-add_subdirectory(eventpipe)
+# When we are not building the JIT, we only build the headers here
+if(CLR_CMAKE_BUILD_SUBSET_JIT)
+  add_subdirectory(eventpipe)
+endif()
 
 if(CLR_CMAKE_HOST_WIN32)
   add_subdirectory(EtwProvider)


### PR DESCRIPTION
* Add new subset to build only the IL tools (ilasm/ildasm)

* New -skipiltools argument to src/coreclr/build-runtime.{cmd,sh}

* Actually do not build JIT if -skipjit argument is used

Fixes https://github.com/dotnet/runtime/issues/48640