### PR TITLE
Don't init tracked temps without GC fields.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4682,6 +4682,12 @@ void CodeGen::genCheckUseBlockInit()
             continue;
         }
 
+        if (varDsc->lvIsTemp && !varDsc->HasGCPtr())
+        {
+            varDsc->lvMustInit = 0;
+            continue;
+        }
+
         if (compiler->info.compInitMem || varDsc->HasGCPtr() || varDsc->lvMustInit)
         {
             if (varDsc->lvTracked)
@@ -4728,8 +4734,7 @@ void CodeGen::genCheckUseBlockInit()
                 unless they are untracked GC type or structs that contain GC pointers */
             CLANG_FORMAT_COMMENT_ANCHOR;
 
-            if ((!varDsc->lvTracked || (varDsc->lvType == TYP_STRUCT)) && varDsc->lvOnFrame &&
-                (!varDsc->lvIsTemp || varDsc->HasGCPtr()))
+            if ((!varDsc->lvTracked || (varDsc->lvType == TYP_STRUCT)) && varDsc->lvOnFrame)
             {
 
                 varDsc->lvMustInit = true;


### PR DESCRIPTION
A zero-init elimination improvement suggested by @erozenfeld, fixes most regressions from https://github.com/dotnet/runtime/pull/48377.

```
x64 windows crossgen: 
Total bytes of delta: -1251 (-0.00% of base)
196 total methods with Code Size differences (182 improved, 14 regressed), 200938 unchanged.

x64 windows pmi:
Total bytes of delta: -8436 (-0.02% of base)
667 total methods with Code Size differences (636 improved, 31 regressed), 267575 unchanged.
```

With this change we have fewer must-init variables, the regressions show cases where we init fewer lclVars but it takes more instructions. For example if before we were initializing 16 bytes with 1 instruction and now we init 14 bytes with 3.