### PR TITLE
Big-endian fix: Marvin hash

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
@@ -48,10 +48,25 @@ namespace System
                     goto NotAscii;
                 }
 
-                // addition is written with -0x80u to allow fall-through to next statement rather than jmp past it
-                p0 += Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(tempValue) + (0x800000u - 0x80u);
+                if (BitConverter.IsLittleEndian)
+                {
+                    // addition is written with -0x80u to allow fall-through to next statement rather than jmp past it
+                    p0 += Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(tempValue) + (0x800000u - 0x80u);
+                }
+                else
+                {
+                    // as above, addition is modified to allow fall-through to next statement rather than jmp past it
+                    p0 += (Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(tempValue) << 16) + 0x8000u - 0x80000000u;
+                }
             }
-            p0 += 0x80u;
+            if (BitConverter.IsLittleEndian)
+            {
+                p0 += 0x80u;
+            }
+            else
+            {
+                p0 += 0x80000000u;
+            }
 
             Block(ref p0, ref p1);
             Block(ref p0, ref p1);


### PR DESCRIPTION
* Fix endian assumptions in Marvin.ComputeHash32OrdinalIgnoreCase
  (use the same logic that already exists in Marvin.ComputeHash32)