### PR TITLE
catch exceptions in callbacks from native code on OSX in SafeDeleteSslContext

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -13,12 +13,12 @@ namespace System.Net
 {
     internal sealed class SafeDeleteSslContext : SafeDeleteContext
     {
-        private const int InitialBufferSize = 2048;
         // mapped from OSX error codes
         private const int OSStatus_writErr = -20;
         private const int OSStatus_readErr = -19;
-        private const int OSStatus_noErr =0;
+        private const int OSStatus_noErr = 0;
         private const int OSStatus_errSSLWouldBlock = -9803;
+        private const int InitialBufferSize = 2048;
         private SafeSslHandle _sslContext;
         private Interop.AppleCrypto.SSLReadFunc _readCallback;
         private Interop.AppleCrypto.SSLWriteFunc _writeCallback;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -14,6 +14,11 @@ namespace System.Net
     internal sealed class SafeDeleteSslContext : SafeDeleteContext
     {
         private const int InitialBufferSize = 2048;
+        // mapped from OSX error codes
+        private const int OSStatus_writErr = -20;
+        private const int OSStatus_readErr = -19;
+        private const int OSStatus_noErr =0;
+        private const int OSStatus_errSSLWouldBlock = -9803;
         private SafeSslHandle _sslContext;
         private Interop.AppleCrypto.SSLReadFunc _readCallback;
         private Interop.AppleCrypto.SSLWriteFunc _writeCallback;
@@ -155,48 +160,59 @@ namespace System.Net
 
         private unsafe int WriteToConnection(void* connection, byte* data, void** dataLength)
         {
-            ulong length = (ulong)*dataLength;
-            Debug.Assert(length <= int.MaxValue);
+            try
+            {
+                ulong length = (ulong)*dataLength;
+                Debug.Assert(length <= int.MaxValue);
 
-            int toWrite = (int)length;
-            var inputBuffer = new ReadOnlySpan<byte>(data, toWrite);
+                int toWrite = (int)length;
+                var inputBuffer = new ReadOnlySpan<byte>(data, toWrite);
 
-            _outputBuffer.EnsureAvailableSpace(toWrite);
-            inputBuffer.CopyTo(_outputBuffer.AvailableSpan);
-            _outputBuffer.Commit(toWrite);
+                _outputBuffer.EnsureAvailableSpace(toWrite);
+                inputBuffer.CopyTo(_outputBuffer.AvailableSpan);
+                _outputBuffer.Commit(toWrite);
+                // Since we can enqueue everything, no need to re-assign *dataLength.
 
-            // Since we can enqueue everything, no need to re-assign *dataLength.
-            const int noErr = 0;
-            return noErr;
+                return OSStatus_noErr;
+            }
+            catch
+            {
+                return OSStatus_writErr;
+            }
         }
 
         private unsafe int ReadFromConnection(void* connection, byte* data, void** dataLength)
         {
-            const int noErr = 0;
-            const int errSSLWouldBlock = -9803;
-            ulong toRead = (ulong)*dataLength;
-
-            if (toRead == 0)
+            try
             {
-                return noErr;
+                ulong toRead = (ulong)*dataLength;
+
+                if (toRead == 0)
+                {
+                    return OSStatus_noErr;
+                }
+
+                uint transferred = 0;
+
+                if (_inputBuffer.ActiveLength == 0)
+                {
+                    *dataLength = (void*)0;
+                    return OSStatus_errSSLWouldBlock;
+                }
+
+                int limit = Math.Min((int)toRead, _inputBuffer.ActiveLength);
+
+                _inputBuffer.ActiveSpan.Slice(0, limit).CopyTo(new Span<byte>(data, limit));
+                _inputBuffer.Discard(limit);
+                transferred = (uint)limit;
+
+                *dataLength = (void*)transferred;
+                return OSStatus_noErr;
             }
-
-            uint transferred = 0;
-
-            if (_inputBuffer.ActiveLength == 0)
+            catch
             {
-                *dataLength = (void*)0;
-                return errSSLWouldBlock;
+                return OSStatus_readErr;
             }
-
-            int limit = Math.Min((int)toRead, _inputBuffer.ActiveLength);
-
-            _inputBuffer.ActiveSpan.Slice(0, limit).CopyTo(new Span<byte>(data, limit));
-            _inputBuffer.Discard(limit);
-            transferred = (uint)limit;
-
-            *dataLength = (void*)transferred;
-            return noErr;
         }
 
         internal void Write(ReadOnlySpan<byte> buf)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -175,8 +175,10 @@ namespace System.Net
 
                 return OSStatus_noErr;
             }
-            catch
+            catch (Exception e)
             {
+                if (NetEventSource.Log.IsEnabled())
+                    NetEventSource.Error(this, $"WritingToConnection failed: {e.Message}");
                 return OSStatus_writErr;
             }
         }
@@ -209,8 +211,10 @@ namespace System.Net
                 *dataLength = (void*)transferred;
                 return OSStatus_noErr;
             }
-            catch
+            catch (Exception e)
             {
+                if (NetEventSource.Log.IsEnabled())
+                    NetEventSource.Error(this, $"ReadFromConnectionfailed: {e.Message}");
                 return OSStatus_readErr;
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -160,6 +160,9 @@ namespace System.Net
 
         private unsafe int WriteToConnection(void* connection, byte* data, void** dataLength)
         {
+            // We don't pool these buffers and we can't because there's a race between their us in the native
+            // read/write callbacks and being disposed when the SafeHandle is disposed. This race is benign currently,
+            // but if we were to pool the buffers we would have a potential use-after-free issue.
             try
             {
                 ulong length = (ulong)*dataLength;


### PR DESCRIPTION
This is alternative to #49657. Based on the feedback, I tried different approach and this is simple, scoped and effective - I did several hundred run (with #49573 clearing) on the whole test set and I did not see any problem. The two functions are called from native OS code and if we throw there is no good way to handle that. With this change, we simply return error code and that will eventually bubble up in OSX Pal. 

I think longer term we will need to change SslStream to avoid using SafeHandle after dispose to address  #28171 and concerns from #47944. That will be separate change independent of the OSX specific handling. 

fixes #49600
fixes #43686
contributes to #49573