### PR TITLE
Fix Alpine 3.13 ARM build

### DIFF
--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -324,11 +324,7 @@ PAL_IsDebuggerPresent();
 
 #ifndef PAL_STDCPP_COMPAT
 
-#if HOST_64BIT || _MSC_VER >= 1400
 typedef __int64 time_t;
-#else
-typedef long time_t;
-#endif
 #define _TIME_T_DEFINED
 #endif // !PAL_STDCPP_COMPAT
 

--- a/src/coreclr/pal/src/cruntime/misc.cpp
+++ b/src/coreclr/pal/src/cruntime/misc.cpp
@@ -174,7 +174,10 @@ PAL_time(PAL_time_t *tloc)
 
     time_t t;
     result = time(&t);
-    *tloc = t;
+    if (tloc != NULL)
+    {
+        *tloc = t;
+    }
 
     LOGEXIT( "time returning %#lx\n",result );
     PERF_EXIT(time);

--- a/src/coreclr/pal/src/cruntime/misc.cpp
+++ b/src/coreclr/pal/src/cruntime/misc.cpp
@@ -172,7 +172,9 @@ PAL_time(PAL_time_t *tloc)
     PERF_ENTRY(time);
     ENTRY( "time( tloc=%p )\n",tloc );
 
-    result = time(tloc);
+    time_t t;
+    result = time(&t);
+    *tloc = t;
 
     LOGEXIT( "time returning %#lx\n",result );
     PERF_EXIT(time);

--- a/src/libraries/Native/Unix/System.Native/pal_random.c
+++ b/src/libraries/Native/Unix/System.Native/pal_random.c
@@ -35,7 +35,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
     if (!sInitializedMRand)
     {
-        srand48(time(NULL));
+        srand48((long int)time(NULL));
         sInitializedMRand = true;
     }
 


### PR DESCRIPTION
Alpine 3.13 is the first version of Alpine Linux that uses 64 bit time_t
on both 64 and 32 bit platforms. That breaks the build as we assumed
that 32 bit platforms use always 32 bit time_t.

This change fixes it by making the PAL time_t type always 64 bit.
Everything still works fine on non-Alpine ARM / x86 Linuxes, since
it only changes the time_t type size outside of PAL.