### PR TITLE
Put test name in generated certificate chains.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -3,6 +3,7 @@
 
 using System.Formats.Asn1;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Test.Cryptography;
 using Xunit;
@@ -71,10 +72,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509ChainStatusFlags intermediateErrors,
             X509ChainStatusFlags rootErrors)
         {
+            string testName = $"{nameof(BuildInvalidSignatureTwice)} {endEntityErrors} {intermediateErrors} {rootErrors}";
             TestDataGenerator.MakeTestChain3(
                 out X509Certificate2 endEntityCert,
                 out X509Certificate2 intermediateCert,
-                out X509Certificate2 rootCert);
+                out X509Certificate2 rootCert,
+                testName: testName);
 
             X509Certificate2 TamperIfNeeded(X509Certificate2 input, X509ChainStatusFlags flags)
             {
@@ -405,10 +408,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             bool saveAllInCustomTrustStore,
             X509ChainStatusFlags chainFlags)
         {
+            string testName = $"{nameof(CustomRootTrustDoesNotTrustIntermediates)} {saveAllInCustomTrustStore} {chainFlags}";
             TestDataGenerator.MakeTestChain3(
                 out X509Certificate2 endEntityCert,
                 out X509Certificate2 intermediateCert,
-                out X509Certificate2 rootCert);
+                out X509Certificate2 rootCert,
+                testName: testName);
 
             using (endEntityCert)
             using (intermediateCert)
@@ -802,7 +807,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         private static void TestNameConstrainedChain(
             string intermediateNameConstraints,
             SubjectAlternativeNameBuilder endEntitySanBuilder,
-            Action<bool, X509Chain> body)
+            Action<bool, X509Chain> body,
+            [CallerMemberName] string testName = null)
         {
             X509Extension[] endEntityExtensions = new []
             {
@@ -832,7 +838,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 out X509Certificate2 intermediateCert,
                 out X509Certificate2 rootCert,
                 intermediateExtensions: intermediateExtensions,
-                endEntityExtensions: endEntityExtensions);
+                endEntityExtensions: endEntityExtensions,
+                testName: testName);
 
             using (endEntityCert)
             using (intermediateCert)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestDataGenerator.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestDataGenerator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
 {
@@ -13,7 +14,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             out X509Certificate2 rootCert,
             IEnumerable<X509Extension> endEntityExtensions = null,
             IEnumerable<X509Extension> intermediateExtensions = null,
-            IEnumerable<X509Extension> rootExtensions = null)
+            IEnumerable<X509Extension> rootExtensions = null,
+            [CallerMemberName] string testName = null)
         {
             using (RSA rootKey = RSA.Create())
             using (RSA intermediateKey = RSA.Create())
@@ -32,7 +34,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     certs,
                     endEntityExtensions,
                     intermediateExtensions,
-                    rootExtensions);
+                    rootExtensions,
+                    testName);
 
                 endEntityCert = certs[0];
                 intermediateCert = certs[1];
@@ -48,7 +51,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             out X509Certificate2 rootCert,
             IEnumerable<X509Extension> endEntityExtensions = null,
             IEnumerable<X509Extension> intermediateExtensions = null,
-            IEnumerable<X509Extension> rootExtensions = null)
+            IEnumerable<X509Extension> rootExtensions = null,
+            [CallerMemberName] string testName = null)
         {
             using (RSA rootKey = RSA.Create())
             using (RSA intermediateKey = RSA.Create())
@@ -68,7 +72,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     certs,
                     endEntityExtensions,
                     intermediateExtensions,
-                    rootExtensions);
+                    rootExtensions,
+                    testName);
 
                 endEntityCert = certs[0];
                 intermediateCert1 = certs[1];
@@ -82,7 +87,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Span<X509Certificate2> certs,
             IEnumerable<X509Extension> endEntityExtensions,
             IEnumerable<X509Extension> intermediateExtensions,
-            IEnumerable<X509Extension> rootExtensions)
+            IEnumerable<X509Extension> rootExtensions,
+            string testName)
         {
             if (keys.Length < 2)
                 throw new ArgumentException(nameof(keys));
@@ -128,7 +134,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             RSASignaturePadding signaturePadding = RSASignaturePadding.Pkcs1;
 
             CertificateRequest rootReq = new CertificateRequest(
-                "CN=Test Root",
+                $"CN=Test Root, O=\"{testName}\"",
                 keys[rootIndex],
                 hashAlgorithm,
                 signaturePadding);
@@ -155,7 +161,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 presentationNumber++;
 
                 CertificateRequest intermediateReq = new CertificateRequest(
-                    $"CN=Intermediate Layer {presentationNumber}",
+                    $"CN=Intermediate Layer {presentationNumber}, O=\"{testName}\"",
                     keys[i],
                     hashAlgorithm,
                     signaturePadding);
@@ -177,7 +183,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
 
             CertificateRequest eeReq = new CertificateRequest(
-                "CN=End-Entity",
+                $"CN=End-Entity, O=\"{testName}\"",
                 keys[0],
                 hashAlgorithm,
                 signaturePadding);


### PR DESCRIPTION
This helps the chain builder to not confuse which certificates should be used in the chain by using unique names for each test.

Contributes to #49984 