### PR TITLE
[Wasm][AOT] Add the ability to the display the native stack frames

### DIFF
--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -3435,7 +3435,11 @@ mono_print_thread_dump_internal (void *sigctx, MonoContext *start_ctx)
 
 	mono_walk_stack_with_ctx (print_stack_frame_to_string, &ctx, MONO_UNWIND_LOOKUP_ALL, text);
 
+#if HOST_WASM
+	g_printerr ("%s", text->str);
+#else
 	mono_runtime_printf ("%s", text->str);
+#endif	
 
 #if HOST_WIN32 && TARGET_WIN32 && _DEBUG
 	OutputDebugStringA(text->str);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -3436,7 +3436,7 @@ mono_print_thread_dump_internal (void *sigctx, MonoContext *start_ctx)
 	mono_walk_stack_with_ctx (print_stack_frame_to_string, &ctx, MONO_UNWIND_LOOKUP_ALL, text);
 
 #if HOST_WASM
-	g_printerr ("%s", text->str);
+	mono_runtime_printf_err ("%s", text->str); //to print the native callstack
 #else
 	mono_runtime_printf ("%s", text->str);
 #endif	


### PR DESCRIPTION
Another approach for PR #45124

How it will be visible in console:
![image](https://user-images.githubusercontent.com/4503299/111661479-cf4f1f00-87ed-11eb-8dd4-074f68cc1480.png)
