### PR TITLE
Big-endian test case fixes: Visual Basic

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/VBMathTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/VBMathTests.cs
@@ -171,9 +171,6 @@ namespace Microsoft.VisualBasic.Tests
         {
             ResetSeed();
 
-            if (!BitConverter.IsLittleEndian)
-                throw new NotImplementedException("big endian tests");
-
             VBMath.Randomize(-2E30);
             Assert.Equal(-0.0297851562f, VBMath.Rnd(0.0f));
             VBMath.Randomize(-0.003356);


### PR DESCRIPTION
* Enable Randomize_SetsExpectedState test case on big-endian systems
  (VBMath.Randomize already handles big-endian systems)