### PR TITLE
Bump Helix workitem timeout for libraries outerloop runs

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -29,6 +29,7 @@
     <_workItemTimeout Condition="'$(Scenario)' == '' and '$(_workItemTimeout)' == '' and ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm')">00:45:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' != '' and '$(_workItemTimeout)' == '' and ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm')">01:00:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' == 'BuildWasmApps' and '$(_workItemTimeout)' == ''">01:00:00</_workItemTimeout>
+    <_workItemTimeout Condition="'$(Scenario)' == '' and '$(_workItemTimeout)' == '' and '$(Outerloop)' == 'true'">00:20:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' == '' and '$(_workItemTimeout)' == ''">00:15:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' != '' and '$(_workItemTimeout)' == ''">00:30:00</_workItemTimeout>
 


### PR DESCRIPTION
System.IO.Compression.Brotli.Tests in debug configuration (which we use in PR builds) takes 870 seconds already which is quite close to the existing 900s timeout.

```
=== TEST EXECUTION SUMMARY ===
   System.IO.Compression.Brotli.Tests  Total: 121, Errors: 0, Failed: 0, Skipped: 0, Time: 870.888s
```

This caused the timeout seen in https://helix.dot.net/api/2019-06-17/jobs/4f8db33f-41d8-43c4-97b9-a65dfd229437/workitems/System.IO.Compression.Brotli.Tests/console