### PR TITLE
Big-endian fixes for ilasm/ildasm

### DIFF
--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -456,7 +456,7 @@ void    AsmMan::EndAssembly()
                     // into the public key buffer).
                     if (m_sStrongName.m_cbPublicKey >= sizeof(PublicKeyBlob) &&
                         (offsetof(PublicKeyBlob, PublicKey) +
-                         ((PublicKeyBlob*)m_sStrongName.m_pbPublicKey)->cbPublicKey) == m_sStrongName.m_cbPublicKey)
+                         VAL32(((PublicKeyBlob*)m_sStrongName.m_pbPublicKey)->cbPublicKey)) == m_sStrongName.m_cbPublicKey)
                         m_sStrongName.m_fFullSign = FALSE;
                     else
                         m_sStrongName.m_fFullSign = TRUE;

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -741,8 +741,8 @@ char* DumpUnicodeString(void* GUICookie,
         if((size_t)pszString & (sizeof(WCHAR)-1))
 #endif
         {
-            L = (cbString+1)*sizeof(WCHAR);
-            pszStringCopy = new WCHAR[cbString+1];
+            L = cbString*sizeof(WCHAR);
+            pszStringCopy = new WCHAR[cbString];
             memcpy(pszStringCopy, pszString, L);
             pszString=pszStringCopy;
         }

--- a/src/coreclr/md/runtime/mdinternalro.cpp
+++ b/src/coreclr/md/runtime/mdinternalro.cpp
@@ -3323,9 +3323,8 @@ HRESULT _FillMDDefaultValue(
 #if BIGENDIAN
         {
             // We need to allocate and swap the string if we're on a big endian
+            // This allocation will be freed by the MDDefaultValue destructor.
             pMDDefaultValue->m_wzValue = new WCHAR[(cbValue + 1) / sizeof (WCHAR)];
-            _ASSERTE(FALSE); // Nothing ever free's this newly allocated array. Inserting assert so that if we ever actually
-            // use this code path, we'll fix it then. (Don't want to fix something I can't test.)
             IfNullGo(pMDDefaultValue->m_wzValue);
             memcpy(const_cast<WCHAR *>(pMDDefaultValue->m_wzValue), pValue, cbValue);
             _ASSERTE(cbValue % sizeof(WCHAR) == 0);


### PR DESCRIPTION
* Add byte swap when accessing PublicKeyBlob in AsmMan::EndAssembly

* Fix access beyond end of pszString in DumpUnicodeString

* Remove unneccessary assert in _FillMDDefaultValue