### PR TITLE
Move System.Net.Http ILLink suppressions to LibraryBuild.

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -35,6 +35,7 @@
     <ILLinkSuppressionsXmlFilePrefix>$(ILLinkDirectory)ILLink.Suppressions</ILLinkSuppressionsXmlFilePrefix>
     <ILLinkSuppressionsXmlFile>$(ILLinkSuppressionsXmlFilePrefix).xml</ILLinkSuppressionsXmlFile>
     <ILLinkSuppressionsConfigurationSpecificXmlFile>$(ILLinkSuppressionsXmlFilePrefix).$(Configuration).xml</ILLinkSuppressionsConfigurationSpecificXmlFile>
+    <ILLinkSuppressionsLibraryBuildXmlFile>$(ILLinkSuppressionsXmlFilePrefix).LibraryBuild.xml</ILLinkSuppressionsLibraryBuildXmlFile>
 
     <!-- if building a PDB, tell illink to rewrite the symbols file -->
     <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' and '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
@@ -73,6 +74,8 @@
                             Include="$(ILLinkSuppressionsXmlFile)" />
     <ILLinkSuppressionsXmls Condition="Exists('$(ILLinkSuppressionsConfigurationSpecificXmlFile)')"
                             Include="$(ILLinkSuppressionsConfigurationSpecificXmlFile)" />
+    <ILLinkSuppressionsXmls Condition="Exists('$(ILLinkSuppressionsLibraryBuildXmlFile)')"
+                            Include="$(ILLinkSuppressionsLibraryBuildXmlFile)" />
     <ILLinkSuppressionsXmls Update="@(ILLinkSuppressionsXmls)" TargetPath="%(FileName).$(AssemblyName).xml" />
   </ItemGroup>
 

--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -6,6 +6,7 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Net.Http.HttpClient.CreateDefaultHandler()</property>
+      <property name="Justification">The Xamarin.iOS and Mono.Android libraries are not present when running the trimmer analysis during our build. A consuming application will get a warning if these libraries aren't present when trimming the full app.</property>
     </attribute>
   </assembly>
 </linker>


### PR DESCRIPTION
This suppression is necessary because we don't have access to the Xamarin and Mono libraries that are used by System.Net.Http.

Contributes to #45623

Follow up from https://github.com/dotnet/runtime/pull/47083#discussion_r597930026.