### PR TITLE
Disable JIT/Methodical/fp/exgen/10w5d_cs_ro for Linux/arm32

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -693,6 +693,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
             <Issue>https://github.com/dotnet/runtime/issues/10001</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/fp/exgen/10w5d_cs_ro/*">
+            <Issue>https://github.com/dotnet/runtime/issues/48892</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- MacOS specific CoreCLR -->


### PR DESCRIPTION
Currently failing in jitstress2_jitstressregs3 configuration.

Issue: https://github.com/dotnet/runtime/issues/48892