### PR TITLE
Fix typo in RuntimeType.cs

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1939,18 +1939,18 @@ namespace System
         {
             RuntimeType[]? typeContext = null;
             RuntimeType[]? methodContext = null;
-            RuntimeType[] genericParamters;
+            RuntimeType[] genericParameters;
 
             if (definition is Type)
             {
                 RuntimeType genericTypeDefinition = (RuntimeType)definition;
-                genericParamters = genericTypeDefinition.GetGenericArgumentsInternal();
+                genericParameters = genericTypeDefinition.GetGenericArgumentsInternal();
                 typeContext = genericArguments;
             }
             else
             {
                 RuntimeMethodInfo genericMethodDefinition = (RuntimeMethodInfo)definition;
-                genericParamters = genericMethodDefinition.GetGenericArgumentsInternal();
+                genericParameters = genericMethodDefinition.GetGenericArgumentsInternal();
                 methodContext = genericArguments;
 
                 RuntimeType? declaringType = (RuntimeType?)genericMethodDefinition.DeclaringType;
@@ -1963,7 +1963,7 @@ namespace System
             for (int i = 0; i < genericArguments.Length; i++)
             {
                 Type genericArgument = genericArguments[i];
-                Type genericParameter = genericParamters[i];
+                Type genericParameter = genericParameters[i];
 
                 if (!RuntimeTypeHandle.SatisfiesConstraints(genericParameter.GetTypeHandleInternal().GetTypeChecked(),
                     typeContext, methodContext, genericArgument.GetTypeHandleInternal().GetTypeChecked()))

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -793,7 +793,7 @@ namespace System
                     SR.Format(SR.Argument_NeverValidGenericArgument, type));
         }
 
-        internal static void SanityCheckGenericArguments(RuntimeType[] genericArguments, RuntimeType[] genericParamters)
+        internal static void SanityCheckGenericArguments(RuntimeType[] genericArguments, RuntimeType[] genericParameters)
         {
             if (genericArguments == null)
                 throw new ArgumentNullException();
@@ -806,9 +806,9 @@ namespace System
                 ThrowIfTypeNeverValidGenericArgument(genericArguments[i]);
             }
 
-            if (genericArguments.Length != genericParamters.Length)
+            if (genericArguments.Length != genericParameters.Length)
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_NotEnoughGenArguments, genericArguments.Length, genericParamters.Length));
+                    SR.Format(SR.Argument_NotEnoughGenArguments, genericArguments.Length, genericParameters.Length));
         }
     }
 }


### PR DESCRIPTION
This typo came up in a reflection stacktrace.