### PR TITLE
Permit ST as a friendly name alias for stateOrProvinceName OID

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
@@ -99,7 +99,7 @@ namespace Internal.Cryptography
         }
 
         /// <summary>Expected size of <see cref="s_friendlyNameToOid"/>.</summary>
-        private const int FriendlyNameToOidCount = 110;
+        private const int FriendlyNameToOidCount = 111;
 
         /// <summary>Expected size of <see cref="s_oidToFriendlyName"/>.</summary>
         private const int OidToFriendlyNameCount = 103;
@@ -238,7 +238,7 @@ namespace Internal.Cryptography
             AddEntry("1.2.840.113549.1.1.1", "RSA");
             AddEntry("1.2.840.113549.1.1.7", "RSAES_OAEP");
             AddEntry("1.2.840.113549.1.1.10", "RSASSA-PSS");
-            AddEntry("2.5.4.8", "S");
+            AddEntry("2.5.4.8", "S", new[] { "ST" });
             AddEntry("1.3.132.0.9", "secP160k1");
             AddEntry("1.3.132.0.8", "secP160r1");
             AddEntry("1.3.132.0.30", "secP160r2");

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -223,6 +223,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal("OU=zzzz + OU=aaaa", dn.Decode(X500DistinguishedNameFlags.None));
         }
 
+        [Fact]
+        public static void NameWithSTIdentifierForState()
+        {
+            X500DistinguishedName dn = new X500DistinguishedName("ST=VA, C=US");
+            Assert.Equal("C=US, S=VA", dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
         public static readonly object[][] WhitespaceBeforeCases =
         {
             // Regular space.


### PR DESCRIPTION
Windows appears to map the friendly name "ST" to 2.5.4.8, so we can permit it as an alternative friendly name in the managed OID lookup.

Closes #49612 