### PR TITLE
Re-enable iOS/tvOS simulator builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,8 +1,8 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="6.0.0-preview.3.21167.1">
+    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="6.0.0-preview.4.21172.5">
       <Uri>https://github.com/dotnet/icu</Uri>
-      <Sha>4515910c7f374fe3332677b3a1b8321072d7f8de</Sha>
+      <Sha>370a34dfa95ba6f071aa315ee85749b21a263a96</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>6.0.100-preview.2.21169.4</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
-    <MicrosoftNETCoreRuntimeICUTransportVersion>6.0.0-preview.3.21167.1</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <MicrosoftNETCoreRuntimeICUTransportVersion>6.0.0-preview.4.21172.5</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>9.0.1-alpha.1.21165.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>9.0.1-alpha.1.21165.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -106,11 +106,11 @@ stages:
       - MacCatalyst_x64
       - MacCatalyst_arm64
       - tvOSSimulator_x64
-      # - tvOSSimulator_arm64
+      - tvOSSimulator_arm64
       - tvOS_arm64
       - iOSSimulator_x64
       - iOSSimulator_x86
-      # - iOSSimulator_arm64
+      - iOSSimulator_arm64
       - iOS_arm
       - iOS_arm64
       - OSX_x64


### PR DESCRIPTION
This re-enables the missing builds, and depends on a fixed ICU package