### PR TITLE
adjust buffer calculation for SslRead

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -365,7 +365,7 @@ internal static partial class Interop
                 {
                     fixed (byte* fixedBuffer = outBuffer)
                     {
-                        retVal = Ssl.SslRead(context, fixedBuffer + offset, outBuffer.Length);
+                        retVal = Ssl.SslRead(context, fixedBuffer + offset, outBuffer.Length - offset);
                     }
                 }
 


### PR DESCRIPTION
I noticed this when working on something else. 
If offset is not 0, we should not pass in outBuffer.Length because we do not start from beginning of the outBuffer.