### PR TITLE
Disable arm64 tvOS/iOS simulator builds until ICU issue is addressed

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -106,11 +106,11 @@ stages:
       - MacCatalyst_x64
       - MacCatalyst_arm64
       - tvOSSimulator_x64
-      - tvOSSimulator_arm64
+      # - tvOSSimulator_arm64
       - tvOS_arm64
       - iOSSimulator_x64
       - iOSSimulator_x86
-      - iOSSimulator_arm64
+      # - iOSSimulator_arm64
       - iOS_arm
       - iOS_arm64
       - OSX_x64


### PR DESCRIPTION
Right now, ICU tvOSSimulator & iOSSimulator arm64 builds aren't - they're device builds. Until we fix ICU, disable these packages.

This should fix builds failing to build.