### PR TITLE
Change some uses of EA_PTRSIZE to TARGET_POINTER_SIZE

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19775,7 +19775,7 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
                         return;
                     }
                 }
-                else if (genTypeSize(sigType) < EA_PTRSIZE)
+                else if (genTypeSize(sigType) < TARGET_POINTER_SIZE)
                 {
                     // Narrowing cast.
                     if (inlArgNode->OperIs(GT_LCL_VAR))

--- a/src/coreclr/jit/typelist.h
+++ b/src/coreclr/jit/typelist.h
@@ -3,7 +3,7 @@
 
 #define GCS EA_GCREF
 #define BRS EA_BYREF
-#define PS EA_PTRSIZE
+#define PS TARGET_POINTER_SIZE
 #define PST (TARGET_POINTER_SIZE / sizeof(int))
 
 #ifdef TARGET_64BIT


### PR DESCRIPTION
This PR changes some occurrences of `EA_PTRSIZE` to `TARGET_POINTER_SIZE` for the clrjit.  This arises from the experimental work in https://github.com/dotnet/runtimelab/pull/647 where the LLVM target does not have `EA_PTRSIZE` defined - its in `instr.h` which is not included as the clrjit for LLVM does not proceed past the Rationalized LIR phase.