### PR TITLE
Get more info from CI repro

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -126,7 +126,6 @@ namespace System.Numerics.Tests
 
         // A test for Distance (Vector3f, Vector3f)
         [Fact]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/49824")]
         public void Vector3DistanceTest()
         {
             Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);

--- a/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -126,7 +126,7 @@ namespace System.Numerics.Tests
 
         // A test for Distance (Vector3f, Vector3f)
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49824")]
+        //[ActiveIssue("https://github.com/dotnet/runtime/issues/49824")]
         public void Vector3DistanceTest()
         {
             Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);
@@ -136,7 +136,7 @@ namespace System.Numerics.Tests
             float actual;
 
             actual = Vector3.Distance(a, b);
-            Assert.True(MathHelper.Equal(expected, actual), "Vector3f.Distance did not return the expected value.");
+            Assert.True(MathHelper.Equal(expected, actual), $"Vector3f.Distance did not return the expected value. Expected = {expected}, actual = {actual}");
         }
 
         // A test for Distance (Vector3f, Vector3f)


### PR DESCRIPTION
Couldn't repro https://github.com/dotnet/runtime/issues/49824 locally, so I'm getting more debug info from the log. IIRC, there have been no code changes here recently, so I'm not sure why this bug occurs