### PR TITLE
Disable Github45929 regression test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -8,6 +8,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_22888/test22888/*">
             <Issue>https://github.com/dotnet/runtime/issues/13703</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929//test45929/*">
+            <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -8,7 +8,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_22888/test22888/*">
             <Issue>https://github.com/dotnet/runtime/issues/13703</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929//test45929/*">
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
         </ExcludeList>
     </ItemGroup>


### PR DESCRIPTION
It has been intermittently failing on a few test runs. Will enable once fixed.  Tracking issue has been created to investigate: https://github.com/dotnet/runtime/issues/49881