### PR TITLE
[browser][wasm] Fix makefile build error with provision-wasm 

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -33,7 +33,7 @@ all: build-native icu-files source-files header-files
 #  If EMSDK_PATH is not set by the caller, download and setup a local emsdk install.
 #
 
-EMSCRIPTEN_VERSION=`cat emscripten-version.txt`
+EMSCRIPTEN_VERSION := $(shell cat $(TOP)/src/mono/wasm/emscripten-version.txt)
 EMSDK_LOCAL_PATH=emsdk
 EMCC=source $(EMSDK_PATH)/emsdk_env.sh 2>/dev/null && emcc
 


### PR DESCRIPTION
Running `make -C src/mono/wasm provision-wasm` produced the following errors:

```
cd emsdk && ./emsdk install `cat emscripten-version.txt`
cat: emscripten-version.txt: No such file or directory
```

as well as the following subsequent errors:

```
HEAD is now at 7cba2e0 2.0.15 (#743)
cd emsdk && ./emsdk install `cat /Users/Jimmy/websharp/projects/runtime-issues/src/mono/wasm/emscripten-version.txt`
```

```
touch .stamp-wasm-install-and-select-`cat
/bin/sh: -c: line 0: unexpected EOF while looking for matching ``'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [.stamp-wasm-install-and-select-`cat] Error 2
```

Fix https://github.com/dotnet/runtime/issues/49862