### PR TITLE
JIT: Fold null checks for const strings

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8143,7 +8143,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 if (addr->IsCnsIntOrI() && addr->IsIconHandle(GTF_ICON_STR_HDL))
                 {
                     tree->gtVNPair = vnStore->VNPairForFunc(tree->TypeGet(), VNF_StrCns, addrNvnp);
-                    assert(addrXvnp == vnStore->VNForEmptyExcSet());
+                    assert(addrXvnp.BothEqual() && (addrXvnp.GetLiberal() == ValueNumStore::VNForEmptyExcSet()));
                 }
                 else
                 {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8139,7 +8139,8 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             {
                 assert(!isVolatile); // We don't expect both volatile and invariant
 
-                if (addr->OperIs(GT_CNS_INT) && addr->IsIconHandle(GTF_ICON_STR_HDL))
+                // Is it a string literal? (it's always non-null)
+                if (addr->IsCnsIntOrI() && addr->IsIconHandle(GTF_ICON_STR_HDL))
                 {
                     tree->gtVNPair = vnStore->VNPairForFunc(tree->TypeGet(), VNF_StrCns, addrNvnp);
                     tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9607,7 +9607,7 @@ VNFunc Compiler::fgValueNumberJitHelperMethodVNFunc(CorInfoHelpFunc helpFunc)
             break;
 
         case CORINFO_HELP_STRCNS:
-            vnf = VNF_StrCns;
+            vnf = VNF_LazyStrCns;
             break;
 
         case CORINFO_HELP_CHKCASTCLASS:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8143,7 +8143,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 if (addr->IsCnsIntOrI() && addr->IsIconHandle(GTF_ICON_STR_HDL))
                 {
                     tree->gtVNPair = vnStore->VNPairForFunc(tree->TypeGet(), VNF_StrCns, addrNvnp);
-                    tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
+                    assert(addrXvnp == vnStore->VNForEmptyExcSet());
                 }
                 else
                 {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8138,12 +8138,21 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             if (tree->gtFlags & GTF_IND_INVARIANT)
             {
                 assert(!isVolatile); // We don't expect both volatile and invariant
-                tree->gtVNPair =
-                    ValueNumPair(vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, ValueNumStore::VNForROH(),
-                                                         addrNvnp.GetLiberal()),
-                                 vnStore->VNForMapSelect(VNK_Conservative, TYP_REF, ValueNumStore::VNForROH(),
-                                                         addrNvnp.GetConservative()));
-                tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
+
+                if (addr->OperIs(GT_CNS_INT) && addr->IsIconHandle(GTF_ICON_STR_HDL))
+                {
+                    tree->gtVNPair = vnStore->VNPairForFunc(tree->TypeGet(), VNF_StrCns, addrNvnp);
+                    tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
+                }
+                else
+                {
+                    tree->gtVNPair =
+                        ValueNumPair(vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, ValueNumStore::VNForROH(),
+                                                             addrNvnp.GetLiberal()),
+                                     vnStore->VNForMapSelect(VNK_Conservative, TYP_REF, ValueNumStore::VNForROH(),
+                                                             addrNvnp.GetConservative()));
+                    tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
+                }
             }
             else if (isVolatile)
             {

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -143,7 +143,8 @@ ValueNumFuncDef(JitReadyToRunNewArr, 3, false, true, false)
 ValueNumFuncDef(Box, 3, false, false, false)
 ValueNumFuncDef(BoxNullable, 3, false, false, false)
 
-ValueNumFuncDef(StrCns, 2, false, true, false)
+ValueNumFuncDef(LazyStrCns, 2, false, true, false)  // lazy-initialized string literal (helper)
+ValueNumFuncDef(StrCns, 2, false, true, false)      // indirect for a string literal
 ValueNumFuncDef(Unbox, 2, false, true, false)
 
 ValueNumFuncDef(LT_UN, 2, false, false, false)      // unsigned or unordered comparisons

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -144,7 +144,7 @@ ValueNumFuncDef(Box, 3, false, false, false)
 ValueNumFuncDef(BoxNullable, 3, false, false, false)
 
 ValueNumFuncDef(LazyStrCns, 2, false, true, false)  // lazy-initialized string literal (helper)
-ValueNumFuncDef(StrCns, 2, false, true, false)      // indirect for a string literal
+ValueNumFuncDef(StrCns, 1, false, true, false)      // indirect for a string literal
 ValueNumFuncDef(Unbox, 2, false, true, false)
 
 ValueNumFuncDef(LT_UN, 2, false, false, false)      // unsigned or unordered comparisons


### PR DESCRIPTION
Similar to https://github.com/dotnet/runtime/pull/37245 but now at the VN level so we can fold more, example:
```csharp
class Program
{
    public string Name;

    public void Foo(string name)
    {
        Name = name ?? throw new ArgumentNullException(nameof(name));
    }

    public void Test() => Foo("hello");
}
```
Current codegen for `Test`:
```asm
; Method Program:Test():this
G_M36831_IG01:         
       56                   push     rsi
       4883EC20             sub      rsp, 32
G_M36831_IG02:             
       48BAA85D6DCD69020000 mov      rdx, 0x269CD6D5DA8
       488B12               mov      rdx, gword ptr [rdx]
       4885D2               test     rdx, rdx
       7410                 je       SHORT G_M36831_IG05
G_M36831_IG03:      
       488D4908             lea      rcx, bword ptr [rcx+8]
       E82075515F           call     CORINFO_HELP_ASSIGN_REF
       90                   nop      
G_M36831_IG04:              
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      
G_M36831_IG05:          
       48B9104AFBE7F97F0000 mov      rcx, 0x7FF9E7FB4A10
       E84A79515F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       B901000000           mov      ecx, 1
       48BAE0E235E8F97F0000 mov      rdx, 0x7FF9E835E2E0
       E8A3D9225F           call     CORINFO_HELP_STRCNS
       488BD0               mov      rdx, rax
       488BCE               mov      rcx, rsi
       E85874ADFF           call     System.ArgumentNullException:.ctor(System.String):this
       488BCE               mov      rcx, rsi
       E8B04C235F           call     CORINFO_HELP_THROW
       CC                   int3     
```
New codegen:
```asm
; Method Program:Test():this
G_M36831_IG01:             
G_M36831_IG02:              
       48BAA85D71DA51010000 mov      rdx, 0x151DA715DA8
       488B12               mov      rdx, gword ptr [rdx]
       488D4908             lea      rcx, bword ptr [rcx+8]
       E82A75525F           call     CORINFO_HELP_ASSIGN_REF
       90                   nop      
G_M36831_IG03:              
       C3                   ret      
; Total bytes of code: 24
```
jit-diff (--pmi -f):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 53004925
Total bytes of diff: 52999397
Total bytes of delta: -5528 (-0.01% of base)
    diff is an improvement.


Top file improvements (bytes):
       -2164 : System.Private.Xml.dasm (-0.06% of base)
        -576 : System.Data.Common.dasm (-0.04% of base)
        -502 : System.Private.DataContractSerialization.dasm (-0.07% of base)
        -385 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -345 : Newtonsoft.Json.dasm (-0.04% of base)
        -332 : System.Speech.dasm (-0.08% of base)
        -201 : Microsoft.Extensions.Logging.Console.dasm (-0.44% of base)
        -192 : System.DirectoryServices.AccountManagement.dasm (-0.05% of base)
        -178 : System.DirectoryServices.dasm (-0.04% of base)
        -142 : System.Composition.AttributedModel.dasm (-18.11% of base)
        -119 : Microsoft.Extensions.Configuration.Xml.dasm (-1.11% of base)
         -80 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -72 : System.Private.CoreLib.dasm (-0.00% of base)
         -62 : System.DirectoryServices.Protocols.dasm (-0.07% of base)
         -46 : System.Configuration.ConfigurationManager.dasm (-0.01% of base)
         -42 : System.Net.Primitives.dasm (-0.07% of base)
         -18 : System.Private.Uri.dasm (-0.02% of base)
         -18 : Microsoft.CSharp.dasm (-0.00% of base)
         -18 : xunit.runner.utility.netcoreapp10.dasm (-0.01% of base)
         -15 : CommandLine.dasm (-0.00% of base)

23 total files with Code Size differences (23 improved, 0 regressed), 248 unchanged.

Top method improvements (bytes):
        -954 (-21.54% of base) : System.Private.Xml.dasm - TypeScope:AddSoapEncodedTypes(String)
        -230 (-3.54% of base) : Newtonsoft.Json.dasm - <ExecuteFilter>d__4:MoveNext():bool:this (8 methods)
        -216 (-10.15% of base) : System.Private.Xml.dasm - DatatypeImplementation:CreateBuiltinTypes()
        -216 (-11.99% of base) : System.Private.Xml.dasm - Preprocessor:GetBuildInSchema():XmlSchema
        -144 (-13.30% of base) : System.Private.Xml.dasm - XmlSchemaValidator:BuildXsiAttributes()
        -144 (-16.29% of base) : System.Speech.dasm - SAPICategories:CompareTokenVersions(ObjectToken,ObjectToken,byref):int
        -119 (-4.45% of base) : Microsoft.Extensions.Configuration.Xml.dasm - XmlStreamConfigurationProvider:Read(Stream,XmlDocumentDecryptor):IDictionary`2
        -115 (-5.94% of base) : Newtonsoft.Json.dasm - <ExecuteFilter>d__12:MoveNext():bool:this
         -94 (-6.62% of base) : System.Private.Xml.dasm - XmlSchemaObjectComparer:NameOf(XmlSchemaObject):XmlQualifiedName
         -72 (-7.28% of base) : System.Speech.dasm - VoiceInfo:.ctor(ObjectToken):this
         -71 (-67.62% of base) : System.Composition.AttributedModel.dasm - SharedAttribute:.ctor():this
         -71 (-60.68% of base) : System.Composition.AttributedModel.dasm - SharedAttribute:.ctor(String):this
         -67 (-30.59% of base) : Microsoft.Extensions.Logging.Console.dasm - JsonConsoleFormatter:.ctor(IOptionsMonitor`1):this
         -67 (-30.59% of base) : Microsoft.Extensions.Logging.Console.dasm - SimpleConsoleFormatter:.ctor(IOptionsMonitor`1):this
         -67 (-30.59% of base) : Microsoft.Extensions.Logging.Console.dasm - SystemdConsoleFormatter:.ctor(IOptionsMonitor`1):this
         -62 (-12.53% of base) : System.DirectoryServices.Protocols.dasm - AddRequest:.ctor(String,String):this
         -60 (-8.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanInterpolatedStringPunctuation():SyntaxToken:this
         -50 (-1.44% of base) : System.DirectoryServices.AccountManagement.dasm - ADStoreCtx:GetGroupsMemberOf(Principal,StoreCtx):ResultSet:this
         -46 (-2.54% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlElementInXmlDoc(int):SyntaxToken:this
         -44 (-1.07% of base) : System.Private.Xml.dasm - ReflectionXmlSerializationReader:WriteLiteralStructMethod(StructMapping,bool,bool,String):Object:this

Top method improvements (percentages):
         -71 (-67.62% of base) : System.Composition.AttributedModel.dasm - SharedAttribute:.ctor():this
         -71 (-60.68% of base) : System.Composition.AttributedModel.dasm - SharedAttribute:.ctor(String):this
         -28 (-50.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:MakeEndOfInterpolatedStringToken():SyntaxToken:this
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlChars:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlDateTime:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlDecimal:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlDouble:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlGuid:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlInt16:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlInt32:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlInt64:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlMoney:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlSingle:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlString:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlXml:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlBinary:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlBoolean:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlByte:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -36 (-32.14% of base) : System.Data.Common.dasm - SqlBytes:GetXsdType(XmlSchemaSet):XmlQualifiedName
         -67 (-30.59% of base) : Microsoft.Extensions.Logging.Console.dasm - JsonConsoleFormatter:.ctor(IOptionsMonitor`1):this

142 total methods with Code Size differences (142 improved, 0 regressed), 268410 unchanged.
```