### PR TITLE
System.IO.Pipelines.PipeReader: Fix TryRead summary

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -12,7 +12,7 @@ namespace System.IO.Pipelines
     {
         private PipeReaderStream? _stream;
 
-        /// <summary>Attempts to synchronously read data the <see cref="System.IO.Pipelines.PipeReader" />.</summary>
+        /// <summary>Attempts to synchronously read data from the <see cref="System.IO.Pipelines.PipeReader" />.</summary>
         /// <param name="result">When this method returns <see langword="true" />, this value is set to a <see cref="System.IO.Pipelines.ReadResult" /> instance that represents the result of the read call; otherwise, this value is set to <see langword="default" />.</param>
         /// <returns><see langword="true" /> if data was available, or if the call was canceled or the writer was completed; otherwise, <see langword="false" />.</returns>
         /// <remarks>If the pipe returns <see langword="false" />, there is no need to call <see cref="System.IO.Pipelines.PipeReader.AdvanceTo(System.SequencePosition,System.SequencePosition)" />.</remarks>


### PR DESCRIPTION
Add missing 'from' to the summary for TryRead.