### PR TITLE
[AndroidCrypto] Make RSAAndroid handle RsaVerificationPrimitive failure (non-internal error)

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -587,7 +587,7 @@ namespace System.Security.Cryptography
             {
                 if (returnValue != 1)
                 {
-                throw new CryptographicException();
+                    throw new CryptographicException();
                 }
             }
 
@@ -810,6 +810,11 @@ namespace System.Security.Cryptography
                     int ret = Interop.AndroidCrypto.RsaVerificationPrimitive(signature, unwrapped, rsa);
 
                     CheckReturn(ret);
+                    if (ret == 0)
+                    {
+                        // Return value of 0 from RsaVerificationPrimitive indicates the signature could not be decrypted.
+                        return false;
+                    }
 
                     Debug.Assert(
                         ret == requiredBytes,


### PR DESCRIPTION
`RsaVerificationPrimitive` returns -1 on internal error, 0 on failure to decrypt, and the length of the decrypted bytes on success. Update `RSAAndroid` to handle the 0 return value.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs