### PR TITLE
Avoid unnecessary allocations in PriorityQueue.EnqueueRange

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -8,24 +8,6 @@ namespace System.Collections.Generic
     /// </summary>
     internal static partial class EnumerableHelpers
     {
-        /// <summary>Attempt to determine the count of the source enumerable without forcing an enumeration.</summary>
-        /// <param name="source">The source enumerable.</param>
-        /// <param name="count">The count determined by the type test.</param>
-        /// <returns>
-        /// True if the source enumerable could be determined without enumerating, false otherwise.
-        /// </returns>
-        internal static bool TryGetCount<T>(IEnumerable<T> source, out int count)
-        {
-            if (source is ICollection<T> ict)
-            {
-                count = ict.Count;
-                return true;
-            }
-
-            count = 0;
-            return false;
-        }
-
         /// <summary>Converts an enumerable to an array using the same logic as List{T}.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>


### PR DESCRIPTION
While investigating the performance regression reported in https://github.com/dotnet/runtime/issues/50052 I discovered an issue in the implementation of `PriorityQueue.EnqueueRange` where the call to `EnumerableHelpers.ToArray` will often  result in unnecessary allocations of buffers.

# Performance

Running the[ `HeapSort` benchmark from dotnet/performance](https://github.com/dotnet/performance/blob/main/src/benchmarks/micro/libraries/System.Collections/PriorityQueue/Perf_PriorityQueue.cs):

## main

|   Method | Size |        Mean |     Error |    StdDev |      Median |         Min |         Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----- |------------:|----------:|----------:|------------:|------------:|------------:|-------:|------:|------:|----------:|
| **HeapSort** |   **10** |    **169.1 ns** |   **0.84 ns** |   **0.70 ns** |    **168.9 ns** |    **168.4 ns** |    **170.8 ns** | **0.0100** |     **-** |     **-** |     **104 B** |
| **HeapSort** |  **100** |  **2,639.9 ns** |   **7.44 ns** |   **6.60 ns** |  **2,638.9 ns** |  **2,626.4 ns** |  **2,650.1 ns** | **0.0744** |     **-** |     **-** |     **824 B** |
| **HeapSort** | **1000** | **71,286.5 ns** | **271.46 ns** | **253.92 ns** | **71,274.5 ns** | **70,843.3 ns** | **71,722.1 ns** | **0.5605** |     **-** |     **-** |   **8,024 B** |

## PR branch

|   Method | Size |        Mean |     Error |    StdDev |      Median |         Min |         Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----- |------------:|----------:|----------:|------------:|------------:|------------:|------:|------:|------:|----------:|
| **HeapSort** |   **10** |    **151.8 ns** |   **0.79 ns** |   **0.62 ns** |    **151.8 ns** |    **150.7 ns** |    **153.0 ns** |     **-** |     **-** |     **-** |         **-** |
| **HeapSort** |  **100** |  **2,582.6 ns** |  **39.87 ns** |  **33.30 ns** |  **2,583.8 ns** |  **2,515.2 ns** |  **2,630.6 ns** |     **-** |     **-** |     **-** |         **-** |
| **HeapSort** | **1000** | **67,370.4 ns** | **222.44 ns** | **185.75 ns** | **67,386.2 ns** | **66,978.4 ns** | **67,707.7 ns** |     **-** |     **-** |     **-** |         **-** |