### PR TITLE
Use latest DiaSymReader and support ARM64 host in crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PdbWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PdbWriter.cs
@@ -86,31 +86,51 @@ namespace ILCompiler.Diagnostics
         UIntPtr _pdbMod;
         ISymNGenWriter2 _ngenWriter;
 
-        private const string DiaSymReaderModuleName32 = "Microsoft.DiaSymReader.Native.x86.dll";
-        private const string DiaSymReaderModuleName64 = "Microsoft.DiaSymReader.Native.amd64.dll";
+        private const string DiaSymReaderModuleNameX86 = "Microsoft.DiaSymReader.Native.x86.dll";
+        private const string DiaSymReaderModuleNameX64 = "Microsoft.DiaSymReader.Native.amd64.dll";
+        private const string DiaSymReaderModuleNameArm = "Microsoft.DiaSymReader.Native.arm.dll";
+        private const string DiaSymReaderModuleNameArm64 = "Microsoft.DiaSymReader.Native.arm64.dll";
 
         private const string CreateNGenPdbWriterFactoryName = "CreateNGenPdbWriter";
 
         [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
-        [DllImport(DiaSymReaderModuleName32, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
-        private extern static void CreateNGenPdbWriter32([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
+        [DllImport(DiaSymReaderModuleNameX86, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
+        private extern static void CreateNGenPdbWriterX86([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
 
         [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
-        [DllImport(DiaSymReaderModuleName64, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
-        private extern static void CreateNGenPdbWriter64([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
+        [DllImport(DiaSymReaderModuleNameX64, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
+        private extern static void CreateNGenPdbWriterX64([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
+        [DllImport(DiaSymReaderModuleNameArm, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
+        private extern static void CreateNGenPdbWriterArm([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
+        [DllImport(DiaSymReaderModuleNameArm64, EntryPoint = CreateNGenPdbWriterFactoryName, PreserveSig = false)]
+        private extern static void CreateNGenPdbWriterArm64([MarshalAs(UnmanagedType.LPWStr)] string ngenImagePath, [MarshalAs(UnmanagedType.LPWStr)] string pdbPath, [MarshalAs(UnmanagedType.IUnknown)] out object ngenPdbWriter);
 
         private static ISymNGenWriter2 CreateNGenWriter(string ngenImagePath, string pdbPath)
         {
             object instance;
 
-            if (IntPtr.Size == 4)
+            switch (RuntimeInformation.ProcessArchitecture)
             {
-                CreateNGenPdbWriter32(ngenImagePath, pdbPath, out instance);
+                case Architecture.X86:
+                    CreateNGenPdbWriterX86(ngenImagePath, pdbPath, out instance);
+                    break;
+                case Architecture.X64:
+                    CreateNGenPdbWriterX64(ngenImagePath, pdbPath, out instance);
+                    break;
+                case Architecture.Arm:
+                    CreateNGenPdbWriterArm(ngenImagePath, pdbPath, out instance);
+                    break;
+                case Architecture.Arm64:
+                    CreateNGenPdbWriterArm64(ngenImagePath, pdbPath, out instance);
+                    break;
+                default:
+                    throw new NotImplementedException();
             }
-            else
-            {
-                CreateNGenPdbWriter64(ngenImagePath, pdbPath, out instance);
-            }
+
             return (ISymNGenWriter2)instance;
         }
 

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -72,13 +72,13 @@
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
-     />
+      />
 
     <Content Include="$(RuntimeBinDir)$(NativeArchFolder)$(LibPrefix)clrjit_*_$(TargetArchitecture)$(LibSuffix)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
-     />
+      />
   </ItemGroup>
 
   <!-- On windows we can re-use the clrjit.dll produced in the build for aot compilation. On Linux
@@ -89,7 +89,7 @@
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="$(LibPrefix)clrjit_$(TargetSpec)$(LibSuffix)"
-     />
+      />
 
     <Content Include="$(RuntimeBinDir)/pgort*.dll"
       CopyToOutputDirectory="PreserveNewest"
@@ -97,18 +97,50 @@
       Link="%(FileName)%(Extension)"
       Condition="'$(PgoInstrument)' != ''"
       />
+
+    <PackageReference Include="Microsoft.DiaSymReader.Native"
+      Version="$(MicrosoftDiaSymReaderNativeVersion)"
+      IsImplicitlyDefined="true"
+      ExcludeAssets="all"
+      GeneratePathProperty="true"
+      />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'windows'">
+    <!-- DiaSymReader for the host architecture, which is used for cross-compilation -->
+    <DiaSymReaderCrossArch>$(CrossHostArch)</DiaSymReaderCrossArch>
+    <DiaSymReaderCrossArch Condition="'$(CrossHostArch)' == 'x64'">amd64</DiaSymReaderCrossArch>
+    <DiaSymReaderCrossArchFileName>Microsoft.DiaSymReader.Native.$(DiaSymReaderCrossArch).dll</DiaSymReaderCrossArchFileName>
+    <DiaSymReaderCrossArchPath>$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\$(DiaSymReaderCrossArchFileName)</DiaSymReaderCrossArchPath>
+
+    <!-- DiaSymReader for the target architecture, which is placed into the package -->
+    <DiaSymReaderTargetArch>$(TargetArchitecture)</DiaSymReaderTargetArch>
+    <DiaSymReaderTargetArch Condition="'$(TargetArchitecture)' == 'x64'">amd64</DiaSymReaderTargetArch>
+    <DiaSymReaderTargetArchFileName>Microsoft.DiaSymReader.Native.$(DiaSymReaderTargetArch).dll</DiaSymReaderTargetArchFileName>
+    <DiaSymReaderTargetArchPath>$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <Content Include="$(DiaSymReaderTargetArchPath)"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="PreserveNewest"
+      Link="%(FileName)%(Extension)"
+      />
   </ItemGroup>
 
   <Target Name="CreateCrossTargetingPackage" AfterTargets="Build" Condition="'$(CrossHostArch)' != ''">
-
     <PropertyGroup>
       <CrossPackageFolder>$(RuntimeBinDir)$(CrossHostArch)\crossgen2</CrossPackageFolder>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageFile Include="$(RuntimeBinDir)crossgen2\*"
-        Exclude="$(RuntimeBinDir)crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)crossgen2\$(LibPrefix)clrjit_*$(LibSuffix)" />
+      <!-- The list of files specific to the target architecture, which we need to replace -->
+      <TargetArchSpecificFiles Include="$(JitInterfaceLibraryName);$(LibPrefix)clrjit_*$(LibSuffix)" />
+      <TargetArchSpecificFiles Include="$(DiaSymReaderTargetArchFileName)" Condition="'$(TargetOS)' == 'windows'" />
+
+      <PackageFile Include="$(RuntimeBinDir)crossgen2\*" Exclude="@(TargetArchSpecificFiles->'$(RuntimeBinDir)crossgen2\%(Identity)')" />
       <PackageFile Include="$(RuntimeBinDir)$(CrossHostArch)\$(LibPrefix)jitinterface_$(CrossHostArch)$(LibSuffix)" />
+      <PackageFile Include="$(DiaSymReaderCrossArchPath)" Condition="'$(TargetOS)' == 'windows'" />
     </ItemGroup>
 
     <MakeDir Directories="$(CrossPackageFolder)" />


### PR DESCRIPTION
When we run `crossgen2.exe` during the build, it normally loads `Microsoft.DiaSymReader.Native.amd64.dll` from `.dotnet\shared\Microsoft.NETCore.App\6.0.0-preview.2.21154.6` directory (the package version is controlled by the `global.json` file). However, the ARM64 version of the `Microsoft.NETCore.App` package still contains the **x64** version of the DLL, which I addressed in #49739 recently. This PR copies the proper version of DiaSymReader library to the `crossgen2` directory in order to use the same bits we ship and allow ARM64-hosted `crossgen2.exe` to emit PDBs. @dotnet/crossgen-contrib