### PR TITLE
Fix CMake detection and DefaultSubsets

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -25,6 +25,8 @@
   <PropertyGroup>
     <DefaultSubsets>clr+mono+libs+host+packs</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsMobile)' == 'true'">mono+libs+packs</DefaultSubsets>
+    <!-- On Windows mono is supported for x86/x64 only -->
+    <DefaultSubsets Condition="'$(TargetOS)' == 'windows' and '$(TargetArchitecture)' != 'x86' and '$(TargetArchitecture)' != 'x64'">clr+libs+host+packs</DefaultSubsets>
   </PropertyGroup>
 
   <!-- Init _subset here in to allow RuntimeFlavor to be set as early as possible -->

--- a/eng/native/set-cmake-path.ps1
+++ b/eng/native/set-cmake-path.ps1
@@ -1,73 +1,45 @@
-# This file probes for the prerequisites for the build system, and outputs commands for eval'ing
-# from the cmd scripts to set variables (and exit on error)
+# This script locates the CMake executable for the build system and outputs either the "set CMakePath=..."
+# command (if CMake is found) or the "exit /b 1" command (if not found) for evaluating from batch files.
 
-function GetCMakeVersions
-{
-  $items = @()
-  $items += @(Get-ChildItem hklm:\SOFTWARE\Wow6432Node\Kitware -ErrorAction SilentlyContinue)
-  $items += @(Get-ChildItem hklm:\SOFTWARE\Kitware -ErrorAction SilentlyContinue)
-  return $items | where { $_.PSChildName.StartsWith("CMake") }
-}
+Set-StrictMode -Version 3
 
-function GetCMakeInfo($regKey)
-{
-  try {
-    $version = [System.Version] $regKey.PSChildName.Split(' ')[1]
+function LocateCMake {
+  # Find the first cmake.exe on the PATH
+  $cmakeApp = (Get-Command cmake.exe -ErrorAction SilentlyContinue)
+  if ($cmakeApp -ne $null) {
+    return $cmakeApp.Path
   }
-  catch {
-    return $null
-  }
-  $itemProperty = Get-ItemProperty $regKey.PSPath;
-  if (Get-Member -inputobject $itemProperty -name "InstallDir" -Membertype Properties) {
-    $cmakeDir = $itemProperty.InstallDir
-  }
-  else {
-    $cmakeDir = $itemProperty.'(default)'
-  }
-  $cmakePath = [System.IO.Path]::Combine($cmakeDir, "artifacts\cmake.exe")
-  if (![System.IO.File]::Exists($cmakePath)) {
-    return $null
-  }
-  return @{'version' = $version; 'path' = $cmakePath}
-}
 
-function LocateCMake
-{
-  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from https://cmake.org/download/ and ensure it is on your path."
-  $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
-  if ($inPathPath -ne $null) {
-    # Resolve the first version of CMake if multiple commands are found
-    if ($inPathPath.Length -gt 1) {
-      return $inPathPath[0].Path
-    }
-    return $inPathPath.Path
+  # Find cmake.exe using the registry
+  $cmakeRegKey = Get-ItemProperty HKLM:\SOFTWARE\Kitware\CMake -Name InstallDir -ErrorAction SilentlyContinue
+  if ($cmakeRegKey -eq $null) {
+    $cmakeRegKey = Get-ItemProperty HKLM:\SOFTWARE\Wow6432Node\Kitware\CMake -Name InstallDir -ErrorAction SilentlyContinue
   }
-  # Let us hope that CMake keep using their current version scheme
-  $validVersions = @()
-  foreach ($regKey in GetCMakeVersions) {
-    $info = GetCMakeInfo($regKey)
-    if ($info -ne $null) {
-      $validVersions += @($info)
+
+  if ($cmakeRegKey -ne $null) {
+    $cmakePath = $cmakeRegKey.InstallDir + "bin\cmake.exe"
+    if (Test-Path $cmakePath -PathType Leaf) {
+      return $cmakePath
     }
   }
-  $newestCMakePath = ($validVersions |
-    Sort-Object -property @{Expression={$_.version}; Ascending=$false} |
-    select -first 1).path
-  if ($newestCMakePath -eq $null) {
-    Throw $errorMsg
-  }
-  return $newestCMakePath
+
+  return $null
 }
 
 try {
   $cmakePath = LocateCMake
+
+  if ($cmakePath -eq $null) {
+    throw "CMake is a pre-requisite to build this repository but it was not found on the PATH or in the registry. Please install CMake from https://cmake.org/download/."
+  }
+
   $version = [Version]$(& $cmakePath --version | Select-String -Pattern '\d+\.\d+\.\d+' | %{$_.Matches.Value})
 
   if ($version -lt [Version]"3.14.0") {
-      Throw "This repository requires CMake 3.14 and recommends CMake 3.16. The newest version of CMake installed is $version. Please install CMake 3.16 or newer from https://cmake.org/download/ and ensure it is on your path."
+    throw "This repository requires CMake 3.14 and recommends CMake 3.16. The version of CMake installed is $version. Please install CMake 3.16 or newer from https://cmake.org/download/."
   }
   elseif ($version -lt [Version]"3.16.0") {
-    [System.Console]::Error.WriteLine("CMake 3.16 or newer is recommended for building this repository. The newest version of CMake installed is $version. Please install CMake 3.16 or newer from https://cmake.org/download/ and ensure it is on your path.")
+    [System.Console]::Error.WriteLine("CMake 3.16 or newer is recommended for building this repository. The newest version of CMake installed is $version. Please install CMake 3.16 or newer from https://cmake.org/download/.")
   }
 
   [System.Console]::WriteLine("set CMakePath=" + $cmakePath)


### PR DESCRIPTION
The ability to detect CMake using the registry was broken during the bulk `bin` -> `artifacts` replacement in https://github.com/dotnet/runtime/commit/cd36d15ef931990c2cf2b0c82384a40b728b6a62#diff-0210f13203bfc065d9fa5845185bab3938dd61e2f9536fb38d9ebe58d40b0778. In addition, for many years CMake installers use the fixed `CMake` registry key name (with no version) and do not allow multiple installations, so the code for choosing the newest CMake version may be removed.

`build.cmd -arch arm` and `build.cmd -arch arm64` have been broken for a long time due to Mono not supporting Windows ARM/ARM64 targets. Fix that by omitting `mono` from the list of the default subsets for Windows ARM/ARM64.