### PR TITLE
Pass the cancellation token to FlushAsync

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
@@ -38,7 +38,7 @@ namespace System.Net.Security
 
         public Task WaitAsync(TaskCompletionSource<bool> waiter) => waiter.Task;
 
-        public Task FlushAsync() => _stream.FlushAsync();
+        public Task FlushAsync() => _stream.FlushAsync(CancellationToken);
 
         public CancellationToken CancellationToken { get; }
     }


### PR DESCRIPTION
- Bonus, is that this removes some indirection going through the Stream base class to call FlushAsync.