### PR TITLE
Revise UnnamedOptionsManager to avoid allocation in ctor

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
@@ -1,22 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace Microsoft.Extensions.Options
 {
-    internal class UnnamedOptionsManager<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :
+    internal sealed class UnnamedOptionsManager<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :
         IOptions<TOptions>
         where TOptions : class
     {
-        private readonly Lazy<TOptions> _lazy;
+        private readonly IOptionsFactory<TOptions> _factory;
+        private volatile object _syncObj;
+        private volatile TOptions _value;
 
-        public UnnamedOptionsManager(IOptionsFactory<TOptions> factory)
+        public UnnamedOptionsManager(IOptionsFactory<TOptions> factory) => _factory = factory;
+
+        public TOptions Value
         {
-            _lazy = new Lazy<TOptions>(() => factory.Create(Options.DefaultName));
-        }
+            get
+            {
+                if (_value is TOptions value)
+                {
+                    return value;
+                }
 
-        public TOptions Value => _lazy.Value;
+                lock (_syncObj ?? Interlocked.CompareExchange(ref _syncObj, new object(), null) ?? _syncObj)
+                {
+                    return _value ??= _factory.Create(Options.DefaultName);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/49852#discussion_r597771124

|             Method |      Mean | Allocated |
|------------------- |----------:|----------:|
|         CreateMain | 28.281 ns |     184 B |
|           CreatePR |  4.504 ns |      40 B |
| CreateAndValueMain | 90.796 ns |     376 B |
|   CreateAndValuePR | 69.512 ns |     256 B |

cc: @davidfowl, @eerhardt 