### PR TITLE
Comments and cleanup for loop cloning

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -44,6 +44,9 @@ typedef BitVec_ValRet_T ASSERT_VALRET_TP;
 // This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
 #define FMT_BB "BB%02u"
 
+// Use this format for loop table indices.
+#define FMT_LP "L%02u"
+
 // And this format for profile weights
 #define FMT_WT "%.7g"
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -616,7 +616,7 @@ struct BasicBlock : private LIR::Range
             this->bbFlags &= ~BBF_PROF_WEIGHT;
         }
 
-        if (this->bbWeight == 0)
+        if (this->bbWeight == BB_ZERO_WEIGHT)
         {
             this->bbFlags |= BBF_RUN_RARELY;
         }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -346,6 +346,9 @@ void CodeGen::genCodeForBBlist()
         if ((block->bbPrev != nullptr) && (block->bbPrev->bbJumpKind == BBJ_COND) &&
             (block->bbWeight != block->bbPrev->bbWeight))
         {
+            JITDUMP("Adding label due to BB weight difference: BBJ_COND " FMT_BB " with weight " FMT_WT
+                    " different from " FMT_BB " with weight " FMT_WT "\n",
+                    block->bbPrev->bbNum, block->bbPrev->bbWeight, block->bbNum, block->bbWeight);
             needLabel = true;
         }
 
@@ -588,7 +591,7 @@ void CodeGen::genCodeForBBlist()
             {
                 if (!foundMismatchedRegVar)
                 {
-                    JITDUMP("Mismatched live reg vars after BB%02u:", block->bbNum);
+                    JITDUMP("Mismatched live reg vars after " FMT_BB ":", block->bbNum);
                     foundMismatchedRegVar = true;
                 }
                 JITDUMP(" V%02u", compiler->lvaTrackedIndexToLclNum(mismatchLiveVarIndex));

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4870,7 +4870,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         DoPhase(this, PHASE_FIND_LOOPS, &Compiler::optFindLoops);
 
         // Clone loops with optimization opportunities, and
-        // choose the one based on dynamic condition evaluation.
+        // choose one based on dynamic condition evaluation.
         //
         DoPhase(this, PHASE_CLONE_LOOPS, &Compiler::optCloneLoops);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6310,13 +6310,13 @@ public:
 
         /* The following values are set only for iterator loops, i.e. has the flag LPFLG_ITER set */
 
-        GenTree*   lpIterTree;    // The "i = i <op> const" tree
-        unsigned   lpIterVar();   // iterator variable #
-        int        lpIterConst(); // the constant with which the iterator is incremented
-        genTreeOps lpIterOper();  // the type of the operation on the iterator (ASG_ADD, ASG_SUB, etc.)
-        void       VERIFY_lpIterTree();
+        GenTree*   lpIterTree;          // The "i = i <op> const" tree
+        unsigned   lpIterVar() const;   // iterator variable #
+        int        lpIterConst() const; // the constant with which the iterator is incremented
+        genTreeOps lpIterOper() const;  // the type of the operation on the iterator (ASG_ADD, ASG_SUB, etc.)
+        void       VERIFY_lpIterTree() const;
 
-        var_types lpIterOperType(); // For overflow instructions
+        var_types lpIterOperType() const; // For overflow instructions
 
         union {
             int lpConstInit; // initial constant value of iterator                           : Valid if LPFLG_CONST_INIT
@@ -6324,69 +6324,74 @@ public:
                                 // LPFLG_VAR_INIT
         };
 
-        /* The following is for LPFLG_ITER loops only (i.e. the loop condition is "i RELOP const or var" */
+        // The following is for LPFLG_ITER loops only (i.e. the loop condition is "i RELOP const or var"
 
-        GenTree*   lpTestTree;   // pointer to the node containing the loop test
-        genTreeOps lpTestOper(); // the type of the comparison between the iterator and the limit (GT_LE, GT_GE, etc.)
-        void       VERIFY_lpTestTree();
+        GenTree*   lpTestTree;         // pointer to the node containing the loop test
+        genTreeOps lpTestOper() const; // the type of the comparison between the iterator and the limit (GT_LE, GT_GE,
+                                       // etc.)
+        void VERIFY_lpTestTree() const;
 
-        bool     lpIsReversed(); // true if the iterator node is the second operand in the loop condition
-        GenTree* lpIterator();   // the iterator node in the loop test
-        GenTree* lpLimit();      // the limit node in the loop test
+        bool     lpIsReversed() const; // true if the iterator node is the second operand in the loop condition
+        GenTree* lpIterator() const;   // the iterator node in the loop test
+        GenTree* lpLimit() const;      // the limit node in the loop test
 
-        int lpConstLimit();    // limit   constant value of iterator - loop condition is "i RELOP const" : Valid if
-                               // LPFLG_CONST_LIMIT
-        unsigned lpVarLimit(); // the lclVar # in the loop condition ( "i RELOP lclVar" )                : Valid if
-                               // LPFLG_VAR_LIMIT
-        bool lpArrLenLimit(Compiler* comp, ArrIndex* index); // The array length in the loop condition ( "i RELOP
-                                                             // arr.len" or "i RELOP arr[i][j].len" )  : Valid if
-                                                             // LPFLG_ARRLEN_LIMIT
+        // Limit constant value of iterator - loop condition is "i RELOP const"
+        // : Valid if LPFLG_CONST_LIMIT
+        int lpConstLimit() const;
+
+        // The lclVar # in the loop condition ( "i RELOP lclVar" )
+        // : Valid if LPFLG_VAR_LIMIT
+        unsigned lpVarLimit() const;
+
+        // The array length in the loop condition ( "i RELOP arr.len" or "i RELOP arr[i][j].len" )
+        // : Valid if LPFLG_ARRLEN_LIMIT
+        bool lpArrLenLimit(Compiler* comp, ArrIndex* index) const;
 
         // Returns "true" iff "*this" contains the blk.
-        bool lpContains(BasicBlock* blk)
+        bool lpContains(BasicBlock* blk) const
         {
             return lpFirst->bbNum <= blk->bbNum && blk->bbNum <= lpBottom->bbNum;
         }
         // Returns "true" iff "*this" (properly) contains the range [first, bottom] (allowing firsts
         // to be equal, but requiring bottoms to be different.)
-        bool lpContains(BasicBlock* first, BasicBlock* bottom)
+        bool lpContains(BasicBlock* first, BasicBlock* bottom) const
         {
             return lpFirst->bbNum <= first->bbNum && bottom->bbNum < lpBottom->bbNum;
         }
 
         // Returns "true" iff "*this" (properly) contains "lp2" (allowing firsts to be equal, but requiring
         // bottoms to be different.)
-        bool lpContains(const LoopDsc& lp2)
+        bool lpContains(const LoopDsc& lp2) const
         {
             return lpContains(lp2.lpFirst, lp2.lpBottom);
         }
 
         // Returns "true" iff "*this" is (properly) contained by the range [first, bottom]
         // (allowing firsts to be equal, but requiring bottoms to be different.)
-        bool lpContainedBy(BasicBlock* first, BasicBlock* bottom)
+        bool lpContainedBy(BasicBlock* first, BasicBlock* bottom) const
         {
             return first->bbNum <= lpFirst->bbNum && lpBottom->bbNum < bottom->bbNum;
         }
 
         // Returns "true" iff "*this" is (properly) contained by "lp2"
         // (allowing firsts to be equal, but requiring bottoms to be different.)
-        bool lpContainedBy(const LoopDsc& lp2)
+        bool lpContainedBy(const LoopDsc& lp2) const
         {
             return lpContains(lp2.lpFirst, lp2.lpBottom);
         }
 
         // Returns "true" iff "*this" is disjoint from the range [top, bottom].
-        bool lpDisjoint(BasicBlock* first, BasicBlock* bottom)
+        bool lpDisjoint(BasicBlock* first, BasicBlock* bottom) const
         {
             return bottom->bbNum < lpFirst->bbNum || lpBottom->bbNum < first->bbNum;
         }
         // Returns "true" iff "*this" is disjoint from "lp2".
-        bool lpDisjoint(const LoopDsc& lp2)
+        bool lpDisjoint(const LoopDsc& lp2) const
         {
             return lpDisjoint(lp2.lpFirst, lp2.lpBottom);
         }
         // Returns "true" iff the loop is well-formed (see code for defn).
-        bool lpWellFormed()
+        bool lpWellFormed() const
         {
             return lpFirst->bbNum <= lpTop->bbNum && lpTop->bbNum <= lpEntry->bbNum &&
                    lpEntry->bbNum <= lpBottom->bbNum &&
@@ -6426,9 +6431,9 @@ protected:
                           BasicBlock*   lpBottom,
                           unsigned char lpExitCnt,
                           BasicBlock*   lpExit,
-                          unsigned      parentLoop = BasicBlock::NOT_IN_LOOP);
-    void optPrintLoopInfo(unsigned lnum);
-    void optPrintLoopRecording(unsigned lnum);
+                          unsigned      parentLoop = BasicBlock::NOT_IN_LOOP) const;
+    void optPrintLoopInfo(unsigned lnum) const;
+    void optPrintLoopRecording(unsigned lnum) const;
 
     void optCheckPreds();
 #endif
@@ -6492,7 +6497,7 @@ protected:
     void optCopyBlkDest(BasicBlock* from, BasicBlock* to);
 
     // Returns true if 'block' is an entry block for any loop in 'optLoopTable'
-    bool optIsLoopEntry(BasicBlock* block);
+    bool optIsLoopEntry(BasicBlock* block) const;
 
     // The depth of the loop described by "lnum" (an index into the loop table.) (0 == top level)
     unsigned optLoopDepth(unsigned lnum)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6193,20 +6193,10 @@ public:
     PhaseStatus optOptimizeLayout(); // Optimize the BasicBlock layout of the method
     PhaseStatus optFindLoops();      // Finds loops and records them in the loop table
 
-    // Optionally clone loops in the loop table.
     void optCloneLoops();
-
-    // Clone loop "loopInd" in the loop table.
     void optCloneLoop(unsigned loopInd, LoopCloneContext* context);
-
-    // Ensure that loop "loopInd" has a unique head block.  (If the existing entry has
-    // non-loop predecessors other than the head entry, create a new, empty block that goes (only) to the entry,
-    // and redirects the preds of the entry to this new block.)  Sets the weight of the newly created block to
-    // "ambientWeight".
     void optEnsureUniqueHead(unsigned loopInd, BasicBlock::weight_t ambientWeight);
-
     void optUnrollLoops(); // Unrolls loops (needs to have cost info)
-
     void optRemoveRedundantZeroInits();
 
 protected:
@@ -6476,8 +6466,6 @@ protected:
     // iff "l2" is not NOT_IN_LOOP, and "l1" contains "l2".
     bool optLoopContains(unsigned l1, unsigned l2);
 
-    // Requires "loopInd" to be a valid index into the loop table.
-
     // Updates the loop table by changing loop "loopInd", whose head is required
     // to be "from", to be "to".  Also performs this transformation for any
     // loop nested in "loopInd" that shares the same head as "loopInd".
@@ -6489,10 +6477,13 @@ protected:
 
     // Marks the containsCall information to "lnum" and any parent loops.
     void AddContainsCallAllContainingLoops(unsigned lnum);
+
     // Adds the variable liveness information from 'blk' to "lnum" and any parent loops.
     void AddVariableLivenessAllContainingLoops(unsigned lnum, BasicBlock* blk);
+
     // Adds "fldHnd" to the set of modified fields of "lnum" and any parent loops.
     void AddModifiedFieldAllContainingLoops(unsigned lnum, CORINFO_FIELD_HANDLE fldHnd);
+
     // Adds "elemType" to the set of modified array element types of "lnum" and any parent loops.
     void AddModifiedElemTypeAllContainingLoops(unsigned lnum, CORINFO_CLASS_HANDLE elemType);
 
@@ -7397,7 +7388,7 @@ public:
     void optObtainLoopCloningOpts(LoopCloneContext* context);
     bool optIsLoopClonable(unsigned loopInd);
 
-    bool optCanCloneLoops();
+    bool optLoopCloningEnabled();
 
 #ifdef DEBUG
     void optDebugLogLoopCloning(BasicBlock* block, Statement* insertBefore);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3388,7 +3388,7 @@ inline void Compiler::LoopDsc::AddModifiedElemType(Compiler* comp, CORINFO_CLASS
     lpArrayElemTypesModified->Set(structHnd, true, ClassHandleSet::Overwrite);
 }
 
-inline void Compiler::LoopDsc::VERIFY_lpIterTree()
+inline void Compiler::LoopDsc::VERIFY_lpIterTree() const
 {
 #ifdef DEBUG
     assert(lpFlags & LPFLG_ITER);
@@ -3397,8 +3397,8 @@ inline void Compiler::LoopDsc::VERIFY_lpIterTree()
 
     assert(lpIterTree->OperIs(GT_ASG));
 
-    GenTree* lhs = lpIterTree->AsOp()->gtOp1;
-    GenTree* rhs = lpIterTree->AsOp()->gtOp2;
+    const GenTree* lhs = lpIterTree->AsOp()->gtOp1;
+    const GenTree* rhs = lpIterTree->AsOp()->gtOp2;
     assert(lhs->OperGet() == GT_LCL_VAR);
 
     switch (rhs->gtOper)
@@ -3420,7 +3420,7 @@ inline void Compiler::LoopDsc::VERIFY_lpIterTree()
 
 //-----------------------------------------------------------------------------
 
-inline unsigned Compiler::LoopDsc::lpIterVar()
+inline unsigned Compiler::LoopDsc::lpIterVar() const
 {
     VERIFY_lpIterTree();
     return lpIterTree->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum();
@@ -3428,7 +3428,7 @@ inline unsigned Compiler::LoopDsc::lpIterVar()
 
 //-----------------------------------------------------------------------------
 
-inline int Compiler::LoopDsc::lpIterConst()
+inline int Compiler::LoopDsc::lpIterConst() const
 {
     VERIFY_lpIterTree();
     GenTree* rhs = lpIterTree->AsOp()->gtOp2;
@@ -3437,14 +3437,14 @@ inline int Compiler::LoopDsc::lpIterConst()
 
 //-----------------------------------------------------------------------------
 
-inline genTreeOps Compiler::LoopDsc::lpIterOper()
+inline genTreeOps Compiler::LoopDsc::lpIterOper() const
 {
     VERIFY_lpIterTree();
     GenTree* rhs = lpIterTree->AsOp()->gtOp2;
     return rhs->OperGet();
 }
 
-inline var_types Compiler::LoopDsc::lpIterOperType()
+inline var_types Compiler::LoopDsc::lpIterOperType() const
 {
     VERIFY_lpIterTree();
 
@@ -3459,7 +3459,7 @@ inline var_types Compiler::LoopDsc::lpIterOperType()
     return type;
 }
 
-inline void Compiler::LoopDsc::VERIFY_lpTestTree()
+inline void Compiler::LoopDsc::VERIFY_lpTestTree() const
 {
 #ifdef DEBUG
     assert(lpFlags & LPFLG_ITER);
@@ -3505,7 +3505,7 @@ inline void Compiler::LoopDsc::VERIFY_lpTestTree()
 
 //-----------------------------------------------------------------------------
 
-inline bool Compiler::LoopDsc::lpIsReversed()
+inline bool Compiler::LoopDsc::lpIsReversed() const
 {
     VERIFY_lpTestTree();
     return ((lpTestTree->AsOp()->gtOp2->gtOper == GT_LCL_VAR) &&
@@ -3514,7 +3514,7 @@ inline bool Compiler::LoopDsc::lpIsReversed()
 
 //-----------------------------------------------------------------------------
 
-inline genTreeOps Compiler::LoopDsc::lpTestOper()
+inline genTreeOps Compiler::LoopDsc::lpTestOper() const
 {
     VERIFY_lpTestTree();
     genTreeOps op = lpTestTree->OperGet();
@@ -3523,7 +3523,7 @@ inline genTreeOps Compiler::LoopDsc::lpTestOper()
 
 //-----------------------------------------------------------------------------
 
-inline GenTree* Compiler::LoopDsc::lpIterator()
+inline GenTree* Compiler::LoopDsc::lpIterator() const
 {
     VERIFY_lpTestTree();
 
@@ -3532,7 +3532,7 @@ inline GenTree* Compiler::LoopDsc::lpIterator()
 
 //-----------------------------------------------------------------------------
 
-inline GenTree* Compiler::LoopDsc::lpLimit()
+inline GenTree* Compiler::LoopDsc::lpLimit() const
 {
     VERIFY_lpTestTree();
 
@@ -3541,7 +3541,7 @@ inline GenTree* Compiler::LoopDsc::lpLimit()
 
 //-----------------------------------------------------------------------------
 
-inline int Compiler::LoopDsc::lpConstLimit()
+inline int Compiler::LoopDsc::lpConstLimit() const
 {
     VERIFY_lpTestTree();
     assert(lpFlags & LPFLG_CONST_LIMIT);
@@ -3553,7 +3553,7 @@ inline int Compiler::LoopDsc::lpConstLimit()
 
 //-----------------------------------------------------------------------------
 
-inline unsigned Compiler::LoopDsc::lpVarLimit()
+inline unsigned Compiler::LoopDsc::lpVarLimit() const
 {
     VERIFY_lpTestTree();
     assert(lpFlags & LPFLG_VAR_LIMIT);
@@ -3565,7 +3565,7 @@ inline unsigned Compiler::LoopDsc::lpVarLimit()
 
 //-----------------------------------------------------------------------------
 
-inline bool Compiler::LoopDsc::lpArrLenLimit(Compiler* comp, ArrIndex* index)
+inline bool Compiler::LoopDsc::lpArrLenLimit(Compiler* comp, ArrIndex* index) const
 {
     VERIFY_lpTestTree();
     assert(lpFlags & LPFLG_ARRLEN_LIMIT);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4219,12 +4219,12 @@ BasicBlock* Compiler::fgConnectFallThrough(BasicBlock* bSrc, BasicBlock* bDst)
                         flowList* newEdge = fgGetPredForBlock(jmpBlk, bSrc);
 
                         jmpBlk->bbWeight = (newEdge->edgeWeightMin() + newEdge->edgeWeightMax()) / 2;
-                        if (bSrc->bbWeight == 0)
+                        if (bSrc->bbWeight == BB_ZERO_WEIGHT)
                         {
-                            jmpBlk->bbWeight = 0;
+                            jmpBlk->bbWeight = BB_ZERO_WEIGHT;
                         }
 
-                        if (jmpBlk->bbWeight == 0)
+                        if (jmpBlk->bbWeight == BB_ZERO_WEIGHT)
                         {
                             jmpBlk->bbFlags |= BBF_RUN_RARELY;
                         }

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -764,7 +764,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase)
     {
         if (createDotFile)
         {
-            fprintf(fgxFile, "    BB%02u [label = \"BB%02u\\n\\n", block->bbNum, block->bbNum);
+            fprintf(fgxFile, "    " FMT_BB " [label = \"" FMT_BB "\\n\\n", block->bbNum, block->bbNum);
 
             // "Raw" Profile weight
             if (block->hasProfileWeight())

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -817,7 +817,7 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
 
         if (condTree->OperGet() == GT_CNS_INT)
         {
-            JITDUMP(" ... found foldable jtrue at [%06u] in BB%02u\n", dspTreeID(tree), block->bbNum);
+            JITDUMP(" ... found foldable jtrue at [%06u] in " FMT_BB "\n", dspTreeID(tree), block->bbNum);
             noway_assert((block->bbNext->countOfInEdges() > 0) && (block->bbJumpDest->countOfInEdges() > 0));
 
             // We have a constant operand, and should have the all clear to optimize.
@@ -849,7 +849,7 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
             // other transitively unreachable blocks.
             if (bNotTaken->bbRefs == 0)
             {
-                JITDUMP("... it looks like BB%02u is now unreachable!\n", bNotTaken->bbNum);
+                JITDUMP("... it looks like " FMT_BB " is now unreachable!\n", bNotTaken->bbNum);
             }
         }
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1732,7 +1732,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             block->bbWeight = bNext->bbWeight;
 
             block->bbFlags |= (bNext->bbFlags & BBF_PROF_WEIGHT); // Set the profile weight flag (if necessary)
-            assert(block->bbWeight != 0);
+            assert(block->bbWeight != BB_ZERO_WEIGHT);
             block->bbFlags &= ~BBF_RUN_RARELY; // Clear any RarelyRun flag
         }
     }
@@ -1914,7 +1914,8 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         // In this case, there's no need to update the preorder and postorder numbering
         // since we're changing the bbNum, this makes the basic block all set.
         //
-        JITDUMP("Renumbering BB%02u to be BB%02u to preserve dominator information\n", block->bbNum, bNext->bbNum);
+        JITDUMP("Renumbering " FMT_BB " to be " FMT_BB " to preserve dominator information\n", block->bbNum,
+                bNext->bbNum);
 
         block->bbNum = bNext->bbNum;
 
@@ -3789,7 +3790,7 @@ bool Compiler::fgReorderBlocks()
                     // if the weight of bDest is greater or equal to the weight of block
                     // also the weight of bDest can't be zero.
                     //
-                    if ((bDest->bbWeight < block->bbWeight) || (bDest->bbWeight == 0))
+                    if ((bDest->bbWeight < block->bbWeight) || (bDest->bbWeight == BB_ZERO_WEIGHT))
                     {
                         reorderBlock = false;
                     }
@@ -4022,7 +4023,7 @@ bool Compiler::fgReorderBlocks()
                         }
                     }
 
-                    if ((bTmp->bbFallsThrough() == false) || (bTmp->bbWeight == 0))
+                    if ((bTmp->bbFallsThrough() == false) || (bTmp->bbWeight == BB_ZERO_WEIGHT))
                     {
                         lastNonFallThroughBlock = bTmp;
                     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1087,15 +1087,15 @@ public:
         return TypeIs(type) || TypeIs(rest...);
     }
 
-    static bool OperIs(genTreeOps operCompare, genTreeOps oper)
+    static bool StaticOperIs(genTreeOps operCompare, genTreeOps oper)
     {
         return operCompare == oper;
     }
 
     template <typename... T>
-    static bool OperIs(genTreeOps operCompare, genTreeOps oper, T... rest)
+    static bool StaticOperIs(genTreeOps operCompare, genTreeOps oper, T... rest)
     {
-        return OperIs(operCompare, oper) || OperIs(operCompare, rest...);
+        return StaticOperIs(operCompare, oper) || StaticOperIs(operCompare, rest...);
     }
 
     bool OperIs(genTreeOps oper) const

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1087,6 +1087,17 @@ public:
         return TypeIs(type) || TypeIs(rest...);
     }
 
+    static bool OperIs(genTreeOps operCompare, genTreeOps oper)
+    {
+        return operCompare == oper;
+    }
+
+    template <typename... T>
+    static bool OperIs(genTreeOps operCompare, genTreeOps oper, T... rest)
+    {
+        return OperIs(operCompare, oper) || OperIs(operCompare, rest...);
+    }
+
     bool OperIs(genTreeOps oper) const
     {
         return OperGet() == oper;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10574,7 +10574,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
         //  d) as internal
         //  e) as rarely run
         dupBlock->bbRefs   = 0;
-        dupBlock->bbWeight = 0;
+        dupBlock->bbWeight = BB_ZERO_WEIGHT;
         dupBlock->bbFlags |= BBF_IMPORTED | BBF_INTERNAL | BBF_RUN_RARELY;
 
         // Insert the block right after the block which is getting reset so that BBJ_CALLFINALLY and BBJ_ALWAYS

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -701,7 +701,7 @@ private:
             call->gtCallThisArg = compiler->gtNewCallArgs(compiler->gtNewLclvNode(thisTemp, TYP_REF));
             call->SetIsGuarded();
 
-            JITDUMP("Direct call [%06u] in block BB%02u\n", compiler->dspTreeID(call), thenBlock->bbNum);
+            JITDUMP("Direct call [%06u] in block " FMT_BB "\n", compiler->dspTreeID(call), thenBlock->bbNum);
 
             // Then invoke impDevirtualizeCall to actually
             // transform the call for us. It should succeed.... as we have
@@ -766,7 +766,7 @@ private:
             call->gtFlags &= ~GTF_CALL_INLINE_CANDIDATE;
             call->SetIsGuarded();
 
-            JITDUMP("Residual call [%06u] moved to block BB%02u\n", compiler->dspTreeID(call), elseBlock->bbNum);
+            JITDUMP("Residual call [%06u] moved to block " FMT_BB "\n", compiler->dspTreeID(call), elseBlock->bbNum);
 
             if (returnTemp != BAD_VAR_NUM)
             {

--- a/src/coreclr/jit/jitexpandarray.h
+++ b/src/coreclr/jit/jitexpandarray.h
@@ -292,7 +292,7 @@ public:
     // Assumptions:
     //    The stack must not be empty.
     //
-    T Top()
+    T Top() const
     {
         assert(Size() > 0);
         return this->m_members[m_used - 1];
@@ -328,7 +328,7 @@ public:
     // Assumptions:
     //    The element index does not exceed the current stack depth.
     //
-    T GetNoExpand(unsigned idx)
+    T GetNoExpand(unsigned idx) const
     {
         assert(idx < m_used);
         return this->m_members[idx];
@@ -364,7 +364,7 @@ public:
     // Return Value:
     //    The stack depth.
     //
-    unsigned Size()
+    unsigned Size() const
     {
         return m_used;
     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3268,9 +3268,9 @@ BasicBlock::weight_t BasicBlock::getCalledCount(Compiler* comp)
 // getBBWeight -- get the normalized weight of this block
 BasicBlock::weight_t BasicBlock::getBBWeight(Compiler* comp)
 {
-    if (this->bbWeight == 0)
+    if (this->bbWeight == BB_ZERO_WEIGHT)
     {
-        return 0;
+        return BB_ZERO_WEIGHT;
     }
     else
     {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -241,7 +241,7 @@ JitExpandArrayStack<LcOptInfo*>* LoopCloneContext::GetLoopOptInfo(unsigned loopN
 //
 void LoopCloneContext::CancelLoopOptInfo(unsigned loopNum)
 {
-    JITDUMP("Cancelling loop cloning for loop L%02u\n", loopNum);
+    JITDUMP("Cancelling loop cloning for loop " FMT_LP "\n", loopNum);
     optInfo[loopNum] = nullptr;
     if (conditions[loopNum] != nullptr)
     {
@@ -454,7 +454,7 @@ void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool
 
     JitExpandArrayStack<LC_Condition>& conds = *conditions[loopNum];
 
-    JITDUMP("Evaluating %d loop cloning conditions for loop L%02u\n", conds.Size(), loopNum);
+    JITDUMP("Evaluating %d loop cloning conditions for loop " FMT_LP "\n", conds.Size(), loopNum);
 
     assert(conds.Size() > 0);
     for (unsigned i = 0; i < conds.Size(); ++i)

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -139,11 +139,12 @@ GenTree* LC_Condition::ToGenTree(Compiler* comp, BasicBlock* bb)
 // Evaluates - Evaluate a given loop cloning condition if it can be statically evaluated.
 //
 // Arguments:
-//      pResult     The evaluation result
+//      pResult     OUT parameter. The evaluation result
 //
 // Return Values:
 //      Returns true if the condition can be statically evaluated. If the condition's result
-//      is statically unknown then return false. In other words, true if "pResult" is valid.
+//      is statically unknown then return false. In other words, `*pResult` is valid only if the
+//      function returns true.
 //
 bool LC_Condition::Evaluates(bool* pResult)
 {
@@ -240,7 +241,7 @@ JitExpandArrayStack<LcOptInfo*>* LoopCloneContext::GetLoopOptInfo(unsigned loopN
 //
 void LoopCloneContext::CancelLoopOptInfo(unsigned loopNum)
 {
-    JITDUMP("Cancelling loop cloning for loop L_%02u\n", loopNum);
+    JITDUMP("Cancelling loop cloning for loop L%02u\n", loopNum);
     optInfo[loopNum] = nullptr;
     if (conditions[loopNum] != nullptr)
     {
@@ -392,36 +393,40 @@ JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* LoopCloneContext::Ensur
 #ifdef DEBUG
 void LoopCloneContext::PrintBlockConditions(unsigned loopNum)
 {
+    printf("Block conditions:\n");
+
     JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* levelCond = blockConditions[loopNum];
     if (levelCond == nullptr || levelCond->Size() == 0)
     {
-        JITDUMP("No block conditions\n");
+        printf("No block conditions\n");
         return;
     }
 
     for (unsigned i = 0; i < levelCond->Size(); ++i)
     {
-        JITDUMP("%d = {", i);
+        printf("%d = {", i);
         for (unsigned j = 0; j < ((*levelCond)[i])->Size(); ++j)
         {
             if (j != 0)
             {
-                JITDUMP(" & ");
+                printf(" & ");
             }
             (*((*levelCond)[i]))[j].Print();
         }
-        JITDUMP("}\n");
+        printf("}\n");
     }
 }
 #endif
 
 //--------------------------------------------------------------------------------------------------
-// EvaluateConditions - Evaluate the loop cloning conditions statically, if it can be evaluated.
+// EvaluateConditions - Evaluate the loop cloning conditions statically, if they can be evaluated.
 //
 // Arguments:
 //      loopNum     the loop index.
-//      pAllTrue    all the cloning conditions evaluated to "true" statically.
-//      pAnyFalse   some cloning condition evaluated to "false" statically.
+//      pAllTrue    OUT parameter. `*pAllTrue` is set to `true` if all the cloning conditions statically
+//                  evaluate to true.
+//      pAnyFalse   OUT parameter. `*pAnyFalse` is set to `true` if some cloning condition statically
+//                  evaluate to false.
 //      verbose     verbose logging required.
 //
 // Return Values:
@@ -436,8 +441,12 @@ void LoopCloneContext::PrintBlockConditions(unsigned loopNum)
 //      all be "AND"ed, so statically we know we will never take the fast path.
 //
 //      Sometimes we simply can't say statically whether "V02 > V01.length" is true or false.
-//      In that case, the "pAllTrue" will be false because this condition doesn't evaluate to "true" and
-//      "pAnyFalse" could be false if no other condition statically evaluates to "false".
+//      In that case, `*pAllTrue` will be false because this condition doesn't evaluate to "true" and
+//      `*pAnyFalse` could be false if no other condition statically evaluates to "false".
+//
+//      If `*pAnyFalse` is true, we set that and return, and `*pAllTrue` is not accurate, since the loop cloning
+//      needs to be aborted.
+//
 void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool* pAnyFalse DEBUGARG(bool verbose))
 {
     bool allTrue  = true;
@@ -445,7 +454,7 @@ void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool
 
     JitExpandArrayStack<LC_Condition>& conds = *conditions[loopNum];
 
-    JITDUMP("Evaluating %d loop cloning conditions for loop %d\n", conds.Size(), loopNum);
+    JITDUMP("Evaluating %d loop cloning conditions for loop L%02u\n", conds.Size(), loopNum);
 
     assert(conds.Size() > 0);
     for (unsigned i = 0; i < conds.Size(); ++i)
@@ -462,11 +471,15 @@ void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool
         // Check if this condition evaluates to true or false.
         if (conds[i].Evaluates(&res))
         {
-            JITDUMP(") evaluates to %d\n", res);
+            JITDUMP(") evaluates to %s\n", dspBool(res));
             if (!res)
             {
                 anyFalse = true;
-                return;
+
+                // Since this will force us to abort loop cloning, there is no need compute an accurate `allTrue`,
+                // so we can break out of the loop now.
+                // REVIEW: it appears we never hit this condition in any test.
+                break;
             }
         }
         else
@@ -476,7 +489,7 @@ void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool
         }
     }
 
-    JITDUMP("Evaluation result allTrue = %d, anyFalse = %d\n", allTrue, anyFalse);
+    JITDUMP("Evaluation result allTrue = %s, anyFalse = %s\n", dspBool(allTrue), dspBool(anyFalse));
     *pAllTrue  = allTrue;
     *pAnyFalse = anyFalse;
 }
@@ -643,6 +656,7 @@ void LoopCloneContext::PrintConditions(unsigned loopNum)
     if (conditions[loopNum]->Size() == 0)
     {
         JITDUMP("Conditions were optimized away! Will always take cloned path.");
+        return;
     }
     for (unsigned i = 0; i < conditions[loopNum]->Size(); ++i)
     {

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -4,34 +4,108 @@
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XX                                                                           XX
-XX                            LoopCloning                                    XX
+XX                            Loop Cloning                                   XX
 XX                                                                           XX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-    Loop cloning optimizations comprise of the following steps:
-        - Loop detection logic which is existing logic in the JIT that records
-        loop information with loop flags.
-        - The next step is to identify loop optimization candidates. This is done
-        by optObtainLoopCloningOpts. The loop context variable is updated with
-        all the necessary information (for ex: block, stmt, tree information)
-        to do the optimization later.
+    Loop cloning is an optimization which duplicates a loop to create two versions.
+    One copy is optimized by hoisting out various dynamic checks, such as array bounds
+    checks that can't be statically eliminated. The checks are dynamically run. If
+    they fail, the original copy of the loop is executed. If they pass, the
+    optimized copy of the loop is executed, knowing that the bounds checks are
+    dynamically unnecessary.
+
+    The optimization can reduce the amount of code executed within a loop body.
+
+    For example:
+
+        public static int f(int[] a, int l)
+        {
+            int sum = 0;
+            for (int i = 0; i < l; i++)
+            {
+                sum += a[i];     // This array bounds check must be executed in the loop
+            }
+        }
+
+    This can be transformed to (in pseudo-code):
+
+        public static int f(int[] a, int l)
+        {
+            int sum = 0;
+            if (a != null && l <= a.Length)
+            {
+                for (int i = 0; i < l; i++)
+                {
+                    sum += a[i]; // no bounds check needed
+                }
+            }
+            else
+            {
+                for (int i = 0; i < l; i++)
+                {
+                    // bounds check needed. We need to do the normal computation (esp., side effects) before the
+exception occurs.
+                    sum += a[i];
+                }
+            }
+        }
+
+    One generalization of this is "loop unswitching".
+
+    Because code is duplicated, this is a code size expanding optimization, and
+    therefore we need to be careful to avoid duplicating too much code unnecessarily.
+
+    Also, there is a risk that we can duplicate the loops and later, downstream
+    phases optimize away the bounds checks even on the un-optimized copy of the loop.
+
+    Loop cloning is implemented with the following steps:
+
+    1. Loop detection logic, which is existing logic in the JIT that records
+       loop information with loop flags.
+
+    2. Identify loop optimization candidates. This is done by optObtainLoopCloningOpts.
+       The loop context variable is updated with all the necessary information (for example:
+       block, stmt, tree information) to do the optimization later.
             a) This involves checking if the loop is well-formed with respect to
             the optimization being performed.
             b) In array bounds check case, reconstructing the morphed GT_INDEX
             nodes back to their array representation.
                 i) The array index is stored in the "context" variable with
                 additional block, tree, stmt info.
-        - Once the optimization candidates are identified, we derive cloning conditions
-          For ex: to clone a simple "for (i=0; i<n; ++i) { a[i] }" loop, we need the
-          following conditions:
+
+    3. Once the optimization candidates are identified, we derive cloning conditions.
+       For example: to clone a simple "for (i=0; i<n; ++i) { a[i] }" loop, we need the
+       following conditions:
+              (a != null) && (n >= 0) && (n <= a.length) && (stride > 0)
+       Note that "&&" implies a short-circuiting operator. This requires each condition
+       to be in its own block with its own comparison and branch instruction. This can
+       be optimized if there are no dependent conditions in a block by using a bitwise
+       AND instead of a short-circuit AND. The (a != null) condition needs to occur before
+       "a.length" is checked. But otherwise, the last three conditions can be computed in
+       the same block, as:
               (a != null) && ((n >= 0) & (n <= a.length) & (stride > 0))
-              a) Note the short circuit AND for (a != null). These are called block
-              conditions or deref-conditions since these conditions need to be in their
-              own blocks to be able to short-circuit.
-                 i) For a doubly nested loop on i, j, we would then have
-                 conditions like
-                 (a != null) && (i < a.len) && (a[i] != null) && (j < a[i].len)
+       Since we're optimizing for the expected fast path case, where all the conditions
+       are true, we expect all the conditions to be executed most of the time. Thus, it
+       is advantageous to make as many as possible non-short-circuiting to reduce the
+       number of compare/branch/blocks needed.
+
+       In the above case, stride == 1, so we statically know stride > 0.
+
+       If we had "for (i=0; i<=n; ++i) { a[i] }", we would need:
+              (a != null) && (n >= 0) && (a.length >= 1) && (n <= a.length - 1) && (stride > 0)
+       This is more complicated. The loop is equivalent (except for possible overflow) to:
+              for (i=0; i<n+1; ++i) { a[i] }"
+       (`n+1` due to the `++i` stride). We'd have to worry about overflow doing this conversion, though.
+
+       REVIEW: why do we need the (n >= 0) condition? We do need to know
+       "array index var initialization value >= array lower bound (0)".
+
+              a) Conditions that need to be in their own blocks to enable short-circuit are called block
+              conditions or deref-conditions.
+                 i) For a doubly nested loop on i, j, we would then have conditions like
+                     (a != null) && (i < a.len) && (a[i] != null) && (j < a[i].len)
                  all short-circuiting creating blocks.
 
                  Advantage:
@@ -43,6 +117,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
                  Heuristic:
                     Therefore we will not clone if we exceed creating 4 blocks.
+                    Note: this means we never clone more than 2-dimension a[i][j] expressions
+                    (see optComputeDerefConditions()).
+                    REVIEW: make this heuristic defined by a COMPlus variable, for easier
+                    experimentation, and make it more dynamic and based on potential benefit?
 
               b) The other conditions called cloning conditions are transformed into LC_Condition
               structs which are then optimized.
@@ -50,38 +128,67 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                  ii) If some conditions evaluate to true statically, then they are removed.
                  iii) If any condition evaluates to false statically, then loop cloning is
                  aborted for that loop.
-        - Then the block splitting occurs and loop cloning conditions is transformed into
-        GenTree and added to the loop cloning choice block.
+
+    4. Then the block splitting occurs and loop cloning conditions are transformed into
+       GenTree and added to the loop cloning choice block (the block that determines which
+       copy of the loop is executed).
 
     Preconditions
-        - Loop detection should have completed and the loop table should be
-        populated with the loop dscs.
-        - The loops that will be considered are the ones with the LPFLG_ITER
-        marked on them.
+
+    1. Loop detection has completed and the loop table is populated.
+
+    2. The loops that will be considered are the ones with the LPFLG_ITER flag:
+       "for (i = icon or lclVar; test_condition(); i++)"
 
     Limitations
-        - For array based optimizations the loop choice condition is checked
-        before the loop body. This implies that the loop initializer statement
-        has not executed at the time of the check. So any loop cloning condition
-        involving the initial value of the loop counter cannot be condition checked
-        as it hasn't been assigned yet at the time of condition checking. Therefore
-        the initial value has to be statically known. This can be fixed with further
-        effort.
 
-    Assumption
-        - The assumption is that the optimization candidates collected during the
-        identification phase will be the ones that will be optimized. In other words,
-        the loop that is present originally will be the fast path. Explicitly, the cloned
-        path will be the slow path and will be unoptimized. This allows us to
-        collect additional information at the same time of identifying the optimization
-        candidates. This later helps us to perform the optimizations during actual cloning.
-        - All loop cloning choice conditions will automatically be "AND"-ed. These are
-        bitwise AND operations.
-        - Perform short circuit AND for (array != null) side effect check
-        before hoisting (limit <= a.length) check.
-          For ex: to clone a simple "for (i=0; i<n; ++i) { a[i] }" loop, we need the
-          following conditions:
-              (a != null) && ((n >= 0) & (n <= a.length) & (stride > 0))
+    1. For array based optimizations the loop choice condition is checked
+       before the loop body. This implies that the loop initializer statement
+       has not executed at the time of the check. So any loop cloning condition
+       involving the initial value of the loop counter cannot be condition checked
+       as it hasn't been assigned yet at the time of condition checking. Therefore
+       the initial value has to be statically known. This can be fixed with further
+       effort.
+
+    2. Loops containing nested exception handling regions are not cloned. (Cloning them
+       would require creating new exception handling regions for the cloned loop, which
+       is "hard".) There are a few other EH-related edge conditions that also cause us to
+       reject cloning.
+
+    3. If the loop contains RETURN blocks, and cloning those would push us over the maximum
+       number of allowed RETURN blocks in the function (either due to GC info encoding limitations
+       or otherwise), we reject cloning.
+
+    4. Loop increment must be `i += 1`
+
+    5. Loop test must be `i < x` where `x` is a constant, a variable, or `a.Length` for array `a`
+
+    (There is some implementation support for decrementing loops, but it is incomplete.
+    There is some implementation support for `i <= x` conditions, but it is incomplete
+    (Compiler::optDeriveLoopCloningConditions() only handles GT_LT conditions))
+
+    6. Loop must have been converted to a do-while form.
+
+    7. There are a few other loop well-formedness conditions.
+
+    8. Multi-dimensional (non-jagged) loop index checking is only partially implemented.
+
+    9. Constant initializations and constant limits must be non-negative (REVIEW: why? The
+       implementation does use `unsigned` to represent them.)
+
+    Assumptions
+
+    1. The assumption is that the optimization candidates collected during the
+       identification phase will be the ones that will be optimized. In other words,
+       the loop that is present originally will be the fast path. The cloned
+       path will be the slow path and will be unoptimized. This allows us to
+       collect additional information at the same time as identifying the optimization
+       candidates. This later helps us to perform the optimizations during actual cloning.
+
+    2. All loop cloning choice conditions will automatically be "AND"-ed. These are bitwise AND operations.
+
+    3. Perform short circuit AND for (array != null) side effect check
+      before hoisting (limit <= a.length) check.
 
 */
 #pragma once
@@ -91,7 +198,7 @@ class Compiler;
 /**
  *
  *  Represents an array access and associated bounds checks.
- *  Array access is required have the array and indices in local variables.
+ *  Array access is required to have the array and indices in local variables.
  *  This struct is constructed using a GT_INDEX node that is broken into
  *  its sub trees.
  *
@@ -130,8 +237,10 @@ struct ArrIndex
  *  other classes are supposed to derive from this base class.
  *
  *  Example usage:
+ *
  *  LcMdArrayOptInfo is multi-dimensional array optimization for which the
  *  loop can be cloned.
+ *
  *  LcArrIndexOptInfo is a jagged array optimization for which the loop
  *  can be cloned.
  *
@@ -143,7 +252,6 @@ struct LcOptInfo
 {
     enum OptType
     {
-#undef LC_OPT
 #define LC_OPT(en) en,
 #include "loopcloningopts.h"
     };
@@ -158,7 +266,6 @@ struct LcOptInfo
     {
         return optType;
     }
-#undef LC_OPT
 #define LC_OPT(en)                                                                                                     \
     en##OptInfo* As##en##OptInfo()                                                                                     \
     {                                                                                                                  \
@@ -175,7 +282,7 @@ struct LcOptInfo
 struct LcMdArrayOptInfo : public LcOptInfo
 {
     GenTreeArrElem* arrElem; // "arrElem" node of an MD array.
-    unsigned        dim;     // "dim" represents upto what level of the rank this optimization applies to.
+    unsigned        dim;     // "dim" represents up to what level of the rank this optimization applies to.
                              //    For example, a[i,j,k] could be the MD array "arrElem" but if "dim" is 2,
                              //    then this node is treated as though it were a[i,j]
     ArrIndex* index;         // "index" cached computation in the form of an ArrIndex representation.
@@ -207,7 +314,7 @@ struct LcMdArrayOptInfo : public LcOptInfo
  */
 struct LcJaggedArrayOptInfo : public LcOptInfo
 {
-    unsigned dim;        // "dim" represents upto what level of the rank this optimization applies to.
+    unsigned dim;        // "dim" represents up to what level of the rank this optimization applies to.
                          //    For example, a[i][j][k] could be the jagged array but if "dim" is 2,
                          //    then this node is treated as though it were a[i][j]
     ArrIndex   arrIndex; // ArrIndex representation of the array.
@@ -312,8 +419,8 @@ struct LC_Array
 
 /**
  *
- * Symbolic representation of either a constant like 1, 2 or a variable V02, V03 etc. or an "LC_Array" or the null
- * constant.
+ * Symbolic representation of either a constant like 1 or 2, or a variable like V02 or V03, or an "LC_Array",
+ * or the null constant.
  */
 struct LC_Ident
 {
@@ -337,7 +444,7 @@ struct LC_Ident
         {
             case Const:
             case Var:
-                return (type == that.type) && constant == that.constant;
+                return (type == that.type) && (constant == that.constant);
             case ArrLen:
                 return (type == that.type) && (arrLen == that.arrLen);
             case Null:
@@ -366,7 +473,7 @@ struct LC_Ident
                 printf("null");
                 break;
             default:
-                assert(false);
+                printf("INVALID");
                 break;
         }
     }
@@ -425,6 +532,10 @@ struct LC_Expr
         if (type == Ident)
         {
             ident.Print();
+        }
+        else
+        {
+            printf("INVALID");
         }
     }
 #endif
@@ -516,11 +627,12 @@ struct LC_Deref
     static LC_Deref* Find(JitExpandArrayStack<LC_Deref*>* children, unsigned lcl);
 
     void DeriveLevelConditions(JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* len);
+
 #ifdef DEBUG
     void Print(unsigned indent = 0)
     {
         unsigned tab = 4 * indent;
-        printf("%*s%d,%d => {", tab, "", Lcl(), level);
+        printf("%*sV%02d, level %d => {", tab, "", Lcl(), level);
         if (children != nullptr)
         {
             for (unsigned i = 0; i < children->Size(); ++i)
@@ -553,23 +665,25 @@ struct LC_Deref
  *       LC_Condition :  LC_Expr genTreeOps LC_Expr
  *       LC_Expr      :  LC_Ident | LC_Ident + Constant
  *       LC_Ident     :  Constant | Var | LC_Array
- *       LC_Array    :  .
+ *       LC_Array     :  .
  *       genTreeOps   :  GT_GE | GT_LE | GT_GT | GT_LT
  *
  */
 struct LoopCloneContext
 {
-    CompAllocator                     alloc;   // The allocator
-    JitExpandArrayStack<LcOptInfo*>** optInfo; // The array of optimization opportunities found in each loop. (loop x
-                                               // optimization-opportunities)
-    JitExpandArrayStack<LC_Condition>** conditions; // The array of conditions that influence which path to take for
-                                                    // each
-                                                    // loop. (loop x cloning-conditions)
-    JitExpandArrayStack<LC_Array>** derefs;         // The array of dereference conditions found in each loop. (loop x
-                                                    // deref-conditions)
-    JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>** blockConditions; // The array of block levels of
-                                                                               // conditions for
-                                                                               // each loop. (loop x level x conditions)
+    CompAllocator alloc; // The allocator
+
+    // The array of optimization opportunities found in each loop. (loop x optimization-opportunities)
+    JitExpandArrayStack<LcOptInfo*>** optInfo;
+
+    // The array of conditions that influence which path to take for each loop. (loop x cloning-conditions)
+    JitExpandArrayStack<LC_Condition>** conditions;
+
+    // The array of dereference conditions found in each loop. (loop x deref-conditions)
+    JitExpandArrayStack<LC_Array>** derefs;
+
+    // The array of block levels of conditions for each loop. (loop x level x conditions)
+    JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>** blockConditions;
 
     LoopCloneContext(unsigned loopCount, CompAllocator alloc) : alloc(alloc)
     {
@@ -589,16 +703,16 @@ struct LoopCloneContext
     // Evaluate conditions into a JTRUE stmt and put it in the block. Reverse condition if 'reverse' is true.
     void CondToStmtInBlock(Compiler* comp, JitExpandArrayStack<LC_Condition>& conds, BasicBlock* block, bool reverse);
 
-    // Get all the optimization information for loop "loopNum"; This information is held in "optInfo" array.
-    // If NULL this allocates the optInfo[loopNum] array for "loopNum"
+    // Get all the optimization information for loop "loopNum"; this information is held in "optInfo" array.
+    // If NULL this allocates the optInfo[loopNum] array for "loopNum".
     JitExpandArrayStack<LcOptInfo*>* EnsureLoopOptInfo(unsigned loopNum);
 
-    // Get all the optimization information for loop "loopNum"; This information is held in "optInfo" array.
-    // If NULL this does not allocate the optInfo[loopNum] array for "loopNum"
+    // Get all the optimization information for loop "loopNum"; this information is held in "optInfo" array.
+    // If NULL this does not allocate the optInfo[loopNum] array for "loopNum".
     JitExpandArrayStack<LcOptInfo*>* GetLoopOptInfo(unsigned loopNum);
 
     // Cancel all optimizations for loop "loopNum" by clearing out the "conditions" member if non-null
-    // and setting the optInfo to "null.", If "null", then the user of this class is not supposed to
+    // and setting the optInfo to "null". If "null", then the user of this class is not supposed to
     // clone this loop.
     void CancelLoopOptInfo(unsigned loopNum);
 
@@ -618,21 +732,25 @@ struct LoopCloneContext
     JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* EnsureBlockConditions(unsigned loopNum,
                                                                                    unsigned totalBlocks);
 
+#ifdef DEBUG
     // Print the block conditions for the loop.
     void PrintBlockConditions(unsigned loopNum);
+#endif
 
     // Does the loop have block conditions?
     bool HasBlockConditions(unsigned loopNum);
 
     // Evaluate the conditions for "loopNum" and indicate if they are either all true or any of them are false.
-    // "pAllTrue" implies all the conditions are statically known to be true.
-    // "pAnyFalse" implies at least one condition is statically known to be false.
-    // If neither of them are true, then some conditions' evaluations are statically unknown.
     //
-    // If all conditions yield true, then the caller doesn't need to clone the loop, but it can perform
-    // fast path optimizations.
-    // If any condition yields false, then the caller needs to abort cloning the loop (neither clone nor
-    // fast path optimizations.)
+    // `pAllTrue` and `pAnyFalse` are OUT parameters.
+    //
+    // If `*pAllTrue` is `true`, then all the conditions are statically known to be true.
+    // The caller doesn't need to clone the loop, but it can perform fast path optimizations.
+    //
+    // If `*pAnyFalse` is `true`, then at least one condition is statically known to be false.
+    // The caller needs to abort cloning the loop (neither clone nor fast path optimizations.)
+    //
+    // If neither `*pAllTrue` nor `*pAnyFalse` is true, then the evaluation of some conditions are statically unknown.
     //
     // Assumes the conditions involve an AND join operator.
     void EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool* pAnyFalse DEBUGARG(bool verbose));

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -176,6 +176,10 @@ exception occurs.
     9. Constant initializations and constant limits must be non-negative (REVIEW: why? The
        implementation does use `unsigned` to represent them.)
 
+    10. The cloned loop (the slow path) is not added to the loop table, meaning certain
+       downstream optimization passes do not see them. See
+       https://github.com/dotnet/runtime/issues/43713.
+
     Assumptions
 
     1. The assumption is that the optimization candidates collected during the

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7034,7 +7034,7 @@ void LinearScan::insertUpperVectorRestore(GenTree*     tree,
     }
     else
     {
-        JITDUMP("at end of BB%02u:\n", block->bbNum);
+        JITDUMP("at end of " FMT_BB ":\n", block->bbNum);
         if (block->bbJumpKind == BBJ_COND || block->bbJumpKind == BBJ_SWITCH)
         {
             noway_assert(!blockRange.IsEmpty());

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16643,7 +16643,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
 #ifdef DEBUG
                         if (verbose)
                         {
-                            printf("Removing loop L%02u (from " FMT_BB " to " FMT_BB ")\n\n", loopNum,
+                            printf("Removing loop " FMT_LP " (from " FMT_BB " to " FMT_BB ")\n\n", loopNum,
                                    optLoopTable[loopNum].lpFirst->bbNum, optLoopTable[loopNum].lpBottom->bbNum);
                         }
 #endif

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1195,7 +1195,7 @@ public:
 #ifdef DEBUG
         if (m_comp->verbose)
         {
-            printf("StartMerge BB%02u\n", block->bbNum);
+            printf("StartMerge " FMT_BB "\n", block->bbNum);
             printf("  :: cseOut    = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseOut));
         }
 #endif // DEBUG
@@ -1207,7 +1207,7 @@ public:
 #ifdef DEBUG
         if (m_comp->verbose)
         {
-            printf("Merge BB%02u and BB%02u\n", block->bbNum, predBlock->bbNum);
+            printf("Merge " FMT_BB " and " FMT_BB "\n", block->bbNum, predBlock->bbNum);
             printf("  :: cseIn     = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseIn));
             printf("  :: cseOut    = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseOut));
         }
@@ -1283,7 +1283,7 @@ public:
 #ifdef DEBUG
         if (m_comp->verbose)
         {
-            printf("EndMerge BB%02u\n", block->bbNum);
+            printf("EndMerge " FMT_BB "\n", block->bbNum);
             printf("  :: cseIn     = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseIn));
             if (((block->bbFlags & BBF_HAS_CALL) != 0) &&
                 !BitVecOps::IsEmpty(m_comp->cseLivenessTraits, block->bbCseIn))
@@ -1451,7 +1451,7 @@ void Compiler::optValnumCSE_Availablity()
 
                     if (verbose)
                     {
-                        printf("BB%02u ", block->bbNum);
+                        printf(FMT_BB " ", block->bbNum);
                         printTreeID(tree);
 
                         printf(" %s of CSE #%02u [weight=%s]%s\n", isUse ? "Use" : "Def", CSEnum, refCntWtd2str(stmw),

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5256,8 +5256,8 @@ bool Compiler::optIsLoopClonable(unsigned loopInd)
         return false;
     }
 
-    if (!((GenTree::OperIs(loop.lpTestOper(), GT_LT, GT_LE) && (loop.lpIterOper() == GT_ADD)) ||
-          (GenTree::OperIs(loop.lpTestOper(), GT_GT, GT_GE) && (loop.lpIterOper() == GT_SUB))))
+    if (!((GenTree::StaticOperIs(loop.lpTestOper(), GT_LT, GT_LE) && (loop.lpIterOper() == GT_ADD)) ||
+          (GenTree::StaticOperIs(loop.lpTestOper(), GT_GT, GT_GE) && (loop.lpIterOper() == GT_SUB))))
     {
         JITDUMP("Loop cloning: rejecting loop " FMT_LP
                 ". Loop test (%s) doesn't agree with the direction (%s) of the loop.\n",


### PR DESCRIPTION
This is a no-diff change

Added various comments to document loop cloning.

Standardized and improved some logging.

Consolidated more loop cloning condition checking into
`optIsLoopClonable` that was previously in `optIdentifyLoopOptInfo`.

Replaced some `0` weights with `BB_ZERO_WEIGHT`.

Made FMT_BB use pervasive.