### PR TITLE
Reduce cost of CreateSecKeyAndSecWebSocketAccept in ClientWebSocket

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -17,9 +17,6 @@ namespace System.Net.WebSockets
 {
     internal sealed class WebSocketHandle
     {
-        /// <summary>GUID appended by the server as part of the security key response.  Defined in the RFC.</summary>
-        private const string WSServerGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-
         /// <summary>Shared, lazily-initialized handler for when using default options.</summary>
         private static SocketsHttpHandler? s_defaultHandler;
 
@@ -242,10 +239,35 @@ namespace System.Net.WebSockets
         [SuppressMessage("Microsoft.Security", "CA5350", Justification = "Required by RFC6455")]
         private static KeyValuePair<string, string> CreateSecKeyAndSecWebSocketAccept()
         {
-            string secKey = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+            // GUID appended by the server as part of the security key response.  Defined in the RFC.
+            ReadOnlySpan<byte> wsServerGuidBytes = new byte[]
+            {
+                (byte)'2', (byte)'5', (byte)'8', (byte)'E', (byte)'A', (byte)'F', (byte)'A', (byte)'5', (byte)'-',
+                (byte)'E', (byte)'9', (byte)'1', (byte)'4', (byte)'-',
+                (byte)'4', (byte)'7', (byte)'D', (byte)'A', (byte)'-',
+                (byte)'9', (byte)'5', (byte)'C', (byte)'A', (byte)'-',
+                (byte)'C', (byte)'5', (byte)'A', (byte)'B', (byte)'0', (byte)'D', (byte)'C', (byte)'8', (byte)'5', (byte)'B', (byte)'1', (byte)'1'
+            };
+
+            Span<byte> bytes = stackalloc byte[24 /* Base64 guid length */ + wsServerGuidBytes.Length];
+
+            // Base64-encode a new Guid's bytes to get the security key
+            bool success = Guid.NewGuid().TryWriteBytes(bytes);
+            Debug.Assert(success);
+            string secKey = Convert.ToBase64String(bytes.Slice(0, 16 /*sizeof(Guid)*/));
+
+            // Get the corresponding ASCII bytes for seckey+wsServerGuidBytes
+            for (int i = 0; i < secKey.Length; i++) bytes[i] = (byte)secKey[i];
+            wsServerGuidBytes.CopyTo(bytes.Slice(secKey.Length));
+
+            // Hash the seckey+wsServerGuidBytes bytes
+            SHA1.TryHashData(bytes, bytes, out int bytesWritten);
+            Debug.Assert(bytesWritten == 20 /* SHA1 hash length */);
+
+            // Return the security key + the base64 encoded hashed bytes
             return new KeyValuePair<string, string>(
                 secKey,
-                Convert.ToBase64String(SHA1.HashData(Encoding.ASCII.GetBytes(secKey + WSServerGuid))));
+                Convert.ToBase64String(bytes.Slice(0, bytesWritten)));
         }
 
         private static void ValidateHeader(HttpHeaders headers, string name, string expectedValue)


### PR DESCRIPTION
This isn't a big deal as it's once per websocket connection, but it annoys me every time I see the unnecessary waste in a trace :smile:, so I'm scratching an itch.

Previously this would allocate:
1. A byte[] for the bytes from the guid
2. A base64-encoded string for (1)
3. A string concatenating (2) and the known server guid
4. A byte[] containing the bytes from (3)
5. A byte[] containing the SHA1-hashed bytes of (4)
6. A base64-encoded string of (5)

Now, it only allocates (2) and (6).

| Method |     Mean | Ratio | Allocated |
|------- |---------:|------:|----------:|
|    Old | 637.4 ns |  1.00 |     472 B |
|    New | 581.1 ns |  0.91 |     152 B |