### PR TITLE
Don't throw when previous enum mapping is not found.

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -936,7 +936,7 @@ namespace System.Xml.Serialization
                 {
                     i++;
                     uniqueName = name + i.ToString(CultureInfo.InvariantCulture);
-                    m = Enums[uniqueName];
+                    Enums.TryGetValue(uniqueName, out m);
                 }
             }
             Enums.Add(uniqueName, mapping);

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -15,10 +15,8 @@
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRSampleType.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRTypeLibrary.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\Primitives.cs" />
-    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs"
-             Link="Common\System\IO\TempFile.cs" />
-    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\DataContractSerializerHelper.cs"
-             Link="Common\System\Runtime\Serialization\DataContractSerializerHelper.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\DataContractSerializerHelper.cs" Link="Common\System\Runtime\Serialization\DataContractSerializerHelper.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
     <Compile Include="SerializationTestTypes\Collections.cs" />
@@ -29,6 +27,7 @@
     <Compile Include="SerializationTestTypes\SampleIObjectRef.cs" />
     <Compile Include="SerializationTestTypes\SampleTypes.cs" />
     <Compile Include="SerializationTestTypes\SelfRefAndCycles.cs" />
+    <Compile Include="XmlSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.CodeDom\src\System.CodeDom.csproj" />

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlSerializerTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlSerializerTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+using Xunit;
+
+public static class XmlSerializerTests
+{
+
+    public const string FakeNS = "http://example.com/XmlSerializerTests";
+
+    [Fact]
+    public static void FlagEnums_With_Different_Namespaces()
+    {
+        StringWriter sw = new StringWriter();
+        XmlTextWriter xml = new XmlTextWriter(sw);
+
+        TwoClasses twoClasses = new TwoClasses
+        {
+            First = new FirstClass { TestingEnumValues = TestEnum.First },
+            Second = new SecondClass { TestingEnumValues = TestEnum.Second }
+        };
+
+        // 43675 - This line throws with inconsistent Flag.type/namespace usage
+        XmlSerializer ser = new XmlSerializer(typeof(TwoClasses));
+
+        ser.Serialize(xml, twoClasses);
+        string s = sw.ToString();
+
+        Assert.Contains("enumtest", s);
+    }
+
+    [Flags]
+    public enum TestEnum
+    {
+        First = 1,
+        Second = 2
+    }
+
+    public class FirstClass
+    {
+        [XmlAttribute("enumtest")]
+        public TestEnum TestingEnumValues;
+    }
+
+    public class SecondClass
+    {
+        [XmlAttribute("enumtest", Namespace = XmlSerializerTests.FakeNS)]
+        public TestEnum TestingEnumValues;
+    }
+
+    public class TwoClasses
+    {
+        public TwoClasses() { }
+
+        [XmlElement("first")]
+        public FirstClass First;
+
+        [XmlElement("second", Namespace = XmlSerializerTests.FakeNS)]
+        public SecondClass Second;
+    }
+
+}


### PR DESCRIPTION
Allow homonymous enums from different namespaces.

This was a regression from the full-framework XmlSerializer.
Previously, enums with the same name but different
namespaces were handled correctly, just like other
types. But early in .Net Core, the list that we used to
track previously seen enum types changed from
Hashtable to Dictionary, and we did not update an
accessor that was previously ok with returning null
but now throws an exception.

The fix is simply to use the non-throwing access
method for the Dictionary, since the code has
always expected and handled the case where
the value is not found.

Fix #43675