### PR TITLE
Big-endian test case fixes: System.Memory tests

### DIFF
--- a/src/libraries/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
@@ -14,9 +14,15 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void SpanRead()
         {
-            Assert.True(BitConverter.IsLittleEndian);
-
-            ulong value = 0x8877665544332211; // [11 22 33 44 55 66 77 88]
+            ulong value; // [11 22 33 44 55 66 77 88]
+            if (BitConverter.IsLittleEndian)
+            {
+                value = 0x8877665544332211;
+            }
+            else
+            {
+                value = 0x1122334455667788;
+            }
             Span<byte> span;
             unsafe
             {
@@ -113,9 +119,15 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void ReadOnlySpanRead()
         {
-            Assert.True(BitConverter.IsLittleEndian);
-
-            ulong value = 0x8877665544332211; // [11 22 33 44 55 66 77 88]
+            ulong value; // [11 22 33 44 55 66 77 88]
+            if (BitConverter.IsLittleEndian)
+            {
+                value = 0x8877665544332211;
+            }
+            else
+            {
+                value = 0x1122334455667788;
+            }
             ReadOnlySpan<byte> span;
             unsafe
             {
@@ -282,8 +294,6 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void SpanWriteAndReadBigEndianHeterogeneousStruct()
         {
-            Assert.True(BitConverter.IsLittleEndian);
-
             Span<byte> spanBE = new byte[Unsafe.SizeOf<TestStruct>()];
 
             WriteInt16BigEndian(spanBE, s_testStruct.S0);
@@ -358,8 +368,6 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void SpanWriteAndReadLittleEndianHeterogeneousStruct()
         {
-            Assert.True(BitConverter.IsLittleEndian);
-
             Span<byte> spanLE = new byte[Unsafe.SizeOf<TestStruct>()];
 
             WriteInt16LittleEndian(spanLE, s_testStruct.S0);
@@ -434,7 +442,6 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void ReadingStructFieldByFieldOrReadAndReverseEndianness()
         {
-            Assert.True(BitConverter.IsLittleEndian);
             Span<byte> spanBE = new byte[Unsafe.SizeOf<TestHelpers.TestStructExplicit>()];
 
             var testExplicitStruct = new TestHelpers.TestStructExplicit

--- a/src/libraries/System.Memory/tests/Binary/BinaryWriterUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Binary/BinaryWriterUnitTests.cs
@@ -14,8 +14,6 @@ namespace System.Buffers.Binary.Tests
         [Fact]
         public void SpanWrite()
         {
-            Assert.True(BitConverter.IsLittleEndian);
-
             Span<byte> span = new byte[8];
 
             byte byteValue = 0x11;
@@ -92,7 +90,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x00FF)]
         public void SpanWriteInt16(short value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[2]);
             WriteInt16BigEndian(span, value);
             short read = ReadInt16BigEndian(span);
@@ -121,7 +118,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x00FF)]
         public void SpanWriteUInt16(ushort value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[2]);
             WriteUInt16BigEndian(span, value);
             ushort read = ReadUInt16BigEndian(span);
@@ -152,7 +148,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x000000FF)]
         public void SpanWriteInt32(int value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[4]);
             WriteInt32BigEndian(span, value);
             int read = ReadInt32BigEndian(span);
@@ -183,7 +178,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x000000FF)]
         public void SpanWriteUInt32(uint value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[4]);
             WriteUInt32BigEndian(span, value);
             uint read = ReadUInt32BigEndian(span);
@@ -218,7 +212,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x00000000000000FF)]
         public void SpanWriteInt64(long value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[8]);
             WriteInt64BigEndian(span, value);
             long read = ReadInt64BigEndian(span);
@@ -253,7 +246,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(0x00000000000000FF)]
         public void SpanWriteUInt64(ulong value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[8]);
             WriteUInt64BigEndian(span, value);
             ulong read = ReadUInt64BigEndian(span);
@@ -290,7 +282,6 @@ namespace System.Buffers.Binary.Tests
         [MemberData(nameof(SpanWriteHalf_TestData))]
         public void SpanWriteHalf(Half value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[4]);
             WriteHalfBigEndian(span, value);
             Half read = ReadHalfBigEndian(span);
@@ -321,7 +312,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(float.NaN)]
         public void SpanWriteSingle(float value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[4]);
             WriteSingleBigEndian(span, value);
             float read = ReadSingleBigEndian(span);
@@ -352,7 +342,6 @@ namespace System.Buffers.Binary.Tests
         [InlineData(double.NaN)]
         public void SpanWriteDouble(double value)
         {
-            Assert.True(BitConverter.IsLittleEndian);
             var span = new Span<byte>(new byte[8]);
             WriteDoubleBigEndian(span, value);
             double read = ReadDoubleBigEndian(span);

--- a/src/libraries/System.Memory/tests/MemoryMarshal/AsBytesReadOnlySpan.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/AsBytesReadOnlySpan.cs
@@ -12,7 +12,15 @@ namespace System.SpanTests
         [Fact]
         public static void ReadOnlySpan_AsBytesUIntToByte()
         {
-            uint[] a = { 0x44332211, 0x88776655 };
+            uint[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new uint[] { 0x44332211, 0x88776655 };
+            }
+            else
+            {
+                a = new uint[] { 0x11223344, 0x55667788 };
+            }
             ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
             ReadOnlySpan<byte> asBytes = MemoryMarshal.AsBytes<uint>(span);
 

--- a/src/libraries/System.Memory/tests/MemoryMarshal/AsBytesSpan.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/AsBytesSpan.cs
@@ -12,7 +12,15 @@ namespace System.SpanTests
         [Fact]
         public static void Span_AsBytesUIntToByte()
         {
-            uint[] a = { 0x44332211, 0x88776655 };
+            uint[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new uint[] { 0x44332211, 0x88776655 };
+            }
+            else
+            {
+                a = new uint[] { 0x11223344, 0x55667788 };
+            }
             Span<uint> span = new Span<uint>(a);
             Span<byte> asBytes = MemoryMarshal.AsBytes<uint>(span);
 

--- a/src/libraries/System.Memory/tests/MemoryMarshal/CastReadOnlySpan.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/CastReadOnlySpan.cs
@@ -12,7 +12,15 @@ namespace System.SpanTests
         [Fact]
         public static void CastReadOnlySpanUIntToUShort()
         {
-            uint[] a = { 0x44332211, 0x88776655 };
+            uint[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new uint[] { 0x44332211, 0x88776655 };
+            }
+            else
+            {
+                a = new uint[] { 0x22114433, 0x66558877 };
+            }
             ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
             ReadOnlySpan<ushort> asUShort = MemoryMarshal.Cast<uint, ushort>(span);
 
@@ -23,7 +31,15 @@ namespace System.SpanTests
         [Fact]
         public static void CastReadOnlySpanShortToLong()
         {
-            short[] a = { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            short[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new short[] { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            }
+            else
+            {
+                a = new short[] { 0x4567, 0x3456, 0x2345, 0x1234, 0x5678 };
+            }
             ReadOnlySpan<short> span = new ReadOnlySpan<short>(a);
             ReadOnlySpan<long> asLong = MemoryMarshal.Cast<short, long>(span);
 

--- a/src/libraries/System.Memory/tests/MemoryMarshal/CastSpan.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/CastSpan.cs
@@ -13,7 +13,15 @@ namespace System.SpanTests
         [Fact]
         public static void CastSpanUIntToUShort()
         {
-            uint[] a = { 0x44332211, 0x88776655 };
+            uint[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new uint[] { 0x44332211, 0x88776655 };
+            }
+            else
+            {
+                a = new uint[] { 0x22114433, 0x66558877 };
+            }
             Span<uint> span = new Span<uint>(a);
             Span<ushort> asUShort = MemoryMarshal.Cast<uint, ushort>(span);
 
@@ -35,7 +43,15 @@ namespace System.SpanTests
         [Fact]
         public static void CastSpanShortToLong()
         {
-            short[] a = { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            short[] a;
+            if (BitConverter.IsLittleEndian)
+            {
+                a = new short[] { 0x1234, 0x2345, 0x3456, 0x4567, 0x5678 };
+            }
+            else
+            {
+                a = new short[] { 0x4567, 0x3456, 0x2345, 0x1234, 0x5678 };
+            }
             Span<short> span = new Span<short>(a);
             Span<long> asLong = MemoryMarshal.Cast<short, long>(span);
 

--- a/src/libraries/System.Memory/tests/SequenceReader/BinaryExtensions.cs
+++ b/src/libraries/System.Memory/tests/SequenceReader/BinaryExtensions.cs
@@ -51,19 +51,19 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(BitConverter.ToInt32(new byte[] { 0, 1, 0, 2 }), intValue);
 
             Assert.True(reader.TryReadBigEndian(out intValue));
-            Assert.Equal(BitConverter.ToInt32(new byte[] { 4, 3, 2, 1 }), intValue);
+            Assert.Equal(0x01020304, intValue);
 
             Assert.True(reader.TryReadLittleEndian(out long longValue));
-            Assert.Equal(BitConverter.ToInt64(new byte[] { 5, 6, 7, 8, 9, 0, 1, 2 }), longValue);
+            Assert.Equal(0x0201000908070605L, longValue);
 
             Assert.True(reader.TryReadBigEndian(out longValue));
-            Assert.Equal(BitConverter.ToInt64(new byte[] { 0, 9, 8, 7, 6, 5, 4, 3 }), longValue);
+            Assert.Equal(0x0304050607080900L, longValue);
 
             Assert.True(reader.TryReadLittleEndian(out short shortValue));
-            Assert.Equal(BitConverter.ToInt16(new byte[] { 1, 2 }), shortValue);
+            Assert.Equal(0x0201, shortValue);
 
             Assert.True(reader.TryReadBigEndian(out shortValue));
-            Assert.Equal(BitConverter.ToInt16(new byte[] { 4, 3 }), shortValue);
+            Assert.Equal(0x0304, shortValue);
         }
     }
 }


### PR DESCRIPTION
* Fix endian assumptions in preparing input byte patterns

* Enable tests that were disabled on big-endian systems