### PR TITLE
Upgrade `StyleCopAnalyzers` to `v1.2.0-beta.333`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,7 +72,7 @@
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.3.21169.6</MicrosoftNETCoreILAsmVersion>
     <!-- Libraries dependencies -->
-    <StyleCopAnalyzersVersion>1.2.0-beta.304</StyleCopAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.333</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
     <SystemCollectionsConcurrentVersion>4.3.0</SystemCollectionsConcurrentVersion>


### PR DESCRIPTION
cc: @sharwell, @danmoseley 

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.333

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/compare/1.2.0-beta.304...1.2.0-beta.333

_Draft PR to run CI, as suggested in https://github.com/dotnet/runtime/pull/45779#issuecomment-748243876_