### PR TITLE
Fix DateTime Tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
@@ -1038,11 +1038,11 @@ namespace System.Tests
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000-07:00c"));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000-07:00c", new MyFormatter()));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000-07:00c", new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
-			
+
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#"));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#", new MyFormatter()));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#", new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
-			
+
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#\0"));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#\0", new MyFormatter()));
             Assert.Throws<FormatException>(() => DateTime.Parse("2020-5-7T09:37:00.0000000+00:00#\0", new MyFormatter(), DateTimeStyles.NoCurrentDateDefault));
@@ -2335,6 +2335,13 @@ namespace System.Tests
             Assert.True(DateTime.TryParseExact(input.AsSpan(), format, culture, style, out DateTime result3));
             Assert.True(DateTime.TryParseExact(input.AsSpan(), new[] { format }, culture, style, out DateTime result4));
 
+            // Some of the parsed strings could not include the the date parts which make the parser use today's date in the result.
+            // It is possible the clock move to the next day between parsing operations or between calculating the expected value and the parsing.
+            // To make the test reliable, we need to check for such case.
+            if (result3.Day != result4.Day) { Assert.True(result4 > result3); result3.AddDays(1); }
+            if (result2.Day != result3.Day) { Assert.True(result3 > result2); result2.AddDays(1); }
+            if (result1.Day != result2.Day) { Assert.True(result2 > result1); result1.AddDays(1); }
+
             Assert.Equal(result1, result2);
             Assert.Equal(result1, result3);
             Assert.Equal(result1, result4);
@@ -2350,6 +2357,8 @@ namespace System.Tests
                 {
                     result1 = result1.ToUniversalTime();
                 }
+
+                if (expected.Value.Day != result1.Day) { Assert.True(result1 > expected.Value); expected.Value.AddDays(1); }
 
                 Assert.Equal(expected, result1);
             }

--- a/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
@@ -2338,9 +2338,9 @@ namespace System.Tests
             // Some of the parsed strings could not include the the date parts which make the parser use today's date in the result.
             // It is possible the clock move to the next day between parsing operations or between calculating the expected value and the parsing.
             // To make the test reliable, we need to check for such case.
-            if (result3.Day != result4.Day) { Assert.True(result4 > result3); result3.AddDays(1); }
-            if (result2.Day != result3.Day) { Assert.True(result3 > result2); result2.AddDays(1); }
-            if (result1.Day != result2.Day) { Assert.True(result2 > result1); result1.AddDays(1); }
+            if (result3.Day != result4.Day) { result3.AddDays(1); Assert.Equal(result3.Day, result4.Day); }
+            if (result2.Day != result3.Day) { result2.AddDays(1); Assert.Equal(result2.Day, result3.Day); }
+            if (result1.Day != result2.Day) { result1.AddDays(1); Assert.Equal(result1.Day, result2.Day); }
 
             Assert.Equal(result1, result2);
             Assert.Equal(result1, result3);
@@ -2358,7 +2358,7 @@ namespace System.Tests
                     result1 = result1.ToUniversalTime();
                 }
 
-                if (expected.Value.Day != result1.Day) { Assert.True(result1 > expected.Value); expected.Value.AddDays(1); }
+                if (expected.Value.Day != result1.Day) { expected.Value.AddDays(1); Assert.Equal(expected.Value.Day, result1.Day); }
 
                 Assert.Equal(expected, result1);
             }

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2317,12 +2317,21 @@ namespace System.Tests
                     {
                         string offset = Regex.Match(tzi.DisplayName, @"(-|)[0-9]{2}:[0-9]{2}").Value;
                         TimeSpan ts = TimeSpan.Parse(offset);
-                        if (tzi.BaseUtcOffset != ts && tzi.Id.IndexOf("Morocco", StringComparison.Ordinal) >= 0)
+                        if (tzi.BaseUtcOffset != ts && (tzi.Id.IndexOf("Morocco", StringComparison.Ordinal) >= 0 || tzi.Id.IndexOf("Volgograd", StringComparison.Ordinal) >= 0))
                         {
                             // Windows data can report display name with UTC+01:00 offset which is not matching the actual BaseUtcOffset.
                             // We special case this in the test to avoid the test failures like:
                             //      01:00 != 00:00:00, dn:(UTC+01:00) Casablanca, sn:Morocco Standard Time
-                            Assert.True(tzi.BaseUtcOffset == new TimeSpan(0, 0, 0), $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
+                            //      04:00 != 03:00:00, dn:(UTC+04:00) Volgograd, sn:Volgograd Standard Time
+                            if (tzi.Id.IndexOf("Morocco", StringComparison.Ordinal) >= 0)
+                            {
+                                Assert.True(tzi.BaseUtcOffset == new TimeSpan(0, 0, 0), $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
+                            }
+                            else
+                            {
+                                // Volgograd, Russia
+                                Assert.True(tzi.BaseUtcOffset == new TimeSpan(3, 0, 0), $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
+                            }
                         }
                         else
                         {

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2317,13 +2317,15 @@ namespace System.Tests
                     {
                         string offset = Regex.Match(tzi.DisplayName, @"(-|)[0-9]{2}:[0-9]{2}").Value;
                         TimeSpan ts = TimeSpan.Parse(offset);
-                        if (tzi.BaseUtcOffset != ts && (tzi.Id.IndexOf("Morocco", StringComparison.Ordinal) >= 0 || tzi.Id.IndexOf("Volgograd", StringComparison.Ordinal) >= 0))
+                        if (PlatformDetection.IsWindows &&
+                            tzi.BaseUtcOffset != ts &&
+                            (tzi.Id.Contains("Morocco")  || tzi.Id.Contains("Volgograd")))
                         {
                             // Windows data can report display name with UTC+01:00 offset which is not matching the actual BaseUtcOffset.
                             // We special case this in the test to avoid the test failures like:
                             //      01:00 != 00:00:00, dn:(UTC+01:00) Casablanca, sn:Morocco Standard Time
                             //      04:00 != 03:00:00, dn:(UTC+04:00) Volgograd, sn:Volgograd Standard Time
-                            if (tzi.Id.IndexOf("Morocco", StringComparison.Ordinal) >= 0)
+                            if (tzi.Id.Contains("Morocco"))
                             {
                                 Assert.True(tzi.BaseUtcOffset == new TimeSpan(0, 0, 0), $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
                             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49524

This change contains a fix to another Time Zones failure too. This fix would avoid the failure on the new Windows builds.