### PR TITLE
Give AOT mono package arch identifiers

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -117,6 +117,26 @@ jobs:
       runtimeFlavor: mono
       platforms:
       - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
       - Linux_arm64
       jobParameters:
         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
@@ -127,7 +147,7 @@ jobs:
           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
           includeRootFolder: true
           displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOT
+          artifactName: LinuxMonoAOTarm64
           archiveExtension: '.tar.gz'
           archiveType: tar
           tarCompression: gz

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -123,7 +123,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: $(librariesDownloadDir)/LinuxMonoAOT
-          artifactFileName: LinuxMonoAOT.tar.gz
+          artifactFileName: LinuxMonoAOT${{ parameters.archType }}.tar.gz
           artifactName: LinuxMonoAOT
           displayName: AOT Mono Artifacts
 


### PR DESCRIPTION
When I added Arm64 AOT runs I had forgotten that the AOT artifacts were not created with a arch identifier. This adds that.