### PR TITLE
Add new Mono embedding API to consume binary runtimeconfig format

### DIFF
--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1249,7 +1249,7 @@ void
 mono_runtime_register_appctx_properties (int nprops, const char **keys,  const char **values)
 {
 	n_appctx_props = nprops;
-	appctx_keys = g_new0 (char*, n_appctx_props);
+	appctx_keys = g_new0 (char *, n_appctx_props);
 	appctx_values = g_new0 (char*, n_appctx_props);
 
 	for (int i = 0; i < nprops; ++i) {

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1250,7 +1250,7 @@ mono_runtime_register_appctx_properties (int nprops, const char **keys,  const c
 {
 	n_appctx_props = nprops;
 	appctx_keys = g_new0 (char *, n_appctx_props);
-	appctx_values = g_new0 (char*, n_appctx_props);
+	appctx_values = g_new0 (char *, n_appctx_props);
 
 	for (int i = 0; i < nprops; ++i) {
 		appctx_keys [i] = g_new0 (char, strlen (keys [i]) + 1);

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1394,7 +1394,7 @@ runtimeconfig_json_read_props (const char *ptr, const char **endp, int nprops, g
 
 		dest_keys [i] = g_utf8_to_utf16 (property_key, strlen (property_key), NULL, NULL, NULL);
 
-		str_len = mono_metadata_decode_value(ptr, &ptr);
+		str_len = mono_metadata_decode_value (ptr, &ptr);
 		property_value = g_new0 (char, str_len + 1);
 		strncpy (property_value, ptr, str_len);
 		property_value [str_len] = '\0';

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1386,7 +1386,7 @@ runtimeconfig_json_read_props (const char *ptr, const char **endp, int nprops, g
 		char *property_key;
 		char *property_value;
 
-		str_len = mono_metadata_decode_value(ptr, &ptr);
+		str_len = mono_metadata_decode_value (ptr, &ptr);
 		property_key = g_new0 (char, str_len + 1);
 		strncpy (property_key, ptr, str_len);
 		property_key [str_len] = '\0';

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1345,7 +1345,7 @@ mono_runtime_install_appctx_properties (void)
 	}
 }
 
-static const char*
+static const char *
 runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **file_map, gpointer *buf_handle)
 {
 	if (arg != NULL)

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1358,7 +1358,7 @@ runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **
 			g_assert (*file_map);
 			file_len = mono_file_map_size (*file_map);
 			g_assert (file_len > 0);
-			buffer = (char*)mono_file_map (file_len, MONO_MMAP_READ|MONO_MMAP_PRIVATE, mono_file_map_fd (*file_map), 0, buf_handle);
+			buffer = (char *)mono_file_map (file_len, MONO_MMAP_READ|MONO_MMAP_PRIVATE, mono_file_map_fd (*file_map), 0, buf_handle);
 			g_assert (buffer);
 			return buffer;
 		}

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1247,8 +1247,8 @@ mono_runtime_register_appctx_properties (int nprops, const char **keys,  const c
 	appctx_values = g_new0 (char*, n_appctx_props);
 
 	for (int i = 0; i < n_appctx_props; ++i) {
-		appctx_keys [i] = g_new0 (char, strlen (keys [i]));
-		appctx_values [i] = g_new0 (char, strlen (values [i]));
+		appctx_keys [i] = g_new0 (char, strlen (keys [i]) + 1);
+		appctx_values [i] = g_new0 (char, strlen (values [i]) + 1);
 		strcpy(appctx_keys [i], keys [i]);
 		strcpy(appctx_values [i], values [i]);
 	}
@@ -1270,7 +1270,7 @@ mono_runtime_install_appctx_properties (void)
 {
 	ERROR_DECL (error);
 	gpointer args [3];
-	int n_runtimeconfig_json_props;
+	int n_runtimeconfig_json_props = 0;
 	int n_total_props;
 	gunichar2 **total_keys;
 	gunichar2 **total_values;
@@ -1282,8 +1282,10 @@ mono_runtime_install_appctx_properties (void)
 	// FIXME: TRUSTED_PLATFORM_ASSEMBLIES is very large
 
 	// Combine and convert properties
-	buffer = runtime_config_arg->runtimeconfig.data.data;
-	n_runtimeconfig_json_props = mono_metadata_decode_value((const char*)buffer, (const char **)&buffer);
+	if (runtime_config_arg){
+		buffer = runtime_config_arg->runtimeconfig.data.data;
+		n_runtimeconfig_json_props = mono_metadata_decode_value((const char*)buffer, (const char **)&buffer);
+	}
 
 	n_total_props = n_appctx_props + n_runtimeconfig_json_props;
 	total_keys = g_new0 (gunichar2*, n_total_props);
@@ -1293,7 +1295,7 @@ mono_runtime_install_appctx_properties (void)
 		total_keys [i] = g_utf8_to_utf16 (appctx_keys [i], strlen (appctx_keys [i]), NULL, NULL, NULL);
 		total_values [i] = g_utf8_to_utf16 (appctx_values [i], strlen (appctx_values [i]), NULL, NULL, NULL);
 	}
-	
+
 	for (int i = 0; i < n_runtimeconfig_json_props; ++i) {
 		int str_len;
 		char *property_key;
@@ -1347,7 +1349,9 @@ mono_runtime_install_appctx_properties (void)
 
 	appctx_keys = NULL;
 	appctx_values = NULL;
-	runtime_config_arg = NULL;
-	runtime_config_cleanup_fn = NULL;
-	runtime_config_user_data = NULL;
+	if (runtime_config_arg){
+		runtime_config_arg = NULL;
+		runtime_config_cleanup_fn = NULL;
+		runtime_config_user_data = NULL;
+	}
 }

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -126,7 +126,7 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 static void
 add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass);
 
-static const char*
+static const char *
 runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **file_map, gpointer *buf_handle);
 
 static void

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1338,7 +1338,7 @@ mono_runtime_install_appctx_properties (void)
 
 	appctx_keys = NULL;
 	appctx_values = NULL;
-	if (runtime_config_arg){
+	if (runtime_config_arg) {
 		runtime_config_arg = NULL;
 		runtime_config_cleanup_fn = NULL;
 		runtime_config_user_data = NULL;

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1348,8 +1348,7 @@ mono_runtime_install_appctx_properties (void)
 static const char *
 runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **file_map, gpointer *buf_handle)
 {
-	if (arg != NULL)
-	{
+	if (arg != NULL) {
 		switch (arg->kind) {
 		case 0: {
 			char *buffer = NULL;

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1253,8 +1253,6 @@ mono_runtime_register_appctx_properties (int nprops, const char **keys,  const c
 	appctx_values = g_new0 (char *, n_appctx_props);
 
 	for (int i = 0; i < nprops; ++i) {
-		appctx_keys [i] = g_new0 (char, strlen (keys [i]) + 1);
-		appctx_values [i] = g_new0 (char, strlen (values [i]) + 1);
 		appctx_keys [i] = g_strdup (keys [i]);
 		appctx_values [i] = g_strdup (values [i]);
 	}

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1292,7 +1292,7 @@ mono_runtime_install_appctx_properties (void)
 
 	// Combine and convert properties
 	if (buffer)
-		n_runtimeconfig_json_props = mono_metadata_decode_value(buffer, &buffer);
+		n_runtimeconfig_json_props = mono_metadata_decode_value (buffer, &buffer);
 
 	n_total_props = n_appctx_props + n_runtimeconfig_json_props;
 	total_keys = g_new0 (gunichar2*, n_total_props);

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -20,6 +20,7 @@
 #include <mono/metadata/loader-internals.h>
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/handle-decl.h>
+#include <mono/mini/mono-private-unstable.h>
 
 G_BEGIN_DECLS
 
@@ -450,7 +451,7 @@ void
 mono_runtime_register_appctx_properties (int nprops, const char **keys,  const char **values);
 
 void
-mono_runtime_register_runtimeconfig_json_properties (int nprops, const char **keys,  const char **values);
+mono_runtime_register_runtimeconfig_json_properties (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void *user_data);
 
 void
 mono_runtime_install_appctx_properties (void);

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -450,6 +450,9 @@ void
 mono_runtime_register_appctx_properties (int nprops, const char **keys,  const char **values);
 
 void
+mono_runtime_register_runtimeconfig_json_properties (int nprops, const char **keys,  const char **values);
+
+void
 mono_runtime_install_appctx_properties (void);
 
 gboolean 

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -22,7 +22,7 @@ typedef struct {
 			const char *path;
 		} name;
 		struct {
-			char *data;
+			const char *data;
 			uint32_t data_len;
 		} data;
 	} runtimeconfig;

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -15,6 +15,21 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/metadata/image.h>
 
+typedef struct {
+	uint32_t kind; // 0 = Path of runtimeconfig.blob, 1 = pointer to image data, >= 2 undefined
+	union {
+		struct {
+			const char *path;
+		} name;
+		struct {
+			const char *data;
+			uint32_t data_len;
+		} data;
+	} runtimeconfig;
+} MonovmRuntimeConfigArguments;
+
+typedef void (*MonovmRuntimeConfigArgumentsCleanup)          (MonovmRuntimeConfigArguments *args, void *user_data);
+
 /* These are used to load the AOT data for aot images compiled with MONO_AOT_FILE_FLAG_SEPARATE_DATA */
 /*
  * Return the AOT data for ASSEMBLY. SIZE is the size of the data. OUT_HANDLE should be set to a handle which is later
@@ -28,6 +43,9 @@ mono_install_load_aot_data_hook (MonoLoadAotDataFunc load_func, MonoFreeAotDataF
 
 MONO_API int
 monovm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues);
+
+MONO_API int 
+monovm_runtimeconfig_initialize (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void* user_data);
 
 //#ifdef HOST_WASM
 typedef void* (*MonoWasmGetNativeToInterpTramp) (MonoMethod *method, void *extra_arg);

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -45,7 +45,7 @@ MONO_API int
 monovm_initialize (int propertyCount, const char **propertyKeys, const char **propertyValues);
 
 MONO_API int 
-monovm_runtimeconfig_initialize (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void* user_data);
+monovm_runtimeconfig_initialize (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void *user_data);
 
 //#ifdef HOST_WASM
 typedef void* (*MonoWasmGetNativeToInterpTramp) (MonoMethod *method, void *extra_arg);

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -22,7 +22,7 @@ typedef struct {
 			const char *path;
 		} name;
 		struct {
-			const char *data;
+			char *data;
 			uint32_t data_len;
 		} data;
 	} runtimeconfig;

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -230,32 +230,6 @@ monovm_initialize (int propertyCount, const char **propertyKeys, const char **pr
 int
 monovm_runtimeconfig_initialize (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void *user_data)
 {
-	switch (arg->kind) {
-	case 0: {
-		MonoFileMap *map;
-		void *ret_handle;
-		char *buffer;
-
-		map = mono_file_map_open (arg->runtimeconfig.name.path);
-		g_assert (map);
-		arg->runtimeconfig.data.data_len = (uint32_t)mono_file_map_size (map);
-		g_assert (arg->runtimeconfig.data.data_len > 0);
-		buffer = (char*)mono_file_map (arg->runtimeconfig.data.data_len, MONO_MMAP_READ|MONO_MMAP_PRIVATE, mono_file_map_fd (map), 0, &ret_handle);
-		g_assert (buffer);
-
-		arg->runtimeconfig.data.data = g_new0 (char, arg->runtimeconfig.data.data_len);
-		memcpy (arg->runtimeconfig.data.data, buffer, sizeof(char) * arg->runtimeconfig.data.data_len);
-
-		mono_file_unmap (map, ret_handle);
-		mono_file_map_close (map);
-		break;
-	}
-	case 1: 
-		break;
-	default:
-		g_assert_not_reached ();
-	}
-
 	mono_runtime_register_runtimeconfig_json_properties (arg, cleanup_fn, user_data);
 	return 0;
 }

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -226,87 +226,38 @@ monovm_initialize (int propertyCount, const char **propertyKeys, const char **pr
 	return 0;
 }
 
-void mono_extract_and_register_properties (const char *buffer, guint64 file_size);
-
 // Initialize monovm with properties set by runtimeconfig.json. Primarily used by mobile targets.
 int
 monovm_runtimeconfig_initialize (MonovmRuntimeConfigArguments *arg, MonovmRuntimeConfigArgumentsCleanup cleanup_fn, void *user_data)
 {
 	switch (arg->kind) {
 	case 0: {
-		guint64 file_size = 0;
 		MonoFileMap *map;
 		void *ret_handle;
 		char *buffer;
 
 		map = mono_file_map_open (arg->runtimeconfig.name.path);
 		g_assert (map);
-		file_size = mono_file_map_size (map);
-		buffer = (char*)mono_file_map (file_size, MONO_MMAP_READ|MONO_MMAP_PRIVATE, mono_file_map_fd (map), 0, &ret_handle);
+		arg->runtimeconfig.data.data_len = (uint32_t)mono_file_map_size (map);
+		g_assert (arg->runtimeconfig.data.data_len > 0);
+		buffer = (char*)mono_file_map (arg->runtimeconfig.data.data_len, MONO_MMAP_READ|MONO_MMAP_PRIVATE, mono_file_map_fd (map), 0, &ret_handle);
 		g_assert (buffer);
 
-		if (file_size <= 0)
-			return 0;
-
-		mono_extract_and_register_properties (buffer, file_size);
+		arg->runtimeconfig.data.data = g_new0 (char, arg->runtimeconfig.data.data_len);
+		memcpy (arg->runtimeconfig.data.data, buffer, sizeof(char) * arg->runtimeconfig.data.data_len);
 
 		mono_file_unmap (map, ret_handle);
 		mono_file_map_close (map);
-		if (cleanup_fn)
-			(*cleanup_fn) (arg, user_data);
-		return 0;
+		break;
 	}
-	case 1: {
-		mono_extract_and_register_properties (arg->runtimeconfig.data.data, (guint64)arg->runtimeconfig.data.data_len);
-		if (cleanup_fn)
-			(*cleanup_fn) (arg, user_data);
-		return 0;
-	}
+	case 1: 
+		break;
 	default:
 		g_assert_not_reached ();
 	}
-}
 
-void
-mono_extract_and_register_properties (const char *buffer, guint64 file_size)
-{
-	int property_count;
-	int str_len;
-	int current_idx = 0;
-	char **property_keys;
-	char **property_values;
-
-	property_count = mono_metadata_decode_value(buffer, &buffer);
-	property_keys = g_new0 (char*, property_count);
-	property_values = g_new0 (char*, property_count);
-	current_idx++;
-	for (int i = 0; i < property_count; ++i)
-	{
-		g_assert (file_size > current_idx);
-		str_len = mono_metadata_decode_value(buffer, &buffer);
-		current_idx++;
-
-		g_assert (file_size > (current_idx + str_len));
-		property_keys [i] = g_new0 (char, str_len + 1);
-		strncpy (property_keys [i], buffer, str_len);
-		property_keys [i][str_len] = '\0';
-		current_idx += str_len;
-		buffer += str_len;
-
-		g_assert (file_size > current_idx);
-		str_len = mono_metadata_decode_value(buffer, &buffer);
-		current_idx++;
-
-		g_assert (file_size >= (current_idx + str_len));
-		property_values [i] = g_new0 (char, str_len + 1);
-		strncpy (property_values [i], buffer, str_len);
-		property_values [i][str_len] = '\0';
-		current_idx += str_len;
-		buffer += str_len;
-	}
-
-	if (property_count > 0)
-		mono_runtime_register_runtimeconfig_json_properties (property_count, (const char**)property_keys, (const char**)property_values);
+	mono_runtime_register_runtimeconfig_json_properties (arg, cleanup_fn, user_data);
+	return 0;
 }
 
 int

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -11,8 +11,6 @@
 #include <mono/mini/mini.h>
 #include <mono/utils/mono-logger-internals.h>
 
-#define MAX_PROPERTY_COUNT 100
-
 typedef struct {
 	int assembly_count;
 	char **basenames; /* Foo.dll */


### PR DESCRIPTION
Fixes #49236