### PR TITLE
FileStreamStrategies refactor

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/LegacyTests/runtimeconfig.template.json
+++ b/src/libraries/System.IO.FileSystem/tests/LegacyTests/runtimeconfig.template.json
@@ -1,5 +1,5 @@
 {
     "configProperties": {
-        "System.IO.UseLegacyFileStream": true
+        "System.IO.UseNet5CompatFileStream": false
     }
 }

--- a/src/libraries/System.IO/tests/LegacyTests/runtimeconfig.template.json
+++ b/src/libraries/System.IO/tests/LegacyTests/runtimeconfig.template.json
@@ -1,5 +1,5 @@
 {
     "configProperties": {
-        "System.IO.UseLegacyFileStream": true
+        "System.IO.UseNet5CompatFileStream": false
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1847,10 +1847,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.LoadICU.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.Unix.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamHelpers.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PersistedFiles.Names.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamHelpers.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Lock.OSX.cs" Condition="'$(IsOSXLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Lock.Unix.cs" Condition="'$(IsOSXLike)' != 'true'" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -424,6 +424,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\UnmanagedMemoryStreamWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\BufferedFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\DerivedFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IObservable.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -392,8 +392,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BufferedStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\BufferedFileStreamStrategy.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\DerivedFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DirectoryNotFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EncodingCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EndOfStreamException.cs" />
@@ -405,12 +403,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileShare.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\HandleInheritability.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\InvalidDataException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\IOException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\MemoryStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\LegacyFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathTooLongException.cs" />
@@ -426,6 +422,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\UnmanagedMemoryAccessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\UnmanagedMemoryStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\UnmanagedMemoryStreamWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\BufferedFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\DerivedFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IObservable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IObserver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IProgress.cs" />
@@ -1635,17 +1635,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\AsyncWindowsFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DisableMediaInsertionPrompt.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DriveInfoInternal.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamHelpers.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamCompletionSource.Win32.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\LegacyFileStreamStrategy.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\SyncWindowsFileStreamStrategy.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\WindowsFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\AsyncWindowsFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamHelpers.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\FileStreamCompletionSource.Win32.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\SyncWindowsFileStreamStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\WindowsFileStreamStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Loader\LibraryNameVariation.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\MemoryFailPoint.Windows.cs" />
@@ -1850,9 +1850,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PersistedFiles.Names.Unix.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\LegacyFileStreamStrategy.Unix.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\LegacyFileStreamStrategy.Lock.OSX.cs" Condition="'$(IsOSXLike)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\LegacyFileStreamStrategy.Lock.Unix.cs" Condition="'$(IsOSXLike)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Lock.OSX.cs" Condition="'$(IsOSXLike)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\Strategies\LegacyFileStreamStrategy.Lock.Unix.cs" Condition="'$(IsOSXLike)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Loader\LibraryNameVariation.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\MemoryFailPoint.Unix.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Strategies;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 using System.Threading;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -66,17 +66,25 @@ namespace System.IO
         private static void ValidateHandle(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
         {
             if (handle.IsInvalid)
+            {
                 throw new ArgumentException(SR.Arg_InvalidHandle, nameof(handle));
-
-            if (access < FileAccess.Read || access > FileAccess.ReadWrite)
+            }
+            else if (access < FileAccess.Read || access > FileAccess.ReadWrite)
+            {
                 throw new ArgumentOutOfRangeException(nameof(access), SR.ArgumentOutOfRange_Enum);
-            if (bufferSize <= 0)
+            }
+            else if (bufferSize <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
-
-            if (handle.IsClosed)
+            }
+            else if (handle.IsClosed)
+            {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
-            if (handle.IsAsync.HasValue && isAsync != handle.IsAsync.GetValueOrDefault())
+            }
+            else if (handle.IsAsync.HasValue && isAsync != handle.IsAsync.GetValueOrDefault())
+            {
                 throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle));
+            }
         }
 
         public FileStream(SafeFileHandle handle, FileAccess access)
@@ -96,53 +104,73 @@ namespace System.IO
             _strategy = FileStreamHelpers.ChooseStrategy(this, handle, access, bufferSize, isAsync);
         }
 
-        public FileStream(string path, FileMode mode) :
-            this(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, DefaultShare, DefaultBufferSize, DefaultIsAsync)
-        { }
+        public FileStream(string path, FileMode mode)
+            : this(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, DefaultShare, DefaultBufferSize, DefaultIsAsync)
+        {
+        }
 
-        public FileStream(string path, FileMode mode, FileAccess access) :
-            this(path, mode, access, DefaultShare, DefaultBufferSize, DefaultIsAsync)
-        { }
+        public FileStream(string path, FileMode mode, FileAccess access)
+            : this(path, mode, access, DefaultShare, DefaultBufferSize, DefaultIsAsync)
+        {
+        }
 
-        public FileStream(string path, FileMode mode, FileAccess access, FileShare share) :
-            this(path, mode, access, share, DefaultBufferSize, DefaultIsAsync)
-        { }
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share)
+            : this(path, mode, access, share, DefaultBufferSize, DefaultIsAsync)
+        {
+        }
 
-        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize) :
-            this(path, mode, access, share, bufferSize, DefaultIsAsync)
-        { }
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize)
+            : this(path, mode, access, share, bufferSize, DefaultIsAsync)
+        {
+        }
 
-        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync) :
-            this(path, mode, access, share, bufferSize, useAsync ? FileOptions.Asynchronous : FileOptions.None)
-        { }
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync)
+            : this(path, mode, access, share, bufferSize, useAsync ? FileOptions.Asynchronous : FileOptions.None)
+        {
+        }
 
         public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
         {
             if (path == null)
+            {
                 throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
-            if (path.Length == 0)
+            }
+            else if (path.Length == 0)
+            {
                 throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
+            }
 
             // don't include inheritable in our bounds check for share
             FileShare tempshare = share & ~FileShare.Inheritable;
             string? badArg = null;
 
             if (mode < FileMode.CreateNew || mode > FileMode.Append)
+            {
                 badArg = nameof(mode);
+            }
             else if (access < FileAccess.Read || access > FileAccess.ReadWrite)
+            {
                 badArg = nameof(access);
+            }
             else if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
+            {
                 badArg = nameof(share);
+            }
 
             if (badArg != null)
+            {
                 throw new ArgumentOutOfRangeException(badArg, SR.ArgumentOutOfRange_Enum);
+            }
 
             // NOTE: any change to FileOptions enum needs to be matched here in the error validation
             if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(options), SR.ArgumentOutOfRange_Enum);
-
-            if (bufferSize <= 0)
+            }
+            else if (bufferSize <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
 
             // Write access validation
             if ((access & FileAccess.Write) == 0)
@@ -155,9 +183,10 @@ namespace System.IO
             }
 
             if ((access & FileAccess.Read) != 0 && mode == FileMode.Append)
+            {
                 throw new ArgumentException(SR.Argument_InvalidAppendMode, nameof(access));
-
-            if ((access & FileAccess.Write) == FileAccess.Write)
+            }
+            else if ((access & FileAccess.Write) == FileAccess.Write)
             {
                 SerializationInfo.ThrowIfDeserializationInProgress("AllowFileWrites", ref s_cachedSerializationSwitch);
             }
@@ -175,8 +204,7 @@ namespace System.IO
             {
                 throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-
-            if (_strategy.IsClosed)
+            else if (_strategy.IsClosed)
             {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
             }
@@ -191,8 +219,7 @@ namespace System.IO
             {
                 throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
-
-            if (_strategy.IsClosed)
+            else if (_strategy.IsClosed)
             {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
             }
@@ -206,7 +233,7 @@ namespace System.IO
             {
                 return Task.FromCanceled(cancellationToken);
             }
-            if (_strategy.IsClosed)
+            else if (_strategy.IsClosed)
             {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
             }
@@ -228,10 +255,13 @@ namespace System.IO
             ValidateBufferArguments(buffer, offset, count);
 
             if (cancellationToken.IsCancellationRequested)
+            {
                 return Task.FromCanceled<int>(cancellationToken);
-
-            if (_strategy.IsClosed)
+            }
+            else if (_strategy.IsClosed)
+            {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
 
             return _strategy.ReadAsync(buffer, offset, count, cancellationToken);
         }
@@ -242,8 +272,7 @@ namespace System.IO
             {
                 return ValueTask.FromCanceled<int>(cancellationToken);
             }
-
-            if (_strategy.IsClosed)
+            else if (_strategy.IsClosed)
             {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
             }
@@ -265,10 +294,13 @@ namespace System.IO
             ValidateBufferArguments(buffer, offset, count);
 
             if (cancellationToken.IsCancellationRequested)
+            {
                 return Task.FromCanceled(cancellationToken);
-
-            if (_strategy.IsClosed)
+            }
+            else if (_strategy.IsClosed)
+            {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
 
             return _strategy.WriteAsync(buffer, offset, count, cancellationToken);
         }
@@ -279,8 +311,7 @@ namespace System.IO
             {
                 return ValueTask.FromCanceled(cancellationToken);
             }
-
-            if (_strategy.IsClosed)
+            else if (_strategy.IsClosed)
             {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
             }
@@ -303,7 +334,10 @@ namespace System.IO
         /// </summary>
         public virtual void Flush(bool flushToDisk)
         {
-            if (_strategy.IsClosed) ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            if (_strategy.IsClosed)
+            {
+                ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
 
             _strategy.Flush(flushToDisk);
         }
@@ -322,7 +356,9 @@ namespace System.IO
         {
             ValidateBufferArguments(buffer, offset, count);
             if (_strategy.IsClosed)
+            {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
         }
 
         /// <summary>Sets the length of this stream to the given value.</summary>
@@ -330,13 +366,21 @@ namespace System.IO
         public override void SetLength(long value)
         {
             if (value < 0)
+            {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            if (_strategy.IsClosed)
+            }
+            else if (_strategy.IsClosed)
+            {
                 ThrowHelper.ThrowObjectDisposedException_FileClosed();
-            if (!CanSeek)
+            }
+            else if (!CanSeek)
+            {
                 ThrowHelper.ThrowNotSupportedException_UnseekableStream();
-            if (!CanWrite)
+            }
+            else if (!CanWrite)
+            {
                 ThrowHelper.ThrowNotSupportedException_UnwritableStream();
+            }
 
             _strategy.SetLength(value);
         }
@@ -354,8 +398,15 @@ namespace System.IO
         {
             get
             {
-                if (_strategy.IsClosed) ThrowHelper.ThrowObjectDisposedException_FileClosed();
-                if (!CanSeek) ThrowHelper.ThrowNotSupportedException_UnseekableStream();
+                if (_strategy.IsClosed)
+                {
+                    ThrowHelper.ThrowObjectDisposedException_FileClosed();
+                }
+                else if (!CanSeek)
+                {
+                    ThrowHelper.ThrowNotSupportedException_UnseekableStream();
+                }
+
                 return _strategy.Length;
             }
         }
@@ -366,17 +417,22 @@ namespace System.IO
             get
             {
                 if (_strategy.IsClosed)
+                {
                     ThrowHelper.ThrowObjectDisposedException_FileClosed();
-
-                if (!CanSeek)
+                }
+                else if (!CanSeek)
+                {
                     ThrowHelper.ThrowNotSupportedException_UnseekableStream();
+                }
 
                 return _strategy.Position;
             }
             set
             {
                 if (value < 0)
+                {
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                }
 
                 _strategy.Seek(value, SeekOrigin.Begin);
             }
@@ -409,8 +465,15 @@ namespace System.IO
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         {
             ValidateBufferArguments(buffer, offset, count);
-            if (_strategy.IsClosed) ThrowHelper.ThrowObjectDisposedException_FileClosed();
-            if (!CanRead) ThrowHelper.ThrowNotSupportedException_UnreadableStream();
+
+            if (_strategy.IsClosed)
+            {
+                ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
+            else if (!CanRead)
+            {
+                ThrowHelper.ThrowNotSupportedException_UnreadableStream();
+            }
 
             return _strategy.BeginRead(buffer, offset, count, callback, state);
         }
@@ -418,7 +481,9 @@ namespace System.IO
         public override int EndRead(IAsyncResult asyncResult)
         {
             if (asyncResult == null)
+            {
                 throw new ArgumentNullException(nameof(asyncResult));
+            }
 
             return _strategy.EndRead(asyncResult);
         }
@@ -426,8 +491,15 @@ namespace System.IO
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         {
             ValidateBufferArguments(buffer, offset, count);
-            if (_strategy.IsClosed) ThrowHelper.ThrowObjectDisposedException_FileClosed();
-            if (!CanWrite) ThrowHelper.ThrowNotSupportedException_UnwritableStream();
+
+            if (_strategy.IsClosed)
+            {
+                ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
+            else if (!CanWrite)
+            {
+                ThrowHelper.ThrowNotSupportedException_UnwritableStream();
+            }
 
             return _strategy.BeginWrite(buffer, offset, count, callback, state);
         }
@@ -435,7 +507,9 @@ namespace System.IO
         public override void EndWrite(IAsyncResult asyncResult)
         {
             if (asyncResult == null)
+            {
                 throw new ArgumentNullException(nameof(asyncResult));
+            }
 
             _strategy.EndWrite(asyncResult);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -395,7 +395,7 @@ namespace System.IO
         /// <param name="value">The byte to write to the stream.</param>
         public override void WriteByte(byte value) => _strategy.WriteByte(value);
 
-        protected override void Dispose(bool disposing) => _strategy?.DisposeInternal(disposing);
+        protected override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
 
         internal void DisposeInternal(bool disposing) => Dispose(disposing);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -397,7 +397,7 @@ namespace System.IO.Strategies
             finally
             {
                 // Make sure the stream's current position reflects where we ended up
-                if (!_fileHandle.IsClosed && CanSeek)
+                if (!_fileHandle.IsClosed && canSeek)
                 {
                     SeekCore(_fileHandle, 0, SeekOrigin.End);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal sealed partial class AsyncWindowsFileStreamStrategy : WindowsFileStreamStrategy, IFileStreamCompletionSourceStrategy
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // this type exists so we can avoid duplicating the buffering logic in every FileStreamStrategy implementation
     internal sealed class BufferedFileStreamStrategy : FileStreamStrategy

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -74,7 +74,7 @@ namespace System.IO.Strategies
             {
                 Debug.Assert(!(_writePos > 0 && _readPos != _readLen), "Read and Write buffers cannot both have data in them at the same time.");
 
-                return _strategy.Position + (_readPos - _readLen + _writePos);
+                return _strategy.Position + _readPos - _readLen + _writePos;
             }
             set
             {
@@ -598,7 +598,7 @@ namespace System.IO.Strategies
                 ClearReadBufferBeforeWrite();
                 EnsureBufferAllocated();
             }
-            else if (_writePos >= _bufferSize - 1)
+            else if (_writePos == _bufferSize - 1)
             {
                 FlushWrite();
             }
@@ -1055,7 +1055,7 @@ namespace System.IO.Strategies
 
         private void EnsureBufferAllocated()
         {
-            Debug.Assert(_bufferSize > 0);
+            Debug.Assert(_bufferSize > 1);
 
             // BufferedFileStreamStrategy is not intended for multi-threaded use, so no worries about the get/set race on _buffer.
             if (_buffer == null)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -23,7 +23,7 @@ namespace System.IO.Strategies
 
         internal BufferedFileStreamStrategy(FileStreamStrategy strategy, int bufferSize)
         {
-            Debug.Assert(bufferSize > 1);
+            Debug.Assert(bufferSize > 1, "Buffering must not be enabled for smaller buffer sizes");
 
             _strategy = strategy;
             _bufferSize = bufferSize;
@@ -1055,8 +1055,6 @@ namespace System.IO.Strategies
 
         private void EnsureBufferAllocated()
         {
-            Debug.Assert(_bufferSize > 1);
-
             // BufferedFileStreamStrategy is not intended for multi-threaded use, so no worries about the get/set race on _buffer.
             if (_buffer == null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -37,7 +37,7 @@ namespace System.IO.Strategies
                 // so we enforce it by passing always true
                 Dispose(true);
             }
-            catch (Exception e) when (FileStream.IsIoRelatedException(e))
+            catch (Exception e) when (FileStreamHelpers.IsIoRelatedException(e))
             {
                 // On finalization, ignore failures from trying to flush the write buffer,
                 // e.g. if this stream is wrapping a pipe and the pipe is now broken.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // this type exists so we can avoid GetType() != typeof(FileStream) checks in FileStream
     // when FileStream was supposed to call base.Method() for such cases, we just call _fileStream.BaseMethod()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamCompletionSource.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamCompletionSource.Win32.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // to avoid code duplicaiton of FileStreamCompletionSource for LegacyFileStreamStrategy and AsyncWindowsFileStreamStrategy
     // we have created the following interface that is a common contract for both of them

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
@@ -11,13 +11,13 @@ using System.Threading.Tasks;
 namespace System.IO.Strategies
 {
     // this type defines a set of stateless FileStream/FileStreamStrategy helper methods
-    internal static class FileStreamHelpers
+    internal static partial class FileStreamHelpers
     {
         // in the future we are most probably going to introduce more strategies (io_uring etc)
-        internal static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+        private static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
             => new LegacyFileStreamStrategy(handle, access, bufferSize, isAsync);
 
-        internal static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        private static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
             => new LegacyFileStreamStrategy(path, mode, access, share, bufferSize, options);
 
         internal static SafeFileHandle OpenHandle(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
@@ -14,10 +14,10 @@ namespace System.IO.Strategies
     internal static partial class FileStreamHelpers
     {
         // in the future we are most probably going to introduce more strategies (io_uring etc)
-        private static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+        private static FileStreamStrategy ChooseStrategyCore(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
             => new LegacyFileStreamStrategy(handle, access, bufferSize, isAsync);
 
-        private static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        private static FileStreamStrategy ChooseStrategyCore(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
             => new LegacyFileStreamStrategy(path, mode, access, share, bufferSize, options);
 
         internal static SafeFileHandle OpenHandle(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
@@ -8,7 +8,7 @@ using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // this type defines a set of stateless FileStream/FileStreamStrategy helper methods
     internal static class FileStreamHelpers

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -12,18 +12,14 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Strategies
 {
     // this type defines a set of stateless FileStream/FileStreamStrategy helper methods
-    internal static class FileStreamHelpers
+    internal static partial class FileStreamHelpers
     {
         internal const int ERROR_BROKEN_PIPE = 109;
         internal const int ERROR_NO_DATA = 232;
         private const int ERROR_HANDLE_EOF = 38;
         private const int ERROR_IO_PENDING = 997;
 
-        // It's enabled by default. We are going to change that (by removing !) once we fix #16354, #25905 and #24847.
-        internal static bool UseLegacyStrategy { get; }
-            = !AppContextConfigHelper.GetBooleanConfig("System.IO.UseLegacyFileStream", "DOTNET_SYSTEM_IO_USELEGACYFILESTREAM");
-
-        internal static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+        private static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
         {
             if (UseLegacyStrategy)
             {
@@ -37,7 +33,7 @@ namespace System.IO.Strategies
             return EnableBufferingIfNeeded(strategy, bufferSize);
         }
 
-        internal static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        private static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
         {
             if (UseLegacyStrategy)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -19,7 +19,7 @@ namespace System.IO.Strategies
         private const int ERROR_HANDLE_EOF = 38;
         private const int ERROR_IO_PENDING = 997;
 
-        private static FileStreamStrategy ChooseStrategy(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+        private static FileStreamStrategy ChooseStrategyCore(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
         {
             if (UseLegacyStrategy)
             {
@@ -33,7 +33,7 @@ namespace System.IO.Strategies
             return EnableBufferingIfNeeded(strategy, bufferSize);
         }
 
-        private static FileStreamStrategy ChooseStrategy(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        private static FileStreamStrategy ChooseStrategyCore(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
         {
             if (UseLegacyStrategy)
             {
@@ -312,7 +312,7 @@ namespace System.IO.Strategies
             isPipe = handleType == Interop.Kernel32.FileTypes.FILE_TYPE_PIPE;
         }
 
-        internal static unsafe void SetLength(SafeFileHandle handle, string? path, long length)
+        internal static unsafe void SetFileLength(SafeFileHandle handle, string? path, long length)
         {
             var eofInfo = new Interop.Kernel32.FILE_END_OF_FILE_INFO
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -142,7 +142,7 @@ namespace System.IO.Strategies
 
             // If we can't check the handle, just assume it is ok.
             if (!(IsHandleSynchronous(handle, ignoreInvalid: false) ?? true))
-                throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
+                ThrowHelper.ThrowArgumentException_HandleNotSync(nameof(handle));
         }
 
         private static unsafe Interop.Kernel32.SECURITY_ATTRIBUTES GetSecAttrs(FileShare share)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // this type defines a set of stateless FileStream/FileStreamStrategy helper methods
     internal static class FileStreamHelpers

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -24,10 +24,10 @@ namespace System.IO.Strategies
         }
 
         internal static FileStreamStrategy ChooseStrategy(FileStream fileStream, SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
-            => WrapIfDerivedType(fileStream, ChooseStrategy(handle, access, bufferSize, isAsync));
+            => WrapIfDerivedType(fileStream, ChooseStrategyCore(handle, access, bufferSize, isAsync));
 
         internal static FileStreamStrategy ChooseStrategy(FileStream fileStream, string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
-            => WrapIfDerivedType(fileStream, ChooseStrategy(path, mode, access, share, bufferSize, options));
+            => WrapIfDerivedType(fileStream, ChooseStrategyCore(path, mode, access, share, bufferSize, options));
 
         private static FileStreamStrategy WrapIfDerivedType(FileStream fileStream, FileStreamStrategy strategy)
             => fileStream.GetType() == typeof(FileStream)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace System.IO.Strategies
+{
+    internal static partial class FileStreamHelpers
+    {
+        // It's enabled by default. We are going to change that (by removing !) once we fix #16354, #25905 and #24847.
+        internal static bool UseLegacyStrategy { get; }
+            = !AppContextConfigHelper.GetBooleanConfig("System.IO.UseLegacyFileStream", "DOTNET_SYSTEM_IO_USELEGACYFILESTREAM");
+
+        internal static FileStreamStrategy ChooseStrategy(FileStream fileStream, SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+            => WrapIfDerivedType(fileStream, ChooseStrategy(handle, access, bufferSize, isAsync));
+
+        internal static FileStreamStrategy ChooseStrategy(FileStream fileStream, string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+            => WrapIfDerivedType(fileStream, ChooseStrategy(path, mode, access, share, bufferSize, options));
+
+        private static FileStreamStrategy WrapIfDerivedType(FileStream fileStream, FileStreamStrategy strategy)
+            => fileStream.GetType() == typeof(FileStream)
+                ? strategy
+                : new DerivedFileStreamStrategy(fileStream, strategy);
+
+        internal static bool IsIoRelatedException(Exception e) =>
+            // These all derive from IOException
+            //     DirectoryNotFoundException
+            //     DriveNotFoundException
+            //     EndOfStreamException
+            //     FileLoadException
+            //     FileNotFoundException
+            //     PathTooLongException
+            //     PipeException
+            e is IOException ||
+            // Note that SecurityException is only thrown on runtimes that support CAS
+            // e is SecurityException ||
+            e is UnauthorizedAccessException ||
+            e is NotSupportedException ||
+            (e is ArgumentException && !(e is ArgumentNullException));
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal abstract class FileStreamStrategy : Stream
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Lock.OSX.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Lock.OSX.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal sealed partial class LegacyFileStreamStrategy : FileStreamStrategy
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Lock.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Lock.Unix.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal sealed partial class LegacyFileStreamStrategy : FileStreamStrategy
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Unix.cs
@@ -8,7 +8,7 @@ using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     /// <summary>Provides an implementation of a file stream for Unix files.</summary>
     internal sealed partial class LegacyFileStreamStrategy : FileStreamStrategy

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Unix.cs
@@ -172,7 +172,7 @@ namespace System.IO.Strategies
                     {
                         FlushWriteBuffer();
                     }
-                    catch (Exception e) when (!disposing && FileStream.IsIoRelatedException(e))
+                    catch (Exception e) when (!disposing && FileStreamHelpers.IsIoRelatedException(e))
                     {
                         // On finalization, ignore failures from trying to flush the write buffer,
                         // e.g. if this stream is wrapping a pipe and the pipe is now broken.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
@@ -434,7 +434,7 @@ namespace System.IO.Strategies
                 else
                 {
                     if (errorCode == ERROR_INVALID_PARAMETER)
-                        throw new ArgumentException(SR.Arg_HandleNotSync, "_fileHandle");
+                        ThrowHelper.ThrowArgumentException_HandleNotSync(nameof(_fileHandle));
 
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
@@ -192,7 +192,7 @@ namespace System.IO.Strategies
                     {
                         FlushWriteBuffer(!disposing);
                     }
-                    catch (Exception e) when (!disposing && FileStream.IsIoRelatedException(e))
+                    catch (Exception e) when (!disposing && FileStreamHelpers.IsIoRelatedException(e))
                     {
                         // On finalization, ignore failures from trying to flush the write buffer,
                         // e.g. if this stream is wrapping a pipe and the pipe is now broken.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
@@ -34,7 +34,7 @@ using Microsoft.Win32.SafeHandles;
  *
  */
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal sealed partial class LegacyFileStreamStrategy : FileStreamStrategy, IFileStreamCompletionSourceStrategy
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.Windows.cs
@@ -328,7 +328,7 @@ namespace System.IO.Strategies
             Debug.Assert(value >= 0, "value >= 0");
             VerifyOSHandlePosition();
 
-            FileStreamHelpers.SetLength(_fileHandle, _path, value);
+            FileStreamHelpers.SetFileLength(_fileHandle, _path, value);
 
             if (_filePosition > value)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/LegacyFileStreamStrategy.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // This type is partial so we can avoid code duplication between Windows and Unix Legacy implementations
     internal sealed partial class LegacyFileStreamStrategy : FileStreamStrategy

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
@@ -33,7 +33,7 @@ namespace System.IO.Strategies
 
             // If we can't check the handle, just assume it is ok.
             if (!(FileStreamHelpers.IsHandleSynchronous(handle, ignoreInvalid: false) ?? true))
-                throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
+                ThrowHelper.ThrowArgumentException_HandleNotSync(nameof(handle));
         }
 
         public override int Read(byte[] buffer, int offset, int count) => ReadSpan(new Span<byte>(buffer, offset, count));
@@ -119,7 +119,7 @@ namespace System.IO.Strategies
                 else
                 {
                     if (errorCode == ERROR_INVALID_PARAMETER)
-                        throw new ArgumentException(SR.Arg_HandleNotSync, "_fileHandle");
+                        ThrowHelper.ThrowArgumentException_HandleNotSync(nameof(_fileHandle));
 
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     internal sealed class SyncWindowsFileStreamStrategy : WindowsFileStreamStrategy
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
@@ -263,7 +263,7 @@ namespace System.IO.Strategies
             Debug.Assert(value >= 0, "value >= 0");
             VerifyOSHandlePosition();
 
-            FileStreamHelpers.SetLength(_fileHandle, _path, value);
+            FileStreamHelpers.SetFileLength(_fileHandle, _path, value);
 
             if (_filePosition > value)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.CompilerServices;
 
-namespace System.IO
+namespace System.IO.Strategies
 {
     // this type serves some basic functionality that is common for Async and Sync Windows File Stream Strategies
     internal abstract class WindowsFileStreamStrategy : FileStreamStrategy

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -220,6 +220,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowArgumentException_HandleNotSync(string paramName)
+        {
+            throw new ArgumentException(SR.Arg_HandleNotSync, paramName);
+        }
+
+        [DoesNotReturn]
         internal static void ThrowArgumentNullException(ExceptionArgument argument)
         {
             throw new ArgumentNullException(GetArgumentName(argument));


### PR DESCRIPTION
@Jozkee @carlossanlop the promised refactor ;)

I've tried to refactor the handling of exit codes for `ReadAsync` and `WriteAsync` but I found that they differ too much to make it worth it.

`ReadAsync` has some special handling of EOF:

https://github.com/dotnet/runtime/blob/ac5c33defa6a9983e85ce8bf0be352cb09f5b8eb/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs#L198-L206

while `WriteAsync` does it a little bit differently:

https://github.com/dotnet/runtime/blob/ac5c33defa6a9983e85ce8bf0be352cb09f5b8eb/src/libraries/System.Private.CoreLib/src/System/IO/AsyncWindowsFileStreamStrategy.cs#L312-L318

Moreover, `ReadAsync` returns a `Task<int>` while `WriteAsync` returns just a `Task` (so it can use `Task.CompletedTask`)

@Jozkee @carlossanlop feel free to merge it as soon as you accept it and the CI passes