### PR TITLE
Delete null check using `OperIsImplicitIndir`.

### DIFF
--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -315,7 +315,7 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
     GenTree*    objectRefPtr = nullptr;
     optPropKind propKind     = optPropKind::OPK_INVALID;
 
-    if (tree->OperIsIndirOrArrLength() || tree->OperIsImplicitIndir())
+    if (tree->OperIsDereference())
     {
         // optFoldNullCheck takes care of updating statement info if a null check is removed.
         optFoldNullCheck(tree, nullCheckMap);
@@ -654,7 +654,7 @@ void Compiler::optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nu
 //
 GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
 {
-    assert(tree->OperIsIndirOrArrLength() || tree->OperIsImplicitIndir());
+    assert(tree->OperIsDereference());
 
     GenTree* addr;
     if (tree->OperIs(GT_ARR_LENGTH))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5761,8 +5761,15 @@ bool GenTree::OperMayThrow(Compiler* comp)
         case GT_XORR:
         case GT_XADD:
         case GT_XCHG:
+        case GT_LOCKADD:
         {
             GenTree* addr = this->AsOp()->gtGetOp1();
+            return comp->fgAddrCouldBeNull(addr);
+        }
+
+        case GT_CMPXCHG:
+        {
+            GenTree* addr = this->AsCmpXchg()->gtOpLocation;
             return comp->fgAddrCouldBeNull(addr);
         }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5678,6 +5678,20 @@ bool GenTree::OperIsImplicitIndir() const
 }
 
 //------------------------------------------------------------------------------
+// OperIsDereference : Check whether the operation contains dereference.
+//
+// Arguments:
+//    this      -  a GenTree node
+//
+// Return Value:
+//    True if the given node contains an dereference.
+//
+bool GenTree::OperIsDereference() const
+{
+    return OperIsIndirOrArrLength() || OperIsImplicitIndir();
+}
+
+//------------------------------------------------------------------------------
 // OperMayThrow : Check whether the operation may throw.
 //
 //

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5743,6 +5743,15 @@ bool GenTree::OperMayThrow(Compiler* comp)
         case GT_NULLCHECK:
             return (((this->gtFlags & GTF_IND_NONFAULTING) == 0) && comp->fgAddrCouldBeNull(this->AsIndir()->Addr()));
 
+        case GT_XAND:
+        case GT_XORR:
+        case GT_XADD:
+        case GT_XCHG:
+        {
+            GenTree* addr = this->AsOp()->gtGetOp1();
+            return comp->fgAddrCouldBeNull(addr);
+        }
+
         case GT_ARR_LENGTH:
             return (((this->gtFlags & GTF_IND_NONFAULTING) == 0) &&
                     comp->fgAddrCouldBeNull(this->AsArrLen()->ArrRef()));

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1517,6 +1517,8 @@ public:
 
     bool OperIsImplicitIndir() const;
 
+    bool OperIsDereference() const;
+
     static bool OperIsAtomicOp(genTreeOps gtOper)
     {
         switch (gtOper)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3870,6 +3870,10 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             GenTree* node = new (this, GT_CMPXCHG) GenTreeCmpXchg(genActualType(callType), op1, op2, op3);
 
             node->AsCmpXchg()->gtOpLocation->gtFlags |= GTF_DONT_CSE;
+            if (fgAddrCouldBeNull(op1))
+            {
+                node->gtFlags |= GTF_EXCEPT;
+            }
             retNode = node;
             break;
         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3825,7 +3825,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             // on a local are probably pretty useless anyway, so we probably don't care.
 
             op1 = gtNewOperNode(interlockedOperator, genActualType(callType), op1, op2);
-            op1->gtFlags |= GTF_GLOB_REF | GTF_ASG;
+            op1->gtFlags |= GTF_GLOB_REF | GTF_ASG | GTF_EXCEPT;
             retNode = op1;
             break;
 #endif // defined(TARGET_XARCH) || defined(TARGET_ARM64)
@@ -4350,7 +4350,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     GenTree*   op1 = impPopStack().val;
                     genTreeOps op  = (ni == NI_System_Threading_Interlocked_Or) ? GT_XORR : GT_XAND;
                     retNode        = gtNewOperNode(op, genActualType(callType), op1, op2);
-                    retNode->gtFlags |= GTF_GLOB_REF | GTF_ASG;
+                    retNode->gtFlags |= GTF_GLOB_REF | GTF_ASG | GTF_EXCEPT;
                 }
                 break;
             }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3825,7 +3825,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             // on a local are probably pretty useless anyway, so we probably don't care.
 
             op1 = gtNewOperNode(interlockedOperator, genActualType(callType), op1, op2);
-            op1->gtFlags |= GTF_GLOB_REF | GTF_ASG | GTF_EXCEPT;
+            op1->gtFlags |= GTF_GLOB_REF | GTF_ASG;
+            if (fgAddrCouldBeNull(op1))
+            {
+                op1->gtFlags |= GTF_EXCEPT;
+            }
             retNode = op1;
             break;
 #endif // defined(TARGET_XARCH) || defined(TARGET_ARM64)
@@ -4350,7 +4354,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     GenTree*   op1 = impPopStack().val;
                     genTreeOps op  = (ni == NI_System_Threading_Interlocked_Or) ? GT_XORR : GT_XAND;
                     retNode        = gtNewOperNode(op, genActualType(callType), op1, op2);
-                    retNode->gtFlags |= GTF_GLOB_REF | GTF_ASG | GTF_EXCEPT;
+                    retNode->gtFlags |= GTF_GLOB_REF | GTF_ASG;
+                    if (fgAddrCouldBeNull(op1))
+                    {
+                        retNode->gtFlags |= GTF_EXCEPT;
+                    }
                 }
                 break;
             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16090,6 +16090,11 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             tree->gtFlags |= tree->AsCmpXchg()->gtOpLocation->gtFlags & GTF_ALL_EFFECT;
             tree->gtFlags |= tree->AsCmpXchg()->gtOpValue->gtFlags & GTF_ALL_EFFECT;
             tree->gtFlags |= tree->AsCmpXchg()->gtOpComparand->gtFlags & GTF_ALL_EFFECT;
+
+            if (fgAddrCouldBeNull(tree->AsCmpXchg()->gtOpLocation))
+            {
+                tree->gtFlags |= GTF_EXCEPT;
+            }
             break;
 
         case GT_STORE_DYN_BLK:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10293,6 +10293,13 @@ void Compiler::fgValueNumberAddExceptionSet(GenTree* tree)
                 fgValueNumberAddExceptionSetForCkFinite(tree);
                 break;
 
+            case GT_XAND:
+            case GT_XORR:
+            case GT_XADD:
+            case GT_XCHG:
+                fgValueNumberAddExceptionSetForIndirection(tree, tree->AsOp()->gtGetOp1());
+                break;
+
 #ifdef FEATURE_HW_INTRINSICS
             case GT_HWINTRINSIC:
                 // ToDo: model the exceptions for Intrinsics

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10297,8 +10297,18 @@ void Compiler::fgValueNumberAddExceptionSet(GenTree* tree)
             case GT_XORR:
             case GT_XADD:
             case GT_XCHG:
-                fgValueNumberAddExceptionSetForIndirection(tree, tree->AsOp()->gtGetOp1());
+            case GT_LOCKADD:
+            {
+                GenTree* addr = tree->AsOp()->gtGetOp1();
+                fgValueNumberAddExceptionSetForIndirection(tree, addr);
                 break;
+            }
+
+            case GT_CMPXCHG:
+            {
+                GenTree* addr = tree->AsCmpXchg()->gtOpLocation;
+                fgValueNumberAddExceptionSetForIndirection(tree, addr);
+            }
 
 #ifdef FEATURE_HW_INTRINSICS
             case GT_HWINTRINSIC:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10308,6 +10308,7 @@ void Compiler::fgValueNumberAddExceptionSet(GenTree* tree)
             {
                 GenTree* addr = tree->AsCmpXchg()->gtOpLocation;
                 fgValueNumberAddExceptionSetForIndirection(tree, addr);
+                break;
             }
 
 #ifdef FEATURE_HW_INTRINSICS


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44087

Small improvements as expected:
```
x64 windows crossgen libs:
Total bytes of delta: -64 (-0.00% of base)
29 total methods with Code Size differences (29 improved, 0 regressed), 201105 unchanged.

x64 windows pmi libs:
Total bytes of delta: -671 (-0.00% of base)
165 total methods with Code Size differences (165 improved, 0 regressed), 268077 unchanged.
```

It is a straight implementation of @erozenfeld suggestion with expansion to XORR, XAND, XCHG.
Also, we noticed that `GT_XORR, GT_XAND, GT_XADD, GT_XCHG` were not marked as `GTF_EXCEPT` so I fixed it as well.