### PR TITLE
Guard use of brew command by OSX

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -14,8 +14,10 @@ if(CLR_CMAKE_TARGET_UNIX)
     add_compile_options(-Wno-unknown-warning-option)
 
     if (NOT CLR_CMAKE_TARGET_ANDROID)
-        execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(ICU_HOMEBREW_INC_PATH "${brew_prefix}/opt/icu4c/include")
+        if (CLR_CMAKE_TARGET_OSX)
+            execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(ICU_HOMEBREW_INC_PATH "${brew_prefix}/opt/icu4c/include")
+        endif()
 
         find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
         if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)


### PR DESCRIPTION
The use of the brew command is guarded by OSX in multiple places:

- eng/native/build-commons.sh
- src/mono/CMakeLists.txt

But not in System.Globalization.Native.

Generally, it's harmless when `brew` is not avaiable (HomeBrew is not installed), except I have a program on my machine that's also `brew` but not 
HomeBrew. This makes the build fail:

      -- Performing Test HAVE_IN_EXCL_UNLINK
      -- Performing Test HAVE_IN_EXCL_UNLINK - Success
      -- Performing Test HAVE_TCP_H_TCP_KEEPALIVE
      -- Performing Test HAVE_TCP_H_TCP_KEEPALIVE - Failed
      -- Performing Test HAVE_BUILTIN_MUL_OVERFLOW
      -- Performing Test HAVE_BUILTIN_MUL_OVERFLOW - Success
      -- Found ZLIB: /usr/lib64/libz.so (found version "1.2.11")
      Usage: brew [global-options] command [command-options-and-arguments]

      Common commands: build, download-build, help, latest-build, list-targets, search

    brew : error : no such option: --prefix [runtime/src/libraries/Native/build-native.proj]
    ...
    ...
      -- Installing: runtime/artifacts/bin/native/net6.0-Linux-Debug-x64/./libSystem.Security.Cryptography.Native.OpenSsl.a
    runtime/src/libraries/Native/build-native.proj(40,5): error MSB3073: The command ""runtime/src/libraries/Native/build-native.sh" x64 Debug outconfig net6.0-Linux-Debug-x64 -os Linux " exited with code -1.

    Build FAILED.

    brew : error : no such option: --prefix [runtime/src/libraries/Native/build-native.proj]
    runtime/src/libraries/Native/build-native.proj(40,5): error MSB3073: The command ""runtime/src/libraries/Native/build-native.sh" x64 Debug outconfig net6.0-Linux-Debug-x64 -os Linux " exited with code -1.
	0 Warning(s)
	2 Error(s)

An alternative fix would be to check if `brew` is actually HomeBrew before calling it.