### PR TITLE
Mono: Fix build on platforms without gsharedvt

### DIFF
--- a/src/mono/mono/mini/arch-stubs.c
+++ b/src/mono/mono/mini/arch-stubs.c
@@ -15,7 +15,7 @@ mono_arch_gsharedvt_sig_supported (MonoMethodSignature *sig)
 }
 
 gpointer
-mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig, gboolean gsharedvt_in, gint32 vcall_offset, gboolean calli)
+mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig, gboolean gsharedvt_in, gint32 vcall_offset, gboolean calli)
 {
 	g_assert_not_reached ();
 	return NULL;


### PR DESCRIPTION
A `MonoMemoryManager*` parameter was added to `mono_arch_get_gsharedvt_call_info()` in https://github.com/dotnet/runtime/commit/34c68c7edf6d61c8ff3d2631003ed86353415479 that was missed in arch-stubs.c