### PR TITLE
Add runtime MVID checks for composite images

### DIFF
--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -5,6 +5,7 @@ Revisions:
 * 1.1 - [Jan Kotas](https://github.com/jkotas) - 2015
 * 3.1 - [Tomas Rylek](https://github.com/trylek) - 2019
 * 4.1 - [Tomas Rylek](https://github.com/trylek) - 2020
+* 5.3 - [Tomas Rylek](https://github.com/trylek) - 2021
 
 # Introduction
 
@@ -161,6 +162,8 @@ The following section types are defined and described later in this document:
 | InliningInfo2             |   114 | Image (added in V4.1)
 | ComponentAssemblies       |   115 | Image (added in V4.1)
 | OwnerCompositeExecutable  |   116 | Image (added in V4.1)
+| PgoInstrumentationData    |   117 | Image (added in V5.2)
+| ManifestAssemblyMvids     |   118 | Image (added in V5.3)
 
 ## ReadyToRunSectionType.CompilerIdentifier
 
@@ -539,6 +542,17 @@ pair; in `Flags`, it has the `READYTORUN_FLAG_COMPONENT` bit set and its section
 the `OwnerCompositeExecutable` section that contains a UTF-8 string encoding the file name of the
 composite R2R executable this MSIL belongs to with extension (without path). Runtime uses this
 information to locate the composite R2R executable with the compiled native code when loading the MSIL.
+
+## ReadyToRunSectionType.PgoInstrumentationData (v5.2+)
+
+**TODO**: document PGO instrumentation data
+
+## ReadyToRunSectionType.ManifestAssemblyMvids (v5.3+)
+
+This section is a binary array of 16-byte MVID records, one for each assembly in the manifest metadata.
+Number of assemblies stored in the manifest metadata is equal to the number of MVID records in the array.
+MVID records are used at runtime to verify that the assemblies loaded match those referenced by the
+manifest metadata representing the versioning bubble.
 
 # Native Format
 

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -80,7 +80,7 @@ enum class ReadyToRunSectionType : uint32_t
     ComponentAssemblies         = 115, // Added in V4.1
     OwnerCompositeExecutable    = 116, // Added in V4.1
     PgoInstrumentationData      = 117, // Added in 5.2
-    ComponentAssemblyMvids      = 118, // Added in V5.3
+    ManifestAssemblyMvids       = 118, // Added in V5.3
 
     // If you add a new section consider whether it is a breaking or non-breaking change.
     // Usually it is non-breaking, but if it is preferable to have older runtimes fail

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -79,7 +79,7 @@ enum class ReadyToRunSectionType : uint32_t
     InliningInfo2               = 114, // Added in V4.1
     ComponentAssemblies         = 115, // Added in V4.1
     OwnerCompositeExecutable    = 116, // Added in V4.1
-    PgoInstrumentationData      = 117, // Added in 5.2
+    PgoInstrumentationData      = 117, // Added in V5.2
     ManifestAssemblyMvids       = 118, // Added in V5.3
 
     // If you add a new section consider whether it is a breaking or non-breaking change.

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -16,7 +16,7 @@
 
 // Keep these in sync with src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
 #define READYTORUN_MAJOR_VERSION 0x0005
-#define READYTORUN_MINOR_VERSION 0x0002
+#define READYTORUN_MINOR_VERSION 0x0003
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 0x003
 
@@ -80,6 +80,7 @@ enum class ReadyToRunSectionType : uint32_t
     ComponentAssemblies         = 115, // Added in V4.1
     OwnerCompositeExecutable    = 116, // Added in V4.1
     PgoInstrumentationData      = 117, // Added in 5.2
+    ComponentAssemblyMvids      = 118, // Added in V5.3
 
     // If you add a new section consider whether it is a breaking or non-breaking change.
     // Usually it is non-breaking, but if it is preferable to have older runtimes fail

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 5;
-        public const ushort CurrentMinorVersion = 2;
+        public const ushort CurrentMinorVersion = 4;
     }
 
 #pragma warning disable 0169

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 5;
-        public const ushort CurrentMinorVersion = 4;
+        public const ushort CurrentMinorVersion = 3;
     }
 
 #pragma warning disable 0169
@@ -66,6 +66,7 @@ namespace Internal.Runtime
         ComponentAssemblies = 115, // Added in 4.1
         OwnerCompositeExecutable = 116, // Added in 4.1
         PgoInstrumentationData = 117, // Added in 5.2
+        ManifestAssemblyMvids = 118, // Added in 5.3
 
         //
         // CoreRT ReadyToRun sections

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ComponentAssemblyMvidHeaderNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ComponentAssemblyMvidHeaderNode.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using Internal.Text;
+using Internal.TypeSystem.Ecma;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ComponentMetadataMvidHeaderNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private ManifestMetadataTableNode _manifestNode;
+
+        public ComponentMetadataMvidHeaderNode(ManifestMetadataTableNode manifestNode)
+        {
+            _manifestNode = manifestNode;
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
+
+        public override bool IsShareable => false;
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.CorHeaderNode;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public int Size => _manifestNode.ComponentAssemblyMvidTableSize;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("__ComponentAssemblyMvids");
+        }
+
+        protected override string GetName(NodeFactory nodeFactory)
+        {
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            AppendMangledName(nodeFactory.NameMangler, sb);
+            return sb.ToString();
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false) => _manifestNode.GetComponentAssemblyMvidTableData(factory, relocsOnly);
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestAssemblyMvidHeaderNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestAssemblyMvidHeaderNode.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             if (relocsOnly)
             {
-                return new ObjectData(Array.Empty<byte>(), null, 1, null);
+                return new ObjectData(Array.Empty<byte>(), null, 0, null);
             }
 
             byte[] manifestAssemblyMvidTable = _manifestNode.GetManifestAssemblyMvidTableData();

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly Dictionary<int, AssemblyName> _moduleIdToAssemblyNameMap;
 
         /// <summary>
-        /// MVID's of the assemblies included in manifest metadata to be emitted as the
+        /// MVIDs of the assemblies included in manifest metadata to be emitted as the
         /// ManifestAssemblyMvid R2R header table used by the runtime to check loaded assemblies
         /// and fail fast in case of mismatch.
         /// </summary>
@@ -260,12 +260,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             byte[] manifestAssemblyMvidTable = new byte[ManifestAssemblyMvidTableSize];
             for (int i = 0; i < _manifestAssemblyMvids.Count; i++)
             {
-                Array.Copy(
-                    sourceArray: _manifestAssemblyMvids[i].ToByteArray(),
-                    sourceIndex: 0,
-                    destinationArray: manifestAssemblyMvidTable,
-                    destinationIndex: GuidByteSize * i,
-                    length: GuidByteSize);
+                _manifestAssemblyMvids[i].TryWriteBytes(new Span<byte>(manifestAssemblyMvidTable, GuidByteSize * i, GuidByteSize));
             }
             return manifestAssemblyMvidTable;
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -570,6 +570,9 @@ namespace ILCompiler.DependencyAnalysis
             Header.Add(Internal.Runtime.ReadyToRunSectionType.ManifestMetadata, ManifestMetadataTable, ManifestMetadataTable);
             Resolver.SetModuleIndexLookup(ManifestMetadataTable.ModuleToIndex);
 
+            ManifestAssemblyMvidHeaderNode mvidTableNode = new ManifestAssemblyMvidHeaderNode(ManifestMetadataTable);
+            Header.Add(Internal.Runtime.ReadyToRunSectionType.ManifestAssemblyMvids, mvidTableNode, mvidTableNode);
+
             AssemblyTableNode assemblyTable = null;
 
             if (CompilationModuleGroup.IsCompositeBuildMode)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -103,7 +103,7 @@
     <Compile Include="..\..\Common\TypeSystem\Interop\InteropTypes.cs" Link="Interop\InteropTypes.cs" />
     <Compile Include="Compiler\AssemblyExtensions.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DeferredTillPhaseNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ComponentAssemblyMvidHeaderNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ManifestAssemblyMvidHeaderNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadMethodCallThunkNodeRange.cs" />
     <Compile Include="Compiler\CallChainProfile.cs" />
     <Compile Include="ObjectWriter\MapFileBuilder.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
@@ -103,6 +103,7 @@
     <Compile Include="..\..\Common\TypeSystem\Interop\InteropTypes.cs" Link="Interop\InteropTypes.cs" />
     <Compile Include="Compiler\AssemblyExtensions.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DeferredTillPhaseNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ComponentAssemblyMvidHeaderNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadMethodCallThunkNodeRange.cs" />
     <Compile Include="Compiler\CallChainProfile.cs" />
     <Compile Include="ObjectWriter\MapFileBuilder.cs" />

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -95,7 +95,7 @@ namespace R2RDump
                         {
                             int mvidOffset = _r2r.GetOffset(mvidSection.RelativeVirtualAddress) + GuidByteSize * assemblyIndex;
                             Guid mvid = new Guid(new ReadOnlySpan<byte>(_r2r.Image, mvidOffset, GuidByteSize));
-                            dividerName += $@" - MVID {mvid}";
+                            dividerName += $@" - MVID {mvid:b}";
                         }
                         WriteDivider(dividerName);
                         ReadyToRunCoreHeader assemblyHeader = _r2r.ReadyToRunAssemblyHeaders[assemblyIndex];
@@ -515,7 +515,7 @@ namespace R2RDump
                     for (int mvidIndex = 0; mvidIndex < mvidCount; mvidIndex++)
                     {
                         Guid mvid = new Guid(new Span<byte>(_r2r.Image, mvidOffset + GuidByteSize * mvidIndex, GuidByteSize));
-                        _writer.WriteLine("MVID[{0}] = {1}", mvidIndex, mvid);
+                        _writer.WriteLine("MVID[{0}] = {1:b}", mvidIndex, mvid);
                     }
                     break;
                 default:

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -18,6 +18,8 @@ namespace R2RDump
 {
     class TextDumper : Dumper
     {
+        private const int GuidByteSize = 16;
+
         public TextDumper(ReadyToRunReader r2r, TextWriter writer, Disassembler disassembler, DumpOptions options)
             : base(r2r, writer, disassembler, options)
         {
@@ -88,7 +90,14 @@ namespace R2RDump
                     int assemblyIndex = 0;
                     foreach (string assemblyName in _r2r.ManifestReferenceAssemblies.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key))
                     {
-                        WriteDivider($@"Component Assembly [{assemblyIndex}]: {assemblyName}");
+                        string dividerName = $@"Component Assembly [{assemblyIndex}]: {assemblyName}";
+                        if (_r2r.ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.ManifestAssemblyMvids, out ReadyToRunSection mvidSection))
+                        {
+                            int mvidOffset = _r2r.GetOffset(mvidSection.RelativeVirtualAddress) + GuidByteSize * assemblyIndex;
+                            Guid mvid = new Guid(new ReadOnlySpan<byte>(_r2r.Image, mvidOffset, GuidByteSize));
+                            dividerName += $@" - MVID {mvid}";
+                        }
+                        WriteDivider(dividerName);
                         ReadyToRunCoreHeader assemblyHeader = _r2r.ReadyToRunAssemblyHeaders[assemblyIndex];
                         foreach (ReadyToRunSection section in NormalizedSections(assemblyHeader))
                         {
@@ -499,6 +508,18 @@ namespace R2RDump
                     }
                     string ownerCompositeExecutable = Encoding.UTF8.GetString(_r2r.Image, oceOffset, section.Size - 1); // exclude the zero terminator
                     _writer.WriteLine("Composite executable: {0}", ownerCompositeExecutable.ToEscapedString());
+                    break;
+                case ReadyToRunSectionType.ManifestAssemblyMvids:
+                    int mvidOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
+                    int mvidCount = section.Size / GuidByteSize;
+                    for (int mvidIndex = 0; mvidIndex < mvidCount; mvidIndex++)
+                    {
+                        Guid mvid = new Guid(new Span<byte>(_r2r.Image, mvidOffset + GuidByteSize * mvidIndex, GuidByteSize));
+                        _writer.WriteLine("MVID[{0}] = {1}", mvidIndex, mvid);
+                    }
+                    break;
+                default:
+                    _writer.WriteLine("Unsupported section type {0}", section.Type);
                     break;
             }
         }

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3087,7 +3087,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
 
         if (registerNewAssembly)
         {
-            pFile->GetAssemblyLoadContext()->AddLoadedAssembly(pDomainAssembly->GetLoadedAssembly());
+            pFile->GetAssemblyLoadContext()->AddLoadedAssembly(pDomainAssembly->GetCurrentAssembly());
         }
     }
     else

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3043,6 +3043,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
 
         // Find the list lock entry
         FileLoadLock * fileLock = (FileLoadLock *)lock->FindFileLock(pFile);
+        bool registerNewAssembly = false;
         if (fileLock == NULL)
         {
             // Check again in case we were racing
@@ -3050,6 +3051,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
             if (result == NULL)
             {
                 // We are the first one in - create the DomainAssembly
+                registerNewAssembly = true;
                 fileLock = FileLoadLock::Create(lock, pFile, pDomainAssembly);
                 pDomainAssembly.SuppressRelease();
 #ifndef CROSSGEN_COMPILE
@@ -3081,6 +3083,11 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
         else
         {
             result->EnsureLoadLevel(targetLevel);
+        }
+
+        if (registerNewAssembly)
+        {
+            pFile->GetAssemblyLoadContext()->AddLoadedAssembly(pDomainAssembly->GetLoadedAssembly());
         }
     }
     else

--- a/src/coreclr/vm/assemblyloadcontext.cpp
+++ b/src/coreclr/vm/assemblyloadcontext.cpp
@@ -24,6 +24,26 @@ NativeImage *AssemblyLoadContext::LoadNativeImage(Module *componentModule, LPCUT
     AssemblyLoadContext *loadContext = componentModule->GetFile()->GetAssemblyLoadContext();
     PTR_LoaderAllocator moduleLoaderAllocator = componentModule->GetLoaderAllocator();
 
-    return NativeImage::Open(componentModule, nativeImageName, loadContext, moduleLoaderAllocator);
+    NativeImage *nativeImage = NativeImage::Open(componentModule, nativeImageName, loadContext, moduleLoaderAllocator);
+    m_nativeImages.Append(nativeImage);
+
+    for (COUNT_T assemblyIndex = 0; assemblyIndex < m_loadedAssemblies.GetCount(); assemblyIndex++)
+    {
+        nativeImage->CheckAssemblyMvid(m_loadedAssemblies[assemblyIndex]);
+    }
+
+    return nativeImage;
+}
+#endif
+
+#ifndef DACCESS_COMPILE
+void AssemblyLoadContext::AddLoadedAssembly(Assembly *loadedAssembly)
+{
+    BaseDomain::LoadLockHolder lock(AppDomain::GetCurrentDomain());
+    m_loadedAssemblies.Append(loadedAssembly);
+    for (COUNT_T nativeImageIndex = 0; nativeImageIndex < m_nativeImages.GetCount(); nativeImageIndex++)
+    {
+        m_nativeImages[nativeImageIndex]->CheckAssemblyMvid(loadedAssembly);
+    }
 }
 #endif

--- a/src/coreclr/vm/assemblyloadcontext.h
+++ b/src/coreclr/vm/assemblyloadcontext.h
@@ -9,6 +9,7 @@
 
 class NativeImage;
 class Module;
+class Assembly;
 
 //
 // Unmanaged counter-part of System.Runtime.Loader.AssemblyLoadContext
@@ -22,6 +23,8 @@ public:
         /* [retval][out] */ UINT_PTR* pBinderId);
 
     NativeImage *LoadNativeImage(Module *componentModule, LPCUTF8 nativeImageName);
+
+    void AddLoadedAssembly(Assembly *loadedAssembly);
 
     INT_PTR GetManagedAssemblyLoadContext()
     {
@@ -40,6 +43,7 @@ protected:
 
 private:
     SArray<NativeImage *> m_nativeImages;
+    SArray<Assembly *> m_loadedAssemblies;
 };
 
 #endif

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -67,7 +67,7 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 
     m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, pLoaderAllocator, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
-    m_pComponentAssemblyMvids = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblyMvids);
+    m_pComponentAssemblyMvids = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ManifestAssemblyMvids);
     m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
     
     // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -67,6 +67,7 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 
     m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, pLoaderAllocator, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
+    m_pComponentAssemblyMvids = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblyMvids);
     m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
     
     // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
@@ -248,6 +249,49 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
         return (PTR_READYTORUN_CORE_HEADER)&pImageBase[componentAssembly->ReadyToRunCoreHeader.VirtualAddress];
     }
     return NULL;
+}
+#endif
+
+#ifndef DACCESS_COMPILE
+void NativeImage::CheckAssemblyMvid(Assembly *assembly) const
+{
+    STANDARD_VM_CONTRACT;
+    if (m_pComponentAssemblyMvids == NULL)
+    {
+        return;
+    }
+
+    const AssemblyNameIndex *assemblyNameIndex = m_assemblySimpleNameToIndexMap.LookupPtr(assembly->GetSimpleName());
+    if (assemblyNameIndex == NULL)
+    {
+        return;
+    }
+
+    GUID assemblyMvid;
+    assembly->GetManifestImport()->GetScopeProps(NULL, &assemblyMvid);
+
+    const byte *pImageBase = (const BYTE *)m_pImageLayout->GetBase();
+    const GUID *componentMvid = (const GUID *)&pImageBase[m_pComponentAssemblyMvids->VirtualAddress] + assemblyNameIndex->Index;
+    if (IsEqualGUID(*componentMvid, assemblyMvid))
+    {
+        return;
+    }
+
+    static const size_t MVID_TEXT_LENGTH = 39;
+    WCHAR assemblyMvidText[MVID_TEXT_LENGTH];
+    StringFromGUID2(assemblyMvid, assemblyMvidText, MVID_TEXT_LENGTH);
+
+    WCHAR componentMvidText[MVID_TEXT_LENGTH];
+    StringFromGUID2(*componentMvid, componentMvidText, MVID_TEXT_LENGTH);
+
+    SString message;
+    message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
+        assembly->GetSimpleName(),
+        assemblyMvidText,
+        SString(SString::Utf8, GetFileName()).GetUnicode(),
+        componentMvidText);
+
+    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, message.GetUnicode());
 }
 #endif
 

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -84,6 +84,7 @@ private:
     PTR_Assembly *m_pNativeMetadataAssemblyRefMap;
     
     IMAGE_DATA_DIRECTORY *m_pComponentAssemblies;
+    IMAGE_DATA_DIRECTORY *m_pComponentAssemblyMvids;
     uint32_t m_componentAssemblyCount;
     uint32_t m_manifestAssemblyCount;
     SHash<AssemblyNameIndexHashTraits> m_assemblySimpleNameToIndexMap;
@@ -121,7 +122,9 @@ public:
     Assembly *LoadManifestAssembly(uint32_t rowid, DomainAssembly *pParentAssembly);
     
     PTR_READYTORUN_CORE_HEADER GetComponentAssemblyHeader(LPCUTF8 assemblySimpleName);
-    
+
+    void CheckAssemblyMvid(Assembly *assembly) const;
+
 private:
     IMDInternalImport *LoadManifestMetadata();
 };


### PR DESCRIPTION
This change introduces runtime consistency checks that make sure that for component assemblies of component images we're loading the same versions of these assemblies (with matching MVID). The change has the following aspects:

1. Producing new R2R header table ManifestAssemblyMvids in Crossgen2;
2. Consuming the new table at runtime and using it to implement the consistency checks;
3. Change to R2RDump to support dumping the new R2R header section;
4. Update of the R2R format spec to include the new table.

I'm still testing the change locally and I intend to author a negative unit test but from my perspective the change should be code complete so I'm looking forward to feedback.

Thanks

Tomas