### PR TITLE
Remove duplicate lines for the src/coreclr/debug folder exception in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,7 +298,7 @@ stage/
 !pal/prebuilt/idl/*_i.c
 
 # Valid 'debug' folder, that contains CLR debugging code
-!debug
+!src/coreclr/debug
 
 # Ignore folders created by the CLR test build
 TestWrappers_x64_[d|D]ebug
@@ -351,9 +351,6 @@ linker
 # ln -s $(pwd)/src/libraries/Common/src src/coreclr/System.Private.CoreLib/common
 src/coreclr/System.Private.CoreLib/shared
 src/coreclr/System.Private.CoreLib/common
-
-# The debug directory should not be ignored
-!src/coreclr/debug
 
 # Exceptions to the exclusions
 !src/coreclr/.nuget/_.pdb

--- a/.gitignore
+++ b/.gitignore
@@ -294,9 +294,6 @@ parts/
 prime/
 stage/
 
-# CLR prebuilt generated files
-!pal/prebuilt/idl/*_i.c
-
 # Valid 'debug' folder, that contains CLR debugging code
 !src/coreclr/debug
 


### PR DESCRIPTION
The `Valid 'debug' folder, that contains CLR debugging code` line had been added in https://github.com/dotnet/coreclr/pull/397, but got out of sync (and ineffective) with the consolidation.

#35021 then re-added the same thing on a different line.

/cc @jkotas @sdmaclea