### PR TITLE
lower the baseline version for system.text.encodings.web

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
+++ b/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <!-- Only CLS-compliant members can be abstract -->
     <NoWarn>$(NoWarn);CS3011</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
+++ b/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="!$(TargetFramework.StartsWith('net4'))' != 'true'">5.0.0.0</AssemblyVersion>
     <!-- Only CLS-compliant members can be abstract -->
     <NoWarn>$(NoWarn);CS3011</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
+++ b/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion Condition="!$(TargetFramework.StartsWith('net4'))' != 'true'">5.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="!$(TargetFramework.StartsWith('net4'))">5.0.0.0</AssemblyVersion>
     <!-- Only CLS-compliant members can be abstract -->
     <NoWarn>$(NoWarn);CS3011</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -6455,7 +6455,7 @@
         "5.0.0",
         "5.0.1"
       ],
-      "BaselineVersion": "5.0.1",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp3.0": "4.0.4.0",
         "net5.0": "5.0.0.0"

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -6455,7 +6455,7 @@
         "5.0.0",
         "5.0.1"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "5.0.1",
       "InboxOn": {
         "netcoreapp3.0": "4.0.4.0",
         "net5.0": "5.0.0.0"


### PR DESCRIPTION
5.0.1 package version of system.text.encodings.web  contains an updated assembly version (5.0.0.1). The shared framework contains 5.0.0.0 which leads to version conflicts.