### PR TITLE
JIT: Don't allocate string literals inside potential BBJ_THROW candidates

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -452,6 +452,7 @@ struct BasicBlock : private LIR::Range
 #define BBF_PATCHPOINT                     MAKE_BBFLAG(36) // Block is a patchpoint
 #define BBF_HAS_CLASS_PROFILE              MAKE_BBFLAG(37) // BB contains a call needing a class profile
 #define BBF_LOOP_ALIGN                     MAKE_BBFLAG(39) // Block is lexically the first block in a loop we intend to align.
+#define BBF_THROW_CANDIDATE                MAKE_BBFLAG(40) // Block is a candidate to be converted to BBJ_THROW
 
 // clang-format on
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -452,7 +452,6 @@ struct BasicBlock : private LIR::Range
 #define BBF_PATCHPOINT                     MAKE_BBFLAG(36) // Block is a patchpoint
 #define BBF_HAS_CLASS_PROFILE              MAKE_BBFLAG(37) // BB contains a call needing a class profile
 #define BBF_LOOP_ALIGN                     MAKE_BBFLAG(39) // Block is lexically the first block in a loop we intend to align.
-#define BBF_THROW_CANDIDATE                MAKE_BBFLAG(40) // Block is a candidate to be converted to BBJ_THROW
 
 // clang-format on
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9588,7 +9588,19 @@ GenTree* Compiler::fgMorphConst(GenTree* tree)
     // guarantee slow performance for that block. Instead cache the return value
     // of CORINFO_HELP_STRCNS and go to cache first giving reasonable perf.
 
-    if ((compCurBB->bbJumpKind == BBJ_THROW) || (compCurBB->bbFlags & BBF_THROW_CANDIDATE))
+    bool useLazyStrCns = false;
+    if (compCurBB->bbJumpKind == BBJ_THROW)
+    {
+        useLazyStrCns = true;
+    }
+    else if (fgGlobalMorph && compCurStmt->GetRootNode()->IsCall())
+    {
+        // Quick check: if the root node of the current statement happens to be a noreturn call.
+        GenTreeCall* call = compCurStmt->GetRootNode()->AsCall();
+        useLazyStrCns = call->IsNoReturn() || fgIsThrow(call);
+    }
+
+    if (useLazyStrCns)
     {
         CorInfoHelpFunc helper = info.compCompHnd->getLazyStringLiteralHelper(tree->AsStrCon()->gtScpHnd);
         if (helper != CORINFO_HELP_UNDEF)
@@ -16921,34 +16933,6 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
     *lnot = *loadw = false;
 
     fgCurrentlyInUseArgTemps = hashBv::Create(this);
-
-    // Check if the current block is a candidate to be converted to BBJ_THROW
-    if (block->bbJumpKind != BBJ_THROW)
-    {
-        auto hasNoReturns = [](GenTree** tree, fgWalkData* data) -> fgWalkResult {
-            if ((*tree)->IsCall())
-            {
-                GenTreeCall* call = (*tree)->AsCall();
-                if (call->IsNoReturn() || data->compiler->fgIsThrow(call))
-                {
-                    return WALK_ABORT;
-                }
-            }
-            return WALK_CONTINUE;
-        };
-
-        // Look for no-return calls inside the current basic block
-        // QMARKs aren't expected to exist at this points.
-        for (Statement* stmt : block->Statements())
-        {
-            GenTree*     expr    = stmt->GetRootNode();
-            fgWalkResult walkRes = fgWalkTreePre(&expr, hasNoReturns, nullptr);
-            if (walkRes == WALK_ABORT)
-            {
-                block->bbFlags |= BBF_THROW_CANDIDATE;
-            }
-        }
-    }
 
     for (Statement* stmt : block->Statements())
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9597,7 +9597,7 @@ GenTree* Compiler::fgMorphConst(GenTree* tree)
     {
         // Quick check: if the root node of the current statement happens to be a noreturn call.
         GenTreeCall* call = compCurStmt->GetRootNode()->AsCall();
-        useLazyStrCns = call->IsNoReturn() || fgIsThrow(call);
+        useLazyStrCns     = call->IsNoReturn() || fgIsThrow(call);
     }
 
     if (useLazyStrCns)


### PR DESCRIPTION
Together with https://github.com/dotnet/runtime/pull/48589, this PR addresses https://github.com/dotnet/runtime/issues/48573#issuecomment-782910710

Example:
```csharp
using System;

class Prog
{
    static void Main(string[] args)
    {
        ThrowIfNull(args, nameof(args));
    }

    private static void ThrowIfNull(object arg, string argName)
    {
        if (arg is null)
            ThrowAE(argName);
    }

    private static void ThrowAE(string arg) => throw new ArgumentNullException(arg);
}
```
Codegen diff for `Main`: https://www.diffchecker.com/tZAYRdBY

As you can see, `nameof(args)` literal is not allocated on heap during JIT compilation, a lazy-allocate helper is emitted instead.

jit-diff (`jit-utils -f --pmi`):
```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 52999910
Total bytes of diff: 53048663
Total bytes of delta: 48753 (0.09% of base)
    diff is a regression.


Top file regressions (bytes):
       39746 : System.Collections.Immutable.dasm (3.08% of base)
        3724 : System.Collections.Concurrent.dasm (0.96% of base)
        3448 : FSharp.Core.dasm (0.09% of base)
         468 : System.Private.DataContractSerialization.dasm (0.06% of base)
         359 : System.Private.Xml.dasm (0.01% of base)
         345 : System.Net.Sockets.dasm (0.20% of base)
         244 : System.Net.Http.WinHttpHandler.dasm (0.26% of base)
         118 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)
          74 : System.Data.Odbc.dasm (0.04% of base)
          59 : System.Drawing.Primitives.dasm (0.15% of base)
          50 : System.Private.CoreLib.dasm (0.00% of base)
          40 : System.Net.Http.dasm (0.01% of base)
          40 : Microsoft.Extensions.Logging.Console.dasm (0.09% of base)
          20 : System.Net.WebSockets.dasm (0.05% of base)
          18 : System.Text.RegularExpressions.dasm (0.01% of base)

15 total files with Code Size differences (0 improved, 15 regressed), 256 unchanged.

Top method regressions (bytes):
        2025 (16.17% of base) : FSharp.Core.dasm - Array2DModule:CopyTo(ref,int,int,ref,int,int,int,int) (8 methods)
         710 ( 5.09% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:SymmetricExcept(IEnumerable`1,MutationInput):MutationResult (8 methods)
         640 (14.24% of base) : System.Collections.Immutable.dasm - ImmutableList`1:ConvertAll(Func`2):ImmutableList`1:this (64 methods)
         640 (14.24% of base) : System.Collections.Immutable.dasm - Builder:ConvertAll(Func`2):ImmutableList`1:this (64 methods)
         580 ( 7.97% of base) : System.Collections.Immutable.dasm - Node:NodeTreeFromList(IOrderedCollection`1,int,int):Node (24 methods)
         504 ( 7.04% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Intersect(IEnumerable`1,MutationInput):MutationResult (8 methods)
         390 ( 4.44% of base) : System.Collections.Immutable.dasm - Builder:AddRange(IEnumerable`1):this (32 methods)
         384 (25.08% of base) : System.Collections.Immutable.dasm - ImmutableSortedDictionary`2:.ctor(Node,int,IComparer`1,IEqualityComparer`1):this (8 methods)
         352 (25.79% of base) : System.Collections.Immutable.dasm - MutationInput:.ctor(SortedInt32KeyNode`1,IEqualityComparer`1,IEqualityComparer`1,int):this (8 methods)
         320 (15.62% of base) : System.Collections.Immutable.dasm - Builder:Sort(int,int,IComparer`1):this (16 methods)
         320 ( 4.75% of base) : System.Collections.Immutable.dasm - Node:CopyTo(ref,int):this (16 methods)
         320 ( 8.36% of base) : System.Collections.Immutable.dasm - Node:CopyTo(int,ref,int,int):this (8 methods)
         320 ( 3.54% of base) : System.Collections.Immutable.dasm - Node:CopyTo(Array,int):this (16 methods)
         310 ( 4.07% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Except(IEnumerable`1,IEqualityComparer`1,IEqualityComparer`1,SortedInt32KeyNode`1):MutationResult (8 methods)
         308 (17.94% of base) : System.Collections.Immutable.dasm - Builder:get_Origin():MutationInput:this (16 methods)
         300 ( 7.18% of base) : System.Collections.Immutable.dasm - Builder:set_KeyComparer(IEqualityComparer`1):this (16 methods)
         272 ( 8.80% of base) : System.Collections.Immutable.dasm - ImmutableSortedDictionary`2:WithComparers(IComparer`1,IEqualityComparer`1):ImmutableSortedDictionary`2:this (8 methods)
         256 (12.22% of base) : System.Collections.Immutable.dasm - ImmutableArray:Create(ref,int,int):ImmutableArray`1 (8 methods)
         256 (10.68% of base) : System.Collections.Immutable.dasm - ImmutableArray:CreateRange(ImmutableArray`1,int,int,Func`2):ImmutableArray`1 (8 methods)
         244 ( 3.75% of base) : System.Collections.Immutable.dasm - ImmutableSortedSet`1:SymmetricExcept(IEnumerable`1):ImmutableSortedSet`1:this (8 methods)

Top method regressions (percentages):
          18 (100.00% of base) : System.Collections.Concurrent.dasm - ThrowHelper:ThrowKeyNullException()
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsBoolean():bool:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsSingle():float:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsDouble():double:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsDecimal():Decimal:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsDateTime():DateTime:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsInt():int:this
          23 (35.94% of base) : System.Private.DataContractSerialization.dasm - XmlReaderDelegator:ReadContentAsLong():long:this
          80 (26.76% of base) : System.Collections.Immutable.dasm - ImmutableList:ToImmutableList(Builder):ImmutableList`1 (8 methods)
          80 (26.76% of base) : System.Collections.Immutable.dasm - ImmutableSortedDictionary:ToImmutableSortedDictionary(Builder):ImmutableSortedDictionary`2 (8 methods)
          80 (26.76% of base) : System.Collections.Immutable.dasm - ImmutableSortedSet:ToImmutableSortedSet(Builder):ImmutableSortedSet`1 (8 methods)
         352 (25.79% of base) : System.Collections.Immutable.dasm - MutationInput:.ctor(SortedInt32KeyNode`1,IEqualityComparer`1,IEqualityComparer`1,int):this (8 methods)
          49 (25.65% of base) : System.Drawing.Primitives.dasm - Color:FromArgb(int,int,int,int):Color
          80 (25.56% of base) : System.Collections.Immutable.dasm - ImmutableArray:ToImmutableArray(Builder):ImmutableArray`1 (8 methods)
          80 (25.40% of base) : System.Collections.Immutable.dasm - NodeEnumerable:.ctor(SortedInt32KeyNode`1):this (8 methods)
         384 (25.08% of base) : System.Collections.Immutable.dasm - ImmutableSortedDictionary`2:.ctor(Node,int,IComparer`1,IEqualityComparer`1):this (8 methods)
          80 (23.81% of base) : System.Collections.Immutable.dasm - ImmutableHashSet`1:Union(IEnumerable`1):ImmutableHashSet`1:this (8 methods)
          80 (23.81% of base) : System.Collections.Immutable.dasm - ImmutableDictionary`2:AddRange(IEnumerable`1):ImmutableDictionary`2:this (8 methods)
          80 (23.26% of base) : System.Collections.Immutable.dasm - ImmutableArrayExtensions:Any(Builder):bool (8 methods)
          80 (23.26% of base) : System.Collections.Concurrent.dasm - IDictionaryDebugView`2:.ctor(IDictionary`2):this (8 methods)

1191 total methods with Code Size differences (0 improved, 1191 regressed), 267367 unchanged.
```
Quite a size regression (for obvious reasons) but each regression is basically a saved GC allocation. 
~ +10 bytes of machine code per each literal (**in the cold sections**)

PS: 67% of the regression is in `System.Collections.Immutable.dasm`