### PR TITLE
Fix release build infinite loop

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5321,22 +5321,20 @@ bool Compiler::verMergeEntryStates(BasicBlock* block, bool* changed)
 /*****************************************************************************
  * 'logMsg' is true if a log message needs to be logged. false if the caller has
  *   already logged it (presumably in a more detailed fashion than done here)
- * 'bVerificationException' is true for a verification exception, false for a
- *   "call unauthorized by host" exception.
  */
 
 void Compiler::verConvertBBToThrowVerificationException(BasicBlock* block DEBUGARG(bool logMsg))
 {
     block->bbJumpKind = BBJ_THROW;
     block->bbFlags |= BBF_FAILED_VERIFICATION;
+    block->bbFlags &= ~BBF_IMPORTED;
 
     impCurStmtOffsSet(block->bbCodeOffs);
 
-#ifdef DEBUG
-    // we need this since BeginTreeList asserts otherwise
+    // Clear the statement list as it exists so far; we're only going to have a verification exception.
     impStmtList = impLastStmt = nullptr;
-    block->bbFlags &= ~BBF_IMPORTED;
 
+#ifdef DEBUG
     if (logMsg)
     {
         JITLOG((LL_ERROR, "Verification failure: while compiling %s near IL offset %x..%xh \n", info.compFullName,


### PR DESCRIPTION
The problem manifested as an infinite loop during the StackLevelSetter phase
in the release build SuperPMI replay of the tests, but also occurs as a
normal release build test run of the varargsupport.il test.

The issue is we had corrupt LIR gtPrev links, with a cycle. The problem had
nothing to do with StackLevelSetter -- it just happened to be the first phase
that iterated in reverse over the gtPrev links.

The corruption was introduced in the importer, in
`verConvertBBToThrowVerificationException`. It required a verification failure
in a filter (possibly also catch) clause where the JIT would throw away the
currently imported code and convert the block to a call to the verification
failure helper.

This was a classic case of important, functional code being under `#ifdef DEBUG`
that is needed in non-DEBUG as well.

The result was we would end up adding an `ASG(LCL_VAR, CATCH_ARG)` to the statement
list twice, with the same `CATCH_ARG` node.

Fixes #45580