### PR TITLE
Non-generic StringComparer conversion for dict and hashset

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -65,11 +65,7 @@ namespace System.Collections.Generic
 
             if (typeof(TKey) == typeof(string))
             {
-                // We know TKey is string from above check so Unsafe.As from
-                // the generic and then from string back to the generic
-                _comparer = Unsafe.As<IEqualityComparer<TKey>?>(
-                    NonRandomizedStringEqualityComparer.GetStringComparer(
-                        Unsafe.As<IEqualityComparer<string>?>(_comparer)));
+                _comparer = (IEqualityComparer<TKey>?)NonRandomizedStringEqualityComparer.GetStringComparer((IEqualityComparer<string>?)_comparer);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Generic
 
             if (typeof(TKey) == typeof(string))
             {
-                _comparer = (IEqualityComparer<TKey>?)NonRandomizedStringEqualityComparer.GetStringComparer((IEqualityComparer<string>?)_comparer);
+                _comparer = (IEqualityComparer<TKey>?)NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -54,7 +54,7 @@ namespace System.Collections.Generic
                 Initialize(capacity);
             }
 
-            if (comparer != null && comparer != EqualityComparer<TKey>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
+            if (comparer is not null && comparer != EqualityComparer<TKey>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
             {
                 _comparer = comparer;
             }
@@ -65,18 +65,11 @@ namespace System.Collections.Generic
 
             if (typeof(TKey) == typeof(string))
             {
-                if (_comparer is null)
-                {
-                    _comparer = (IEqualityComparer<TKey>)NonRandomizedStringEqualityComparer.WrappedAroundDefaultComparer;
-                }
-                else if (ReferenceEquals(_comparer, StringComparer.Ordinal))
-                {
-                    _comparer = (IEqualityComparer<TKey>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinal;
-                }
-                else if (ReferenceEquals(_comparer, StringComparer.OrdinalIgnoreCase))
-                {
-                    _comparer = (IEqualityComparer<TKey>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinalIgnoreCase;
-                }
+                // We know TKey is string from above check so Unsafe.As from
+                // the generic and then from string back to the generic
+                _comparer = Unsafe.As<IEqualityComparer<TKey>>(
+                    NonRandomizedStringEqualityComparer.GetStringComparer(
+                        Unsafe.As<IEqualityComparer<string>>(_comparer)));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -67,9 +67,9 @@ namespace System.Collections.Generic
             {
                 // We know TKey is string from above check so Unsafe.As from
                 // the generic and then from string back to the generic
-                _comparer = Unsafe.As<IEqualityComparer<TKey>>(
+                _comparer = Unsafe.As<IEqualityComparer<TKey>?>(
                     NonRandomizedStringEqualityComparer.GetStringComparer(
-                        Unsafe.As<IEqualityComparer<string>>(_comparer)));
+                        Unsafe.As<IEqualityComparer<string>?>(_comparer)));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -62,10 +62,13 @@ namespace System.Collections.Generic
             // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
             // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
             // hash buckets become unbalanced.
-
             if (typeof(TKey) == typeof(string))
             {
-                _comparer = (IEqualityComparer<TKey>?)NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
+                IEqualityComparer<string>? stringComparer = NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
+                if (stringComparer is not null)
+                {
+                    _comparer = (IEqualityComparer<TKey>?)stringComparer;
+                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -67,9 +67,9 @@ namespace System.Collections.Generic
             {
                 // We know T is string from above check so Unsafe.As from
                 // the generic and then from string back to the generic
-                _comparer = Unsafe.As<IEqualityComparer<T>>(
+                _comparer = Unsafe.As<IEqualityComparer<T>?>(
                     NonRandomizedStringEqualityComparer.GetStringComparer(
-                        Unsafe.As<IEqualityComparer<string>>(_comparer)));
+                        Unsafe.As<IEqualityComparer<string>?>(_comparer)));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -62,10 +62,13 @@ namespace System.Collections.Generic
             // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
             // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
             // hash buckets become unbalanced.
-
             if (typeof(T) == typeof(string))
             {
-                _comparer = (IEqualityComparer<T>?)NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
+                IEqualityComparer<string>? stringComparer = NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
+                if (stringComparer is not null)
+                {
+                    _comparer = (IEqualityComparer<T>?)stringComparer;
+                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -54,7 +54,7 @@ namespace System.Collections.Generic
 
         public HashSet(IEqualityComparer<T>? comparer)
         {
-            if (comparer != null && comparer != EqualityComparer<T>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
+            if (comparer is not null && comparer != EqualityComparer<T>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
             {
                 _comparer = comparer;
             }
@@ -65,18 +65,11 @@ namespace System.Collections.Generic
 
             if (typeof(T) == typeof(string))
             {
-                if (_comparer is null)
-                {
-                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundDefaultComparer;
-                }
-                else if (ReferenceEquals(_comparer, StringComparer.Ordinal))
-                {
-                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinal;
-                }
-                else if (ReferenceEquals(_comparer, StringComparer.OrdinalIgnoreCase))
-                {
-                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinalIgnoreCase;
-                }
+                // We know T is string from above check so Unsafe.As from
+                // the generic and then from string back to the generic
+                _comparer = Unsafe.As<IEqualityComparer<T>>(
+                    NonRandomizedStringEqualityComparer.GetStringComparer(
+                        Unsafe.As<IEqualityComparer<string>>(_comparer)));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Generic
 
             if (typeof(T) == typeof(string))
             {
-                _comparer = (IEqualityComparer<T>?)NonRandomizedStringEqualityComparer.GetStringComparer((IEqualityComparer<string>?)_comparer);
+                _comparer = (IEqualityComparer<T>?)NonRandomizedStringEqualityComparer.GetStringComparer(_comparer);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -65,11 +65,7 @@ namespace System.Collections.Generic
 
             if (typeof(T) == typeof(string))
             {
-                // We know T is string from above check so Unsafe.As from
-                // the generic and then from string back to the generic
-                _comparer = Unsafe.As<IEqualityComparer<T>?>(
-                    NonRandomizedStringEqualityComparer.GetStringComparer(
-                        Unsafe.As<IEqualityComparer<string>?>(_comparer)));
+                _comparer = (IEqualityComparer<T>?)NonRandomizedStringEqualityComparer.GetStringComparer((IEqualityComparer<string>?)_comparer);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.Serialization;
-using Internal.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -20,9 +18,9 @@ namespace System.Collections.Generic
         // that was passed in to the ctor. The caller chooses one of these singletons so that the
         // GetUnderlyingEqualityComparer method can return the correct value.
 
-        internal static readonly NonRandomizedStringEqualityComparer WrappedAroundDefaultComparer = new OrdinalComparer(EqualityComparer<string?>.Default);
-        internal static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinal = new OrdinalComparer(StringComparer.Ordinal);
-        internal static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinalIgnoreCase = new OrdinalIgnoreCaseComparer(StringComparer.OrdinalIgnoreCase);
+        private static readonly NonRandomizedStringEqualityComparer WrappedAroundDefaultComparer = new OrdinalComparer(EqualityComparer<string?>.Default);
+        private static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinal = new OrdinalComparer(StringComparer.Ordinal);
+        private static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinalIgnoreCase = new OrdinalIgnoreCaseComparer(StringComparer.OrdinalIgnoreCase);
 
         private readonly IEqualityComparer<string?> _underlyingComparer;
 
@@ -108,6 +106,27 @@ namespace System.Collections.Generic
             {
                 return RandomizedStringEqualityComparer.Create(_underlyingComparer, ignoreCase: true);
             }
+        }
+
+        public static IEqualityComparer<string> GetStringComparer(IEqualityComparer<string>? comparer)
+        {
+            // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
+            // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
+            // hash buckets become unbalanced.
+            if (comparer is null)
+            {
+                comparer = WrappedAroundDefaultComparer;
+            }
+            else if (ReferenceEquals(comparer, StringComparer.Ordinal))
+            {
+                comparer = WrappedAroundStringComparerOrdinal;
+            }
+            else if (ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase))
+            {
+                comparer = WrappedAroundStringComparerOrdinalIgnoreCase;
+            }
+
+            return comparer;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -102,7 +102,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public static IEqualityComparer<string> GetStringComparer(IEqualityComparer<string>? comparer)
+        public static IEqualityComparer<string>? GetStringComparer(object? comparer)
         {
             // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
             // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
@@ -121,7 +121,7 @@ namespace System.Collections.Generic
                 return stringComparers.WrappedAroundStringComparerOrdinalIgnoreCase;
             }
 
-            return comparer;
+            return (IEqualityComparer<string>?)comparer;
         }
 
         private class StringComparers


### PR DESCRIPTION
Move the `string` comparer switching out of the generic dictionary (it only applies to `string`) so doesn't need to be there for every shared generic.
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3196205
Total bytes of diff: 3195323
Total bytes of delta: -882 (-0.03% of base)
    diff is an improvement.


Total byte diff includes 108 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    1 unique methods,      108 unique bytes

Top file improvements (bytes):
        -882 : System.Private.CoreLib.dasm (-0.03% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions (bytes):
         108 (     ∞ of base) : System.Private.CoreLib.dasm - NonRandomizedStringEqualityComparer:GetStringComparer(Object):IEqualityComparer`1 (0 base, 1 diff methods)

Top method improvements (bytes):
        -825 (-40.05% of base) : System.Private.CoreLib.dasm - Dictionary`2:.ctor(int,IEqualityComparer`1):this (10 methods)
        -165 (-54.82% of base) : System.Private.CoreLib.dasm - HashSet`1:.ctor(IEqualityComparer`1):this

Top method regressions (percentages):
         108 (     ∞ of base) : System.Private.CoreLib.dasm - NonRandomizedStringEqualityComparer:GetStringComparer(Object):IEqualityComparer`1 (0 base, 1 diff methods)

Top method improvements (percentages):
        -165 (-54.82% of base) : System.Private.CoreLib.dasm - HashSet`1:.ctor(IEqualityComparer`1):this
        -825 (-40.05% of base) : System.Private.CoreLib.dasm - Dictionary`2:.ctor(int,IEqualityComparer`1):this (10 methods)

3 total methods with Code Size differences (2 improved, 1 regressed), 21241 unchanged.
```