### PR TITLE
Big-endian test case fixes: XML

### DIFF
--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -5755,7 +5755,14 @@ namespace System.Xml.Tests
                         w.WriteBinHex(Wbase64, 0, (int)Wbase64len);
                         w.WriteEndElement();
                     }
-                    Assert.True(utils.CompareReader("<root a='610062006300' />"));
+                    if (System.BitConverter.IsLittleEndian)
+                    {
+                        Assert.True(utils.CompareReader("<root a='610062006300' />"));
+                    }
+                    else
+                    {
+                        Assert.True(utils.CompareReader("<root a='006100620063' />"));
+                    }
                 }
 
                 // Call WriteBinHex and verify results can be read as a string
@@ -5777,7 +5784,14 @@ namespace System.Xml.Tests
                         w.WriteBinHex(Wbase64, 0, (int)Wbase64len);
                         w.WriteEndElement();
                     }
-                    Assert.True(utils.CompareReader("<root>610062006300</root>"));
+                    if (System.BitConverter.IsLittleEndian)
+                    {
+                        Assert.True(utils.CompareReader("<root>610062006300</root>"));
+                    }
+                    else
+                    {
+                        Assert.True(utils.CompareReader("<root>006100620063</root>"));
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/EncodeDecodeTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/EncodeDecodeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -47,7 +48,8 @@ namespace System.Xml.Tests
             string strUni = string.Empty;
             for (int i = 0; i < _dbyte.Length; i = i + 2)
             {
-                strUni += (BitConverter.ToChar(_dbyte, i)).ToString();
+                char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_dbyte, i, 2));
+                strUni += c.ToString();
             }
             CError.WriteLine(strUni + " " + XmlConvert.EncodeName(strUni));
             CError.Compare(XmlConvert.EncodeName(strUni), "_xFF71_", "EncodeName");

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests1.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeName((BitConverter.ToChar(_byte_BaseChar, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_BaseChar, i, 2));
+            strEnVal = XmlConvert.EncodeName(c.ToString());
             CError.Compare(strEnVal, _Expbyte_BaseChar[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests2.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeNmToken((BitConverter.ToChar(_byte_BaseChar, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_BaseChar, i, 2));
+            strEnVal = XmlConvert.EncodeNmToken(c.ToString());
 
             if (_Expbyte_BaseChar[i / 2] != "_x0387_" && _Expbyte_BaseChar[i / 2] != "_x0640_" && _Expbyte_BaseChar[i / 2] != "_x064B_" && _Expbyte_BaseChar[i / 2] != "_x0670_" && _Expbyte_BaseChar[i / 2] != "_x06D6_" && _Expbyte_BaseChar[i / 2] != "_x06E4_" && _Expbyte_BaseChar[i / 2] != "_x06E7_" && _Expbyte_BaseChar[i / 2] != "_x093C_" && _Expbyte_BaseChar[i / 2] != "_x093E_" && _Expbyte_BaseChar[i / 2] != "_x0962_" && _Expbyte_BaseChar[i / 2] != "_x09E2_" && _Expbyte_BaseChar[i / 2] != "_x09EF_" && _Expbyte_BaseChar[i / 2] != "_x0A71_" && _Expbyte_BaseChar[i / 2] != "_x0ABC_" && _Expbyte_BaseChar[i / 2] != "_x0ABE_" && _Expbyte_BaseChar[i / 2] != "_x0B3C_" && _Expbyte_BaseChar[i / 2] != "_x0B3E_" && _Expbyte_BaseChar[i / 2] != "_x0E31_" && _Expbyte_BaseChar[i / 2] != "_x0E34_" && _Expbyte_BaseChar[i / 2] != "_x0E46_" && _Expbyte_BaseChar[i / 2] != "_x0EB1_" && _Expbyte_BaseChar[i / 2] != "_x0EB4_" && _Expbyte_BaseChar[i / 2] != "_x0EBC_" && _Expbyte_BaseChar[i / 2] != "_x0F3F_")
             {

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests3.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlBaseCharConvertTests3.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -28,7 +29,8 @@ namespace System.Xml.Tests
             string strDeVal = string.Empty;
             string strVal = string.Empty;
 
-            strVal = (BitConverter.ToChar(_byte_BaseChar, i)).ToString();
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_BaseChar, i, 2));
+            strVal = c.ToString();
             strEnVal = XmlConvert.EncodeName(strVal);
             CError.Compare(strEnVal, _Expbyte_BaseChar[i / 2], "Encode Comparison failed at " + i);
 

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests1.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeName((BitConverter.ToChar(_byte_CombiningChar, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_CombiningChar, i, 2));
+            strEnVal = XmlConvert.EncodeName(c.ToString());
             CError.Compare(strEnVal, _Expbyte_CombiningChar[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests2.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeNmToken((BitConverter.ToChar(_byte_CombiningChar, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_CombiningChar, i, 2));
+            strEnVal = XmlConvert.EncodeNmToken(c.ToString());
             if (_Expbyte_CombiningChar[i / 2] != "_x0A6F_" && _Expbyte_CombiningChar[i / 2] != "_x0E46_")
             {
                 CError.Compare(strEnVal, _Expbyte_CombiningChar[i / 2], "Comparison failed at " + i);

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests3.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlCombiningCharConvertTests3.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -28,7 +29,8 @@ namespace System.Xml.Tests
             string strEnVal = string.Empty;
             string strVal = string.Empty;
 
-            strVal = (BitConverter.ToChar(_byte_CombiningChar, i)).ToString();
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_CombiningChar, i, 2));
+            strVal = c.ToString();
             strEnVal = XmlConvert.EncodeName(strVal);
             CError.Compare(strEnVal, _Expbyte_CombiningChar[i / 2], "Encode Comparison failed at " + i);
 

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests1.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeName((BitConverter.ToChar(_byte_Digit, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Digit, i, 2));
+            strEnVal = XmlConvert.EncodeName(c.ToString());
             CError.Compare(strEnVal, _Expbyte_Digit[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests2.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeNmToken((BitConverter.ToChar(_byte_Digit, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Digit, i, 2));
+            strEnVal = XmlConvert.EncodeNmToken(c.ToString());
             if (_Expbyte_Digit[i / 2] != "_x0A70_")
             {
                 CError.Compare(strEnVal, _Expbyte_Digit[i / 2], "Comparison failed at " + i);

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests3.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlDigitCharConvertTests3.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -28,7 +29,8 @@ namespace System.Xml.Tests
             string strEnVal = string.Empty;
             string strVal = string.Empty;
 
-            strVal = (BitConverter.ToChar(_byte_Digit, i)).ToString();
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Digit, i, 2));
+            strVal = c.ToString();
             strEnVal = XmlConvert.EncodeName(strVal);
             CError.Compare(strEnVal, _Expbyte_Digit[i / 2], "Encode Comparison failed at " + i);
 

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests1.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeName((BitConverter.ToChar(_byte_EmbeddedNull, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_EmbeddedNull, i, 2));
+            strEnVal = XmlConvert.EncodeName(c.ToString());
             CError.Compare(strEnVal, _Expbyte_EmbeddedNull[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests2.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeNmToken((BitConverter.ToChar(_byte_EmbeddedNull, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_EmbeddedNull, i, 2));
+            strEnVal = XmlConvert.EncodeNmToken(c.ToString());
             CError.Compare(strEnVal, _Expbyte_EmbeddedNull[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests3.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlEmbeddedNullCharConvertTests3.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -28,7 +29,8 @@ namespace System.Xml.Tests
             string strEnVal = string.Empty;
             string strVal = string.Empty;
 
-            strVal = (BitConverter.ToChar(_byte_EmbeddedNull, i)).ToString();
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_EmbeddedNull, i, 2));
+            strVal = c.ToString();
             strEnVal = XmlConvert.EncodeName(strVal);
             CError.Compare(strEnVal, _Expbyte_EmbeddedNull[i / 2], "Encode Comparison failed at " + i);
 

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests1.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeName((BitConverter.ToChar(_byte_Ideographic, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Ideographic, i, 2));
+            strEnVal = XmlConvert.EncodeName(c.ToString());
             CError.Compare(strEnVal, _Expbyte_Ideographic[i / 2], "Comparison failed at " + i);
             return TEST_PASS;
         }

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests2.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -26,7 +27,8 @@ namespace System.Xml.Tests
             int i = ((CurVariation.id) - 1) * 2;
             string strEnVal = string.Empty;
 
-            strEnVal = XmlConvert.EncodeNmToken((BitConverter.ToChar(_byte_Ideographic, i)).ToString());
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Ideographic, i, 2));
+            strEnVal = XmlConvert.EncodeNmToken(c.ToString());
             if (_Expbyte_Ideographic[i / 2] != "_x302A_")
             {
                 CError.Compare(strEnVal, _Expbyte_Ideographic[i / 2], "Comparison failed at " + i);

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests3.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/XmlIdeographicCharConvertTests3.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using OLEDB.Test.ModuleCore;
+using System.Buffers.Binary;
 
 namespace System.Xml.Tests
 {
@@ -28,7 +29,8 @@ namespace System.Xml.Tests
             string strEnVal = string.Empty;
             string strVal = string.Empty;
 
-            strVal = (BitConverter.ToChar(_byte_Ideographic, i)).ToString();
+            char c = (char)BinaryPrimitives.ReadUInt16LittleEndian(new Span<byte>(_byte_Ideographic, i, 2));
+            strVal = c.ToString();
             strEnVal = XmlConvert.EncodeName(strVal);
             CError.Compare(strEnVal, _Expbyte_Ideographic[i / 2], "Encode Comparison failed at " + i);
 


### PR DESCRIPTION
* Update expected results for endian-dependent tests BinHex_9/BinHex_10

* Input strings for XML encode/decode tests are hard-coded little-endian