### PR TITLE
Rename ConstLog2 to IntegralLog2 and make it a 'constexpr' function

### DIFF
--- a/src/coreclr/jit/smallhash.h
+++ b/src/coreclr/jit/smallhash.h
@@ -32,7 +32,7 @@ struct HashTableInfo<TKey*>
     static unsigned GetHashCode(const TKey* key)
     {
         // Shift off bits that are not likely to be significant
-        size_t keyval = reinterpret_cast<size_t>(key) >> ConstLog2<__alignof(TKey)>::value;
+        size_t keyval = reinterpret_cast<size_t>(key) >> IntegralLog2(__alignof(TKey));
 
         // Truncate and return the result
         return static_cast<unsigned>(keyval);
@@ -627,7 +627,7 @@ class SmallHashTable final : public HashTableBase<TKey, TValue, TKeyInfo, TAlloc
 
     enum : unsigned
     {
-        RoundedNumInlineBuckets = 1 << ConstLog2<NumInlineBuckets>::value
+        RoundedNumInlineBuckets = 1 << IntegralLog2(NumInlineBuckets)
     };
 
     typename TBase::Bucket m_inlineBuckets[RoundedNumInlineBuckets];

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -71,34 +71,16 @@ inline IteratorPair<TIterator> MakeIteratorPair(TIterator begin, TIterator end)
     return IteratorPair<TIterator>(begin, end);
 }
 
-// Recursive template definition to calculate the base-2 logarithm
-// of a constant value.
-template <unsigned val, unsigned acc = 0>
-struct ConstLog2
+// Calculates the base-2 logarithm of an integer. Can be used for compile-time constants.
+constexpr int IntegralLog2(unsigned value, unsigned accumulator = 0)
 {
-    enum
+    if (value == 0 || value == 1)
     {
-        value = ConstLog2<val / 2, acc + 1>::value
-    };
-};
+        return accumulator;
+    }
 
-template <unsigned acc>
-struct ConstLog2<0, acc>
-{
-    enum
-    {
-        value = acc
-    };
-};
-
-template <unsigned acc>
-struct ConstLog2<1, acc>
-{
-    enum
-    {
-        value = acc
-    };
-};
+    return IntegralLog2(value / 2, accumulator + 1);
+}
 
 inline const char* dspBool(bool b)
 {


### PR DESCRIPTION
Are there reasons to avoid `constexpr` in Jit code? The only existing usage of it in the function context that I could find is in the `JitPrimeInfo` constructor.

I've renamed the function as it can now be used outside of compile-time-constants-only contexts, but I actually do not have strong preference either way.

Is `utils.h` the right place for this function? It is only used in `smallhash.h`, perhaps it should be moved there?

Edit:
```
/__w/1/s/src/coreclr/jit/utils.h:79:9: error: statement not allowed in constexpr function
#define return for (;1;__ReturnOK::safe_to_return()) return
```
I see. Well, now I know 😄.