### PR TITLE
Avoid boxing response content length in SocketsHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
@@ -74,6 +74,11 @@ namespace System.Net.Http.Headers
                 // back incurs multiple allocations, on top of which if the response headers are enumerated,
                 // we then need to format the boxed length back into a string.  Given typical usage patterns,
                 // it's better to just parse each time and pay the few additional nanoseconds to re-parse.
+                // If parsing multiple times ever becomes a perf issue, we could cache the Content-Length value
+                // on HttpContentHeaders as a `long`. This would require additional coordination with the underlying
+                // HttpHeaders header store (in case someone then called something like Add or Remove on
+                // Content-Length at the HttpHeaders level), e.g. a callback to HttpContentHeaders that
+                // Content-Length has been modified in the store and any cached value should be discarded.
                 if (TryGetHeaderValue(KnownHeaders.ContentLength.Descriptor, out object? storedValue))
                 {
                     // storedValue could be a raw string, a boxed long, or a HeaderStoreItemInfo containing

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -705,7 +705,7 @@ namespace System.Net.Http.Headers
             (_headerStore ??= new Dictionary<HeaderDescriptor, object>()).Add(descriptor, value);
         }
 
-        private bool TryGetHeaderValue(HeaderDescriptor descriptor, [NotNullWhen(true)] out object? value)
+        internal bool TryGetHeaderValue(HeaderDescriptor descriptor, [NotNullWhen(true)] out object? value)
         {
             if (_headerStore == null)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -604,9 +604,10 @@ namespace System.Net.Http
                 {
                     // If we sent an Expect: 100-continue header, and didn't receive a 100-continue. Handle the final response accordingly.
                     // Note that the developer may have added an Expect: 100-continue header even if there is no Content.
+                    long? requestContentLength;
                     if ((int)response.StatusCode >= 300 &&
                         request.Content != null &&
-                        (request.Content.Headers.ContentLength == null || request.Content.Headers.ContentLength.GetValueOrDefault() > Expect100ErrorSendThreshold) &&
+                        ((requestContentLength = request.Content.Headers.ContentLength) == null || requestContentLength.GetValueOrDefault() > Expect100ErrorSendThreshold) &&
                         !AuthenticationHelper.IsSessionAuthenticationChallenge(response))
                     {
                         // For error final status codes, try to avoid sending the payload if its size is unknown or if it's known to be "big".
@@ -659,6 +660,7 @@ namespace System.Net.Http
 
                 // Create the response stream.
                 Stream responseStream;
+                long? responseContentLength;
                 if (ReferenceEquals(normalizedMethod, HttpMethod.Head) || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
                     responseStream = EmptyReadStream.Instance;
@@ -678,9 +680,9 @@ namespace System.Net.Http
                 {
                     responseStream = new RawConnectionStream(this);
                 }
-                else if (response.Content.Headers.ContentLength != null)
+                else if ((responseContentLength = response.Content.Headers.ContentLength) != null)
                 {
-                    long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
+                    long contentLength = responseContentLength.GetValueOrDefault();
                     if (contentLength <= 0)
                     {
                         responseStream = EmptyReadStream.Instance;


### PR DESCRIPTION
The current header model means every Content-Length response results in us boxing a long and allocating a HeaderStoreItemInfo to track it.  And if raw headers are enumerated after that, we then end up regenerating a string from that boxed long (this isn't currently an issue, but will be when we expose the ability to enumerate raw headers).  The ContentLength property is generally only accessed once or twice, making it faster to just parse it every time.

In a test that does:
```C#
for (int iter = 0; iter < 10_000; iter++)
{
    using (HttpResponseMessage r = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Get, _uri), default))
    using (Stream s = await r.Content.ReadAsStreamAsync())
        await s.CopyToAsync(Stream.Null);
}
```
the highlighted lines here are removed completely after this change:
![image](https://user-images.githubusercontent.com/2642209/110999160-f15c2380-834d-11eb-92d8-866ac6b35722.png)

There's not a huge throughput bump from this; it's a little bit in the noise, but against a localhost server just serving up a super simple response with a small response body, looks to be around 1-2%.

But, honestly, the main reason I wanted to make this change is because these allocations just bother me every time I look at a trace. :smile:

cc: @geoffkizer, @scalablecory 