### PR TITLE
Big-endian test case fixes: big-integer numerics

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -677,6 +677,10 @@ namespace System.Numerics.Tests
             // ctor(byte[]): array is 1 byte
             tempUInt64 = (uint)s_random.Next(0, 256);
             tempByteArray = BitConverter.GetBytes(tempUInt64);
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(tempByteArray);
+            }
             if (tempByteArray[0] > 127)
             {
                 VerifyCtorByteArray(new byte[] { tempByteArray[0] });
@@ -719,6 +723,10 @@ namespace System.Numerics.Tests
             {
                 tempUInt64 = unchecked((uint)s_random.Next(int.MinValue, int.MaxValue));
                 tempByteArray = BitConverter.GetBytes(tempUInt64);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
 
                 VerifyCtorByteArray(
                     new byte[] {
@@ -741,6 +749,10 @@ namespace System.Numerics.Tests
             {
                 tempUInt64 = unchecked((uint)s_random.Next(int.MinValue, int.MaxValue));
                 tempByteArray = BitConverter.GetBytes(tempUInt64);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
 
                 if (tempUInt64 > int.MaxValue)
                 {
@@ -781,6 +793,10 @@ namespace System.Numerics.Tests
                 tempUInt64 <<= 8;
                 tempUInt64 += (ulong)s_random.Next(0, 256);
                 tempByteArray = BitConverter.GetBytes(tempUInt64);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
 
                 if (tempUInt64 >= (ulong)0x00080000)
                 {
@@ -823,6 +839,10 @@ namespace System.Numerics.Tests
                 tempUInt64 <<= 32;
                 tempUInt64 += unchecked((uint)s_random.Next(int.MinValue, int.MaxValue));
                 tempByteArray = BitConverter.GetBytes(tempUInt64);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
 
                 if (tempUInt64 > long.MaxValue)
                 {
@@ -1073,11 +1093,21 @@ namespace System.Numerics.Tests
                     tempBigInteger = tempBigInteger + (new BigInteger(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0xFF }));
                 }
 
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
                 Assert.Equal(BitConverter.ToInt64(tempByteArray, 0), (long)tempBigInteger);
             }
             else
             {
-                Assert.Equal(BitConverter.ToInt64(value, 0), (long)bigInteger);
+                byte[] tempByteArray = new byte[8];
+                Array.Copy(value, tempByteArray, 8);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
+                Assert.Equal(BitConverter.ToInt64(tempByteArray, 0), (long)bigInteger);
             }
 
             if (IsOutOfRangeUInt64(value))
@@ -1108,11 +1138,21 @@ namespace System.Numerics.Tests
                     }
                 }
 
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
                 Assert.Equal(BitConverter.ToUInt64(tempByteArray, 0), (ulong)tempBigInteger);
             }
             else
             {
-                Assert.Equal(BitConverter.ToUInt64(value, 0), (ulong)bigInteger);
+                byte[] tempByteArray = new byte[8];
+                Array.Copy(value, tempByteArray, 8);
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray);
+                }
+                Assert.Equal(BitConverter.ToUInt64(tempByteArray, 0), (ulong)bigInteger);
             }
 
             VerifyBigIntegerUsingIdentities(bigInteger, isZero);

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -131,6 +131,10 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(-1000, -8 * tempByteArray1.Length));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
                 VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
 
@@ -139,6 +143,10 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(-1000, -8 * tempByteArray1.Length));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
                 VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
             }
         }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -146,6 +146,10 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
                 VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
@@ -154,6 +158,10 @@ namespace System.Numerics.Tests
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 100);
                 tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
                 VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
         }


### PR DESCRIPTION
* Fix endian assumptions in CtorByteArray tests
  (the byte array must always be in little-endian byte order)

* Fix endian assumptions in left-/right-shift tests
  (byte array representing shift count must be in little-endian)