### PR TITLE
Clear the buffers fields

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -795,6 +795,7 @@ namespace System.IO.Pipelines
                 }
 
                 _writingHead = null;
+                _writingHeadMemory = default;
                 _readHead = null;
                 _readTail = null;
                 _lastExaminedIndex = -1;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -328,6 +328,7 @@ namespace System.IO.Pipelines
                     // Mark bytes as written *after* flushing
                     _head = null;
                     _tail = null;
+                    _tailMemory = default;
                     _bytesBuffered = 0;
 
                     return new FlushResult(isCanceled: false, isCompleted: false);
@@ -395,6 +396,7 @@ namespace System.IO.Pipelines
             // Mark bytes as written *after* flushing
             _head = null;
             _tail = null;
+            _tailMemory = default;
             _bytesBuffered = 0;
         }
     }


### PR DESCRIPTION
- This makes it easier to reason about gcroots in dumps