### PR TITLE
Big-endian fix: PEBuilder.CalculateChecksum

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
@@ -549,7 +549,8 @@ namespace System.Reflection.PortableExecutable
 
                     while (ptr < end)
                     {
-                        checksum = AggregateChecksum(checksum, *(ushort*)ptr);
+                        // little-endian encoding:
+                        checksum = AggregateChecksum(checksum, (ushort)(ptr[1] << 8 | ptr[0]));
                         ptr += sizeof(ushort);
                     }
                 }


### PR DESCRIPTION
* Always use little-endian encoding to compute checksum