### PR TITLE
Fix stress-http and stress-ssl builds on Linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -292,7 +292,7 @@
 !**/src/pal/prebuilt/idl/*_i.c
 
 # Valid 'debug' folder, that contains CLR debugging code
-!**/src/debug
+!**/src/**/debug
 
 # Ignore folders created by the CLR test build
 **/TestWrappers_x64_[d|D]ebug


### PR DESCRIPTION
Files under `src/coreclr/debug/*` are not being added to the stress docker images, because `.dockerignore` is filtering them out.

/cc @ManickaP @eiriktsarpalis @wfurt