### PR TITLE
"==0" optimization in Boolean logic #13573

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -79,6 +79,8 @@ class FgStack;             // defined in fgbasic.cpp
 class Instrumentor;        // defined in fgprofile.cpp
 class SpanningTreeVisitor; // defined in fgprofile.cpp
 class CSE_DataFlow;        // defined in OptCSE.cpp
+struct OptBoolsDsc;        // defined in optimizer.cpp
+struct OptTestInfo;
 #ifdef DEBUG
 struct IndentStack;
 #endif
@@ -6315,35 +6317,10 @@ public:
     void optOptimizeBools();
 
 private:
-    struct OptBoolsDsc
-    {
-        BasicBlock* b1; // The first Basic Block with the BBJ_COND conditional jump type
-        BasicBlock* b2; // The next basic block of b1
-        BasicBlock* b3; // The next basic block of b2
-
-        GenTree* t1; // The root node of b1
-        GenTree* t2; // The root node of b2
-        GenTree* t3; // The root node of b3
-
-        GenTree* t1CompPtr; // The compare node (i.e. GT_EQ or GT_NE node) of t1
-        GenTree* t2CompPtr; // The compare node (i.e. GT_EQ or GT_NE node) of t2
-
-        GenTree* c1; // The first operand of t1CompPtr
-        GenTree* c2; // The first operand of t2CompPtr
-
-        bool sameTarget; // if b1 and b2 jumps to the same destination
-
-        genTreeOps foldOp;   // The fold operator (e.g., GT_AND or GT_OR)
-        var_types  foldType; // The type of the folded tree
-        genTreeOps cmpOp;    // The comparison operator (e.g., GT_EQ or GT_NE)
-        bool       bool1;    // If tree t1CompPtr is boolean comparison
-        bool       bool2;    // If tree t2CompPtr is boolean comparison
-    };
-
-    void optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
-    void optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
+    bool optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc);
+    bool optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc);
     Statement* optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc);
-    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    GenTree* optIsBoolComp(OptTestInfo* optTest);
     bool optOptimizeBoolsChkTypeCostCond(OptBoolsDsc* pOptBoolsDsc);
     void optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc);
     void optReturnGetFoldAndCompOper(OptBoolsDsc* pOptBoolsDsc);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6315,7 +6315,9 @@ public:
     void optOptimizeBools();
 
 private:
-    GenTree* optIsBoolCond(GenTree* condBranch, GenTree** compPtr, bool* boolPtr);
+    void optOptimizeBoolsBbjCond(BasicBlock* b1, BasicBlock* b2, bool* change);
+    void optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
+    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6318,13 +6318,8 @@ private:
     void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
     void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
     GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
-    void     optReturnGetFoldAndCompOper(GenTree*    tree1,
-                                         GenTree*    tree2,
-                                         ssize_t     it3val,
-                                         bool        bool1,
-                                         bool        bool2,
-                                         genTreeOps* foldOp,
-                                         genTreeOps* cmpOp);
+    void optReturnGetFoldAndCompOper(
+        GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1, bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6319,13 +6319,9 @@ public:
 private:
     bool optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc);
     bool optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc);
-    Statement* optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc);
     GenTree* optIsBoolComp(OptTestInfo* optTest);
-    bool optOptimizeBoolsChkTypeCostCond(OptBoolsDsc* pOptBoolsDsc);
-    void optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc);
-    void optReturnGetFoldAndCompOper(OptBoolsDsc* pOptBoolsDsc);
 #ifdef DEBUG
-    void optOptimizeBoolsGcStress(BasicBlock* condBlock);
+    void optOptimizeBoolsGcStress(BasicBlock* b1);
 #endif
 public:
     PhaseStatus optInvertLoops();    // Invert loops so they're entered at top and tested at bottom.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6316,13 +6316,6 @@ private:
 public:
     void optOptimizeBools();
 
-private:
-    bool optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc);
-    bool optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc);
-    GenTree* optIsBoolComp(OptTestInfo* optTest);
-#ifdef DEBUG
-    void optOptimizeBoolsGcStress(BasicBlock* b1);
-#endif
 public:
     PhaseStatus optInvertLoops();    // Invert loops so they're entered at top and tested at bottom.
     PhaseStatus optOptimizeLayout(); // Optimize the BasicBlock layout of the method

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6317,36 +6317,36 @@ public:
 private:
     struct OptBoolsDsc
     {
-        BasicBlock* b1;         // The first Basic Block with the BBJ_COND conditional jump type
-        BasicBlock* b2;         // The next basic block of b1
-        BasicBlock* b3;         // The next basic block of b2
+        BasicBlock* b1; // The first Basic Block with the BBJ_COND conditional jump type
+        BasicBlock* b2; // The next basic block of b1
+        BasicBlock* b3; // The next basic block of b2
 
-        GenTree*    t1;         // The root node of b1
-        GenTree*    t2;         // The root node of b2
-        GenTree*    t3;         // The root node of b3
+        GenTree* t1; // The root node of b1
+        GenTree* t2; // The root node of b2
+        GenTree* t3; // The root node of b3
 
-        GenTree*    t1CompPtr;  // The compare node (i.e. GT_EQ or GT_NE node) of t1
-        GenTree*    t2CompPtr;  // The compare node (i.e. GT_EQ or GT_NE node) of t2
+        GenTree* t1CompPtr; // The compare node (i.e. GT_EQ or GT_NE node) of t1
+        GenTree* t2CompPtr; // The compare node (i.e. GT_EQ or GT_NE node) of t2
 
-        GenTree*    c1;         // The first operand of t1CompPtr
-        GenTree*    c2;         // The first operand of t2CompPtr
+        GenTree* c1; // The first operand of t1CompPtr
+        GenTree* c2; // The first operand of t2CompPtr
 
-        bool        sameTarget; // if b1 and b2 jumps to the same destination
+        bool sameTarget; // if b1 and b2 jumps to the same destination
 
-        genTreeOps  foldOp;     // The fold operator (e.g., GT_AND or GT_OR)
-        var_types   foldType;   // The type of the folded tree
-        genTreeOps  cmpOp;      // The comparison operator (e.g., GT_EQ or GT_NE)
-        bool        bool1;      // If tree t1CompPtr is boolean comparison
-        bool        bool2;      // If tree t2CompPtr is boolean comparison
+        genTreeOps foldOp;   // The fold operator (e.g., GT_AND or GT_OR)
+        var_types  foldType; // The type of the folded tree
+        genTreeOps cmpOp;    // The comparison operator (e.g., GT_EQ or GT_NE)
+        bool       bool1;    // If tree t1CompPtr is boolean comparison
+        bool       bool2;    // If tree t2CompPtr is boolean comparison
     };
 
-    void       optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
-    void       optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
+    void optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
+    void optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
     Statement* optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc);
-    GenTree*   optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
-    bool       optOptimizeBoolsChkTypeCostCond(OptBoolsDsc* pOptBoolsDsc);
-    void       optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc);
-    void       optReturnGetFoldAndCompOper(OptBoolsDsc* pOptBoolsDsc);
+    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    bool optOptimizeBoolsChkTypeCostCond(OptBoolsDsc* pOptBoolsDsc);
+    void optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc);
+    void optReturnGetFoldAndCompOper(OptBoolsDsc* pOptBoolsDsc);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6318,6 +6318,13 @@ private:
     void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
     void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
     GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    void     optReturnGetFoldAndCompOper(GenTree*    tree1,
+                                         GenTree*    tree2,
+                                         ssize_t     it3val,
+                                         bool        bool1,
+                                         bool        bool2,
+                                         genTreeOps* foldOp,
+                                         genTreeOps* cmpOp);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6315,11 +6315,25 @@ public:
     void optOptimizeBools();
 
 private:
-    void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
-    void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
-    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
-    void optReturnGetFoldAndCompOper(
-        GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1, bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
+    void       optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
+    Statement* optOptimizeBoolsChkBlkCond(
+        BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, GenTree** t1, GenTree** t2, GenTree** t3, bool* sameTarget);
+    GenTree*   optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    bool       optOptimizeBoolsChkTypeCostCond(GenTree* t1, GenTree* t2, GenTree* c1, GenTree* c2);
+    void       optOptimizeBoolsUpdateTrees(BasicBlock* b1,
+                                           BasicBlock* b2,
+                                           BasicBlock* b3,
+                                           GenTree*    t1,
+                                           GenTree*    t2,
+                                           genTreeOps  foldOp,
+                                           var_types   foldType,
+                                           genTreeOps  cmpOp,
+                                           bool        bool1,
+                                           bool        bool2,
+                                           bool        sameTarget);
+    void       optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
+    void       optReturnGetFoldAndCompOper(
+              GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1,  bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6315,25 +6315,38 @@ public:
     void optOptimizeBools();
 
 private:
-    void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
-    Statement* optOptimizeBoolsChkBlkCond(
-        BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, GenTree** t1, GenTree** t2, GenTree** t3, bool* sameTarget);
-    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
-    bool optOptimizeBoolsChkTypeCostCond(GenTree* t1, GenTree* t2, GenTree* c1, GenTree* c2);
-    void optOptimizeBoolsUpdateTrees(BasicBlock* b1,
-                                     BasicBlock* b2,
-                                     BasicBlock* b3,
-                                     GenTree*    t1,
-                                     GenTree*    t2,
-                                     genTreeOps  foldOp,
-                                     var_types   foldType,
-                                     genTreeOps  cmpOp,
-                                     bool        bool1,
-                                     bool        bool2,
-                                     bool        sameTarget);
-    void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
-    void optReturnGetFoldAndCompOper(
-        GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1, bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
+    struct OptBoolsDsc
+    {
+        BasicBlock* b1;         // The first Basic Block with the BBJ_COND conditional jump type
+        BasicBlock* b2;         // The next basic block of b1
+        BasicBlock* b3;         // The next basic block of b2
+
+        GenTree*    t1;         // The root node of b1
+        GenTree*    t2;         // The root node of b2
+        GenTree*    t3;         // The root node of b3
+
+        GenTree*    t1CompPtr;  // The compare node (i.e. GT_EQ or GT_NE node) of t1
+        GenTree*    t2CompPtr;  // The compare node (i.e. GT_EQ or GT_NE node) of t2
+
+        GenTree*    c1;         // The first operand of t1CompPtr
+        GenTree*    c2;         // The first operand of t2CompPtr
+
+        bool        sameTarget; // if b1 and b2 jumps to the same destination
+
+        genTreeOps  foldOp;     // The fold operator (e.g., GT_AND or GT_OR)
+        var_types   foldType;   // The type of the folded tree
+        genTreeOps  cmpOp;      // The comparison operator (e.g., GT_EQ or GT_NE)
+        bool        bool1;      // If tree t1CompPtr is boolean comparison
+        bool        bool2;      // If tree t2CompPtr is boolean comparison
+    };
+
+    void       optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
+    void       optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* change);
+    Statement* optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc);
+    GenTree*   optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    bool       optOptimizeBoolsChkTypeCostCond(OptBoolsDsc* pOptBoolsDsc);
+    void       optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc);
+    void       optReturnGetFoldAndCompOper(OptBoolsDsc* pOptBoolsDsc);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6315,25 +6315,25 @@ public:
     void optOptimizeBools();
 
 private:
-    void       optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
+    void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
     Statement* optOptimizeBoolsChkBlkCond(
         BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, GenTree** t1, GenTree** t2, GenTree** t3, bool* sameTarget);
-    GenTree*   optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
-    bool       optOptimizeBoolsChkTypeCostCond(GenTree* t1, GenTree* t2, GenTree* c1, GenTree* c2);
-    void       optOptimizeBoolsUpdateTrees(BasicBlock* b1,
-                                           BasicBlock* b2,
-                                           BasicBlock* b3,
-                                           GenTree*    t1,
-                                           GenTree*    t2,
-                                           genTreeOps  foldOp,
-                                           var_types   foldType,
-                                           genTreeOps  cmpOp,
-                                           bool        bool1,
-                                           bool        bool2,
-                                           bool        sameTarget);
-    void       optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
-    void       optReturnGetFoldAndCompOper(
-              GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1,  bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
+    GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
+    bool optOptimizeBoolsChkTypeCostCond(GenTree* t1, GenTree* t2, GenTree* c1, GenTree* c2);
+    void optOptimizeBoolsUpdateTrees(BasicBlock* b1,
+                                     BasicBlock* b2,
+                                     BasicBlock* b3,
+                                     GenTree*    t1,
+                                     GenTree*    t2,
+                                     genTreeOps  foldOp,
+                                     var_types   foldType,
+                                     genTreeOps  cmpOp,
+                                     bool        bool1,
+                                     bool        bool2,
+                                     bool        sameTarget);
+    void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
+    void optReturnGetFoldAndCompOper(
+        GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1, bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6315,8 +6315,8 @@ public:
     void optOptimizeBools();
 
 private:
-    void optOptimizeBoolsBbjCond(BasicBlock* b1, BasicBlock* b2, bool* change);
-    void optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
+    void optOptimizeBoolsCondBlock(BasicBlock* b1, BasicBlock* b2, bool* change);
+    void optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, BasicBlock* b3, bool* change);
     GenTree* optIsBoolComp(GenTree* tree, GenTree** compPtr, bool* boolPtr);
 #ifdef DEBUG
     void optOptimizeBoolsGcStress(BasicBlock* condBlock);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -80,7 +80,6 @@ class Instrumentor;        // defined in fgprofile.cpp
 class SpanningTreeVisitor; // defined in fgprofile.cpp
 class CSE_DataFlow;        // defined in OptCSE.cpp
 class OptBoolsDsc;         // defined in optimizer.cpp
-struct OptTestInfo;
 #ifdef DEBUG
 struct IndentStack;
 #endif

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -79,7 +79,7 @@ class FgStack;             // defined in fgbasic.cpp
 class Instrumentor;        // defined in fgprofile.cpp
 class SpanningTreeVisitor; // defined in fgprofile.cpp
 class CSE_DataFlow;        // defined in OptCSE.cpp
-struct OptBoolsDsc;        // defined in optimizer.cpp
+class OptBoolsDsc;         // defined in optimizer.cpp
 struct OptTestInfo;
 #ifdef DEBUG
 struct IndentStack;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8079,8 +8079,8 @@ void Compiler::optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, Basic
         return;
     }
 
-    genTreeOps foldOp = GT_NONE;
-    genTreeOps cmpOp  = GT_NONE;
+    genTreeOps foldOp   = GT_NONE;
+    genTreeOps cmpOp    = GT_NONE;
     var_types  foldType = c1->TypeGet();
     if (varTypeIsGC(foldType))
     {
@@ -8106,11 +8106,11 @@ void Compiler::optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, Basic
     }
 
     t1->SetOper(cmpOp);
-    t1->AsOp()->gtOp1         = cmpOp1;
-    t1->AsOp()->gtOp2->gtType = foldType; // Could have been varTypeIsGC()
+    t1->AsOp()->gtOp1                        = cmpOp1;
+    t1->AsOp()->gtOp2->gtType                = foldType; // Could have been varTypeIsGC()
     t1->AsOp()->gtOp2->AsIntCon()->gtIconVal = 0;
-    s1->GetRootNode()->gtOper = GT_RETURN;
-    s1->GetRootNode()->gtType = s2->GetRootNode()->gtType;
+    s1->GetRootNode()->gtOper                = GT_RETURN;
+    s1->GetRootNode()->gtType                = s2->GetRootNode()->gtType;
 
 #if FEATURE_SET_FLAGS
     // For comparisons against zero we will have the GTF_SET_FLAGS set
@@ -8201,13 +8201,8 @@ void Compiler::optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, Basic
 //      foldOp: On success, return the fold operator of GT_AND or GT_OR.
 //      cmpOp:  On success, return the comparison operator of GT_EQ or GT_NE
 //
-void Compiler::optReturnGetFoldAndCompOper(GenTree*    tree1,
-                                           GenTree*    tree2,
-                                           ssize_t     it3val,
-                                           bool        bool1,
-                                           bool        bool2,
-                                           genTreeOps* foldOp,
-                                           genTreeOps* cmpOp)
+void Compiler::optReturnGetFoldAndCompOper(
+    GenTree* tree1, GenTree* tree2, ssize_t it3val, bool bool1, bool bool2, genTreeOps* foldOp, genTreeOps* cmpOp)
 {
     genTreeOps foldOper;
     genTreeOps cmpOper;
@@ -8241,7 +8236,7 @@ void Compiler::optReturnGetFoldAndCompOper(GenTree*    tree1,
         foldOper = GT_AND;
         cmpOper  = GT_EQ;
     }
-    else if((t1Oper == GT_NE && t2Oper == GT_NE) && (it1val == 0 && it2val == 0 && it3val == 1))
+    else if ((t1Oper == GT_NE && t2Oper == GT_NE) && (it1val == 0 && it2val == 0 && it3val == 1))
     {
         // Case: x == 1 || y == 1
         //      t1:c1==1 t2:c2==1 is reversed from optIsBoolComp() to: t1:c1!=0 t2:c2!=0 t3:c3==1

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7859,11 +7859,11 @@ void Compiler::optOptimizeBoolsBbjCond(BasicBlock* b1, BasicBlock* b2, bool* cha
     BasicBlock::weight_t edgeSumMax = edge1->edgeWeightMax() + edge2->edgeWeightMax();
     if ((edgeSumMax >= edge1->edgeWeightMax()) && (edgeSumMax >= edge2->edgeWeightMax()))
     {
-        edge1->setEdgeWeights(edgeSumMin, edgeSumMax);
+        edge1->setEdgeWeights(edgeSumMin, edgeSumMax, b1->bbJumpDest);
     }
     else
     {
-        edge1->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT);
+        edge1->setEdgeWeights(BB_ZERO_WEIGHT, BB_MAX_WEIGHT, b1->bbJumpDest);
     }
 
     /* Get rid of the second block (which is a BBJ_COND) */
@@ -8166,8 +8166,8 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
 #ifdef DEBUG
     if (verbose)
     {
-        printf("Folded %sboolean conditions of " FMT_BB " and " FMT_BB " to :\n", c2->OperIsLeaf() ? "" : "non-leaf ",
-               b1->bbNum, b2->bbNum);
+        printf("Folded %sboolean conditions of " FMT_BB ", " FMT_BB " and " FMT_BB " to :\n", c2->OperIsLeaf() ? "" : "non-leaf ",
+               b1->bbNum, b2->bbNum, b3->bbNum);
         gtDispStmt(s1);
         printf("\n");
     }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7914,7 +7914,6 @@ void Compiler::optOptimizeBoolsBbjCond(BasicBlock* b1, BasicBlock* b2, bool* cha
         printf("\n");
     }
 #endif
-
 }
 
 /*
@@ -7963,7 +7962,7 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
 
     GenTree* t2 = s2->GetRootNode();
     GenTree* t3 = s3->GetRootNode();
-    if(t2->gtOper != GT_RETURN || t3->gtOper!= GT_RETURN)
+    if (t2->gtOper != GT_RETURN || t3->gtOper != GT_RETURN)
     {
         return;
     }
@@ -8145,7 +8144,7 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
     b1->bbJumpKind = b2->bbJumpKind;
     b1->bbJumpSwt  = b2->bbJumpSwt;
 
-    //fgAddRefPred(b2->bbJumpDest, b1);
+    // fgAddRefPred(b2->bbJumpDest, b1);
 
     /* Get rid of the second & third block (which is a BBJ_RETURN) */
 
@@ -8176,14 +8175,13 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
 #ifdef DEBUG
     if (verbose)
     {
-        printf("Folded %sboolean conditions of " FMT_BB ", " FMT_BB " and " FMT_BB " to :\n", c2->OperIsLeaf() ? "" : "non-leaf ",
-               b1->bbNum, b2->bbNum, b3->bbNum);
+        printf("Folded %sboolean conditions of " FMT_BB ", " FMT_BB " and " FMT_BB " to :\n",
+               c2->OperIsLeaf() ? "" : "non-leaf ", b1->bbNum, b2->bbNum, b3->bbNum);
         gtDispStmt(s1);
         printf("\n");
     }
 #endif
 }
-
 
 /******************************************************************************
  *

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8130,7 +8130,7 @@ void Compiler::optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, Basic
             return;
         }
     }
-    else  if (t1->gtOper == GT_NE && t2->gtOper == GT_EQ)
+    else if (t1->gtOper == GT_NE && t2->gtOper == GT_EQ)
     {
         if (it1val == 0 && it2val == 0 && it3val == 0)
         {
@@ -8177,9 +8177,8 @@ void Compiler::optOptimizeBoolsReturnBlock(BasicBlock* b1, BasicBlock* b2, Basic
         }
     }
 
-    //
     // Now update the trees
-    //
+
     GenTree* cmpOp1 = gtNewOperNode(foldOp, foldType, c1, c2);
     if (bool1 && bool2)
     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7970,6 +7970,11 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
         return;
     }
 
+    if (!varTypeIsIntegral(t2->TypeGet()) || !varTypeIsIntegral(t3->TypeGet()))
+    {
+        return;
+    }
+
     /* Find the condition for the first block */
 
     Statement* s1 = b1->lastStmt();

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7860,7 +7860,7 @@ Statement* Compiler::optOptimizeBoolsChkBlkCond(
     }
 
     GenTree* t2 = s2->GetRootNode();
-    
+
     if (!optReturnBlock)
     {
         noway_assert(t2->gtOper == GT_JTRUE);
@@ -8143,7 +8143,6 @@ void Compiler::optOptimizeBoolsUpdateTrees(BasicBlock* b1,
         fgUpdateLoopsAfterCompacting(b1, b3);
     }
 }
-
 
 //
 //  optOptimizeBoolsReturnBlock: Optimize boolean when b1.bbJumpKind is BBJ_COND and b2.bbJumpKind is BBJ_RETURN.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7644,8 +7644,8 @@ void Compiler::optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change
 {
     // Check if b1 and b2 jump to the same target and get back pointers to t1 and t2 tree nodes
 
-    pOptBoolsDsc->t3 = nullptr;
-    pOptBoolsDsc->sameTarget = false;   // Do b1 and b2 have the same bbJumpDest?
+    pOptBoolsDsc->t3         = nullptr;
+    pOptBoolsDsc->sameTarget = false; // Do b1 and b2 have the same bbJumpDest?
 
     Statement* s1;
     s1 = optOptimizeBoolsChkBlkCond(pOptBoolsDsc);
@@ -7787,10 +7787,10 @@ void Compiler::optOptimizeBoolsCondBlock(OptBoolsDsc* pOptBoolsDsc, bool* change
 //
 Statement* Compiler::optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc)
 {
-    BasicBlock* b1 = pOptBoolsDsc->b1;
-    BasicBlock* b2 = pOptBoolsDsc->b2;
-    BasicBlock* b3 = pOptBoolsDsc->b3;
-    bool* sameTarget = &pOptBoolsDsc->sameTarget;
+    BasicBlock* b1         = pOptBoolsDsc->b1;
+    BasicBlock* b2         = pOptBoolsDsc->b2;
+    BasicBlock* b3         = pOptBoolsDsc->b3;
+    bool*       sameTarget = &pOptBoolsDsc->sameTarget;
 
     bool optReturnBlock = false;
     if (b3)
@@ -7924,12 +7924,13 @@ Statement* Compiler::optOptimizeBoolsChkBlkCond(OptBoolsDsc* pOptBoolsDsc)
 //                                  if cost to fold is not too expensive.
 //
 // Arguments:
-//      pOptBoolsDsc    The descriptor for boolean optimization with pointers to tree compare nodes and its first operand,
-//                      where,
+//      pOptBoolsDsc    The descriptor for boolean optimization with pointers to tree compare nodes
+//                      and its first operand, where
 //                          t1CompPtr:  The first tree pointing to GT_NE or GT_EQ GenTree node
 //                          t2CompPtr:  The second tree pointing to GT_NE or GT_EQ GenTree node
 //                          c1:         The first operand of t1CompPtr
 //                          c2:         The first operand of t2CompPtr
+
 // Return:
 //      True if it meets type conditions and cost conditions.	Else false.
 //
@@ -8033,8 +8034,8 @@ void Compiler::optOptimizeBoolsUpdateTrees(OptBoolsDsc* pOptBoolsDsc)
     {
         // Update tree when b1: BBJ_COND and b2: GT_RETURN (BBJ_RETURN)
         t1CompPtr->AsOp()->gtOp2->AsIntCon()->gtIconVal = 0;
-        b1->lastStmt()->GetRootNode()->gtOper    = GT_RETURN;
-        b1->lastStmt()->GetRootNode()->gtType    = b2->lastStmt()->GetRootNode()->gtType;
+        pOptBoolsDsc->t1->gtOper                        = GT_RETURN;
+        pOptBoolsDsc->t1->gtType                        = pOptBoolsDsc->t2->gtType;
     }
 
 #if FEATURE_SET_FLAGS
@@ -8220,7 +8221,7 @@ void Compiler::optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* chan
 
     // Get the fold operator and the comparison operator
 
-    var_types  foldType = c1->TypeGet();
+    var_types foldType = c1->TypeGet();
     if (varTypeIsGC(foldType))
     {
         foldType = TYP_I_IMPL;
@@ -8228,7 +8229,7 @@ void Compiler::optOptimizeBoolsReturnBlock(OptBoolsDsc* pOptBoolsDsc, bool* chan
     pOptBoolsDsc->foldType = foldType;
 
     pOptBoolsDsc->foldOp = GT_NONE;
-    pOptBoolsDsc->cmpOp = GT_NONE;
+    pOptBoolsDsc->cmpOp  = GT_NONE;
 
     optReturnGetFoldAndCompOper(pOptBoolsDsc);
     if (pOptBoolsDsc->foldOp == GT_NONE || pOptBoolsDsc->cmpOp == GT_NONE)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7973,6 +7973,17 @@ void Compiler::optOptimizeBoolsBbjReturn(BasicBlock* b1, BasicBlock* b2, BasicBl
         return;
     }
 
+    /* The third block is Return with "CNS_INT int 0/1" */
+    if (t3->AsOp()->gtOp1->gtOper != GT_CNS_INT)
+    {
+        return;
+    }
+
+    if (t3->AsOp()->gtOp1->gtType != TYP_INT)
+    {
+        return;
+    }
+
     /* Find the condition for the first block */
 
     Statement* s1 = b1->lastStmt();

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7700,7 +7700,7 @@ bool OptBoolsDsc::optOptimizeBoolsCondBlock()
 
     // Check if m_b1 and m_b2 jump to the same target and get back pointers to m_testInfo1 and t2 tree nodes
 
-    m_t3         = nullptr;
+    m_t3 = nullptr;
 
     // Check if m_b1 and m_b2 have the same bbJumpDest
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7627,9 +7627,9 @@ class OptBoolsDsc
 public:
     OptBoolsDsc(BasicBlock* b1, BasicBlock* b2, Compiler* comp)
     {
-        m_b1 = b1;
-        m_b2 = b2;
-        m_b3 = nullptr;
+        m_b1   = b1;
+        m_b2   = b2;
+        m_b3   = nullptr;
         m_comp = comp;
     }
 
@@ -8177,7 +8177,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
 //
 // Arguments:
 //      b3:    Pointer to basic block b3
-// 
+//
 //  Returns:
 //      true if boolean optimization is done and m_b1, m_b2 and m_b3 are folded into m_b1, else false.
 //

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
@@ -38,6 +38,25 @@ public class CBoolTest
         return (x == 0 && y == 0 && z == 0 && w == 0);
     }
 
+    // Cases that skip optimization
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreOne(int x, int y)
+    {
+        return (x == 1 && y == 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool IsEitherZero(int x, int y)
+    {
+        return (x == 0 || y == 0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool IsEitherOne(int x, int y)
+    {
+        return (x == 1 || y == 1);
+    }
+
     public static int Main()
     {
         // Optimize boolean
@@ -81,6 +100,29 @@ public class CBoolTest
         if (!AreZero4(0, 0, 0, 0))
         {
             Console.WriteLine("CBoolTest:AreZero4 failed");
+            return 101;
+        }
+
+        // Skip optimization
+
+        // Test if ANDing or GT_NE requires both operands to be boolean
+        if (!AreOne(1, 1))
+        {
+            Console.WriteLine("CBoolTest:AreOne failed");
+            return 101;
+        }
+
+        // Test if ANDing requires both operands to be boolean
+        if (!IsEitherZero(0, 1))
+        {
+            Console.WriteLine("CBoolTest:IsEitherZero failed");
+            return 101;
+        }
+
+        // Test if GT_NE requires both operands to be boolean
+        if (!IsEitherOne(0, 1))
+        {
+            Console.WriteLine("CBoolTest:IsEitherOne failed");
             return 101;
         }
 

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
@@ -38,54 +38,52 @@ public class CBoolTest
         return (x == 0 && y == 0 && z == 0 && w == 0);
     }
 
-    // Cases that skip optimization
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool AreOne(int x, int y)
-    {
-        return (x == 1 && y == 1);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool IsEitherZero(int x, int y)
-    {
-        return (x == 0 || y == 0);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool IsEitherOne(int x, int y)
-    {
-        return (x == 1 || y == 1);
-    }
-
     public static int Main()
     {
-        try
+        // Optimize boolean
+
+        if (!AreZero(0, 0))
         {
-            // Optimize boolean
-
-            AreZero(0, 0);
-            AreNull(null, null);
-            AreNull(new Object(), new Object());
-            AreZero(1, 1);
-            AreZero2(0, 0);
-            AreZero3(0, 0, 0);
-            AreZero4(0, 0, 0, 0);
-
-            // Skip optimization
-
-            // Test if ANDing or GT_NE requires both operands to be boolean
-            AreOne(1, 1);
-            // Test if ANDing requires both operands to be boolean
-            IsEitherZero(0, 1);
-            // Test if GT_NE requires both operands to be boolean
-            IsEitherOne(0, 1);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
+            Console.WriteLine("CBoolTest:AreZero failed");
             return 101;
         }
-        Console.WriteLine("PASSED");
+
+        if (!AreNull(null, null))
+        {
+            Console.WriteLine("CBoolTest:AreNull(null, null) failed");
+            return 101;
+        }
+
+        if (AreNull(new Object(), new Object()))
+        {
+            Console.WriteLine("CBoolTest:AreNull(obj, obj) failed");
+            return 101;
+        }
+
+        if (AreZero(1, 1))
+        {
+            Console.WriteLine("CBoolTest:AreZero(1, 1) failed");
+            return 101;
+        }
+
+        if (!AreZero2(0, 0))
+        {
+            Console.WriteLine("CBoolTest:AreZero2 failed");
+            return 101;
+        }
+
+        if (!AreZero3(0, 0, 0))
+        {
+            Console.WriteLine("CBoolTest:AreZero3 failed");
+            return 101;
+        }
+
+        if (!AreZero4(0, 0, 0, 0))
+        {
+            Console.WriteLine("CBoolTest:AreZero4 failed");
+            return 101;
+        }
+
         return 100;
     }
 }

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// unit test for boolean optimization
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class CBoolTest
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreZero(int x, int y)
+    {
+        return (x == 0 && y == 0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreNull(object x, object y)
+    {
+        return (x == null && y == null);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreZero2(int x, int y)
+    {
+        return x == 0 && y == 0 && BitConverter.IsLittleEndian;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreZero3(int x, int y, int z)
+    {
+        return x == 0 && y == 0 && z == 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreZero4(int x, int y, int z, int w)
+    {
+        return (x == 0 && y == 0 && z == 0 && w == 0);
+    }
+
+    // Cases that skip optimization
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreOne(int x, int y)
+    {
+        return (x == 1 && y == 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool IsEitherZero(int x, int y)
+    {
+        return (x == 0 || y == 0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool IsEitherOne(int x, int y)
+    {
+        return (x == 1 || y == 1);
+    }
+
+    public static int Main()
+    {
+        try
+        {
+            // Optimize boolean
+
+            AreZero(0, 0);
+            AreNull(null, null);
+            AreNull(new Object(), new Object());
+            AreZero(1, 1);
+            AreZero2(0, 0);
+            AreZero3(0, 0, 0);
+            AreZero4(0, 0, 0, 0);
+
+            // Skip optimization
+
+            // Test if ANDing or GT_NE requires both operands to be boolean
+            AreOne(1, 1);
+            // Test if ANDing requires both operands to be boolean
+            IsEitherZero(0, 1);
+            // Test if GT_NE requires both operands to be boolean
+            IsEitherOne(0, 1);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            return 101;
+        }
+        Console.WriteLine("PASSED");
+        return 100;
+    }
+}

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.cs
@@ -63,7 +63,25 @@ public class CBoolTest
 
         if (!AreZero(0, 0))
         {
-            Console.WriteLine("CBoolTest:AreZero failed");
+            Console.WriteLine("CBoolTest:AreZero(0, 0) failed");
+            return 101;
+        }
+
+        if (AreZero(1, 1))
+        {
+            Console.WriteLine("CBoolTest:AreZero(1, 1) failed");
+            return 101;
+        }
+
+        if (AreZero(0, 2))
+        {
+            Console.WriteLine("CBoolTest:AreZero(0, 2) failed");
+            return 101;
+        }
+
+        if (AreZero(3, 0))
+        {
+            Console.WriteLine("CBoolTest:AreZero(3, 0) failed");
             return 101;
         }
 
@@ -79,27 +97,39 @@ public class CBoolTest
             return 101;
         }
 
-        if (AreZero(1, 1))
+        if (!AreZero2(0, 0))
         {
-            Console.WriteLine("CBoolTest:AreZero(1, 1) failed");
+            Console.WriteLine("CBoolTest:AreZero2(0, 0) failed");
             return 101;
         }
 
-        if (!AreZero2(0, 0))
+        if (AreZero2(2, 1))
         {
-            Console.WriteLine("CBoolTest:AreZero2 failed");
+            Console.WriteLine("CBoolTest:AreZero2(2, 1) failed");
             return 101;
         }
 
         if (!AreZero3(0, 0, 0))
         {
-            Console.WriteLine("CBoolTest:AreZero3 failed");
+            Console.WriteLine("CBoolTest:AreZero3(0, 0, 0) failed");
+            return 101;
+        }
+
+        if (AreZero3(0, 1, 2))
+        {
+            Console.WriteLine("CBoolTest:AreZero3(0, 1, 2) failed");
             return 101;
         }
 
         if (!AreZero4(0, 0, 0, 0))
         {
-            Console.WriteLine("CBoolTest:AreZero4 failed");
+            Console.WriteLine("CBoolTest:AreZero4(0, 0, 0, 0) failed");
+            return 101;
+        }
+
+        if (AreZero4(0, 1, 2, 3))
+        {
+            Console.WriteLine("CBoolTest:AreZero4(0, 1, 2, 3) failed");
             return 101;
         }
 
@@ -108,21 +138,42 @@ public class CBoolTest
         // Test if ANDing or GT_NE requires both operands to be boolean
         if (!AreOne(1, 1))
         {
-            Console.WriteLine("CBoolTest:AreOne failed");
+            Console.WriteLine("CBoolTest:AreOne(1, 1) failed");
+            return 101;
+        }
+
+        // Skip cases where x or y is greather than 1
+        if (AreOne(3, 1))
+        {
+            Console.WriteLine("CBoolTest:AreOne(1, 3) failed");
             return 101;
         }
 
         // Test if ANDing requires both operands to be boolean
         if (!IsEitherZero(0, 1))
         {
-            Console.WriteLine("CBoolTest:IsEitherZero failed");
+            Console.WriteLine("CBoolTest:IsEitherZero(0, 1) failed");
+            return 101;
+        }
+
+        // Skip cases where x and y have opposite bits set
+        if (IsEitherZero(2, 1))
+        {
+            Console.WriteLine("CBoolTest:IsEitherZero(2, 1) failed");
             return 101;
         }
 
         // Test if GT_NE requires both operands to be boolean
         if (!IsEitherOne(0, 1))
         {
-            Console.WriteLine("CBoolTest:IsEitherOne failed");
+            Console.WriteLine("CBoolTest:IsEitherOne(0, 1) failed");
+            return 101;
+        }
+
+        // Skip cases where either x or y is greater than 1
+        if (IsEitherOne(2, 0))
+        {
+            Console.WriteLine("CBoolTest:IsEitherOne(2, 0) failed");
             return 101;
         }
 

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.csproj
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/OptimizeBools/optboolsreturn.csproj
+++ b/src/tests/JIT/opt/OptimizeBools/optboolsreturn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/13573.

It optimizes `Integral type` Boolean logic with two operands when the first BB is conditional BB (e.g., BBJ_COND) and the second BB is conditional return (e.g., GT_RETURN > BBJ_RETURN).
For example, it changes below logic: 
- x==0 && y==0 to (x|y)==0

In case the folding involves ANDing or comparison to GT_NE, it gets optimized only if the tree is evaluated as BOOLEAN.
- x!=0 && y!=0 to (x&y) !=0
- x==0 || y==0 to (x&y)==0
- x==1 || y==1 to (x|y) !=0

**Edit:** Note: However, above 3 cases are not optimized because the operand of tree is not evaluated as boolean expression in the current JIT.

This PR does not optimze cases where it requries NOT transformation of x or y because the cost of NOT operation is large.
- (x | !y) != 0
- (!x | y) != 0

```
public static bool AreZero(int x, int y) {
    return x == 0 && y == 0;
}
```

3 Basic Blocks are folded as below:
**Before:**
```
*** marking local variables in block BB01 (weight=1   )
STMT00000 (IL 0x000...0x001)
               [000003] -----+------              *  JTRUE     void  
               [000002] J----+-N----              \--*  NE        int   
               [000000] -----+------                 +--*  LCL_VAR   int    V00 arg0         
               [000001] -----+------                 \--*  CNS_INT   int    0
New refCnts for V00: refCnt =  1, refCntWtd = 1   

*** marking local variables in block BB02 (weight=0.50)
STMT00002 (IL 0x003...0x007)
               [000009] -----+------              *  RETURN    int   
               [000008] -----+------              \--*  EQ        int   
               [000006] -----+------                 +--*  LCL_VAR   int    V01 arg1         
               [000007] -----+------                 \--*  CNS_INT   int    0
New refCnts for V01: refCnt =  1, refCntWtd = 0.50

*** marking local variables in block BB03 (weight=0.50)
STMT00001 (IL 0x008...0x009)
               [000005] -----+------              *  RETURN    int   
               [000004] -----+------              \--*  CNS_INT   int    0
```
**After:**
```
Folded boolean conditions of BB01, BB02 and BB03 to :
STMT00000 (IL 0x000...0x001)
               [000003] -----+------              *  RETURN    int
               [000002] J----+-N----              \--*  EQ        int   
               [000011] ------------                 +--*  OR        int   
               [000000] -----+------                 |  +--*  LCL_VAR   int    V00 arg0         
     (  3,  2) [000006] ------------                 |  \--*  LCL_VAR   int    V01 arg1         
               [000001] -----+------                 \--*  CNS_INT   int    0
```
**Diff:**
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 531
Total bytes of diff: 483
Total bytes of delta: -48 (-9.04% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 113888.dasm (-7.14% of base)
         -16 : 159193.dasm (-11.35% of base)
         -16 : 109061.dasm (-9.64% of base)

3 total files with Code Size differences (3 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-7.14% of base) : 113888.dasm - Microsoft.Extensions.Primitives.StringSegment:Equals(Microsoft.Extensions.Primitives.StringSegment,int):bool:this
         -16 (-11.35% of base) : 159193.dasm - System.Xml.Linq.XElement:AttributesEqual(System.Xml.Linq.XElement):bool:this
         -16 (-9.64% of base) : 109061.dasm - Microsoft.CSharp.RuntimeBinder.RuntimeBinderExtensions:IsEquivalentTo(System.Reflection.ParameterInfo,System.Reflection.ParameterInfo,System.Reflection.MethodBase,System.Reflection.MethodBase):bool

Top method improvements (percentages):
         -16 (-11.35% of base) : 159193.dasm - System.Xml.Linq.XElement:AttributesEqual(System.Xml.Linq.XElement):bool:this
         -16 (-9.64% of base) : 109061.dasm - Microsoft.CSharp.RuntimeBinder.RuntimeBinderExtensions:IsEquivalentTo(System.Reflection.ParameterInfo,System.Reflection.ParameterInfo,System.Reflection.MethodBase,System.Reflection.MethodBase):bool
         -16 (-7.14% of base) : 113888.dasm - Microsoft.Extensions.Primitives.StringSegment:Equals(Microsoft.Extensions.Primitives.StringSegment,int):bool:this

3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged.
```

