### PR TITLE
Fix str.Remove(str.Length) to not throw

### DIFF
--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -4496,7 +4496,7 @@ namespace System.Tests
         [InlineData("", 0, 0, "")]
         public static void Remove(string s, int startIndex, int count, string expected)
         {
-            if (startIndex + count == s.Length && count != 0)
+            if (startIndex + count == s.Length)
             {
                 Assert.Equal(expected, s.Remove(startIndex));
             }
@@ -4512,8 +4512,8 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => s.Remove(-1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => s.Remove(-1, 0));
 
-            // Start index >= string.Length
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => s.Remove(s.Length));
+            // Start index > string.Length
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => s.Remove(s.Length + 1));
 
             // Count < 0
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => s.Remove(0, -1));

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -874,11 +874,8 @@ namespace System
         // a remove that just takes a startindex.
         public string Remove(int startIndex)
         {
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_StartIndex);
-
-            if (startIndex >= Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_StartIndexLessThanLength);
+            if ((uint)startIndex > Length)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex < 0 ? SR.ArgumentOutOfRange_StartIndex : SR.ArgumentOutOfRange_StartIndexLessThanLength);
 
             return Substring(0, startIndex);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50094