### PR TITLE
Stop reading TargetFramework prop in props files

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <PropertyGroup>
+    <!-- Build for NetCoreAppCurrent by default if no BuildTargetFramework is supplied or if not all configurations are built. -->
     <TraversalGlobalProperties Condition="'$(BuildAllConfigurations)' != 'true'">BuildTargetFramework=$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(NetCoreAppCurrent)'))</TraversalGlobalProperties>
   </PropertyGroup>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -47,8 +47,11 @@
     <DefaultMonoSubsets Condition="'$(TargetOS)' == 'Browser'">$(DefaultMonoSubsets)mono.wasmruntime+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(MonoCrossAOTTargetOS)' != ''">$(DefaultMonoSubsets)mono.aotcross+</DefaultMonoSubsets>
     <DefaultMonoSubsets>$(DefaultMonoSubsets)mono.runtime+mono.corelib+mono.packages</DefaultMonoSubsets>
-
-    <DefaultLibrariesSubsets>libs.native+libs.ref+libs.src+libs.pretest+libs.packages</DefaultLibrariesSubsets>
+     
+    <DefaultLibrariesSubsets Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
+                                        '$(BuildTargetFramework)' == '' or
+                                        '$(BuildAllConfigurations)' == 'true'">libs.native+</DefaultLibrariesSubsets>
+    <DefaultLibrariesSubsets>$(DefaultLibrariesSubsets)libs.ref+libs.src+libs.pretest+libs.packages</DefaultLibrariesSubsets>
 
     <DefaultHostSubsets>host.native+host.pkg+host.tools+host.tests</DefaultHostSubsets>
     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' == 'Mono'"></DefaultHostSubsets>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <ILLinkTrimAssemblyArtifactsRootDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(BuildSettings)'))</ILLinkTrimAssemblyArtifactsRootDir>
+    <ILLinkTrimAssemblyArtifactsRootDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(NetCoreAppCurrentBuildSettings)'))</ILLinkTrimAssemblyArtifactsRootDir>
     <ILLinkTrimAssemblySuppressionsXmlsDir>$(ILLinkTrimAssemblyArtifactsRootDir)suppressions-xmls\</ILLinkTrimAssemblySuppressionsXmlsDir>
   </PropertyGroup>
 
@@ -54,15 +54,15 @@
        Must be enabled by setting BinPlaceILLinkTrimAssembly=true
   -->
   <ItemGroup Condition="'$(BinPlaceILLinkTrimAssembly)' == 'true'">
-    <BinPlaceTargetFramework Include="$(BuildSettings)">
+    <BinPlaceTargetFramework Include="$(NetCoreAppCurrentBuildSettings)">
       <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)trimmed</RuntimePath>
       <ItemName>TrimmedItem</ItemName>
     </BinPlaceTargetFramework>
-    <BinPlaceTargetFramework Include="$(BuildSettings)">
+    <BinPlaceTargetFramework Include="$(NetCoreAppCurrentBuildSettings)">
       <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)reports</RuntimePath>
       <ItemName>TrimmingReport</ItemName>
     </BinPlaceTargetFramework>
-    <BinPlaceTargetFramework Include="$(BuildSettings)">
+    <BinPlaceTargetFramework Include="$(NetCoreAppCurrentBuildSettings)">
       <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)pretrimmed</RuntimePath>
       <ItemName>PreTrimmedItem</ItemName>
     </BinPlaceTargetFramework>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -24,13 +24,9 @@
   <Import Sdk="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <BuildTargetFramework Condition="'$(BuildTargetFramework)' == '' and '$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '(-[^;]+)', ''))</BuildTargetFramework>
     <!-- Build all .NET Framework configurations when net48 is passed in. This is for convenience. -->
     <AdditionalBuildTargetFrameworks Condition="'$(BuildTargetFramework)' == 'net48'">net45;net451;net452;net46;net461;net462;net47;net471;net472</AdditionalBuildTargetFrameworks>
     <AdditionalBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildAllProjects)' == 'true'">$(AdditionalBuildTargetFrameworks);netstandard2.0</AdditionalBuildTargetFrameworks>
-    <!-- Initialize BuildSettings from the individual properties. -->
-    <BuildSettings>$(BuildTargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BuildSettings>
-    <BuildSettings Condition="'$(BuildTargetFramework)' == ''">$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BuildSettings>
   </PropertyGroup>
 
   <!-- Define test projects and companions -->
@@ -57,10 +53,6 @@
 
   <!-- Common repo directories -->
   <PropertyGroup>
-    <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->
-    <_targetFrameworkValue>$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(TargetFramework)'))</_targetFrameworkValue>
-    <_targetFrameworkValue>$([MSBuild]::ValueOrDefault('$(_targetFrameworkValue)', '$(NetCoreAppCurrent)'))</_targetFrameworkValue>
-    <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_targetFrameworkValue)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NativeBinDir>
     <PkgDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'pkg'))</PkgDir>
   </PropertyGroup>
 
@@ -78,8 +70,7 @@
 
   <PropertyGroup>
     <BuildingNETCoreAppVertical Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
-                                           '$(BuildAllConfigurations)' == 'true'">true</BuildingNETCoreAppVertical>
-    <BinPlaceTestSharedFramework Condition="'$(BuildingNETCoreAppVertical)' == 'true'">true</BinPlaceTestSharedFramework>
+                                           '$(BuildTargetFramework)' == ''">true</BuildingNETCoreAppVertical>
   </PropertyGroup>
 
   <!-- Import packaging props -->
@@ -143,9 +134,6 @@
 
     <ASPNETCoreAppPackageRefPath>$(ArtifactsBinDir)pkg\aspnetcoreapp\ref</ASPNETCoreAppPackageRefPath>
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
-
-    <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
-    <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', '$(MicrosoftNetCoreAppFrameworkName)', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
 
     <MicrosoftNetCoreAppRefPackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.ref'))</MicrosoftNetCoreAppRefPackDir>
     <MicrosoftNetCoreAppRefPackRefDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'ref', '$(NetCoreAppCurrent)'))</MicrosoftNetCoreAppRefPackRefDir>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -12,7 +12,12 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
+    <NetCoreAppCurrentBuildSettings>$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</NetCoreAppCurrentBuildSettings>
+    <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(NetCoreAppCurrentBuildSettings)'))</NativeBinDir>
+    <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(NetCoreAppCurrentBuildSettings)'))</TestHostRootPath>
+    <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', '$(MicrosoftNetCoreAppFrameworkName)', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
+
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable</NoWarn>
     <!-- Ignore Obsolete errors within the generated shims that type-forward types.
@@ -90,7 +95,7 @@
 
     <!-- Setup the shared framework directory for testing -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
-                              Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
+                              Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
       <NativePath >$(NETCoreAppTestSharedFrameworkPath)</NativePath>
       <RuntimePath Condition="'$(IsNETCoreAppSrc)' == 'true'">$(NETCoreAppTestSharedFrameworkPath)</RuntimePath>
     </BinPlaceTargetFrameworks>

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -3,15 +3,12 @@
     <!-- Hardcode version paths in a global location. -->
     <NativeVersionFile Condition="'$(TargetOS)' == 'windows'">$(ArtifactsObjDir)_version.h</NativeVersionFile>
     <NativeVersionFile Condition="'$(TargetOS)' != 'windows'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
-    <TargetFramework>$(BuildTargetFramework)</TargetFramework>
-    <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
     <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)</_BuildNativeArgs>
     <_BuildNativeArgs Condition="'$(Ninja)' == 'true'">$(_BuildNativeArgs) ninja</_BuildNativeArgs>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="native-binplace.proj"
-                      Condition="'$(BuildingNETCoreAppVertical)' == 'true'" />
+    <ProjectReference Include="native-binplace.proj" />
   </ItemGroup>
 
   <Target Name="BuildNativeUnix"
@@ -42,8 +39,7 @@
 
   <Target Name="BuildNativeWindows"
           BeforeTargets="Build"
-          Condition="$([MSBuild]::IsOsPlatform(Windows)) and
-                     '$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+          Condition="$([MSBuild]::IsOsPlatform(Windows))">
     <!-- Run script that invokes Cmake to create VS files, and then calls msbuild to compile them -->
     <Message Text="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" Importance="High"/>
     <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" />

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
-    <TargetFramework>$(BuildTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <BinPlaceRuntime>false</BinPlaceRuntime>
     <BinPlaceNative>true</BinPlaceNative>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -7,7 +7,7 @@
     <Message Text="Trimming $(PackageRID) runtime pack assemblies with ILLinker..." Importance="high" />
 
     <PropertyGroup>
-      <LibrariesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(BuildSettings)', 'trimmed-runtimepack'))</LibrariesTrimmedArtifactsPath>
+      <LibrariesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(NetCoreAppCurrentBuildSettings)', 'trimmed-runtimepack'))</LibrariesTrimmedArtifactsPath>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -85,7 +85,7 @@
           AfterTargets="BuildExternalsProject"
           Inputs="$(NETCoreAppTestSharedFrameworkPath)*.*"
           Outputs="$(NETCoreAppTestSharedFrameworkPath)$(MicrosoftNetCoreAppFrameworkName).deps.json"
-          Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
+          Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)"
                                          RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"

--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -36,7 +36,7 @@
         HelixAccessToken=$(HelixAccessToken);
         HelixTargetQueues=$(HelixTargetQueues);
         BuildTargetFramework=$(BuildTargetFramework);
-        BuildSettings=$(BuildSettings)
+        BuildSettings=$(BuildTargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)
       </_PropertiesToPass>
     </PropertyGroup>
 
@@ -83,7 +83,7 @@
 
     <!-- The Helix correlation payload file -->
     <TestArchiveRuntimeFile Condition="'$(TestPackages)' != 'true' and
-                                       '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">$(TestArchiveRuntimeRoot)test-runtime-$(BuildSettings).zip</TestArchiveRuntimeFile>
+                                       '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">$(TestArchiveRuntimeRoot)test-runtime-$(NetCoreAppCurrentBuildSettings).zip</TestArchiveRuntimeFile>
     <TestArchiveRuntimeFile Condition="'$(TestPackages)' == 'true'">$(TestArchiveRuntimeRoot)packages-testPayload-$(Configuration).zip</TestArchiveRuntimeFile>
   </PropertyGroup>
 
@@ -132,17 +132,19 @@
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateOneScenarioTestEnvFile" StopOnFirstFailure="true" />
   </Target>
 
-  <!--
-    We need to include all dlls in the runtime path as inputs to make it really incremental. If we use the root folder,
-    if a dll is updated, the folder's timestamp is not updated, therefore skipped.
-  -->
-  <ItemGroup>
-    <_RuntimeInputs Include="$(TestHostRootPath)**/*.dll" />
+  <Target Name="_CollectRuntimeInputs">
+    <!--
+      We need to include all dlls in the runtime path as inputs to make it really incremental. If we use the root folder,
+      if a dll is updated, the folder's timestamp is not updated, therefore skipped.
+    -->
+    <ItemGroup>
+      <_RuntimeInput Include="$(TestHostRootPath)**/*.dll" />
 
-    <!-- Add the scenario TestEnv batch files -->
-    <_RuntimeInputs Condition=" '$(Scenarios)' != '' and '$(TargetsWindows)' == 'true' " Include="$(TestHostRootPath)**/*.cmd" />
-    <_RuntimeInputs Condition=" '$(Scenarios)' != '' and '$(TargetsWindows)' != 'true' " Include="$(TestHostRootPath)**/*.sh" />
-  </ItemGroup>
+      <!-- Add the scenario TestEnv batch files -->
+      <_RuntimeInput Condition=" '$(Scenarios)' != '' and '$(TargetsWindows)' == 'true' " Include="$(TestHostRootPath)**/*.cmd" />
+      <_RuntimeInput Condition=" '$(Scenarios)' != '' and '$(TargetsWindows)' != 'true' " Include="$(TestHostRootPath)**/*.sh" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="IncludeDumpDocsInTesthost"
           Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
@@ -159,8 +161,8 @@
   </Target>
 
   <Target Name="CompressRuntimeDirectory"
-          DependsOnTargets="IncludeDumpDocsInTesthost"
-          Inputs="@(_RuntimeInputs);@(TestArchiveRuntimeDependency)"
+          DependsOnTargets="IncludeDumpDocsInTesthost;_CollectRuntimeInputs"
+          Inputs="@(_RuntimeInput);@(TestArchiveRuntimeDependency)"
           Outputs="$(TestArchiveRuntimeFile)"
           Condition="'$(TestPackages)' != 'true' and
                      '$(TargetsMobile)' != 'true' and

--- a/src/libraries/shims/ApiCompat.proj
+++ b/src/libraries/shims/ApiCompat.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(NetCoreAppCurrent)'))</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <!-- Set to true to build this project -->
     <BaselineApiCompat Condition="'$(BaselineApiCompat)' == ''">false</BaselineApiCompat>
     <PreviousNetCoreApp>net5.0</PreviousNetCoreApp>

--- a/src/libraries/shims/Directory.Build.props
+++ b/src/libraries/shims/Directory.Build.props
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <IsNETCoreAppSrc>true</IsNETCoreAppSrc>
     <IsNETCoreAppRef>true</IsNETCoreAppRef>
-    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">$(TargetFramework)</NuGetTargetMoniker>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/shims/netfxreference.props
+++ b/src/libraries/shims/netfxreference.props
@@ -2,7 +2,6 @@
   <!-- IMPORTANT: please rebuild generateShims.proj when making changes to this file -->
   <ItemGroup>
     <NetFxReference Include="mscorlib" />
-    <NetFxReference Condition="'$(TargetFramework)' != 'netcoreapp2.0'" Include="Microsoft.VisualBasic" />
     <NetFxReference Include="System" />
     <NetFxReference Include="System.ComponentModel.DataAnnotations" />
     <NetFxReference Include="System.Configuration" />

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -6,7 +6,7 @@
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <ProjTemplatePath>$(RepositoryEngineeringDir)slngen.template.proj</ProjTemplatePath>
     <NuGetConfigTemplatePath>$(RepositoryEngineeringDir)slngen.nuget.config</NuGetConfigTemplatePath>
   </PropertyGroup>

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -47,8 +47,8 @@
              Properties="$(TraversalGlobalProperties)" />
   </Target>
 
-  <Import Condition="'$(BuildingNetCoreAppVertical)' == 'true'"
-          Project="$(MSBuildThisFileDirectory)\illink-sharedframework.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)illink-sharedframework.targets"
+          Condition="'$(BuildingNETCoreAppVertical)' == 'true'" />
 
   <Target Name="RunApiCompat"
           Condition="'@(ApiCompatProject)' != ''"


### PR DESCRIPTION
The TargetFramework property isn't expected to be set in props files
before a project's body is evaluated.

Don't let BuildTargetFramework property fallback to TargetFramework as
BTF's sole intent is to convey the TargetFramework to filter to and not
the current selected TargetFramework. Reduce usage of BTF so that it is
only used in places where code is actually conditioned on filtering.