### PR TITLE
ReadOnlySequence: Removed useless bit masking on SequencePosition.

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -25,7 +25,7 @@ namespace System.Buffers
 
             SequenceType type = GetSequenceType();
             object? endObject = _endObject;
-            int startIndex = GetIndex(position);
+            int startIndex = position.GetInteger();
             int endIndex = GetIndex(_endInteger);
 
             if (type == SequenceType.MultiSegment)
@@ -273,7 +273,7 @@ namespace System.Buffers
         {
             object? startObject = start.GetObject();
             object? endObject = _endObject;
-            int startIndex = GetIndex(start);
+            int startIndex = start.GetInteger();
             int endIndex = GetIndex(_endInteger);
 
             if (startObject != endObject)
@@ -333,7 +333,7 @@ namespace System.Buffers
 
         private void BoundsCheck(in SequencePosition position, bool positionIsNotNull)
         {
-            uint sliceStartIndex = (uint)GetIndex(position);
+            uint sliceStartIndex = (uint)position.GetInteger();
 
             object? startObject = _startObject;
             object? endObject = _endObject;
@@ -462,9 +462,6 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetIndex(in SequencePosition position) => position.GetInteger() & ReadOnlySequence.IndexBitMask;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int GetIndex(int Integer) => Integer & ReadOnlySequence.IndexBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -476,9 +473,9 @@ namespace System.Buffers
 
             return new ReadOnlySequence<T>(
                 start.GetObject(),
-                GetIndex(start) | (_startInteger & ReadOnlySequence.FlagBitMask),
+                start.GetInteger() | (_startInteger & ReadOnlySequence.FlagBitMask),
                 end.GetObject(),
-                GetIndex(end) | (_endInteger & ReadOnlySequence.FlagBitMask)
+                end.GetInteger() | (_endInteger & ReadOnlySequence.FlagBitMask)
             );
         }
 
@@ -491,7 +488,7 @@ namespace System.Buffers
 
             return new ReadOnlySequence<T>(
                 start.GetObject(),
-                GetIndex(start) | (_startInteger & ReadOnlySequence.FlagBitMask),
+                start.GetInteger() | (_startInteger & ReadOnlySequence.FlagBitMask),
                 _endObject,
                 _endInteger
             );

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -105,8 +105,8 @@ namespace System.Buffers
 
             _startObject = startSegment;
             _endObject = endSegment;
-            _startInteger = ReadOnlySequence.SegmentToSequenceStart(startIndex);
-            _endInteger = ReadOnlySequence.SegmentToSequenceEnd(endIndex);
+            _startInteger = startIndex;
+            _endInteger = endIndex;
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace System.Buffers
 
             _startObject = array;
             _endObject = array;
-            _startInteger = ReadOnlySequence.ArrayToSequenceStart(0);
+            _startInteger = 0;
             _endInteger = ReadOnlySequence.ArrayToSequenceEnd(array.Length);
         }
 
@@ -135,7 +135,7 @@ namespace System.Buffers
 
             _startObject = array;
             _endObject = array;
-            _startInteger = ReadOnlySequence.ArrayToSequenceStart(start);
+            _startInteger = start;
             _endInteger = ReadOnlySequence.ArrayToSequenceEnd(start + length);
         }
 
@@ -150,7 +150,7 @@ namespace System.Buffers
                 _startObject = manager;
                 _endObject = manager;
                 _startInteger = ReadOnlySequence.MemoryManagerToSequenceStart(index);
-                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(length);
+                _endInteger = length;
             }
             else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
             {
@@ -158,7 +158,7 @@ namespace System.Buffers
                 int start = segment.Offset;
                 _startObject = array;
                 _endObject = array;
-                _startInteger = ReadOnlySequence.ArrayToSequenceStart(start);
+                _startInteger = start;
                 _endInteger = ReadOnlySequence.ArrayToSequenceEnd(start + segment.Count);
             }
             else if (typeof(T) == typeof(char))
@@ -224,7 +224,7 @@ namespace System.Buffers
 
                     begin = SeekMultiSegment(startSegment.Next!, endObject!, endIndex, start - currentLength, ExceptionArgument.start);
 
-                    int beginIndex = GetIndex(begin);
+                    int beginIndex = begin.GetInteger();
                     object beginObject = begin.GetObject()!;
 
                     if (beginObject != endObject)
@@ -275,7 +275,7 @@ namespace System.Buffers
             uint endIndex = (uint)GetIndex(_endInteger);
             object? endObject = _endObject;
 
-            uint sliceEndIndex = (uint)GetIndex(end);
+            uint sliceEndIndex = (uint)end.GetInteger();
             object? sliceEndObject = end.GetObject();
 
             if (sliceEndObject == null)
@@ -352,7 +352,7 @@ namespace System.Buffers
             object? endObject = _endObject;
 
             // Check start before length
-            uint sliceStartIndex = (uint)GetIndex(start);
+            uint sliceStartIndex = (uint)start.GetInteger();
             object? sliceStartObject = start.GetObject();
 
             if (sliceStartObject == null)
@@ -453,7 +453,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySequence<T> Slice(SequencePosition start, SequencePosition end)
         {
-            BoundsCheck((uint)GetIndex(start), start.GetObject(), (uint)GetIndex(end), end.GetObject());
+            BoundsCheck((uint)start.GetInteger(), start.GetObject(), (uint)end.GetInteger(), end.GetObject());
             return SliceImpl(start, end);
         }
 
@@ -540,7 +540,7 @@ namespace System.Buffers
             object? startObject = _startObject;
             object? endObject = _endObject;
 
-            uint positionIndex = (uint)GetIndex(position);
+            uint positionIndex = (uint)position.GetInteger();
 
             // if sequence object is null we suppose start segment
             if (positionIsNull)
@@ -667,30 +667,17 @@ namespace System.Buffers
         public const int FlagBitMask = 1 << 31;
         public const int IndexBitMask = ~FlagBitMask;
 
-        public const int SegmentStartMask = 0;
-        public const int SegmentEndMask = 0;
-
-        public const int ArrayStartMask = 0;
         public const int ArrayEndMask = FlagBitMask;
 
         public const int MemoryManagerStartMask = FlagBitMask;
-        public const int MemoryManagerEndMask = 0;
 
         public const int StringStartMask = FlagBitMask;
         public const int StringEndMask = FlagBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int SegmentToSequenceStart(int startIndex) => startIndex | SegmentStartMask;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int SegmentToSequenceEnd(int endIndex) => endIndex | SegmentEndMask;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ArrayToSequenceStart(int startIndex) => startIndex | ArrayStartMask;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ArrayToSequenceEnd(int endIndex) => endIndex | ArrayEndMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int MemoryManagerToSequenceStart(int startIndex) => startIndex | MemoryManagerStartMask;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int MemoryManagerToSequenceEnd(int endIndex) => endIndex | MemoryManagerEndMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int StringToSequenceStart(int startIndex) => startIndex | StringStartMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
In PR #47969, I fixed a bug by stopping to propagate the bit flag in the SequencePosition.
Now we can expect that the SequencePosition passed as an argument won't have this bit flag, so any bitmasking operation on arguments is useless.

Benchmark shows no significant changes, but the Code Size is a few bytes smaller on some functions:

|                          Method |        Job | Branch |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD | Code Size |
|-------------------------------- |----------- |------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|
|              IterateTryGetArray | Job-COAKWQ | main   |  6.298 ns | 0.1499 ns | 0.1472 ns |  6.213 ns |  6.191 ns |  6.591 ns |  1.00 |    0.03 |     689 B |
|              IterateTryGetArray | Job-INGEYJ | PR     |  6.308 ns | 0.0887 ns | 0.0830 ns |  6.287 ns |  6.236 ns |  6.502 ns |  1.00 |    0.00 |     682 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|             IterateForEachArray | Job-COAKWQ | main   | 16.578 ns | 0.3582 ns | 0.3175 ns | 16.393 ns | 16.297 ns | 17.245 ns |  0.99 |    0.02 |     871 B |
|             IterateForEachArray | Job-INGEYJ | PR     | 16.825 ns | 0.1884 ns | 0.1670 ns | 16.746 ns | 16.646 ns | 17.056 ns |  1.00 |    0.00 |     864 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|         IterateGetPositionArray | Job-COAKWQ | main   | 16.706 ns | 0.2245 ns | 0.1875 ns | 16.661 ns | 16.444 ns | 17.093 ns |  1.04 |    0.01 |     600 B |
|         IterateGetPositionArray | Job-INGEYJ | PR     | 16.057 ns | 0.1622 ns | 0.1517 ns | 16.096 ns | 15.850 ns | 16.257 ns |  1.00 |    0.00 |     572 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                      FirstArray | Job-COAKWQ | main   |  7.501 ns | 0.1494 ns | 0.2984 ns |  7.505 ns |  6.774 ns |  8.008 ns |  0.89 |    0.03 |   4,011 B |
|                      FirstArray | Job-INGEYJ | PR     |  8.566 ns | 0.1049 ns | 0.0981 ns |  8.555 ns |  8.424 ns |  8.714 ns |  1.00 |    0.00 |   4,011 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                  FirstSpanArray | Job-COAKWQ | main   |  9.159 ns | 0.0597 ns | 0.0529 ns |  9.163 ns |  9.078 ns |  9.231 ns |  0.88 |    0.01 |   8,791 B |
|                  FirstSpanArray | Job-INGEYJ | PR     | 10.366 ns | 0.1620 ns | 0.1515 ns | 10.333 ns | 10.108 ns | 10.575 ns |  1.00 |    0.00 |   8,791 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                 FirstSpanMemory | Job-COAKWQ | main   | 11.236 ns | 0.0261 ns | 0.0232 ns | 11.236 ns | 11.190 ns | 11.277 ns |  1.12 |    0.03 |   9,146 B |
|                 FirstSpanMemory | Job-INGEYJ | PR     |  9.989 ns | 0.1916 ns | 0.2207 ns |  9.900 ns |  9.726 ns | 10.436 ns |  1.00 |    0.00 |   9,146 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|          FirstSpanSingleSegment | Job-COAKWQ | main   | 18.736 ns | 0.0456 ns | 0.0427 ns | 18.721 ns | 18.696 ns | 18.834 ns |  0.99 |    0.00 |   8,929 B |
|          FirstSpanSingleSegment | Job-INGEYJ | PR     | 18.879 ns | 0.0135 ns | 0.0112 ns | 18.875 ns | 18.864 ns | 18.903 ns |  1.00 |    0.00 |   8,929 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|            FirstSpanTenSegments | Job-COAKWQ | main   | 18.816 ns | 0.0870 ns | 0.0772 ns | 18.782 ns | 18.739 ns | 19.014 ns |  1.01 |    0.00 |   8,929 B |
|            FirstSpanTenSegments | Job-INGEYJ | PR     | 18.651 ns | 0.0278 ns | 0.0232 ns | 18.642 ns | 18.633 ns | 18.713 ns |  1.00 |    0.00 |   8,929 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                      SliceArray | Job-COAKWQ | main   |  5.938 ns | 0.0853 ns | 0.0756 ns |  5.902 ns |  5.878 ns |  6.134 ns |  1.04 |    0.01 |   1,702 B |
|                      SliceArray | Job-INGEYJ | PR     |  5.721 ns | 0.0143 ns | 0.0119 ns |  5.718 ns |  5.713 ns |  5.753 ns |  1.00 |    0.00 |   1,702 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|             IterateTryGetMemory | Job-COAKWQ | main   | 26.141 ns | 0.4960 ns | 0.8010 ns | 25.816 ns | 25.376 ns | 27.922 ns |  0.96 |    0.03 |   1,044 B |
|             IterateTryGetMemory | Job-INGEYJ | PR     | 27.709 ns | 0.2697 ns | 0.2522 ns | 27.667 ns | 27.369 ns | 28.149 ns |  1.00 |    0.00 |   1,037 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|            IterateForEachMemory | Job-COAKWQ | main   | 35.871 ns | 0.4337 ns | 0.4056 ns | 35.998 ns | 35.165 ns | 36.652 ns |  1.01 |    0.01 |   1,226 B |
|            IterateForEachMemory | Job-INGEYJ | PR     | 35.357 ns | 0.2844 ns | 0.2660 ns | 35.229 ns | 35.082 ns | 36.028 ns |  1.00 |    0.00 |   1,219 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|        IterateGetPositionMemory | Job-COAKWQ | main   | 40.512 ns | 0.5047 ns | 0.4721 ns | 40.795 ns | 39.967 ns | 41.150 ns |  1.02 |    0.01 |     955 B |
|        IterateGetPositionMemory | Job-INGEYJ | PR     | 39.519 ns | 0.0434 ns | 0.0339 ns | 39.510 ns | 39.484 ns | 39.598 ns |  1.00 |    0.00 |     927 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                     FirstMemory | Job-COAKWQ | main   |  7.635 ns | 0.0360 ns | 0.0336 ns |  7.624 ns |  7.595 ns |  7.702 ns |  1.01 |    0.01 |   4,366 B |
|                     FirstMemory | Job-INGEYJ | PR     |  7.566 ns | 0.1009 ns | 0.0843 ns |  7.519 ns |  7.488 ns |  7.717 ns |  1.00 |    0.00 |   4,366 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                     SliceMemory | Job-COAKWQ | main   |  8.301 ns | 0.0110 ns | 0.0086 ns |  8.300 ns |  8.288 ns |  8.321 ns |  1.03 |    0.00 |   2,057 B |
|                     SliceMemory | Job-INGEYJ | PR     |  8.052 ns | 0.0093 ns | 0.0078 ns |  8.050 ns |  8.039 ns |  8.068 ns |  1.00 |    0.00 |   2,057 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|      IterateTryGetSingleSegment | Job-COAKWQ | main   | 12.872 ns | 0.0501 ns | 0.0418 ns | 12.856 ns | 12.842 ns | 12.986 ns |  1.00 |    0.00 |     827 B |
|      IterateTryGetSingleSegment | Job-INGEYJ | PR     | 12.927 ns | 0.0232 ns | 0.0181 ns | 12.923 ns | 12.909 ns | 12.972 ns |  1.00 |    0.00 |     820 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|     IterateForEachSingleSegment | Job-COAKWQ | main   | 24.504 ns | 0.0502 ns | 0.0419 ns | 24.504 ns | 24.437 ns | 24.586 ns |  0.94 |    0.01 |   1,009 B |
|     IterateForEachSingleSegment | Job-INGEYJ | PR     | 26.158 ns | 0.1803 ns | 0.1598 ns | 26.075 ns | 26.025 ns | 26.567 ns |  1.00 |    0.00 |   1,002 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
| IterateGetPositionSingleSegment | Job-COAKWQ | main   | 23.849 ns | 0.2413 ns | 0.2257 ns | 23.869 ns | 23.589 ns | 24.136 ns |  1.04 |    0.01 |     738 B |
| IterateGetPositionSingleSegment | Job-INGEYJ | PR     | 22.904 ns | 0.1079 ns | 0.0843 ns | 22.884 ns | 22.860 ns | 23.169 ns |  1.00 |    0.00 |     710 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|              FirstSingleSegment | Job-COAKWQ | main   |  4.520 ns | 0.0899 ns | 0.1261 ns |  4.495 ns |  4.353 ns |  4.726 ns |  1.03 |    0.03 |   4,149 B |
|              FirstSingleSegment | Job-INGEYJ | PR     |  4.392 ns | 0.0294 ns | 0.0246 ns |  4.388 ns |  4.356 ns |  4.438 ns |  1.00 |    0.00 |   4,149 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|              SliceSingleSegment | Job-COAKWQ | main   |  6.582 ns | 0.0641 ns | 0.0535 ns |  6.580 ns |  6.500 ns |  6.648 ns |  1.03 |    0.01 |   1,840 B |
|              SliceSingleSegment | Job-INGEYJ | PR     |  6.370 ns | 0.0084 ns | 0.0066 ns |  6.368 ns |  6.365 ns |  6.384 ns |  1.00 |    0.00 |   1,840 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|        IterateTryGetTenSegments | Job-COAKWQ | main   | 37.915 ns | 0.7733 ns | 0.7595 ns | 37.842 ns | 36.974 ns | 39.269 ns |  0.96 |    0.02 |     827 B |
|        IterateTryGetTenSegments | Job-INGEYJ | PR     | 39.468 ns | 0.0718 ns | 0.0600 ns | 39.439 ns | 39.414 ns | 39.614 ns |  1.00 |    0.00 |     820 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|       IterateForEachTenSegments | Job-COAKWQ | main   | 61.813 ns | 0.4910 ns | 0.4593 ns | 62.000 ns | 61.091 ns | 62.274 ns |  1.02 |    0.01 |   1,009 B |
|       IterateForEachTenSegments | Job-INGEYJ | PR     | 60.403 ns | 0.2959 ns | 0.2471 ns | 60.382 ns | 60.139 ns | 60.898 ns |  1.00 |    0.00 |   1,002 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|   IterateGetPositionTenSegments | Job-COAKWQ | main   | 71.600 ns | 0.5075 ns | 0.4747 ns | 71.765 ns | 70.754 ns | 72.112 ns |  0.94 |    0.01 |     738 B |
|   IterateGetPositionTenSegments | Job-INGEYJ | PR     | 76.023 ns | 0.0711 ns | 0.0555 ns | 76.018 ns | 75.921 ns | 76.128 ns |  1.00 |    0.00 |     710 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                FirstTenSegments | Job-COAKWQ | main   |  3.801 ns | 0.0761 ns | 0.0712 ns |  3.770 ns |  3.733 ns |  3.910 ns |  1.01 |    0.02 |   4,149 B |
|                FirstTenSegments | Job-INGEYJ | PR     |  3.733 ns | 0.0213 ns | 0.0178 ns |  3.735 ns |  3.689 ns |  3.762 ns |  1.00 |    0.00 |   4,149 B |
|                                 |            |        |           |           |           |           |           |           |       |         |           |
|                SliceTenSegments | Job-COAKWQ | main   | 22.448 ns | 0.3313 ns | 0.3099 ns | 22.394 ns | 22.053 ns | 22.907 ns |  1.00 |    0.01 |   1,840 B |
|                SliceTenSegments | Job-INGEYJ | PR     | 22.337 ns | 0.0561 ns | 0.0498 ns | 22.317 ns | 22.267 ns | 22.419 ns |  1.00 |    0.00 |   1,840 B |