### PR TITLE
Allow jit to disregard PGO; PGO changes for SPMI and MCS

### DIFF
--- a/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
@@ -24,6 +24,26 @@ int verbJitFlags::DoWork(const char* nameOfInput)
         mc->repGetJitFlags(&corJitFlags, sizeof(corJitFlags));
         unsigned long long rawFlags = corJitFlags.GetFlagsRaw();
 
+        // We co-opt unused flag bits to note if there's pgo data,
+        // and if so, what kind
+        //
+        bool hasEdgeProfile = false;
+        bool hasClassProfile = false;
+        if (mc->hasPgoData(hasEdgeProfile, hasClassProfile))
+        {
+            rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_PGO);
+
+            if (hasEdgeProfile)
+            {
+                rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE);
+            }
+
+            if (hasClassProfile)
+            {
+                rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
+            }
+        }
+
         int index = flagMap.GetIndex(rawFlags);
         if (index == -1)
         {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -54,9 +54,9 @@ enum EXTRA_JIT_FLAGS
 
 // Asserts to catch changes in corjit flags definitions.
 
-static_assert(EXTRA_JIT_FLAGS::HAS_PGO == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED36, "Jit Flags Mismatch");
-static_assert(EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED35, "Jit Flags Mismatch");
-static_assert(EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED34, "Jit Flags Mismatch");
+static_assert((int)EXTRA_JIT_FLAGS::HAS_PGO == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED36, "Jit Flags Mismatch");
+static_assert((int)EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED35, "Jit Flags Mismatch");
+static_assert((int)EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED34, "Jit Flags Mismatch");
 
 class MethodContext
 {

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -52,6 +52,12 @@ enum EXTRA_JIT_FLAGS
     HAS_CLASS_PROFILE = 61
 };
 
+// Asserts to catch changes in corjit flags definitions.
+
+static_assert(EXTRA_JIT_FLAGS::HAS_PGO == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED36, "Jit Flags Mismatch");
+static_assert(EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED35, "Jit Flags Mismatch");
+static_assert(EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE == CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED34, "Jit Flags Mismatch");
+
 class MethodContext
 {
 public:

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -43,6 +43,15 @@ const char* toString(CorInfoType cit);
 
 #define METHOD_IDENTITY_INFO_SIZE 0x10000 // We assume that the METHOD_IDENTITY_INFO_SIZE will not exceed 64KB
 
+// Special "jit flags" for noting some method context features
+
+enum EXTRA_JIT_FLAGS
+{
+    HAS_PGO = 63,
+    HAS_EDGE_PROFILE = 62,
+    HAS_CLASS_PROFILE = 61
+};
+
 class MethodContext
 {
 public:
@@ -81,6 +90,8 @@ public:
 
     int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
     int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
+
+    bool hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile);
 
     void recGlobalContext(const MethodContext& other);
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -279,6 +279,12 @@ std::string SpmiDumpHelper::DumpJitFlags(unsigned long long flags)
 
     AddFlag(NO_INLINING);
 
+    // "Extra jit flag" support
+    //
+    AddFlagNumeric(HAS_PGO, EXTRA_JIT_FLAGS::HAS_PGO);
+    AddFlagNumeric(HAS_EDGE_PROFILE, EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE);
+    AddFlagNumeric(HAS_CLASS_PROFILE, EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
+
 #undef AddFlag
 #undef AddFlagNumeric
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -159,7 +159,7 @@ WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const W
     const size_t folderPathLength   = wcslen(folderPath);
     const size_t fileNameLength     = wcslen(fileName);
     const size_t extensionLength    = wcslen(extension);
-    const size_t maxPathLength      = MAX_PATH - 50; // subtract 50 because excel doesn't like paths longer then 230.
+    const size_t maxPathLength      = 50;
     const size_t randomStringLength = 8;
 
     size_t fullPathLength   = folderPathLength + 1 + extensionLength;

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -156,58 +156,76 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
 // All lengths in this function exclude the terminal NULL.
 WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const WCHAR* extension)
 {
-    const size_t folderPathLength   = wcslen(folderPath);
-    const size_t fileNameLength     = wcslen(fileName);
     const size_t extensionLength    = wcslen(extension);
-    const size_t maxPathLength      = 50;
+    const size_t fileNameLength     = wcslen(fileName);
     const size_t randomStringLength = 8;
+    const size_t maxPathLength      = MAX_PATH - 50;
+    bool         appendRandomString = false;
 
-    size_t fullPathLength   = folderPathLength + 1 + extensionLength;
-    bool appendRandomString = false;
+    // See how long the folder part is, and start building the file path with the folder part.
+    //
+    WCHAR* fullPath = new WCHAR[MAX_PATH];
+    fullPath[0] = W('\0');
+    const size_t folderPathLength = GetFullPathNameW(folderPath, MAX_PATH, (LPWSTR)fullPath, NULL);
 
-    if (fileNameLength > 0)
+    if (folderPathLength == 0)
     {
-        fullPathLength += fileNameLength;
+        LogError("GetResultFileName - can't resolve folder path '%ws'", folderPath);
+        return nullptr;
     }
-    else
+
+    // Account for the folder, directory separator and extension.
+    //
+    size_t fullPathLength = folderPathLength + 1 + extensionLength;
+
+    // If we won't have room for a minimal file name part, bail.
+    //
+    if ((fullPathLength + randomStringLength) > maxPathLength)
     {
+        LogError("GetResultFileName - folder path '%ws' length + minimal file name exceeds limit %d", fullPath, maxPathLength);
+        return nullptr;
+    }
+
+    // Now figure out the file name part.
+    //
+    const size_t maxFileNameLength = maxPathLength - fullPathLength;
+    size_t usableFileNameLength = 0;
+
+    if (fileNameLength == 0)
+    {
+        // No file name provided. Use random string.
+        //
         fullPathLength += randomStringLength;
         appendRandomString = true;
     }
-
-    size_t charsToDelete = 0;
-
-    if (fullPathLength > maxPathLength)
+    else if (fileNameLength < maxFileNameLength)
     {
-        // The path name is too long; creating the file will fail. This can happen because we use the command line,
-        // which for ngen includes lots of environment variables, for example.
-        // Shorten the file name and add a random string to the end to avoid collisions.
-
-        charsToDelete = fullPathLength - maxPathLength + randomStringLength;
-
-        if (fileNameLength >= charsToDelete)
-        {
-            appendRandomString = true;
-            fullPathLength = maxPathLength;
-        }
-        else
-        {
-            LogError("GetResultFileName - path to the output file is too long '%ws\\%ws.%ws(%d)'", folderPath, fileName, extension, fullPathLength);
-            return nullptr;
-        }
+        // Reasonable length file name, use as is.
+        //
+        usableFileNameLength = fileNameLength;
+        fullPathLength += fileNameLength;
+        appendRandomString = false;
+    }
+    else
+    {
+        // Overly long file name, truncate and add random string.
+        //
+        usableFileNameLength = maxFileNameLength - randomStringLength;
+        fullPathLength += maxFileNameLength;
+        appendRandomString = true;
     }
 
-    WCHAR* fullPath = new WCHAR[fullPathLength + 1];
-    fullPath[0] = W('\0');
-    wcsncat_s(fullPath, fullPathLength + 1, folderPath, folderPathLength);
+    // Append the file name part
+    //
     wcsncat_s(fullPath, fullPathLength + 1, DIRECTORY_SEPARATOR_STR_W, 1);
+    wcsncat_s(fullPath, fullPathLength + 1, fileName, usableFileNameLength);
 
-    if (fileNameLength > charsToDelete)
-    {
-        wcsncat_s(fullPath, fullPathLength + 1, fileName, fileNameLength - charsToDelete);
-        ReplaceIllegalCharacters(fullPath + folderPathLength + 1);
-    }
+    // Clean up anything in the file part that can't be in a file name.
+    //
+    ReplaceIllegalCharacters(fullPath + folderPathLength + 1);
 
+    // Append random string, if we're using it.
+    //
     if (appendRandomString)
     {
        unsigned randomNumber = 0;
@@ -223,6 +241,8 @@ WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const W
        wcsncat_s(fullPath, fullPathLength + 1, randomString, randomStringLength);
     }
 
+    // Append extension
+    //
     wcsncat_s(fullPath, fullPathLength + 1, extension, extensionLength);
 
     return fullPath;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2207,9 +2207,9 @@ void CodeGen::genGenerateMachineCode()
                    compiler->fgHaveValidEdgeWeights ? "valid" : "invalid", compiler->fgCalledCount);
         }
 
-        if (compiler->fgProfileData_ILSizeMismatch)
+        if (compiler->fgPgoFailReason != nullptr)
         {
-            printf("; discarded IBC profile data due to mismatch in ILSize\n");
+            printf("; %s\n", compiler->fgPgoFailReason);
         }
 
         if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_ALT_JIT))

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2901,9 +2901,9 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
         // Optionally, discard the profile data.
         //
-        else if (JitConfig.JitDisablePGO() == 1)
+        else if (JitConfig.JitDisablePGO() != 0)
         {
-            fgPgoFailReason  = "PGO data available, but JitDisablePGO == 1";
+            fgPgoFailReason  = "PGO data available, but JitDisablePGO != 0";
             fgPgoQueryResult = E_FAIL;
             fgPgoData        = nullptr;
             fgPgoSchema      = nullptr;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5584,7 +5584,7 @@ protected:
     void        fgIncorporateEdgeCounts();
 
 public:
-    bool                                   fgProfileData_ILSizeMismatch;
+    const char*                            fgPgoFailReason;
     ICorJitInfo::PgoInstrumentationSchema* fgPgoSchema;
     BYTE*                                  fgPgoData;
     UINT32                                 fgPgoSchemaCount;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21504,6 +21504,15 @@ void Compiler::considerGuardedDevirtualization(
 
     JITDUMP("Considering guarded devirtualization\n");
 
+    // We currently only get likely class guesses when there is PGO data. So if we've disabled
+    // PGO, just bail out.
+
+    if (JitConfig.JitDisablePGO() != 0)
+    {
+        JITDUMP("Not guessing for class; pgo disabled\n");
+        return;
+    }
+
     // See if there's a likely guess for the class.
     //
     const unsigned       likelihoodThreshold = isInterface ? 25 : 30;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -458,6 +458,9 @@ CONFIG_INTEGER(JitMinimalPrejitProfiling, W("JitMinimalPrejitProfiling"), 0)
 CONFIG_INTEGER(JitClassProfiling, W("JitClassProfiling"), 1)
 CONFIG_INTEGER(JitEdgeProfiling, W("JitEdgeProfiling"), 1)
 
+// Profile consumption options
+CONFIG_INTEGER(JitDisablePGO, W("JitDisablePGO"), 0) // Ignore pgo data
+
 // Control when Virtual Calls are expanded
 CONFIG_INTEGER(JitExpandCallsEarly, W("JitExpandCallsEarly"), 1) // Expand Call targets early (in the global morph
                                                                  // phase)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1731,11 +1731,14 @@ class SuperPMIReplayAsmDiffs:
         if self.coreclr_args.base_jit_option:
             for o in self.coreclr_args.base_jit_option:
                 base_option_flags += "-jitoption", o
+        base_option_flags_for_diff_artifact = base_option_flags
 
         diff_option_flags = []
+        diff_option_flags_for_diff_artifact = []
         if self.coreclr_args.diff_jit_option:
             for o in self.coreclr_args.diff_jit_option:
-                diff_option_flags += "-jitoption2", o
+                diff_option_flags += "-jit2option", o
+                diff_option_flags_for_diff_artifact += "-jitoption", o
 
         if self.coreclr_args.altjit:
             altjit_asm_diffs_flags += [
@@ -1889,8 +1892,8 @@ class SuperPMIReplayAsmDiffs:
                                 return generated_txt
 
                             # Generate diff and base JIT dumps
-                            base_txt = await create_one_artifact(self.base_jit_path, base_location, flags + base_option_flags)
-                            diff_txt = await create_one_artifact(self.diff_jit_path, diff_location, flags + diff_option_flags)
+                            base_txt = await create_one_artifact(self.base_jit_path, base_location, flags + base_option_flags_for_diff_artifact)
+                            diff_txt = await create_one_artifact(self.diff_jit_path, diff_location, flags + diff_option_flags_for_diff_artifact)
 
                             if base_txt != diff_txt:
                                 jit_differences_queue.put_nowait(item)


### PR DESCRIPTION
* COMPlus_JitDisablePGO will now block the jit from using profile data. Useful
for investigations and (someday) bug triage.

* `-jitoption` now works for `superpmi.py asmdiffs`. It only applies to
the base jit.

* Limit SPMI file size path component to 50 chars, so that SPMI can handle
being run in directories with long paths we can't control (as happens with
tools like `crank`).

* Enhance `mcs -jitflags` output to describe how many method contexts have
PGO data, and which kinds of data they hold. Useful for validating that an
SPMI collection done via dynamic PGO has actually collected an interesting
set of jit requests.