### PR TITLE
Enable building repo on Windows ARM64

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -209,6 +209,9 @@ if %__TotalSpecifiedBuildArch% GTR 1 (
     goto Usage
 )
 
+set __ProcessorArch=%PROCESSOR_ARCHITEW6432%
+if "%__ProcessorArch%"=="" set __ProcessorArch=%PROCESSOR_ARCHITECTURE%
+
 if %__BuildArchX64%==1      set __BuildArch=x64
 if %__BuildArchX86%==1 (
     set __BuildArch=x86
@@ -221,7 +224,7 @@ if %__BuildArchArm%==1 (
 )
 if %__BuildArchArm64%==1 (
     set __BuildArch=arm64
-    set __CrossArch=x64
+    if /i not "%__ProcessorArch%"=="ARM64" set __CrossArch=x64
 )
 
 set /A __TotalSpecifiedBuildType=__BuildTypeDebug + __BuildTypeChecked + __BuildTypeRelease
@@ -252,7 +255,7 @@ REM Determine if this is a cross-arch build. Only do cross-arch build if we're a
 if %__SkipCrossArchNative% EQU 0 (
     if %__BuildNative% EQU 1 (
         if /i "%__BuildArch%"=="arm64" (
-            set __BuildCrossArchNative=1
+            if defined __CrossArch set __BuildCrossArchNative=1
         )
         if /i "%__BuildArch%"=="arm" (
             set __BuildCrossArchNative=1
@@ -597,7 +600,9 @@ if %__BuildNative% EQU 1 (
     )
     if /i "%__BuildArch%" == "arm64" (
         set __VCBuildArch=x86_arm64
-        set ___CrossBuildDefine="-DCLR_CMAKE_CROSS_ARCH=1" "-DCLR_CMAKE_CROSS_HOST_ARCH=%__CrossArch%"
+        if defined __CrossArch (
+            set ___CrossBuildDefine="-DCLR_CMAKE_CROSS_ARCH=1" "-DCLR_CMAKE_CROSS_HOST_ARCH=%__CrossArch%"
+        )
     )
 
     echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -130,7 +130,7 @@ if "%__RuntimeFlavor%" NEQ "Mono" (
     copy /B /Y "%__CoreClrArtifacts%\corehost\PDB\singlefilehost.pdb"  "%__CMakeBinDir%/corehost/PDB/"
 
     echo Embedding "%__CoreClrArtifacts%\mscordaccore.dll" into "%__CMakeBinDir%\corehost\singlefilehost.exe"
-    if /i "%__BuildArch%" == "x64"  (
+    if not exist "%__CoreClrArtifacts%\x64\dactabletools\InjectResource.exe" (
         "%__CoreClrArtifacts%\dactabletools\InjectResource.exe"     /bin:"%__CoreClrArtifacts%\mscordaccore.dll" /dll:"%__CMakeBinDir%\corehost\singlefilehost.exe" /name:MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER
     ) else (
         "%__CoreClrArtifacts%\x64\dactabletools\InjectResource.exe" /bin:"%__CoreClrArtifacts%\mscordaccore.dll" /dll:"%__CMakeBinDir%\corehost\singlefilehost.exe" /name:MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER


### PR DESCRIPTION
Enable building the repo on Windows ARM64 without x64 emulation. Fixes #42008.

I verified that `build -arch arm64 -s clr+libs+host+packs` (debug and release) works successfully on Windows 20H2 ARM64 with 4 GiB of RAM. @dotnet/runtime-infrastructure