### PR TITLE
Update Microsoft.DotNet.Helix.Sdk to 6.0.0-beta.21166.5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,9 +10,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>287fba3cbedce004fbd9823c268327960a69ca88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21155.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21166.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>287fba3cbedce004fbd9823c268327960a69ca88</Sha>
+      <Sha>b80229ca3c7bae93ff9b4a50807c7efb0518e771</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21160.7">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21155.1",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21155.1",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21155.1",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21166.5",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21155.1",
     "Microsoft.Build.NoTargets": "2.0.17",
     "Microsoft.Build.Traversal": "2.1.1",


### PR DESCRIPTION
Includes https://github.com/dotnet/arcade/pull/7103