### PR TITLE
[browser][build] Only override and set EMSDK_PATH if it is not already set.

### DIFF
--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
     <ProvisionEmscriptenDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'wasm', 'emsdk'))</ProvisionEmscriptenDir>
     <ShouldProvisionEmscripten Condition="'$(OS)' == 'Windows_NT' and '$(TargetArchitecture)' == 'wasm' and '$(EMSDK_PATH)' == '' and !Exists('$(ProvisionEmscriptenDir)')">true</ShouldProvisionEmscripten>
-    <EMSDK_PATH Condition="Exists('$(ProvisionEmscriptenDir)')">$(ProvisionEmscriptenDir.Replace('\', '/'))</EMSDK_PATH>
+    <EMSDK_PATH Condition="Exists('$(ProvisionEmscriptenDir)') and '$(EMSDK_PATH)' == ''">$(ProvisionEmscriptenDir.Replace('\', '/'))</EMSDK_PATH>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/49809