### PR TITLE
Remove duplicate method name string initialization

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5611,18 +5611,6 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
 
     info.compProfilerCallback = false; // Assume false until we are told to hook this method.
 
-#if defined(DEBUG) || defined(LATE_DISASM)
-    const char* classNamePtr;
-
-    info.compMethodName = eeGetMethodName(info.compMethodHnd, &classNamePtr);
-    unsigned len        = (unsigned)roundUp(strlen(classNamePtr) + 1);
-    info.compClassName  = getAllocator(CMK_DebugOnly).allocate<char>(len);
-    strcpy_s((char*)info.compClassName, len, classNamePtr);
-
-    info.compFullName  = eeGetMethodFullName(info.compMethodHnd);
-    info.compPerfScore = 0.0;
-#endif // defined(DEBUG) || defined(LATE_DISASM)
-
 #ifdef DEBUG
     if (!compIsForInlining())
     {


### PR DESCRIPTION
Both `compInit` and `compCompile` were initializing the method/class/full
name strings. The call to `eeGetMethodFullName` is not cheap, and shows
up high on a SuperPMI replay trace.

Remove the duplicate initialization in `compCompile`.

Speeds up SuperPMI replay and asm diffs.