### PR TITLE
Avoid forcing parsing of DefaultRequestHeaders and from message.ToString()

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -357,7 +357,7 @@ namespace System.Net.Http.Headers
             {
                 if (headers[i] is HttpHeaders hh)
                 {
-                    foreach (KeyValuePair<string, IEnumerable<string>> header in hh)
+                    foreach (KeyValuePair<string, string[]> header in hh.EnumerateWithoutValidation())
                     {
                         foreach (string headerValue in header.Value)
                         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -204,18 +204,23 @@ namespace System.Net.Http.Functional.Tests
 
             rm.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain", 0.2));
             rm.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml", 0.1));
+            rm.Headers.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.5"); // validate this remains unparsed
             rm.Headers.Add("Custom-Request-Header", "value1");
             rm.Content.Headers.Add("Custom-Content-Header", "value2");
 
-            Assert.Equal(
-                "Method: PUT, RequestUri: 'http://a.com/', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:" + Environment.NewLine +
-                "{" + Environment.NewLine +
-                "  Accept: text/plain; q=0.2" + Environment.NewLine +
-                "  Accept: text/xml; q=0.1" + Environment.NewLine +
-                "  Custom-Request-Header: value1" + Environment.NewLine +
-                "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
-                "  Custom-Content-Header: value2" + Environment.NewLine +
-                "}", rm.ToString());
+            for (int i = 0; i < 2; i++) // make sure ToString() doesn't impact subsequent use
+            {
+                Assert.Equal(
+                    "Method: PUT, RequestUri: 'http://a.com/', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:" + Environment.NewLine +
+                    "{" + Environment.NewLine +
+                    "  Accept: text/plain; q=0.2" + Environment.NewLine +
+                    "  Accept: text/xml; q=0.1" + Environment.NewLine +
+                    "  Accept-Language: en-US,en;q=0.5" + Environment.NewLine +
+                    "  Custom-Request-Header: value1" + Environment.NewLine +
+                    "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
+                    "  Custom-Content-Header: value2" + Environment.NewLine +
+                    "}", rm.ToString());
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -121,6 +121,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.5"); // validation would add spaces
+                    client.DefaultRequestHeaders.TryAddWithoutValidation("From", "invalidemail"); // would fail to parse if validated
 
                     var m = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     (await client.SendAsync(TestAsync, m)).Dispose();
@@ -128,7 +129,8 @@ namespace System.Net.Http.Functional.Tests
             }, async server =>
             {
                 List<string> headers = await server.AcceptConnectionSendResponseAndCloseAsync();
-                Assert.Contains(headers, header => header.Contains("en-US,en;q=0.5"));
+                Assert.Contains(headers, header => header.Contains("Accept-Language: en-US,en;q=0.5"));
+                Assert.Contains(headers, header => header.Contains("From: invalidemail"));
             });
         }
     }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -114,7 +114,7 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_HttpProtocolTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public async Task DefaultRequestHeaders_Invalid_SentUnparsed()
+        public async Task DefaultRequestHeaders_SentUnparsed()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49463
cc: @geoffkizer 