### PR TITLE
Don't try bypassing `uname` for CPU detection on Mac

### DIFF
--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -27,17 +27,6 @@ if [ "$os" = "SunOS" ]; then
         os="Solaris"
     fi
     CPUName=$(isainfo -n)
-elif [ "$os" = "OSX" ]; then
-    # On OSX, universal binaries make uname -m unreliable. The uname -m response changes
-    # based on what hardware is being emulated.
-    # Use sysctl instead.
-    if [ "$(sysctl -q -n hw.optional.arm64)" = "1" ]; then
-        CPUName=arm64
-    elif [ "$(sysctl -q -n hw.optional.x86_64)" = "1" ]; then
-        CPUName=x86_64
-    else
-        CPUName=$(uname -m)
-    fi
 else
     # For the rest of the operating systems, use uname(1) to determine what the CPU is.
     CPUName=$(uname -m)


### PR DESCRIPTION
On Apple Silicon, the command `arch -x86_64 XYZ` allows executing XYZ as if on an AMD64 CPU, rather than an ARMv8 CPU, for cases where both are possible (e.g. a shell script like build.sh).

The deleted lines of code bypass the lies `arch` writes into uname, and instead forcibly detects the true nature of the host system's CPU regardless of whether or not the developer has reasons to lie.

Whilst this trick was important in the early days of bringing up Apple Silicon support, it should hopefully now be obsolete.

This fixes linking of LLVM in Mono runtime builds, where `arch -x86_64 ./build.sh -arch x64` would still attempt to link against ARM64 LLVM.