### PR TITLE
Add test coverage for Module.GetMethod/s

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -176,6 +176,60 @@ namespace System.Reflection.Tests
             Assert.Equal(TestModule.GetField("TestLong", BindingFlags.NonPublic | BindingFlags.Static), fields[1]);
         }
 
+        [Fact]
+        public void GetMethod_NullName()
+        {
+            var ex = AssertExtensions.Throws<ArgumentNullException>("name", () => Module.GetMethod(null));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+
+            ex = AssertExtensions.Throws<ArgumentNullException>("name", () => Module.GetMethod(null, Type.EmptyTypes));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+        }
+
+        [Fact]
+        public void GetMethod_NullTypes()
+        {
+            var ex = AssertExtensions.Throws<ArgumentNullException>("types", () => Module.GetMethod("TestMethodFoo", null));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+        }
+
+        [Fact]
+        public void GetMethod_AmbiguousMatch()
+        {
+            var ex = Assert.Throws<AmbiguousMatchException>(() => TestModule.GetMethod("TestMethodFoo"));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+        }
+
+        [Fact]
+        public void GetMethod()
+        {
+            var method = TestModule.GetMethod("TestMethodFoo", Type.EmptyTypes);
+            Assert.True(method.IsPublic);
+            Assert.True(method.IsStatic);
+            Assert.Equal(typeof(void), method.ReturnType);
+            Assert.Empty(method.GetParameters());
+
+            method = TestModule.GetMethod("TestMethodBar", BindingFlags.NonPublic | BindingFlags.Static, null, CallingConventions.Any, new[] { typeof(int) }, null);
+            Assert.False(method.IsPublic);
+            Assert.True(method.IsStatic);
+            Assert.Equal(typeof(int), method.ReturnType);
+            Assert.Equal(typeof(int), method.GetParameters().Single().ParameterType);
+        }
+
+        [Fact]
+        public void GetMethods()
+        {
+            var methodNames = TestModule.GetMethods().Select(m => m.Name).ToArray();
+            AssertExtensions.SequenceEqual(new[]{ "TestMethodFoo", "TestMethodFoo" }, methodNames );
+
+            methodNames = TestModule.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Select(m => m.Name).ToArray();
+            AssertExtensions.SequenceEqual(new[]{ "TestMethodFoo", "TestMethodFoo", "TestMethodBar" }, methodNames );
+        }
+
         public static IEnumerable<object[]> Types =>
             Module.GetTypes().Select(t => new object[] { t });
 

--- a/src/libraries/System.Runtime/tests/TestModule/System.Reflection.TestModule.il
+++ b/src/libraries/System.Runtime/tests/TestModule/System.Reflection.TestModule.il
@@ -27,6 +27,22 @@
     ret
 }
 
+.method public static void TestMethodFoo()
+{
+    ret
+}
+
+.method public static void TestMethodFoo(int32 myInt)
+{
+    ret
+}
+
+.method private static int32 TestMethodBar(int32 myInt)
+{
+    ldarg.0
+    ret
+}
+
 .namespace System.Reflection.TestModule
 {
     .class public Dummy extends [System.Runtime]System.Object


### PR DESCRIPTION
Adds missing test coverage for Module.GetMethod and Module.GetMethods

Fix dotnet/runtime#49926