### PR TITLE
Big-endian test case fixes: BinaryWriter

### DIFF
--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.WriteByteCharTests.cs
@@ -579,13 +579,13 @@ namespace System.IO.Tests
 
                     char testChar;
 
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    testChar = (char)((ushort)baseStream.ReadByte() + ((ushort)baseStream.ReadByte() << 8));
                     Assert.Equal('a', testChar);
 
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    testChar = (char)((ushort)baseStream.ReadByte() + ((ushort)baseStream.ReadByte() << 8));
                     Assert.Equal('7', testChar);
 
-                    testChar = BitConverter.ToChar(new byte[] { (byte)baseStream.ReadByte(), (byte)baseStream.ReadByte() }, 0);
+                    testChar = (char)((ushort)baseStream.ReadByte() + ((ushort)baseStream.ReadByte() << 8));
                     Assert.Equal(char.MaxValue, testChar);
                 }
             }


### PR DESCRIPTION
* Fix endian assumption in BinaryWriter_WriteSpan
  (BinaryWriter always uses little-endian byte order)