### PR TITLE
Big-endian fix: ResourceReader.AllocateStringForNameIndex

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -383,7 +383,19 @@ namespace System.Resources
                     string? s = null;
                     char* charPtr = (char*)_ums.PositionPointer;
 
-                    s = new string(charPtr, 0, byteLen / 2);
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        s = new string(charPtr, 0, byteLen / 2);
+                    }
+                    else
+                    {
+                        char[] arr = new char[byteLen / 2];
+                        for (int i = 0; i < arr.Length; i++)
+                        {
+                            arr[i] = (char)BinaryPrimitives.ReverseEndianness((short)charPtr[i]);
+                        }
+                        s = new string(arr);
+                    }
 
                     _ums.Position += byteLen;
                     dataOffset = _store.ReadInt32();


### PR DESCRIPTION
* Use Encoding.Unicode.GetString when accessing memory-mapped resources
  (just as is already done for resource files read from a stream)

* Performs byte-swaps on big-endian systems, and also eliminates a
  semantic difference between memory-mapped and stream resources
  w.r.t. handling surrogate characters