### PR TITLE
[metadata] Don't access MonoTableInfo:rows, use table_info_get_rows()

### DIFF
--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -653,7 +653,7 @@ mono_assembly_fill_assembly_name_full (MonoImage *image, MonoAssemblyName *aname
 	guint32 cols [MONO_ASSEMBLY_SIZE];
 	gint32 machine, flags;
 
-	if (!t->rows)
+	if (!table_info_get_rows (t))
 		return FALSE;
 
 	mono_metadata_decode_row (t, 0, cols, MONO_ASSEMBLY_SIZE);
@@ -1237,8 +1237,9 @@ mono_assembly_load_reference (MonoImage *image, int index)
 	if (!image->references) {
 		MonoTableInfo *t = &image->tables [MONO_TABLE_ASSEMBLYREF];
 	
-		image->references = g_new0 (MonoAssembly *, t->rows + 1);
-		image->nreferences = t->rows;
+		int n = table_info_get_rows (t);
+		image->references = g_new0 (MonoAssembly *, n + 1);
+		image->nreferences = n;
 	}
 	reference = image->references [index];
 	mono_image_unlock (image);
@@ -2334,7 +2335,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 	predicate = req->predicate;
 	user_data = req->predicate_ud;
 
-	if (!image->tables [MONO_TABLE_ASSEMBLY].rows) {
+	if (!table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLY])) {
 		/* 'image' doesn't have a manifest -- maybe someone is trying to Assembly.Load a .netmodule */
 		*status = MONO_IMAGE_IMAGE_INVALID;
 		return NULL;
@@ -3685,7 +3686,8 @@ mono_assembly_has_skip_verification (MonoAssembly *assembly)
 
 	t = &assembly->image->tables [MONO_TABLE_DECLSECURITY];
 
-	for (i = 0; i < t->rows; ++i) {
+	int rows = table_info_get_rows (t);
+	for (i = 0; i < rows; ++i) {
 		mono_metadata_decode_row (t, i, cols, MONO_DECL_SECURITY_SIZE);
 		if ((cols [MONO_DECL_SECURITY_PARENT] & MONO_HAS_DECL_SECURITY_MASK) != MONO_HAS_DECL_SECURITY_ASSEMBLY)
 			continue;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -433,7 +433,8 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 
 	error_init (error);
 
-	if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || tidx > tt->rows) {
+	/* FIXME: metadata-update - this function needs extensive work */
+	if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || tidx > table_info_get_rows (tt)) {
 		mono_error_set_bad_image (error, image, "Invalid typedef token %x", type_token);
 		return NULL;
 	}
@@ -620,19 +621,19 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	first_method_idx = cols [MONO_TYPEDEF_METHOD_LIST] - 1;
 	mono_class_set_first_method_idx (klass, first_method_idx);
 
-	if (tt->rows > tidx){		
+	if (table_info_get_rows (tt) > tidx){		
 		mono_metadata_decode_row (tt, tidx, cols_next, MONO_TYPEDEF_SIZE);
 		field_last  = cols_next [MONO_TYPEDEF_FIELD_LIST] - 1;
 		method_last = cols_next [MONO_TYPEDEF_METHOD_LIST] - 1;
 	} else {
-		field_last  = image->tables [MONO_TABLE_FIELD].rows;
-		method_last = image->tables [MONO_TABLE_METHOD].rows;
+		field_last  = table_info_get_rows (&image->tables [MONO_TABLE_FIELD]);
+		method_last = table_info_get_rows (&image->tables [MONO_TABLE_METHOD]);
 	}
 
 	if (cols [MONO_TYPEDEF_FIELD_LIST] && 
-	    cols [MONO_TYPEDEF_FIELD_LIST] <= image->tables [MONO_TABLE_FIELD].rows)
+	    cols [MONO_TYPEDEF_FIELD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_FIELD]))
 		mono_class_set_field_count (klass, field_last - first_field_idx);
-	if (cols [MONO_TYPEDEF_METHOD_LIST] <= image->tables [MONO_TABLE_METHOD].rows)
+	if (cols [MONO_TYPEDEF_METHOD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
 		mono_class_set_method_count (klass, method_last - first_method_idx);
 
 	/* reserve space to store vector pointer in arrays */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2678,12 +2678,13 @@ mono_class_name_from_token (MonoImage *image, guint32 type_token)
 	
 	switch (type_token & 0xff000000){
 	case MONO_TOKEN_TYPE_DEF: {
-		guint32 cols [MONO_TYPEDEF_SIZE];
-		MonoTableInfo *tt = &image->tables [MONO_TABLE_TYPEDEF];
 		guint tidx = mono_metadata_token_index (type_token);
 
-		if (tidx > tt->rows)
+		if (mono_metadata_table_bounds_check (image, MONO_TABLE_TYPEDEF, tidx))
 			return g_strdup_printf ("Invalid type token 0x%08x", type_token);
+
+		guint32 cols [MONO_TYPEDEF_SIZE];
+		MonoTableInfo *tt = &image->tables [MONO_TABLE_TYPEDEF];
 
 		mono_metadata_decode_row (tt, tidx - 1, cols, MONO_TYPEDEF_SIZE);
 		name = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAME]);
@@ -2695,12 +2696,13 @@ mono_class_name_from_token (MonoImage *image, guint32 type_token)
 	}
 
 	case MONO_TOKEN_TYPE_REF: {
-		guint32 cols [MONO_TYPEREF_SIZE];
-		MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
 		guint tidx = mono_metadata_token_index (type_token);
 
-		if (tidx > t->rows)
+		if (mono_metadata_table_bounds_check (image, MONO_TABLE_TYPEREF, tidx))
 			return g_strdup_printf ("Invalid type token 0x%08x", type_token);
+
+		guint32 cols [MONO_TYPEREF_SIZE];
+		MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
 
 		mono_metadata_decode_row (t, tidx-1, cols, MONO_TYPEREF_SIZE);
 		name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
@@ -2738,7 +2740,7 @@ mono_assembly_name_from_token (MonoImage *image, guint32 type_token)
 		MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
 		guint32 idx = mono_metadata_token_index (type_token);
 
-		if (idx > t->rows)
+		if (mono_metadata_table_bounds_check (image, MONO_TABLE_TYPEREF, idx))
 			return g_strdup_printf ("Invalid type token 0x%08x", type_token);
 	
 		mono_metadata_decode_row (t, idx-1, cols, MONO_TYPEREF_SIZE);
@@ -2973,7 +2975,9 @@ mono_image_init_name_cache (MonoImage *image)
 	/* Temporary hash table to avoid lookups in the nspace_table */
 	name_cache2 = g_hash_table_new (NULL, NULL);
 
-	for (i = 1; i <= t->rows; ++i) {
+	/* FIXME: metadata-update */
+	int rows = table_info_get_rows (t);
+	for (i = 1; i <= rows; ++i) {
 		mono_metadata_decode_row (t, i - 1, cols, MONO_TYPEDEF_SIZE);
 		visib = cols [MONO_TYPEDEF_FLAGS] & TYPE_ATTRIBUTE_VISIBILITY_MASK;
 		/*
@@ -3002,7 +3006,8 @@ mono_image_init_name_cache (MonoImage *image)
 		guint32 cols [MONO_EXP_TYPE_SIZE];
 		int i;
 
-		for (i = 0; i < t->rows; ++i) {
+		rows = table_info_get_rows (t);
+		for (i = 0; i < rows; ++i) {
 			mono_metadata_decode_row (t, i, cols, MONO_EXP_TYPE_SIZE);
 
 			guint32 impl = cols [MONO_EXP_TYPE_IMPLEMENTATION];
@@ -3191,7 +3196,8 @@ search_modules (MonoImage *image, const char *name_space, const char *name, gboo
 	 * Note: image->modules contains the contents of the MODULEREF table, while
 	 * the real module list is in the FILE table.
 	 */
-	for (i = 0; i < file_table->rows; i++) {
+	int rows = table_info_get_rows (file_table);
+	for (i = 0; i < rows; i++) {
 		guint32 cols [MONO_FILE_SIZE];
 		mono_metadata_decode_row (file_table, i, cols, MONO_FILE_SIZE);
 		if (cols [MONO_FILE_FLAGS] == FILE_CONTAINS_NO_METADATA)
@@ -3244,7 +3250,7 @@ mono_class_from_name_checked_aux (MonoImage *image, const char* name_space, cons
 
 	/* FIXME: get_class_from_name () can't handle types in the EXPORTEDTYPE table */
 	// The AOT cache in get_class_from_name is case-sensitive, so don't bother with it for case-insensitive lookups
-	if (get_class_from_name && image->tables [MONO_TABLE_EXPORTEDTYPE].rows == 0 && case_sensitive) {
+	if (get_class_from_name && table_info_get_rows (&image->tables [MONO_TABLE_EXPORTEDTYPE]) == 0 && case_sensitive) {
 		gboolean res = get_class_from_name (image, name_space, name, &klass);
 		if (res) {
 			if (!klass) {

--- a/src/mono/mono/metadata/coree.c
+++ b/src/mono/mono/metadata/coree.c
@@ -119,7 +119,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 		 * loader trampolines should be used and assembly loading should
 		 * probably be delayed until the first call to an exported function.
 		 */
-		if (image->tables [MONO_TABLE_ASSEMBLY].rows && image->image_info->cli_cli_header.ch_vtable_fixups.rva) {
+		if (table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLY]) && image->image_info->cli_cli_header.ch_vtable_fixups.rva) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
 			assembly = mono_assembly_request_open (file_name, &req, NULL);

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -1623,6 +1623,8 @@ mono_custom_attrs_from_index_checked (MonoImage *image, guint32 idx, gboolean ig
 	error_init (error);
 
 	ca = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
+	/* FIXME: metadata-update */
+	int rows = table_info_get_rows (ca);
 
 	i = mono_metadata_custom_attrs_from_index (image, idx);
 	if (!i)
@@ -1630,7 +1632,7 @@ mono_custom_attrs_from_index_checked (MonoImage *image, guint32 idx, gboolean ig
 	i --;
 	// initial size chosen arbitrarily, but default is 16 which is rather small
 	attr_array = g_array_sized_new (TRUE, TRUE, sizeof (guint32), 128);
-	while (i < ca->rows) {
+	while (i < rows) {
 		if (mono_metadata_decode_row_col (ca, i, MONO_CUSTOM_ATTR_PARENT) != idx)
 			break;
 		attr_array = g_array_append_val (attr_array, i);
@@ -1978,14 +1980,16 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 		return NULL;
 	ca = &image->tables [MONO_TABLE_METHOD];
 
+	/* FIXME: metadata-update */
 	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
-	if (method_index == ca->rows) {
-		ca = &image->tables [MONO_TABLE_PARAM];
-		param_last = ca->rows + 1;
+	int rows = table_info_get_rows (ca);
+	if (method_index == rows) {
+		param_last = rows + 1;
 	} else {
 		param_last = mono_metadata_decode_row_col (ca, method_index, MONO_METHOD_PARAMLIST);
-		ca = &image->tables [MONO_TABLE_PARAM];
 	}
+	ca = &image->tables [MONO_TABLE_PARAM];
+
 	found = FALSE;
 	for (i = param_list; i < param_last; ++i) {
 		param_pos = mono_metadata_decode_row_col (ca, i - 1, MONO_PARAM_SEQUENCE);
@@ -2345,7 +2349,7 @@ custom_attr_class_name_from_methoddef (MonoImage *image, guint32 method_token, c
 		guint32 cols [MONO_TYPEDEF_SIZE];
 		guint tidx = mono_metadata_token_index (type_token);
 
-		if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || tidx > tt->rows) {
+		if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || mono_metadata_table_bounds_check (image, MONO_TABLE_TYPEDEF, tidx)) {
 			/* "Invalid typedef token %x", type_token */
 			return FALSE;
 		}
@@ -2485,7 +2489,8 @@ metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAsse
 		return;
 	i --;
 	gboolean stop_iterating = FALSE;
-	while (!stop_iterating && i < ca->rows) {
+	int rows = table_info_get_rows (ca);
+	while (!stop_iterating && i < rows) {
 		if (mono_metadata_decode_row_col (ca, i, MONO_CUSTOM_ATTR_PARENT) != idx)
 			break;
 		mono_metadata_decode_row (ca, i, cols, MONO_CUSTOM_ATTR_SIZE);
@@ -2600,7 +2605,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 
 		tdef = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
 		guint32 parent, field_idx, col, mtoken, idx;
-		for (int i = 0; i < tdef->rows; ++i) {
+		int rows = table_info_get_rows (tdef);
+		for (int i = 0; i < rows; ++i) {
 			parent = mono_metadata_decode_row_col (tdef, i, MONO_CUSTOM_ATTR_PARENT);
 			if ((parent & MONO_CUSTOM_ATTR_MASK) != MONO_CUSTOM_ATTR_FIELDDEF)
 				continue;
@@ -2616,13 +2622,16 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 			}
 		}
 	} else {
+		/* FIXME: metadata-update */
+
 		/* Memberref pointing to a typeref */
 		tdef = &image->tables [MONO_TABLE_MEMBERREF];
 
 		/* Check whenever the assembly references the WeakAttribute type */
 		gboolean found = FALSE;
 		tdef = &image->tables [MONO_TABLE_TYPEREF];
-		for (int i = 0; i < tdef->rows; ++i) {
+		int rows = table_info_get_rows (tdef);
+		for (int i = 0; i < rows; ++i) {
 			guint32 string_offset = mono_metadata_decode_row_col (tdef, i, MONO_TYPEREF_NAME);
 			const char *name = mono_metadata_string_heap (image, string_offset);
 			if (!strcmp (name, "WeakAttribute")) {
@@ -2636,7 +2645,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 
 		/* Find the memberref pointing to a typeref */
 		tdef = &image->tables [MONO_TABLE_MEMBERREF];
-		for (int i = 0; i < tdef->rows; ++i) {
+		rows = table_info_get_rows (tdef);
+		for (int i = 0; i < rows; ++i) {
 			guint32 cols [MONO_MEMBERREF_SIZE];
 			const char *sig;
 
@@ -2686,7 +2696,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 
 		tdef = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
 		guint32 parent, field_idx, col, mtoken, idx;
-		for (int i = 0; i < tdef->rows; ++i) {
+		rows = table_info_get_rows (tdef);
+		for (int i = 0; i < rows; ++i) {
 			parent = mono_metadata_decode_row_col (tdef, i, MONO_CUSTOM_ATTR_PARENT);
 			if ((parent & MONO_CUSTOM_ATTR_MASK) != MONO_CUSTOM_ATTR_FIELDDEF)
 				continue;

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -622,13 +622,13 @@ load_tables (MonoImage *image)
 		if ((valid_mask & ((guint64) 1 << table)) == 0){
 			if (table > MONO_TABLE_LAST)
 				continue;
-			image->tables [table].rows = 0;
+			image->tables [table].rows_ = 0;
 			continue;
 		}
 		if (table > MONO_TABLE_LAST) {
 			g_warning("bits in valid must be zero above 0x37 (II - 23.1.6)");
 		} else {
-			image->tables [table].rows = read32 (rows);
+			image->tables [table].rows_ = read32 (rows);
 		}
 		rows++;
 		valid++;
@@ -680,16 +680,16 @@ mono_image_check_for_module_cctor (MonoImage *image)
 		image->checked_module_cctor = TRUE;
 		return;
 	}
-	if (t->rows >= 1) {
+	if (table_info_get_rows (t) >= 1) {
 		guint32 nameidx = mono_metadata_decode_row_col (t, 0, MONO_TYPEDEF_NAME);
 		const char *name = mono_metadata_string_heap (image, nameidx);
 		if (strcmp (name, "<Module>") == 0) {
 			guint32 first_method = mono_metadata_decode_row_col (t, 0, MONO_TYPEDEF_METHOD_LIST) - 1;
 			guint32 last_method;
-			if (t->rows > 1)
+			if (table_info_get_rows (t) > 1)
 				last_method = mono_metadata_decode_row_col (t, 1, MONO_TYPEDEF_METHOD_LIST) - 1;
 			else 
-				last_method = mt->rows;
+				last_method = table_info_get_rows (mt);
 			for (; first_method < last_method; first_method++) {
 				nameidx = mono_metadata_decode_row_col (mt, first_method, MONO_METHOD_NAME);
 				name = mono_metadata_string_heap (image, nameidx);
@@ -1114,7 +1114,7 @@ void
 mono_image_load_names (MonoImage *image)
 {
 	/* modules don't have an assembly table row */
-	if (image->tables [MONO_TABLE_ASSEMBLY].rows) {
+	if (table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLY])) {
 		image->assembly_name = mono_metadata_string_heap (image, 
 			mono_metadata_decode_row_col (&image->tables [MONO_TABLE_ASSEMBLY],
 					0, MONO_ASSEMBLY_NAME));
@@ -1124,7 +1124,7 @@ mono_image_load_names (MonoImage *image)
 	/* Minimal ENC delta images index the combined string heap of the base and delta image,
 	 * so the module index is out of bounds here.
 	 */
-	if (image->tables [MONO_TABLE_MODULE].rows && !image->minimal_delta) {
+	if (table_info_get_rows (&image->tables [MONO_TABLE_MODULE]) && !image->minimal_delta) {
 		image->module_name = mono_metadata_string_heap (image,
 			mono_metadata_decode_row_col (&image->tables [MONO_TABLE_MODULE],
 					0, MONO_MODULE_NAME));
@@ -1186,12 +1186,12 @@ static void
 dump_encmap (MonoImage *image)
 {
 	MonoTableInfo *encmap = &image->tables [MONO_TABLE_ENCMAP];
-	if (!encmap || !encmap->rows)
+	if (!encmap || !table_info_get_rows (encmap))
 		return;
 
 	if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE)) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "ENCMAP for %s", image->filename);
-		for (int i = 0; i < encmap->rows; ++i) {
+		for (int i = 0; i < table_info_get_rows (encmap); ++i) {
 			guint32 cols [MONO_ENCMAP_SIZE];
 			mono_metadata_decode_row (encmap, i, cols, MONO_ENCMAP_SIZE);
 			int token = cols [MONO_ENCMAP_TOKEN];
@@ -2626,7 +2626,7 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 
 	error_init (error);
 
-	if (fileidx < 1 || fileidx > t->rows)
+	if (fileidx < 1 || fileidx > table_info_get_rows (t))
 		return NULL;
 
 	mono_image_lock (image);
@@ -2665,8 +2665,9 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 		}
 
 		if (!image->files) {
-			image->files = g_new0 (MonoImage*, t->rows);
-			image->file_count = t->rows;
+			int n = table_info_get_rows (t);
+			image->files = g_new0 (MonoImage*, n);
+			image->file_count = n;
 		}
 		image->files [fileidx - 1] = res;
 		mono_image_unlock (image);
@@ -2773,7 +2774,7 @@ mono_image_get_public_key (MonoImage *image, guint32 *size)
 			*size = ((MonoDynamicImage*)image)->public_key_len;
 		return (char*)((MonoDynamicImage*)image)->public_key;
 	}
-	if (image->tables [MONO_TABLE_ASSEMBLY].rows != 1)
+	if (table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLY]) != 1)
 		return NULL;
 	tok = mono_metadata_decode_row_col (&image->tables [MONO_TABLE_ASSEMBLY], 0, MONO_ASSEMBLY_PUBLIC_KEY);
 	if (!tok)
@@ -2836,7 +2837,7 @@ mono_image_get_table_rows (MonoImage *image, int table_id)
 {
 	if (table_id < 0 || table_id >= MONO_TABLE_NUM)
 		return 0;
-	return image->tables [table_id].rows;
+	return table_info_get_rows (&image->tables [table_id]);
 }
 
 /**
@@ -2845,7 +2846,7 @@ mono_image_get_table_rows (MonoImage *image, int table_id)
 int
 mono_table_info_get_rows (const MonoTableInfo *table)
 {
-	return table->rows;
+	return table_info_get_rows (table);
 }
 
 /**

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1476,10 +1476,10 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 
 		param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
 
-		if (idx < methodt->rows)
+		if (idx < table_info_get_rows (methodt))
 			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
 		else
-			lastp = paramt->rows + 1;
+			lastp = table_info_get_rows (paramt) + 1;
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
 			if (cols [MONO_PARAM_SEQUENCE] && cols [MONO_PARAM_SEQUENCE] <= signature->param_count) /* skip return param spec and bounds check*/
@@ -1571,10 +1571,10 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 		guint32 cols [MONO_PARAM_SIZE];
 		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
 
-		if (idx < methodt->rows)
+		if (idx < table_info_get_rows (methodt))
 			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
 		else
-			lastp = paramt->rows + 1;
+			lastp = table_info_get_rows (paramt) + 1;
 
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
@@ -1625,10 +1625,10 @@ mono_method_has_marshal_info (MonoMethod *method)
 		guint32 cols [MONO_PARAM_SIZE];
 		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
 
-		if (idx + 1 < methodt->rows)
+		if (idx + 1 < table_info_get_rows (methodt))
 			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
 		else
-			lastp = paramt->rows + 1;
+			lastp = table_info_get_rows (paramt) + 1;
 
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -538,7 +538,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 void
 mono_image_effective_table_slow (const MonoTableInfo **t, int *idx)
 {
-	if (G_LIKELY (*idx < (*t)->rows))
+	if (G_LIKELY (*idx < table_info_get_rows (*t)))
 		return;
 
 	/* FIXME: don't let any thread other than the updater thread see values from a delta image
@@ -590,9 +590,9 @@ mono_image_effective_table_slow (const MonoTableInfo **t, int *idx)
 		table = &dmeta->tables [tbl_index];
 		ridx = mono_image_relative_delta_index (dmeta, mono_metadata_make_token (tbl_index, *idx + 1)) - 1;
 		g++;
-	} while (ridx < 0 || ridx >= table->rows);
+	} while (ridx < 0 || ridx >= table_info_get_rows (table));
 
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "effective table for %s: 0x%08x -> 0x%08x (rows = 0x%08x) (gen %d, g %d)", mono_meta_table_name (tbl_index), *idx, ridx, table->rows, metadata_update_local_generation (base, dmeta), g);
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "effective table for %s: 0x%08x -> 0x%08x (rows = 0x%08x) (gen %d, g %d)", mono_meta_table_name (tbl_index), *idx, ridx, table_info_get_rows (table), metadata_update_local_generation (base, dmeta), g);
 
 	*t = table;
 	*idx = ridx;
@@ -628,7 +628,7 @@ mono_image_relative_delta_index (MonoImage *image_dmeta, int token)
 	/* this helper expects and returns as "index origin = 1" */
 	g_assert (index > 0);
 
-	if (!encmap->rows || !image_dmeta->minimal_delta)
+	if (!table_info_get_rows (encmap) || !image_dmeta->minimal_delta)
 		return mono_metadata_token_index (token);
 
 	DeltaInfo *delta_info = delta_info_lookup (image_dmeta);
@@ -639,7 +639,8 @@ mono_image_relative_delta_index (MonoImage *image_dmeta, int token)
 	mono_metadata_decode_row (encmap, index_map - 1, cols, MONO_ENCMAP_SIZE);
 	int map_entry = cols [MONO_ENCMAP_TOKEN];
 
-	while (mono_metadata_token_table (map_entry) == table && mono_metadata_token_index (map_entry) < index && index_map < encmap->rows) {
+	int encmap_rows = table_info_get_rows (encmap);
+	while (mono_metadata_token_table (map_entry) == table && mono_metadata_token_index (map_entry) < index && index_map < encmap_rows) {
 		mono_metadata_decode_row (encmap, ++index_map - 1, cols, MONO_ENCMAP_SIZE);
 		map_entry = cols [MONO_ENCMAP_TOKEN];
 	}
@@ -648,12 +649,12 @@ mono_image_relative_delta_index (MonoImage *image_dmeta, int token)
 		if (mono_metadata_token_index (map_entry) == index) {
 			/* token resolves to this generation */
 			int return_val = index_map - delta_info->enc_recs [table] + 1;
-			g_assert (return_val > 0 && return_val <= image_dmeta->tables[table].rows);
+			g_assert (return_val > 0 && return_val <= table_info_get_rows (&image_dmeta->tables[table]));
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "relative index for token 0x%08x -> table 0x%02x row 0x%08x", token, table, return_val);
 			return return_val;
 		} else {
 			/* otherwise the last entry in the encmap is for this table, but is still less than the index - the index is in the next generation */
-			g_assert (mono_metadata_token_index (map_entry) < index && index_map == encmap->rows);
+			g_assert (mono_metadata_token_index (map_entry) < index && index_map == encmap_rows);
 			return -1;
 		}
 	} else {
@@ -671,7 +672,7 @@ delta_info_init (MonoImage *image_dmeta, MonoImage *image_base)
 
 	g_assert (!delta_info_lookup (image_dmeta));
 
-	if (!encmap->rows)
+	if (!table_info_get_rows (encmap))
 		return NULL;
 
 	DeltaInfo *delta_info = g_malloc0 (sizeof (DeltaInfo));
@@ -680,7 +681,7 @@ delta_info_init (MonoImage *image_dmeta, MonoImage *image_base)
 	if (image_base->delta_image == image_base->delta_image_last) {
 		/* this is the first update. */
 		for (int i = 0; i < MONO_TABLE_NUM; ++i) {
-			delta_info->count[i].prev_gen_rows = image_base->tables[i].rows;
+			delta_info->count[i].prev_gen_rows = table_info_get_rows (&image_base->tables[i]);
 		}
 	} else {
 		/* Current image_dmeta is image_base->delta_image_last->data,
@@ -698,7 +699,8 @@ delta_info_init (MonoImage *image_dmeta, MonoImage *image_base)
 
 	/* TODO: while going through the tables, update delta_info->count[tbl].{modified,inserted}_rows */
 
-	for (idx = 1; idx <= encmap->rows; ++idx) {
+	int encmap_rows = table_info_get_rows (encmap);
+	for (idx = 1; idx <= encmap_rows; ++idx) {
 		guint32 cols[MONO_ENCMAP_SIZE];
 		mono_metadata_decode_row (encmap, idx - 1, cols, MONO_ENCMAP_SIZE);
 		uint32_t tok = cols [MONO_ENCMAP_TOKEN];
@@ -765,7 +767,7 @@ static gboolean
 apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer dil_data, uint32_t dil_length, MonoError *error)
 {
 	MonoTableInfo *table_enclog = &image_dmeta->tables [MONO_TABLE_ENCLOG];
-	int rows = table_enclog->rows;
+	int rows = table_info_get_rows (table_enclog);
 
 	gboolean unsupported_edits = FALSE;
 
@@ -787,13 +789,13 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 		int token_table = mono_metadata_token_table (log_token);
 		int token_index = mono_metadata_token_index (log_token);
 
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x (%s idx=0x%02x) (base table has 0x%04x rows)\tfunc=0x%02x\n", i, log_token, mono_meta_table_name (token_table), token_index, image_base->tables [token_table].rows, func_code);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x (%s idx=0x%02x) (base table has 0x%04x rows)\tfunc=0x%02x\n", i, log_token, mono_meta_table_name (token_table), token_index, table_info_get_rows (&image_base->tables [token_table]), func_code);
 
 
 		if (token_table != MONO_TABLE_METHOD)
 			continue;
 
-		if (token_index > image_base->tables [token_table].rows) {
+		if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "\tcannot add new method with token 0x%08x", log_token);
 			mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: cannot add new method with token 0x%08x", log_token);
 			unsupported_edits = TRUE;
@@ -817,7 +819,7 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 		} else if (token_table == MONO_TABLE_METHOD) {
 			/* handled above */
 		} else {
-			if (token_index <= image_base->tables [token_table].rows) {
+			if (token_index <= table_info_get_rows (&image_base->tables [token_table])) {
 				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x we do not support patching of existing table cols.", i, log_token);
 				mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: we do not support patching of existing table cols. token=0x%08x", log_token);
 				unsupported_edits = TRUE;
@@ -857,7 +859,7 @@ static gboolean
 apply_enclog_pass2 (MonoImage *image_base, uint32_t generation, MonoImage *image_dmeta, gconstpointer dil_data, uint32_t dil_length, MonoError *error)
 {
 	MonoTableInfo *table_enclog = &image_dmeta->tables [MONO_TABLE_ENCLOG];
-	int rows = table_enclog->rows;
+	int rows = table_info_get_rows (table_enclog);
 
 	gboolean assemblyref_updated = FALSE;
 	for (int i = 0; i < rows ; ++i) {
@@ -882,7 +884,7 @@ apply_enclog_pass2 (MonoImage *image_base, uint32_t generation, MonoImage *image
 		}
 
 		if (token_table == MONO_TABLE_ASSEMBLYREF) {
-			g_assert (token_index > image_base->tables [token_table].rows);
+			g_assert (token_index > table_info_get_rows (&image_base->tables [token_table]));
 
 			if (assemblyref_updated)
 				continue;
@@ -891,12 +893,12 @@ apply_enclog_pass2 (MonoImage *image_base, uint32_t generation, MonoImage *image
 
 			/* FIXME: use DeltaInfo:prev_gen_rows instead of looping */
 			/* TODO: do we know that there will never be modified rows in ASSEMBLYREF? */
-			int old_rows = image_base->tables [MONO_TABLE_ASSEMBLYREF].rows;
+			int old_rows = table_info_get_rows (&image_base->tables [MONO_TABLE_ASSEMBLYREF]);
 			for (GList *l = image_base->delta_image; l; l = l->next) {
 				MonoImage *delta_child = l->data;
-				old_rows += delta_child->tables [MONO_TABLE_ASSEMBLYREF].rows;
+				old_rows += table_info_get_rows (&delta_child->tables [MONO_TABLE_ASSEMBLYREF]);
 			}
-			int new_rows = image_dmeta->tables [MONO_TABLE_ASSEMBLYREF].rows;
+			int new_rows = table_info_get_rows (&image_dmeta->tables [MONO_TABLE_ASSEMBLYREF]);
 
 			old_rows -= new_rows;
 			g_assert (new_rows > 0);
@@ -914,7 +916,7 @@ apply_enclog_pass2 (MonoImage *image_base, uint32_t generation, MonoImage *image
 
 			g_free (old_array);
 		} else if (token_table == MONO_TABLE_METHOD) {
-			if (token_index > image_base->tables [token_table].rows) {
+			if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
 				g_error ("EnC: new method added, should be caught by pass1");
 			}
 
@@ -937,9 +939,9 @@ apply_enclog_pass2 (MonoImage *image_base, uint32_t generation, MonoImage *image
 			/* TODO: happens changing the class (adding field or method). we ignore it, but dragons are here */
 
 			/* existing entries are supposed to be patched */
-			g_assert (token_index <= image_base->tables [token_table].rows);
+			g_assert (token_index <= table_info_get_rows (&image_base->tables [token_table]));
 		} else {
-			g_assert (token_index > image_base->tables [token_table].rows);
+			g_assert (token_index > table_info_get_rows (&image_base->tables [token_table]));
 			if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE))
 				g_print ("todo: do something about this table index: 0x%02x\n", token_table);
 		}
@@ -1007,7 +1009,7 @@ mono_image_load_enc_delta (MonoImage *image_base, gconstpointer dmeta_bytes, uin
 	MonoTableInfo *table_enclog = &image_dmeta->tables [MONO_TABLE_ENCLOG];
 	MonoTableInfo *table_encmap = &image_dmeta->tables [MONO_TABLE_ENCMAP];
 
-	if (!table_enclog->rows && !table_encmap->rows) {
+	if (!table_info_get_rows (table_enclog) && !table_info_get_rows (table_encmap)) {
 		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "No enclog or encmap in delta image for base=%s, nothing to do", basename);
 		mono_metadata_update_cancel (generation);
 		return;
@@ -1020,7 +1022,7 @@ mono_image_load_enc_delta (MonoImage *image_base, gconstpointer dmeta_bytes, uin
 	}
 
 	/* if there are updates, start tracking the tables of the base image, if we weren't already. */
-	if (table_enclog->rows)
+	if (table_info_get_rows (table_enclog))
 		table_to_image_add (image_base);
 
 	delta_info_init (image_dmeta, image_base);

--- a/src/mono/mono/metadata/metadata.h
+++ b/src/mono/mono/metadata/metadata.h
@@ -231,7 +231,8 @@ MONO_API int mono_metadata_compute_size (MonoImage   *meta,
  *
  */
 MONO_API const char    *mono_metadata_locate        (MonoImage *meta, int table, int idx);
-MONO_API const char    *mono_metadata_locate_token  (MonoImage *meta, uint32_t token);
+MONO_API MONO_RT_EXTERNAL_ONLY
+const char    *mono_metadata_locate_token  (MonoImage *meta, uint32_t token);
 
 MONO_API const char    *mono_metadata_string_heap   (MonoImage *meta, uint32_t table_index);
 MONO_API const char    *mono_metadata_blob_heap     (MonoImage *meta, uint32_t table_index);

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -990,12 +990,12 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 		orig_scope = method_aux->dll;
 	}
 	else {
-		if (!piinfo->implmap_idx || piinfo->implmap_idx > im->rows)
+		if (!piinfo->implmap_idx || mono_metadata_table_bounds_check (image, MONO_TABLE_IMPLMAP, piinfo->implmap_idx))
 			goto exit;
 
 		mono_metadata_decode_row (im, piinfo->implmap_idx - 1, im_cols, MONO_IMPLMAP_SIZE);
 
-		if (!im_cols [MONO_IMPLMAP_SCOPE] || im_cols [MONO_IMPLMAP_SCOPE] > mr->rows)
+		if (!im_cols [MONO_IMPLMAP_SCOPE] || mono_metadata_table_bounds_check (image, MONO_TABLE_MODULEREF, im_cols [MONO_IMPLMAP_SCOPE]))
 			goto exit;
 
 		piinfo->piflags = im_cols [MONO_IMPLMAP_FLAGS];

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3226,7 +3226,7 @@ static guint32
 find_typespec_for_class (MonoAotCompile *acfg, MonoClass *klass)
 {
 	int i;
-	int len = acfg->image->tables [MONO_TABLE_TYPESPEC].rows;
+	int len = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPESPEC]);
 
 	/* FIXME: Search referenced images as well */
 	if (!acfg->typespec_classes) {
@@ -4562,7 +4562,8 @@ add_wrappers (MonoAotCompile *acfg)
 	 * so there is only one wrapper of a given type, or inlining their contents into their
 	 * callers.
 	 */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	int rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
@@ -4739,7 +4740,8 @@ add_wrappers (MonoAotCompile *acfg)
 	 */
 #if 0
 	/* remoting-invoke wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoMethodSignature *sig;
 		
@@ -4758,7 +4760,8 @@ add_wrappers (MonoAotCompile *acfg)
 #endif
 
 	/* delegate-invoke wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPEDEF]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoClass *klass;
 		
@@ -4876,7 +4879,8 @@ add_wrappers (MonoAotCompile *acfg)
 	}
 
 	/* array access wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPESPEC].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPESPEC]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoClass *klass;
 		
@@ -4910,7 +4914,8 @@ add_wrappers (MonoAotCompile *acfg)
 	}
 
 	/* Synchronized wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
@@ -4943,7 +4948,8 @@ add_wrappers (MonoAotCompile *acfg)
 	}
 
 	/* pinvoke wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
@@ -4965,7 +4971,8 @@ add_wrappers (MonoAotCompile *acfg)
 	}
  
 	/* native-to-managed wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
@@ -5130,7 +5137,8 @@ MONO_RESTORE_WARNING
 	}
 
 	/* StructureToPtr/PtrToStructure wrappers */
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPEDEF]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoClass *klass;
 		
@@ -5603,7 +5611,8 @@ add_generic_instances (MonoAotCompile *acfg)
 	if (acfg->aot_opts.no_instances)
 		return;
 
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHODSPEC].rows; ++i) {
+	int rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHODSPEC]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_SPEC | (i + 1);
 		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
@@ -5712,7 +5721,8 @@ add_generic_instances (MonoAotCompile *acfg)
 		add_extra_method (acfg, method);
 	}
 
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPESPEC].rows; ++i) {
+	rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPESPEC]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoClass *klass;
 
@@ -6053,7 +6063,6 @@ get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method)
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *) method;
 	MonoTableInfo *tables = image->tables;
 	MonoTableInfo *im = &tables [MONO_TABLE_IMPLMAP];
-	MonoTableInfo *mr = &tables [MONO_TABLE_MODULEREF];
 	guint32 im_cols [MONO_IMPLMAP_SIZE];
 	char *import;
 
@@ -6061,12 +6070,13 @@ get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method)
 	if (import != NULL)
 		return import;
 
-	if (!piinfo->implmap_idx || piinfo->implmap_idx > im->rows)
+	if (piinfo->implmap_idx == 0 || mono_metadata_table_bounds_check (image, MONO_TABLE_IMPLMAP, piinfo->implmap_idx))
 		return NULL;
 
 	mono_metadata_decode_row (im, piinfo->implmap_idx - 1, im_cols, MONO_IMPLMAP_SIZE);
 
-	if (!im_cols [MONO_IMPLMAP_SCOPE] || im_cols [MONO_IMPLMAP_SCOPE] > mr->rows)
+	int module_idx = im_cols [MONO_IMPLMAP_SCOPE];
+	if (module_idx == 0 || mono_metadata_table_bounds_check (image, MONO_TABLE_MODULEREF, module_idx))
 		return NULL;
 
 	import = g_strdup_printf ("%s", mono_metadata_string_heap (image, im_cols [MONO_IMPLMAP_NAME]));
@@ -10923,11 +10933,12 @@ emit_class_info (MonoAotCompile *acfg)
 	int i;
 	gint32 *offsets;
 
-	offsets = g_new0 (gint32, acfg->image->tables [MONO_TABLE_TYPEDEF].rows);
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i)
+	int rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPEDEF]);
+	offsets = g_new0 (gint32, rows);
+	for (i = 0; i < rows; ++i)
 		offsets [i] = emit_klass_info (acfg, MONO_TOKEN_TYPE_DEF | (i + 1));
 
-	acfg->stats.offsets_size += emit_offset_table (acfg, "class_info_offsets", MONO_AOT_TABLE_CLASS_INFO_OFFSETS, acfg->image->tables [MONO_TABLE_TYPEDEF].rows, 10, offsets);
+	acfg->stats.offsets_size += emit_offset_table (acfg, "class_info_offsets", MONO_AOT_TABLE_CLASS_INFO_OFFSETS, rows, 10, offsets);
 	g_free (offsets);
 }
 
@@ -10950,11 +10961,12 @@ emit_class_name_table (MonoAotCompile *acfg)
 	/*
 	 * Construct a chained hash table for mapping class names to typedef tokens.
 	 */
-	table_size = g_spaced_primes_closest ((int)(acfg->image->tables [MONO_TABLE_TYPEDEF].rows * 1.5));
+	int rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_TYPEDEF]);
+	table_size = g_spaced_primes_closest ((int)(rows * 1.5));
 	table = g_ptr_array_sized_new (table_size);
 	for (i = 0; i < table_size; ++i)
 		g_ptr_array_add (table, NULL);
-	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
 		klass = mono_class_get_checked (acfg->image, token, error);
@@ -12140,7 +12152,8 @@ collect_methods (MonoAotCompile *acfg)
 	MonoImage *image = acfg->image;
 
 	/* Collect methods */
-	for (i = 0; i < image->tables [MONO_TABLE_METHOD].rows; ++i) {
+	int rows = table_info_get_rows (&image->tables [MONO_TABLE_METHOD]);
+	for (i = 0; i < rows; ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
@@ -12196,7 +12209,8 @@ collect_methods (MonoAotCompile *acfg)
 	}
 
 	/* gsharedvt methods */
-	for (mindex = 0; mindex < image->tables [MONO_TABLE_METHOD].rows; ++mindex) {
+	rows = table_info_get_rows (&image->tables [MONO_TABLE_METHOD]);
+	for (mindex = 0; mindex < rows; ++mindex) {
 		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (mindex + 1);
@@ -13915,7 +13929,8 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 	}
 
 	if (!(mono_aot_mode_is_interp (&acfg->aot_opts) && !mono_aot_mode_is_full (&acfg->aot_opts))) {
-		for (int method_index = 0; method_index < acfg->image->tables [MONO_TABLE_METHOD].rows; ++method_index)
+		int rows = table_info_get_rows (&acfg->image->tables [MONO_TABLE_METHOD]);
+		for (int method_index = 0; method_index < rows; ++method_index)
 			g_ptr_array_add (acfg->method_order,GUINT_TO_POINTER (method_index));
 	}
 

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -1979,7 +1979,7 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 		if (!sofile) {
 			// Maybe do these on more platforms ?
 #ifndef HOST_WASM
-			if (mono_aot_only && !mono_use_interpreter && assembly->image->tables [MONO_TABLE_METHOD].rows) {
+			if (mono_aot_only && !mono_use_interpreter && table_info_get_rows (&assembly->image->tables [MONO_TABLE_METHOD])) {
 				aot_name = g_strdup_printf ("%s%s", assembly->image->name, MONO_SOLIB_EXT);
 				g_error ("Failed to load AOT module '%s' ('%s') in aot-only mode.\n", aot_name, assembly->image->name);
 				g_free (aot_name);
@@ -3543,7 +3543,7 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 		}
 
 		if (!method) {
-			if (method_index >= image->tables [MONO_TABLE_METHOD].rows) {
+			if (method_index >= table_info_get_rows (&image->tables [MONO_TABLE_METHOD])) {
 				/*
 				 * This is hit for extra methods which are called directly, so they are
 				 * not in amodule->extra_methods.


### PR DESCRIPTION
Rename the field to rows_.

Also updated some bounds checks to use mono_metadata_table_bounds_check (which
is metadata-update aware) where the subsequent lookups go through the metadata
decode functions and should just work with metadata-update.

Added FIXME: metadata-update in cases where the table row size is assumed to be
fixed or is used as a sentinel value, or where the decoding may depend on
sorting properties that metadata updates probably won't uphold.

Contributes to #44806 