### PR TITLE
Fix ./build.sh --portableBuild false

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -155,7 +155,9 @@
     <!-- There are no Mac Catalyst, iOS or tvOS tools and it can be built on OSX only, so use that -->
     <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'maccatalyst' or '$(_runtimeOS)' == 'ios' or '$(_runtimeOS)' == 'iOSSimulator' or '$(_runtimeOS)' == 'tvos' or '$(_runtimeOS)' == 'tvOSSimulator'">osx-x64</_toolRuntimeRID>
 
-    <MicrosoftNetCoreIlasmPackageRuntimeId>$(_toolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
+    <!-- There are no non-portable builds for Ilasm/Ildasm -->
+    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(PortableBuild)' != 'true' and '$(_portableOS)' == 'linux'">linux-$(_hostArch)</MicrosoftNetCoreIlasmPackageRuntimeId>
+    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_toolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
 
     <_packageRID Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(TargetArchitecture)</_packageRID>
     <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -133,5 +133,5 @@ jobs:
     - SourceBuild_Linux_x64
     jobParameters:
       nameSuffix: SourceBuild
-      buildArgs: -subset clr+libs+host+packs /p:DotNetBuildFromSource=true
+      buildArgs: -subset clr+libs+host+packs /p:DotNetBuildFromSource=true --portableBuild false
       timeoutInMinutes: 90

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -1069,6 +1069,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_CIPHER_CTX_free local_EVP_CIPHER_CTX_free
 #define EVP_CIPHER_CTX_new local_EVP_CIPHER_CTX_new
 #define EVP_CIPHER_CTX_reset local_EVP_CIPHER_CTX_reset
+#define EVP_PKEY_get0_RSA local_EVP_PKEY_get0_RSA
 #define EVP_PKEY_up_ref local_EVP_PKEY_up_ref
 #define HMAC_CTX_free local_HMAC_CTX_free
 #define HMAC_CTX_new local_HMAC_CTX_new


### PR DESCRIPTION
Non-portable builds are used by source-build and also useful for testing/debugging things, like trying out OpenSSL 3.0:
https://github.com/dotnet/runtime/issues/46526#issuecomment-803198852

Fixes: https://github.com/dotnet/runtime/issues/43219

Should I add a CI run that verifies `./build.sh --portableBuild false` works?