### PR TITLE
Big-endian test case fixes: System.Runtime

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/BitConverterArray.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/BitConverterArray.cs
@@ -7,6 +7,16 @@ namespace System.Tests
 {
     public class BitConverterArray : BitConverterBase
     {
+        private byte[] RangeToLittleEndian(byte[] array, int index, int length)
+        {
+            if (!BitConverter.IsLittleEndian)
+            {
+                array = (byte[]) array.Clone();
+                Array.Reverse(array, index, length);
+            }
+            return array;
+        }
+
         public override void ConvertFromBool(bool boolean, byte[] expected)
         {
             Assert.Equal(expected, BitConverter.GetBytes(boolean));
@@ -14,101 +24,121 @@ namespace System.Tests
 
         public override void ConvertFromShort(short num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromChar(char character, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Assert.Equal(expected, BitConverter.GetBytes(character));
         }
 
         public override void ConvertFromInt(int num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromLong(long num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromUShort(ushort num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromUInt(uint num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromULong(ulong num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromHalf(Half num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromFloat(float num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ConvertFromDouble(double num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Assert.Equal(expected, BitConverter.GetBytes(num));
         }
 
         public override void ToChar(int index, char expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             Assert.Equal(expected, BitConverter.ToChar(byteArray, index));
         }
 
         public override void ToInt16(int index, short expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             Assert.Equal(expected, BitConverter.ToInt16(byteArray, index));
         }
 
         public override void ToInt32(int expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, 0, 4);
             Assert.Equal(expected, BitConverter.ToInt32(byteArray, 0));
         }
 
         public override void ToInt64(int index, long expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             Assert.Equal(expected, BitConverter.ToInt64(byteArray, index));
         }
 
         public override void ToUInt16(int index, ushort expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             Assert.Equal(expected, BitConverter.ToUInt16(byteArray, index));
         }
 
         public override void ToUInt32(int index, uint expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 4);
             Assert.Equal(expected, BitConverter.ToUInt32(byteArray, index));
         }
 
         public override void ToUInt64(int index, ulong expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             Assert.Equal(expected, BitConverter.ToUInt64(byteArray, index));
         }
 
         public override void ToHalf(int index, Half expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             Assert.Equal(expected, BitConverter.ToHalf(byteArray, index));
         }
 
         public override void ToSingle(int index, float expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 4);
             Assert.Equal(expected, BitConverter.ToSingle(byteArray, index));
         }
 
         public override void ToDouble(int index, double expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             Assert.Equal(expected, BitConverter.ToDouble(byteArray, index));
         }
 

--- a/src/libraries/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/BitConverterSpan.cs
@@ -37,6 +37,16 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => { BitConverter.ToBoolean(Span<byte>.Empty); });
         }
 
+        private byte[] RangeToLittleEndian(byte[] array, int index, int length)
+        {
+            if (!BitConverter.IsLittleEndian)
+            {
+                array = (byte[]) array.Clone();
+                Array.Reverse(array, index, length);
+            }
+            return array;
+        }
+
         public override void ConvertFromBool(bool boolean, byte[] expected)
         {
             Span<byte> span = new Span<byte>(new byte[1]);
@@ -46,6 +56,7 @@ namespace System.Tests
 
         public override void ConvertFromShort(short num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -53,6 +64,7 @@ namespace System.Tests
 
         public override void ConvertFromChar(char character, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, character));
             Assert.Equal(expected, span.ToArray());
@@ -60,6 +72,7 @@ namespace System.Tests
 
         public override void ConvertFromInt(int num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -67,6 +80,7 @@ namespace System.Tests
 
         public override void ConvertFromLong(long num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -74,6 +88,7 @@ namespace System.Tests
 
         public override void ConvertFromUShort(ushort num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -81,6 +96,7 @@ namespace System.Tests
 
         public override void ConvertFromUInt(uint num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -88,6 +104,7 @@ namespace System.Tests
 
         public override void ConvertFromULong(ulong num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -95,6 +112,7 @@ namespace System.Tests
 
         public override void ConvertFromHalf(Half num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 2);
             Span<byte> span = new Span<byte>(new byte[2]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -102,6 +120,7 @@ namespace System.Tests
 
         public override void ConvertFromFloat(float num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 4);
             Span<byte> span = new Span<byte>(new byte[4]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -109,6 +128,7 @@ namespace System.Tests
 
         public override void ConvertFromDouble(double num, byte[] expected)
         {
+            expected = RangeToLittleEndian(expected, 0, 8);
             Span<byte> span = new Span<byte>(new byte[8]);
             Assert.True(BitConverter.TryWriteBytes(span, num));
             Assert.Equal(expected, span.ToArray());
@@ -116,6 +136,7 @@ namespace System.Tests
 
         public override void ToChar(int index, char expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             BitConverter.ToChar(span);
             Assert.Equal(expected, BitConverter.ToChar(span.Slice(index)));
@@ -123,54 +144,63 @@ namespace System.Tests
 
         public override void ToInt16(int index, short expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToInt16(span.Slice(index)));
         }
 
         public override void ToInt32(int expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, 0, 4);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToInt32(byteArray));
         }
 
         public override void ToInt64(int index, long expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToInt64(span.Slice(index)));
         }
 
         public override void ToUInt16(int index, ushort expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt16(span.Slice(index)));
         }
 
         public override void ToUInt32(int index, uint expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 4);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt32(span.Slice(index)));
         }
 
         public override void ToUInt64(int index, ulong expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToUInt64(span.Slice(index)));
         }
 
         public override void ToHalf(int index, Half expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 2);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToHalf(span.Slice(index)));
         }
 
         public override void ToSingle(int index, float expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 4);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToSingle(span.Slice(index)));
         }
 
         public override void ToDouble(int index, double expected, byte[] byteArray)
         {
+            byteArray = RangeToLittleEndian(byteArray, index, 8);
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(byteArray);
             Assert.Equal(expected, BitConverter.ToDouble(span.Slice(index)));
         }

--- a/src/libraries/System.Runtime/tests/System/BufferTests.cs
+++ b/src/libraries/System.Runtime/tests/System/BufferTests.cs
@@ -91,6 +91,10 @@ namespace System.Tests
         [InlineData(new uint[] { 0x01234567, 0x89abcdef }, 7, 0x89)]
         public static void GetByte(Array array, int index, int expected)
         {
+            if (!BitConverter.IsLittleEndian)
+            {
+                index = index ^ 3;
+            }
             Assert.Equal(expected, Buffer.GetByte(array, index));
         }
 
@@ -211,6 +215,10 @@ namespace System.Tests
         [InlineData(new uint[] { 0x01234542, 0x89abcdef }, 7, 0xa2, new uint[] { 0x01234542, 0xa2abcdef })]
         public static void SetByte(Array array, int index, byte value, Array expected)
         {
+            if (!BitConverter.IsLittleEndian)
+            {
+                index = index ^ 3;
+            }
             Buffer.SetByte(array, index, value);
             Assert.Equal(expected, array);
         }


### PR DESCRIPTION
* Byte-swap input/output for BitConverter tests

* Update byte index for GetByte/SetByte tests on big-endian systems