### PR TITLE
Slimmer IOptions<T>

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(OptionsManager<>)));
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(UnnamedOptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
             services.TryAdd(ServiceDescriptor.Transient(typeof(IOptionsFactory<>), typeof(OptionsFactory<>)));

--- a/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Extensions.Options
             _lazy = new Lazy<TOptions>(() => factory.Create(Options.DefaultName));
         }
 
-        /// <summary>
-        /// The default configured <typeparamref name="TOptions"/> instance, equivalent to Get(Options.DefaultName).
-        /// </summary>
         public TOptions Value => _lazy.Value;
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.Options
+{
+    internal class UnnamedOptionsManager<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :
+        IOptions<TOptions>
+        where TOptions : class
+    {
+        private readonly Lazy<TOptions> _lazy;
+
+        public UnnamedOptionsManager(IOptionsFactory<TOptions> factory)
+        {
+            _lazy = new Lazy<TOptions>(() => factory.Create(Options.DefaultName));
+        }
+
+        /// <summary>
+        /// The default configured <typeparamref name="TOptions"/> instance, equivalent to Get(Options.DefaultName).
+        /// </summary>
+        public TOptions Value => _lazy.Value;
+    }
+}


### PR DESCRIPTION
- Use a Lazy<T> instead of the IOptionsCache<T> (which is a concurrent dictionary)

Fixes https://github.com/dotnet/runtime/issues/45260