### PR TITLE
[crossgen2] Fix memory leak in _corInfoImpls.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -23,7 +23,7 @@ using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler
 {
-    public abstract class Compilation : ICompilation
+    public abstract class Compilation : ICompilation, IDisposable
     {
         protected readonly DependencyAnalyzerBase<NodeFactory> _dependencyGraph;
         protected readonly NodeFactory _nodeFactory;
@@ -67,6 +67,7 @@ namespace ILCompiler
             _methodILCache = new ILCache(ilProvider, NodeFactory.CompilationModuleGroup);
         }
 
+        public abstract void Dispose();
         public abstract void Compile(string outputFileName);
         public abstract void WriteDependencyLog(string outputFileName);
 
@@ -218,6 +219,7 @@ namespace ILCompiler
     {
         void Compile(string outputFileName);
         void WriteDependencyLog(string outputFileName);
+        void Dispose();
     }
 
     public sealed class ReadyToRunCodegenCompilation : Compilation
@@ -638,5 +640,10 @@ namespace ILCompiler
         }
 
         public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CopiedFieldRva(field);
+
+        public override void Dispose()
+        {
+            _corInfoImpls?.Clear();
+        }
     }
 }

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -632,6 +632,7 @@ namespace ILCompiler
 
                 if (_commandLineOptions.DgmlLogFileName != null)
                     compilation.WriteDependencyLog(_commandLineOptions.DgmlLogFileName);
+                compilation.Dispose();
             }
 
             return 0;

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -632,6 +632,7 @@ namespace ILCompiler
 
                 if (_commandLineOptions.DgmlLogFileName != null)
                     compilation.WriteDependencyLog(_commandLineOptions.DgmlLogFileName);
+
                 compilation.Dispose();
             }
 


### PR DESCRIPTION
This pull request fixes crossgen2 potentially memory leak.

`ConditionalWeakTable  _corInfoImpls` elements keeps `_compilation` reference which keeps reference to whole table `_corInfoImpls`. The circular reference together with issue #12255 potentionally leads to memory leak in crossgen2 if that table is created more than once. As example `_corInfoImpls` table is created several times in pipeline mode #37411. `WeakReference` allows GC to collect the table and prevents the leak.

cc @jkotas @davidwrighton @MichalStrehovsky @gbalykov @alpencolt 