### PR TITLE
Fix incorrect merge suppressing my change to publish CG2 framework

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -62,15 +62,10 @@
   </UsingTask>
 
   <PropertyGroup>
-    <OriginalDotnetRootValue />
+    <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
   </PropertyGroup>
 
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
-    <PropertyGroup>
-      <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="DOTNET_INSTALL_DIR: $(DOTNET_INSTALL_DIR)" />
     <SetEnvVar Name="DOTNET_ROOT" Value="$(DOTNET_INSTALL_DIR)" />
   </Target>
 

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -49,7 +49,7 @@
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <DOTNET_ROOT>$(RepoRoot)</DOTNET_ROOT>
+      <DOTNET_ROOT>$([System.IO.Path]::Combine('$(RepoRoot)', '.dotnet'))</DOTNET_ROOT>
     </PropertyGroup>
   </Target>
 

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -47,14 +47,13 @@
   </PropertyGroup>
 
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
-    <ReadLinesFromFile File="$(ArtifactsDir)/toolset/sdk.txt">
-      <Output TaskParameter="Lines" ItemName="DotNetRoot"/>
-    </ReadLinesFromFile>
-
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <DOTNET_ROOT>@(DotNetRoot)</DOTNET_ROOT>
     </PropertyGroup>
+
+    <ReadLinesFromFile File="$(RepoRoot)/artifacts/toolset/sdk.txt">
+      <Output TaskParameter="Lines" PropertyName="DOTNET_ROOT"/>
+    </ReadLinesFromFile>
 
     <Message Importance="High" Text="DOTNET_ROOT=$(DOTNET_ROOT)" />
   </Target>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -41,6 +41,26 @@
   <!-- Crossgen2 bring-up before SDK 6.0 Preview 2 propagates to the runtime repo. -->
   <!-- https://github.com/dotnet/runtime/issues/48252 -->
 
+  <UsingTask
+    TaskName="SetEnvVar"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+
+    <ParameterGroup>
+      <Name ParameterType="System.String" Required="true" />
+      <Value ParameterType="System.String" Required="false" />
+    </ParameterGroup>
+
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          Environment.SetEnvironmentVariable(Name, Value);
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <PropertyGroup>
     <OriginalDotnetRootValue />
     <DOTNET_ROOT />
@@ -52,16 +72,14 @@
     </PropertyGroup>
 
     <ReadLinesFromFile File="$(RepoRoot)/artifacts/toolset/sdk.txt">
-      <Output TaskParameter="Lines" PropertyName="DOTNET_ROOT"/>
+      <Output TaskParameter="Lines" PropertyName="DotnetRoot"/>
     </ReadLinesFromFile>
 
-    <Message Importance="High" Text="DOTNET_ROOT=$(DOTNET_ROOT)" />
+    <SetEnvVar Name="DOTNET_ROOT" Value="$(DotnetRoot)" />
   </Target>
 
   <Target Name="RestoreDotnetRootAfterRunningCrossgen2" AfterTargets="_CreateR2RImages">
-    <PropertyGroup>
-      <DOTNET_ROOT>$(OriginalDotnetRootValue)</DOTNET_ROOT>
-    </PropertyGroup>
+    <SetEnvVar Name="DOTNET_ROOT" Value="$(OriginalDotnetRootValue)" />
   </Target>
 
   <!-- End of hack to patch DOTNET_ROOT for the duration of Crossgen2 compilation. -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -63,17 +63,20 @@
 
   <PropertyGroup>
     <OriginalDotnetRootValue />
-    <DOTNET_ROOT />
   </PropertyGroup>
 
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
+      <DotnetSdkRootFile>$(RepoRoot)/artifacts/toolset/sdk.txt</DotnetSdkRootFile>
     </PropertyGroup>
 
-    <ReadLinesFromFile File="$(RepoRoot)/artifacts/toolset/sdk.txt">
+    <ReadLinesFromFile File="$(DotnetSdkRootFile)">
       <Output TaskParameter="Lines" PropertyName="DotnetRoot"/>
     </ReadLinesFromFile>
+
+    <Message Importance="High" Text="DotnetSdkRootFile: $(DotnetSdkRootFile)" />
+    <Message Importance="High" Text="DotnetRoot:        $(DotnetRoot)" />
 
     <SetEnvVar Name="DOTNET_ROOT" Value="$(DotnetRoot)" />
   </Target>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -68,7 +68,7 @@
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <DotnetSdkRootFile>$(RepoRoot)/artifacts/toolset/sdk.txt</DotnetSdkRootFile>
+      <DotnetSdkRootFile>$([MSBuild]::NormalizePath('$(RepoRoot)', 'artifacts', 'toolset', 'sdk.txt'))</DotnetSdkRootFile>
     </PropertyGroup>
 
     <ReadLinesFromFile File="$(DotnetSdkRootFile)">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -70,7 +70,12 @@
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
       <ToolsetDir>$([MSBuild]::NormalizePath('$(RepoRoot)', 'artifacts', 'toolset'))</ToolsetDir>
       <DotnetSdkRootFile>$([MSBuild]::NormalizePath('$(ToolsetDir)', 'sdk.txt'))</DotnetSdkRootFile>
+      <ScriptExt>.sh</ScriptExt>
+      <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     </PropertyGroup>
+
+    <Message Importance="High" Text="Initializing DotNet CLI" />
+    <Exec Command="$(RepoRoot)/dotnet$(ScriptExt) --version" />
 
     <Message Importance="High" Condition="Exists('$(ToolsetDir)')" Text="ToolsetDir exists: $(ToolsetDir)" />
     <Message Importance="High" Condition="Exists('$(DotnetSdkRootFile)')" Text="sdk.txt file exists: $(DotnetSdkRootFile)" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -47,10 +47,16 @@
   </PropertyGroup>
 
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
+    <ReadLinesFromFile File="$(ArtifactsDir)/toolset/sdk.txt">
+      <Output TaskParameter="Lines" ItemName="DotNetRoot"/>
+    </ReadLinesFromFile>
+
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <DOTNET_ROOT>$([System.IO.Path]::Combine('$(RepoRoot)', '.dotnet'))</DOTNET_ROOT>
+      <DOTNET_ROOT>@(DotNetRoot)</DOTNET_ROOT>
     </PropertyGroup>
+
+    <Message Importance="High" Text="DOTNET_ROOT=$(DOTNET_ROOT)" />
   </Target>
 
   <Target Name="RestoreDotnetRootAfterRunningCrossgen2" AfterTargets="_CreateR2RImages">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -68,11 +68,16 @@
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <DotnetSdkRootFile>$([MSBuild]::NormalizePath('$(RepoRoot)', 'artifacts', 'toolset', 'sdk.txt'))</DotnetSdkRootFile>
+      <ToolsetDir>$([MSBuild]::NormalizePath('$(RepoRoot)', 'artifacts', 'toolset'))</ToolsetDir>
+      <DotnetSdkRootFile>$([MSBuild]::NormalizePath('$(ToolsetDir)', 'sdk.txt'))</DotnetSdkRootFile>
     </PropertyGroup>
 
+    <Message Importance="High" Condition="Exists('$(ToolsetDir)')" Text="ToolsetDir exists: $(ToolsetDir)" />
+    <Message Importance="High" Condition="Exists('$(DotnetSdkRootFile)')" Text="sdk.txt file exists: $(DotnetSdkRootFile)" />
+    <Message Importance="High" Text="sdk.txt file content: $([System.IO.File]::ReadAllText('$(DotnetSdkRootFile)'))" />
+
     <ReadLinesFromFile File="$(DotnetSdkRootFile)">
-      <Output TaskParameter="Lines" PropertyName="DotnetRoot"/>
+      <Output TaskParameter="Lines" PropertyName="DotnetRoot" />
     </ReadLinesFromFile>
 
     <Message Importance="High" Text="DotnetSdkRootFile: $(DotnetSdkRootFile)" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -68,27 +68,10 @@
   <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
     <PropertyGroup>
       <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
-      <ToolsetDir>$([MSBuild]::NormalizePath('$(RepoRoot)', 'artifacts', 'toolset'))</ToolsetDir>
-      <DotnetSdkRootFile>$([MSBuild]::NormalizePath('$(ToolsetDir)', 'sdk.txt'))</DotnetSdkRootFile>
-      <ScriptExt>.sh</ScriptExt>
-      <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     </PropertyGroup>
 
-    <Message Importance="High" Text="Initializing DotNet CLI" />
-    <Exec Command="$(RepoRoot)/dotnet$(ScriptExt) --version" />
-
-    <Message Importance="High" Condition="Exists('$(ToolsetDir)')" Text="ToolsetDir exists: $(ToolsetDir)" />
-    <Message Importance="High" Condition="Exists('$(DotnetSdkRootFile)')" Text="sdk.txt file exists: $(DotnetSdkRootFile)" />
-    <Message Importance="High" Text="sdk.txt file content: $([System.IO.File]::ReadAllText('$(DotnetSdkRootFile)'))" />
-
-    <ReadLinesFromFile File="$(DotnetSdkRootFile)">
-      <Output TaskParameter="Lines" PropertyName="DotnetRoot" />
-    </ReadLinesFromFile>
-
-    <Message Importance="High" Text="DotnetSdkRootFile: $(DotnetSdkRootFile)" />
-    <Message Importance="High" Text="DotnetRoot:        $(DotnetRoot)" />
-
-    <SetEnvVar Name="DOTNET_ROOT" Value="$(DotnetRoot)" />
+    <Message Importance="High" Text="DOTNET_INSTALL_DIR: $(DOTNET_INSTALL_DIR)" />
+    <SetEnvVar Name="DOTNET_ROOT" Value="$(DOTNET_INSTALL_DIR)" />
   </Target>
 
   <Target Name="RestoreDotnetRootAfterRunningCrossgen2" AfterTargets="_CreateR2RImages">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -6,6 +6,7 @@
       <CrossDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">x64</CrossDir>
       <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
       <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>
+      <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
       <PublishReadyToRunCrossgen2ExtraArgs>--targetarch:$(TargetArchitecture)</PublishReadyToRunCrossgen2ExtraArgs>
 
       <JitTargetOSComponent>unix</JitTargetOSComponent>


### PR DESCRIPTION
As David discovered, I apparently made a merge bug in rebasing my
CG2 framework switch-over change prior to checking in that actually
suppressed CG2 publishing due to losing the property
PublishReadyToRunUseCrossgen2. This change fixes that deficiency.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 