### PR TITLE
Change HostWriter to Ignore Extra Space in MemoryMappedFile

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
@@ -174,15 +174,16 @@ namespace Microsoft.NET.HostModel.AppHost
             File.Copy(sourcePath, destinationPath, overwrite: true);
         }
 
-        internal static void WriteToStream(MemoryMappedViewAccessor sourceViewAccessor, FileStream fileStream)
+        internal static void WriteToStream(MemoryMappedViewAccessor sourceViewAccessor, FileStream fileStream, long length)
         {
             int pos = 0;
             int bufSize = 16384; //16K
 
             byte[] buf = new byte[bufSize];
+            length = Math.Min(length, sourceViewAccessor.Capacity);
             do
             {
-                int bytesRequested = Math.Min((int)sourceViewAccessor.Capacity - pos, bufSize);
+                int bytesRequested = Math.Min((int)length - pos, bufSize);
                 if (bytesRequested <= 0)
                 {
                     break;


### PR DESCRIPTION
Fixes #49493.

On Windows, `MemoryMappedViewAccessor.Capacity` is rounded up to the next page boundary.  This results in improperly sized executables when publishing for non-Windows RIDs where the executable size is not page size aligned.  This is fixed by capturing the source host size, and using it as an upper-bound when writing the transformed host out to disk.