### PR TITLE
[wasm] Remove extraneous emission of MONO_PATH value

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -400,8 +400,6 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             {"MONO_ENV_OPTIONS", string.Empty} // we do not want options to be provided out of band to the cross compilers
         };
 
-        Utils.LogInfo ($"MONO_PATH={paths}");
-
         try
         {
             // run the AOT compiler


### PR DESCRIPTION
this removes messages like:
```
AOT'ing 31 assemblies
  MONO_PATH=D:\temp\b7\app\obj\Debug\net6.0\linked
  MONO_PATH=D:\temp\b7\app\obj\Debug\net6.0\linked
  ...
```

The environment variables are already logged as part of invoking the process. And can be seen
with detailed verbosity.

```
         Using working directory: /Users/radical/dev/runtime/src/mono/sample/wasm/console/bin/browser-wasm/publish
         Setting environment variables for execution:
                MONO_PATH = /Users/radical/dev/runtime/src/mono/sample/wasm/console/bin/browser-wasm/publish:/Users/radical/dev/runtime/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Release/runtimes/browser-wasm/native/:/Users/radical/dev/runtime/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Release/runtimes/browser-wasm/lib/net6.0
                MONO_ENV_OPTIONS =
```

This can be done with the samples as:
    `$ make MSBUILD_ARGS="/v:detailed"`