### PR TITLE
[System.Memory.Data] Add `Empty` to `BinaryData`

### DIFF
--- a/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
+++ b/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
@@ -12,6 +12,7 @@ namespace System
         public BinaryData(object? jsonSerializable, System.Text.Json.JsonSerializerOptions? options = null, System.Type? type = null) { }
         public BinaryData(System.ReadOnlyMemory<byte> data) { }
         public BinaryData(string data) { }
+        public static BinaryData Empty { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public static System.BinaryData FromBytes(byte[] data) { throw null; }

--- a/src/libraries/System.Memory.Data/src/System/BinaryData.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryData.cs
@@ -23,6 +23,11 @@ namespace System
         private readonly ReadOnlyMemory<byte> _bytes;
 
         /// <summary>
+        /// Returns an empty BinaryData.
+        /// </summary>
+        public static BinaryData Empty { get; } = new BinaryData(ReadOnlyMemory<byte>.Empty);
+
+        /// <summary>
         /// Creates a <see cref="BinaryData"/> instance by wrapping the
         /// provided byte array.
         /// </summary>

--- a/src/libraries/System.Memory.Data/tests/BinaryDataTests.cs
+++ b/src/libraries/System.Memory.Data/tests/BinaryDataTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -570,6 +571,18 @@ namespace System.Tests
             Assert.False(stream.CanRead);
             Assert.False(stream.CanSeek);
 
+        }
+
+        [Fact]
+        public void EmptyIsEmpty()
+        {
+            Assert.Equal(Array.Empty<byte>(), BinaryData.Empty.ToArray());
+        }
+
+        [Fact]
+        public void EmptyIsSingleton()
+        {
+            Assert.Same(BinaryData.Empty, BinaryData.Empty);
         }
 
         private class TestModel


### PR DESCRIPTION
This is useful for APIs which return `BinaryData` and want to use a
singleton instead of allocating a new `BinaryData` each
time. Previously, developers would need to create their own static
copy of an empty binary data, now they can just use `Empty`

Fixes #49670