### PR TITLE
Big-endian test case fixes: Xoshiro hash

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
@@ -388,7 +388,10 @@ namespace System.Tests
             r.NextBytes(Span<byte>.Empty);
         }
 
-        [Fact]
+        // The following test makes assumptions about the implementation that hold
+        // true only on little-endian platforms.
+        public static bool IsLittleEndian => BitConverter.IsLittleEndian;
+        [ConditionalFact(nameof(IsLittleEndian))]
         public void Xoshiro_AlgorithmBehavesAsExpected()
         {
             // This test is validating implementation detail.  If the algorithm used by `new Random()` is ever

--- a/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
@@ -388,10 +388,7 @@ namespace System.Tests
             r.NextBytes(Span<byte>.Empty);
         }
 
-        // The following test makes assumptions about the implementation that hold
-        // true only on little-endian platforms.
-        public static bool IsLittleEndian => BitConverter.IsLittleEndian;
-        [ConditionalFact(nameof(IsLittleEndian))]
+        [ConditionalFact(typeof(BitConverter), nameof(BitConverter.IsLittleEndian))] // test makes little-endian assumptions
         public void Xoshiro_AlgorithmBehavesAsExpected()
         {
             // This test is validating implementation detail.  If the algorithm used by `new Random()` is ever


### PR DESCRIPTION
* Skip endian-dependent part of Xoshiro_AlgorithmBehavesAsExpected on
  big-endian systems