### PR TITLE
Big-endian fix: System.Reflection.Metadata BlobBuilder/BlobWriter

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -956,10 +956,9 @@ namespace System.Reflection.Metadata
             }
             else
             {
-                byte[] bytes = Encoding.Unicode.GetBytes(value);
-                fixed (byte* ptr = &bytes[0])
+                for (int i = 0; i < value.Length; i++)
                 {
-                    WriteBytesUnchecked((byte*)ptr, bytes.Length);
+                    WriteUInt16((ushort)value[i]);
                 }
             }
         }
@@ -990,10 +989,9 @@ namespace System.Reflection.Metadata
             }
             else
             {
-                byte[] bytes = Encoding.Unicode.GetBytes(value);
-                fixed (byte* ptr = bytes)
+                for (int i = 0; i < value.Length; i++)
                 {
-                    WriteBytesUnchecked((byte*)ptr, bytes.Length);
+                    WriteUInt16((ushort)value[i]);
                 }
             }
         }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -381,9 +381,19 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (char* ptr = &value[0])
+            if (BitConverter.IsLittleEndian)
             {
-                WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                fixed (char* ptr = &value[0])
+                {
+                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                }
+            }
+            else
+            {
+                for (int i = 0; i < value.Length; i++)
+                {
+                    WriteUInt16((ushort)value[i]);
+                }
             }
         }
 
@@ -398,9 +408,19 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(value));
             }
 
-            fixed (char* ptr = value)
+            if (BitConverter.IsLittleEndian)
             {
-                WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                fixed (char* ptr = value)
+                {
+                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                }
+            }
+            else
+            {
+                for (int i = 0; i < value.Length; i++)
+                {
+                    WriteUInt16((ushort)value[i]);
+                }
             }
         }
 


### PR DESCRIPTION
* BlobBuilder: do not use Encoding.Unicode.GetBytes but simple
  byte-swaps on big-endian systems (fixes a semantic difference
  to little-endian code w.r.t. surrogate char handling)

* BlobWriter: add big-endian WriteUTF16 code path like BlobBuilder