### PR TITLE
Fix incremental build R2R of System.Private.CoreLib

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -40,6 +40,11 @@
       <BuildPerfMap Condition="$(BuildDll) and '$(TargetOS)' == 'Linux'">true</BuildPerfMap>
     </PropertyGroup>
 
+    <ItemGroup>
+      <CrossGen2DllFiles Condition="'$(CrossDir)' == ''" Include="$(BinDir)/crossgen2/*" />
+      <CrossGen2DllFiles Condition="'$(CrossDir)' != ''" Include="$(BinDir)/$(CrossDir)/crossgen2/*" />
+    </ItemGroup>
+
     <PropertyGroup>
       <CoreLibAssemblyName>System.Private.CoreLib</CoreLibAssemblyName>
       <CoreLibInputPath>$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '$(CoreLibAssemblyName).dll'))</CoreLibInputPath>
@@ -53,7 +58,7 @@
 
   <Target Name="InvokeCrossgen"
           DependsOnTargets="PrepareForCrossgen"
-          Inputs="$(CoreLibInputPath)"
+          Inputs="$(CoreLibInputPath);@(CrossGen2DllFiles)"
           Outputs="$(CoreLibOutputPath);$(CoreLibNiPdbPath);$(CoreLibPerfMapPath)"
           AfterTargets="Build">
 


### PR DESCRIPTION
- Add dependency on newly compiled crossgen2 binaries
- Will force recompile of S.P.C if the ready to run compiler changes in addition to recompiling if S.P.C changes