### PR TITLE
Enable the latest managed pgo data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -60,6 +60,7 @@
     <RepoToolsLocalDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'tools-local'))</RepoToolsLocalDir>
     <RepoTasksDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'tasks'))</RepoTasksDir>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
+    <MibcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'mibc'))</MibcOptimizationDataDir>
     <XmlDocDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'docs'))</XmlDocDir>
     <XmlDocFileRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'net'))</XmlDocFileRoot>
     <DocsDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'docs'))</DocsDir>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
-    <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
+    <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
     <!--
       The NETStandard.Library targeting pack uses this patch version, which does not match the
@@ -116,6 +116,9 @@
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>5.0.0-beta.21159.1</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>5.0.0-beta.21159.1</SystemWindowsExtensionsTestDataVersion>
     <!-- dotnet-optimization dependencies -->
+    <optimizationwindows_ntx64MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationwindows_ntx64MIBCRuntimeVersion>
+    <optimizationwindows_ntx86MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationwindows_ntx86MIBCRuntimeVersion>
+    <optimizationlinuxx64MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationlinuxx64MIBCRuntimeVersion>
     <optimizationwindows_ntx64IBCCoreFxVersion>99.99.99-master-20200806.6</optimizationwindows_ntx64IBCCoreFxVersion>
     <optimizationlinuxx64IBCCoreFxVersion>99.99.99-master-20200806.6</optimizationlinuxx64IBCCoreFxVersion>
     <optimizationwindows_ntx64IBCCoreCLRVersion>99.99.99-master-20200806.6</optimizationwindows_ntx64IBCCoreCLRVersion>

--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -34,4 +34,41 @@
 
   </Target>
 
+
+  <ItemGroup>
+    <!-- Mibc data to use when exact architecture match is available -->
+    <MIBCPackageDef Include="optimization.windows_nt-x86.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x86"/>
+    <MIBCPackageDef Include="optimization.windows_nt-x64.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x64"/>
+    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux/x64"/>
+
+    <!-- Mibc data to use when exact architecture match not available -->
+    <MIBCPackageDef Include="optimization.windows_nt-x64.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows"/>
+    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux"/>
+    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="OSX"/>
+
+    <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)/$(TargetArchitecture)'))" />
+    <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)'))" Condition="'@(MIBCPackage)' == ''" />
+
+    <PackageDownload Include="@(MIBCPackage)" Version="[%(Version)]" />
+  </ItemGroup>
+
+  <!-- IBC data packages don't follow NuGet conventions.  -->
+  <Target Name="GetMIBCData"
+          AfterTargets="Restore">
+
+    <ItemGroup>
+      <MIBCPackage>
+        <PackagePath>$(NuGetPackageRoot)%(MIBCPackage.Identity)\%(MIBCPackage.Version)</PackagePath>
+      </MIBCPackage>
+      <_optimizationMibcFile Include="%(MIBCPackage.PackagePath)\**\*.mibc" SubdirectoryName="$(TargetOS)/$(TargetArchitecture)" />
+    </ItemGroup>
+
+    <Error Condition="'@(_optimizationMibcFile)' == ''" Text="Failed to restore Mibc optimization data" />
+
+    <Copy SourceFiles="@(_optimizationMibcFile)"
+          DestinationFiles="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+
+  </Target>
 </Project>

--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -37,20 +37,20 @@
 
   <ItemGroup>
     <!-- Mibc data to use when exact architecture match is available -->
-    <MIBCPackageDef Include="optimization.windows_nt-x86.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x86"/>
-    <MIBCPackageDef Include="optimization.windows_nt-x64.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x64"/>
-    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux/x64"/>
+    <MIBCPackageDef Include="optimization.windows_nt-x86.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x86"/>
+    <MIBCPackageDef Include="optimization.windows_nt-x64.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x64"/>
+    <MIBCPackageDef Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux/x64"/>
 
     <!-- Mibc data to use when exact architecture match not available -->
-    <MIBCPackageDef Include="optimization.windows_nt-x64.MIBC.Runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows"/>
-    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux"/>
-    <MIBCPackageDef Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="OSX"/>
+    <MIBCPackageDef Include="optimization.windows_nt-x64.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows"/>
+    <MIBCPackageDef Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux"/>
+    <MIBCPackageDef Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="OSX"/>
 
     <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)/$(TargetArchitecture)'))" />
     <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)'))" Condition="'@(MIBCPackage)' == ''" />
 
     <!-- Fallback in case no os specific data is available-->
-    <MIBCPackage Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" Condition="'@(MIBCPackage)' == ''" />
+    <MIBCPackage Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" Condition="'@(MIBCPackage)' == ''" />
 
     <PackageDownload Include="@(MIBCPackage)" Version="[%(Version)]" />
   </ItemGroup>
@@ -61,11 +61,11 @@
 
     <ItemGroup>
       <MIBCPackage>
-        <PackagePath>$(NuGetPackageRoot)%(MIBCPackage.Identity)\%(MIBCPackage.Version)</PackagePath>
+        <PackagePath>$(NuGetPackageRoot)%(MIBCPackage.Identity)/%(MIBCPackage.Version)</PackagePath>
       </MIBCPackage>
-      <_optimizationMibcFile Include="%(MIBCPackage.PackagePath)\**\*.mibc" SubdirectoryName="$(TargetOS)/$(TargetArchitecture)" />
+      <_optimizationMibcFile Include="%(MIBCPackage.PackagePath)/**/*.mibc" SubdirectoryName="$(TargetOS)/$(TargetArchitecture)" />
       <ExcessFilesCurrentlyPresent Include="$(MibcOptimizationDataDir)/**" 
-                                   Exclude="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)\%(RecursiveDir)%(Filename)%(Extension)')"/>
+                                   Exclude="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)/%(RecursiveDir)%(Filename)%(Extension)')"/>
     </ItemGroup>
 
     <Error Condition="'@(_optimizationMibcFile)' == ''" Text="Failed to restore Mibc optimization data" />
@@ -75,7 +75,7 @@
 
     <!-- Copy the correct mibc files into place -->
     <Copy SourceFiles="@(_optimizationMibcFile)"
-          DestinationFiles="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="true" />
 

--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <!-- Mibc data to use when exact architecture match is available -->
-    <MIBCPackageDef Include="optimization.windows_nt-x86.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x86"/>
+    <MIBCPackageDef Include="optimization.windows_nt-x86.mibc.runtime" Version="$(optimizationwindows_ntx86MIBCRuntimeVersion)" MibcArchitecture="Windows/x86"/>
     <MIBCPackageDef Include="optimization.windows_nt-x64.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" MibcArchitecture="Windows/x64"/>
     <MIBCPackageDef Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" MibcArchitecture="Linux/x64"/>
 

--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -49,6 +49,9 @@
     <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)/$(TargetArchitecture)'))" />
     <MIBCPackage Include="@(MIBCPackageDef->HasMetadata('MibcArchitecture')->WithMetadataValue('MibcArchitecture','$(TargetOS)'))" Condition="'@(MIBCPackage)' == ''" />
 
+    <!-- Fallback in case no os specific data is available-->
+    <MIBCPackage Include="optimization.linux-x64.MIBC.Runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" Condition="'@(MIBCPackage)' == ''" />
+
     <PackageDownload Include="@(MIBCPackage)" Version="[%(Version)]" />
   </ItemGroup>
 
@@ -61,10 +64,16 @@
         <PackagePath>$(NuGetPackageRoot)%(MIBCPackage.Identity)\%(MIBCPackage.Version)</PackagePath>
       </MIBCPackage>
       <_optimizationMibcFile Include="%(MIBCPackage.PackagePath)\**\*.mibc" SubdirectoryName="$(TargetOS)/$(TargetArchitecture)" />
+      <ExcessFilesCurrentlyPresent Include="$(MibcOptimizationDataDir)/**" 
+                                   Exclude="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)\%(RecursiveDir)%(Filename)%(Extension)')"/>
     </ItemGroup>
 
     <Error Condition="'@(_optimizationMibcFile)' == ''" Text="Failed to restore Mibc optimization data" />
 
+    <!-- Clean mibc restore directory so that no extra mibc files are present. Improves incremental build resiliency -->
+    <Delete Files="@(ExcessFilesCurrentlyPresent)" />
+
+    <!-- Copy the correct mibc files into place -->
     <Copy SourceFiles="@(_optimizationMibcFile)"
           DestinationFiles="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -80,7 +80,7 @@
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
       <MibcArgs>@(OptimizationMibcFiles->'-m:%(Identity)', ' ')</MibcArgs>
-      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true'">$(CrossGenDllCmd) $(MibcArgs) --embed-pgo-data</CrossGenDllCmd>
+      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'">$(CrossGenDllCmd) $(MibcArgs) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
     </PropertyGroup>

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -70,11 +70,17 @@
     <Message Importance="High"
       Text="Generating native image of System.Private.CoreLib for $(OSPlatformConfig). Logging to $(CrossGenCoreLibLog)" />
 
+    <ItemGroup>
+      <OptimizationMibcFiles Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" />
+    </ItemGroup>
+
     <PropertyGroup>
       <CrossGenDllCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', '$(CrossDir)', 'crossgen2', 'crossgen2.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
+      <MibcArgs>@(OptimizationMibcFiles->'-m:%(Identity)', ' ')</MibcArgs>
+      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true'">$(CrossGenDllCmd) $(MibcArgs) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
     </PropertyGroup>

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2445,10 +2445,10 @@ void EfficientEdgeCountReconstructor::Propagate()
 {
     // We don't expect mismatches or convergence failures.
     //
-    
+
     // Mismatches are currently expected as the flow for static pgo doesn't prevent them now.
-    //    assert(!m_mismatch); 
-    
+    //    assert(!m_mismatch);
+
     assert(!m_failedToConverge);
 
     // If any issues arose during reconstruction, don't set weights.

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2445,7 +2445,10 @@ void EfficientEdgeCountReconstructor::Propagate()
 {
     // We don't expect mismatches or convergence failures.
     //
-    assert(!m_mismatch);
+    
+    // Mismatches are currently expected as the flow for static pgo doesn't prevent them now.
+    //    assert(!m_mismatch); 
+    
     assert(!m_failedToConverge);
 
     // If any issues arose during reconstruction, don't set weights.

--- a/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
+++ b/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public bool DetailedProgressMessages;
         public List<FileInfo> InputFilesToMerge;
         public List<AssemblyName> IncludedAssemblies = new List<AssemblyName>();
+        public bool DumpMibc = false;
+        public FileInfo InputFileToDump;
 
         public string[] HelpArgs = Array.Empty<string>();
 
@@ -259,6 +261,26 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 #endif
             }
 
+            var dumpCommand = syntax.DefineCommand(name: "dump", value: ref command, help: "Dump the contents of a Mibc file.");
+            if (dumpCommand.IsActive)
+            {
+                DumpMibc = true;
+                HelpArgs = new string[] { "dump", "--help", "input", "output" };
+
+                VerbosityOption();
+                HelpOption();
+
+                string inputFileToDump = null;
+                syntax.DefineParameter(name: "input", ref inputFileToDump, "Name of the input mibc file to dump.");
+                if (inputFileToDump != null)
+                    InputFileToDump = new FileInfo(inputFileToDump);
+
+                string outputFile = null;
+                syntax.DefineParameter(name: "output", ref outputFile, "Name of the output dump file.");
+                if (outputFile != null)
+                    OutputFileName = new FileInfo(outputFile);
+            }
+
 
             if (syntax.ActiveCommand == null)
             {
@@ -341,7 +363,7 @@ Example tracing commands used to generate the input to this tool:
         private void ParseCommmandLineHelper(string[] args)
         {
             ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, DefineArgumentSyntax);
-            if (Help || (!FileType.HasValue && (InputFilesToMerge == null)))
+            if (Help || (!FileType.HasValue && (InputFilesToMerge == null) && !DumpMibc))
             {
                 Help = true;
             }

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -1,5 +1,17 @@
 <Project>
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
+    <ItemGroup>
+      <OptimizationMibcFiles Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PublishReadyToRunCrossgen2ExtraArgsList Include="--targetarch:$(TargetArchitecture)"/>
+
+      <!-- Only use mibc files if UsingToolIbcOptimization is false. Allows enabling/disabling using ibc instead of mibc data -->
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true'" Include="@(OptimizationMibcFiles->'-m:%(Identity)')"/>
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true'" Include="--embed-pgo-data"/>
+    </ItemGroup>
+
     <!-- The following property group can be simplified once runtime repo switches over to SDK 6.0 drop -->
     <PropertyGroup>
       <CrossDir />
@@ -7,7 +19,7 @@
       <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
       <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>
       <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
-      <PublishReadyToRunCrossgen2ExtraArgs>--targetarch:$(TargetArchitecture)</PublishReadyToRunCrossgen2ExtraArgs>
+      <PublishReadyToRunCrossgen2ExtraArgs>@(PublishReadyToRunCrossgen2ExtraArgsList)</PublishReadyToRunCrossgen2ExtraArgs>
 
       <JitTargetOSComponent>unix</JitTargetOSComponent>
       <JitTargetOSComponent Condition="'$(TargetOS)' == 'windows'">win</JitTargetOSComponent>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -8,8 +8,8 @@
       <PublishReadyToRunCrossgen2ExtraArgsList Include="--targetarch:$(TargetArchitecture)"/>
 
       <!-- Only use mibc files if UsingToolIbcOptimization is false. Allows enabling/disabling using ibc instead of mibc data -->
-      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true'" Include="@(OptimizationMibcFiles->'-m:%(Identity)')"/>
-      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true'" Include="--embed-pgo-data"/>
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'" Include="@(OptimizationMibcFiles->'-m:%(Identity)')"/>
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'" Include="--embed-pgo-data"/>
     </ItemGroup>
 
     <!-- The following property group can be simplified once runtime repo switches over to SDK 6.0 drop -->


### PR DESCRIPTION
- Implementation is parallel to existing ibc handling, so that it can be toggled on/off by adjusting the `UsingToolIbcOptimization` property
- Use the same data for all assemblies produced in current build
- Apply data to release builds only
- Disable mismatch assertions in jit for current state where il mismatches are common
