### PR TITLE
Use new VS detection script in DacTableGen

### DIFF
--- a/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
+++ b/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
@@ -8,21 +8,20 @@
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="vswhere" Version="$(VSWhereVersion)" IsImplicitlyDefined="true" GeneratePathProperty="true" />
-  </ItemGroup>
-
   <Target Name="ResolveDIALibToCopy" BeforeTargets="AssignTargetPaths">
-    <PropertyGroup>
-      <VSWherePath>"$([MSBuild]::NormalizePath('$(Pkgvswhere)','tools','vswhere.exe'))"</VSWherePath>
-    </PropertyGroup>
     <Exec
-      Command="$(VSWherePath) -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"
+      Command="
+        call &quot;$(RepositoryEngineeringDir)native\init-vs-env.cmd&quot;
+        if defined VSINSTALLDIR echo %VSINSTALLDIR%"
       EchoOff="true"
       ConsoleToMsBuild="true"
       StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="VSInstallationPath" />
     </Exec>
+
+    <Error
+      Condition="!Exists('$(VSInstallationPath)')"
+      Text="VSINSTALLDIR environment variable was not set correctly. You may need to repair Visual Studio installation." />
 
     <PropertyGroup>
       <_MsDiaSubDir>$(BuildArchitecture)</_MsDiaSubDir>


### PR DESCRIPTION
Improve error reporting in case Visual Studio is installed without VC Tools (see #49679).

Old error message:
```
C:\Repos\runtime\.dotnet\sdk\6.0.100-preview.2.21155.3\Microsoft.Common.CurrentVersion.targets(4941,5): error MSB3030: Could not copy the file "C:\DIA SDK\bin\amd64\msdia140.dll" because it was not found.
```
New error message:
```
EXEC : error : Visual Studio 2019 with C++ tools required. Please see https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/windows-requirements.md for build requirements.
```