### PR TITLE
Crossgen2-related CoreCLR test infra fixes

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -128,6 +128,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         echo -r:$CORE_ROOT/mscorlib.dll>>$__ResponseFile
         echo --verify-type-and-field-layout>>$__ResponseFile
         echo --targetarch:$(TargetArchitecture)>>$__ResponseFile
+        echo -O>>$__ResponseFile
 
         echo "Response file: $__ResponseFile"
         cat $__ResponseFile
@@ -282,6 +283,7 @@ if defined RunCrossGen2 (
     echo -r:!CORE_ROOT!\Microsoft.*.dll>>!__ResponseFile!
     echo -r:!CORE_ROOT!\mscorlib.dll>>!__ResponseFile!
     echo -r:!CORE_ROOT!\netstandard.dll>>!__ResponseFile!
+    echo -O>>!__ResponseFile!
 
     if not "$(__CreatePdb)" == "" (
         echo --pdb>>!__ResponseFile!

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -568,7 +568,7 @@ if defined __CreatePdb (
 if defined __CompositeBuildMode (
     set __CrossgenCmd=%__CrossgenCmd% --composite
 ) else (
-    set __CrossgenCmd=%__CrossgenCmd% --large-bubble --crossgen2-parallelism 1
+    set __CrossgenCmd=%__CrossgenCmd% --crossgen2-parallelism 1
 )
 
 set __CrossgenDir=%__BinDir%

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -159,7 +159,7 @@ precompile_coreroot_fx()
     fi
 
     local outputDir="$__TestIntermediatesDir/crossgen.out"
-    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$outputDir\" --large-bubble --release --nocleanup --target-arch $__BuildArch -dop $__NumProc"
+    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$outputDir\" --release --nocleanup --target-arch $__BuildArch -dop $__NumProc"
 
     if [[ "$__CompositeBuildMode" != 0 ]]; then
         crossgenCmd="$crossgenCmd --composite"


### PR DESCRIPTION
(*) When compiling tests with Crossgen2, use optimizations by default
like Crossgen1 does.

(*) Don't use large version bubble when Crossgen2-compiling
the framework. While at some point this had value as preparatory
testing for composite mode, it's not a shipping scenario right now
and it was hiding the codegen bug causing the issue

https://github.com/dotnet/runtime/issues/49826

in System.Text.Json.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 