### PR TITLE
Remove some allocations related to logging configuration

### DIFF
--- a/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
+++ b/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
@@ -19,14 +19,9 @@ namespace Microsoft.Extensions.Logging
             for (int i = 0; i < attributes.Count; i++)
             {
                 CustomAttributeData attributeData = attributes[i];
-                if (attributeData.AttributeType.FullName == AliasAttibuteTypeFullName)
+                if (attributeData.AttributeType.FullName == AliasAttibuteTypeFullName &&
+                    attributeData.ConstructorArguments.Count > 0)
                 {
-                    if (attributeData.ConstructorArguments.Count == 0)
-                    {
-                        // Maybe the user defined their own ProviderAliasAttribute?
-                        continue;
-                    }
-
                     CustomAttributeTypedArgument arg = attributeData.ConstructorArguments[0];
 
                     Debug.Assert(arg.ArgumentType == typeof(string));

--- a/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
+++ b/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -13,16 +14,24 @@ namespace Microsoft.Extensions.Logging
 
         internal static string GetAlias(Type providerType)
         {
-            foreach (CustomAttributeData attributeData in CustomAttributeData.GetCustomAttributes(providerType))
+            IList<CustomAttributeData> attributes = CustomAttributeData.GetCustomAttributes(providerType);
+
+            for (int i = 0; i < attributes.Count; i++)
             {
+                CustomAttributeData attributeData = attributes[i];
                 if (attributeData.AttributeType.FullName == AliasAttibuteTypeFullName)
                 {
-                    foreach (CustomAttributeTypedArgument arg in attributeData.ConstructorArguments)
+                    if (attributeData.ConstructorArguments.Count == 0)
                     {
-                        Debug.Assert(arg.ArgumentType == typeof(string));
-
-                        return arg.Value?.ToString();
+                        // Maybe the user defined their own ProviderAliasAttribute?
+                        continue;
                     }
+
+                    CustomAttributeTypedArgument arg = attributeData.ConstructorArguments[0];
+
+                    Debug.Assert(arg.ArgumentType == typeof(string));
+
+                    return arg.Value?.ToString();
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         /// Gets the collection of <see cref="LoggerFilterRule"/> used for filtering log messages.
         /// </summary>
-        public IList<LoggerFilterRule> Rules { get; } = new List<LoggerFilterRule>();
+        public IList<LoggerFilterRule> Rules => RulesInternal;
+
+        // Concrete represenation of the rule list
+        internal List<LoggerFilterRule> RulesInternal { get; } = new List<LoggerFilterRule>();
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         public IList<LoggerFilterRule> Rules => RulesInternal;
 
-        // Concrete represenation of the rule list
+        // Concrete representation of the rule list
         internal List<LoggerFilterRule> RulesInternal { get; } = new List<LoggerFilterRule>();
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerRuleSelector.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerRuleSelector.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
 
             string providerAlias = ProviderAliasUtilities.GetAlias(providerType);
             LoggerFilterRule current = null;
-            foreach (LoggerFilterRule rule in options.Rules)
+            foreach (LoggerFilterRule rule in options.RulesInternal)
             {
                 if (IsBetter(rule, current, providerType.FullName, category)
                     || (!string.IsNullOrEmpty(providerAlias) && IsBetter(rule, current, providerAlias, category)))


### PR DESCRIPTION
- Today we allocate enumerators when enumerating custom attributes, this changes a for loop into a foreach and removes the inner foreach loop.

![image](https://user-images.githubusercontent.com/95136/112045640-4e9f6400-8b08-11eb-9789-8ca4f40b653a.png)
