### PR TITLE
Always clear the local buffer in ArrayBuffer

### DIFF
--- a/src/libraries/Common/src/System/Net/ArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/ArrayBuffer.cs
@@ -41,15 +41,12 @@ namespace System.Net
             _activeStart = 0;
             _availableStart = 0;
 
-            if (_usePool)
-            {
-                byte[] array = _bytes;
-                _bytes = null!;
+            byte[] array = _bytes;
+            _bytes = null!;
 
-                if (array != null)
-                {
-                    ArrayPool<byte>.Shared.Return(array);
-                }
+            if (_usePool && array != null)
+            {
+                ArrayPool<byte>.Shared.Return(array);
             }
         }
 


### PR DESCRIPTION
- SslStream was holding onto a 4K byte[] after the handshake was complete. This was because the ArrayBuffer struct doesn't clear the local buffer field in dispose. This changes that.

Before:
![image](https://user-images.githubusercontent.com/95136/110900739-1605bc00-82b8-11eb-8ce8-d59d620c2ec3.png)

After:
![image](https://user-images.githubusercontent.com/95136/111022943-eb386800-838a-11eb-8775-340b314631f3.png)

Blocked on https://github.com/dotnet/runtime/pull/49945
