### PR TITLE
Update the minimum version of the SDK to 6.0 Preview 2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.1.21103.13",
+    "version": "6.0.100-preview.2.21155.3",
     "allowPrerelease": true,
     "rollForward": "major"
   },


### PR DESCRIPTION
**Part of April's batched infrastructure rollout: https://github.com/dotnet/runtime/issues/49889**

We want to update the minimum required version of the SDK to 6.0 Preview 2 which is already publicly available. The target version of the SDK is already set to 6.0 Preview 2.