### PR TITLE
JIT: Add rootTreeOp to DumpFg

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -826,7 +826,6 @@ bool Compiler::fgDumpFlowGraph(Phases phase)
             const char* rootTreeOpName = "n/a";
             if (block->lastNode() != nullptr)
             {
-                // lastNode is firstStmt->GetRootNode() in case of non-LIR
                 rootTreeOpName = GenTree::OpName(block->lastNode()->OperGet());
             }
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -822,10 +822,19 @@ bool Compiler::fgDumpFlowGraph(Phases phase)
             {
                 fprintf(fgxFile, "\n            loopHead=\"true\"");
             }
+
+            const char* rootTreeOpName = "n/a";
+            if (block->lastNode() != nullptr)
+            {
+                // lastNode is firstStmt->GetRootNode() in case of non-LIR
+                rootTreeOpName = GenTree::OpName(block->lastNode()->OperGet());
+            }
+
             fprintf(fgxFile, "\n            weight=");
             fprintfDouble(fgxFile, ((double)block->bbWeight) / weightDivisor);
             fprintf(fgxFile, "\n            codeEstimate=\"%d\"", fgGetCodeEstimate(block));
             fprintf(fgxFile, "\n            startOffset=\"%d\"", block->bbCodeOffs);
+            fprintf(fgxFile, "\n            rootTreeOp=\"%s\"", rootTreeOpName);
             fprintf(fgxFile, "\n            endOffset=\"%d\"", block->bbCodeOffsEnd);
             fprintf(fgxFile, ">");
             fprintf(fgxFile, "\n        </block>");


### PR DESCRIPTION
I'm using a custom tool to visualize flow graphs and I'd like to add a "rootNodeOp" field to the XML, I hope it won't break any other tool.

![image](https://user-images.githubusercontent.com/523221/112209933-1ba1c100-8c2b-11eb-88e1-28aec2ba9000.png)

cc @AndyAyersMS 