### PR TITLE
Add more support for Julian time zones POSIX rules

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -1320,33 +1320,21 @@ namespace System
                     // numbers less than 59 (up to Feb 28). Otherwise we'll skip this POSIX rule.
                     // We've never encountered any time zone file using this format for days beyond Feb 28.
 
-                    if ((uint)(date[0] - '0') <= '9'-'0')
+                    if (int.TryParse(date, out int julianDay) && julianDay < 59)
                     {
-                        int julianDay = (int) (date[0] - '0');
-                        int index = 1;
-
-                        while (index < date.Length && julianDay < 59 && ((uint)(date[index] - '0') <= '9'-'0'))
+                        int d, m;
+                        if (julianDay <= 30) // January
                         {
-                            julianDay = julianDay * 10 + (int) (date[index] - '0');
-                            index++;
-                        };
-
-                        if (julianDay < 59) // Up to Feb 28.
-                        {
-                            int d, m;
-                            if (julianDay <= 30) // January
-                            {
-                                m = 1;
-                                d = julianDay + 1;
-                            }
-                            else // February
-                            {
-                                m = 2;
-                                d = julianDay - 30;
-                            }
-
-                            return TransitionTime.CreateFixedDateRule(ParseTimeOfDay(time), m, d);
+                            m = 1;
+                            d = julianDay + 1;
                         }
+                        else // February
+                        {
+                            m = 2;
+                            d = julianDay - 30;
+                        }
+
+                        return TransitionTime.CreateFixedDateRule(ParseTimeOfDay(time), m, d);
                     }
 
                     // Since we can't support this rule, return null to indicate to skip the POSIX rule.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -1315,21 +1315,21 @@ namespace System
                     // For example if n is specified as 60, this means in leap year the rule will start at Mar 1,
                     // while in non leap year the rule will start at Mar 2.
                     //
-                    // This n Julian day format is very uncommon and rarely used and mostely used for convenience
-                    // to specify dates like January 1st which we can support without any major modification to the Adjustment rules.
-                    // We'll support this rule for day numbers less than 59 (up to Feb 28). Otherwise we'll
-                    // skip this POSIX rule. So far we never encountered any time zone file used this format for days beyond Feb 28.
+                    // This n Julian day format is very uncommon and mostly  used for convenience to specify dates like January 1st
+                    // which we can support without any major modification to the Adjustment rules. We'll support this rule  for day
+                    // numbers less than 59 (up to Feb 28). Otherwise we'll skip this POSIX rule.
+                    // We've never encountered any time zone file using this format for days beyond Feb 28.
 
                     if ((uint)(date[0] - '0') <= '9'-'0')
                     {
-                        int julianDay = 0;
-                        int index = 0;
+                        int julianDay = (int) (date[0] - '0');
+                        int index = 1;
 
-                        do
+                        while (index < date.Length && julianDay < 59 && ((uint)(date[index] - '0') <= '9'-'0'))
                         {
                             julianDay = julianDay * 10 + (int) (date[index] - '0');
                             index++;
-                        } while (index < date.Length && ((uint)(date[index] - '0') <= '9'-'0'));
+                        };
 
                         if (julianDay < 59) // Up to Feb 28.
                         {
@@ -1360,7 +1360,7 @@ namespace System
         }
 
         /// <summary>
-        /// Parses a string like Jn or n into month and day values.
+        /// Parses a string like Jn into month and day values.
         /// </summary>
         private static void TZif_ParseJulianDay(ReadOnlySpan<char> date, out int month, out int day)
         {

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -2351,6 +2352,74 @@ namespace System.Tests
                     Assert.True(Math.Abs((tzi.GetUtcOffset(ar.DateStart)).TotalHours) <= 14.0);
                 }
             }
+        }
+
+        private static byte [] timeZoneFileContents = new byte[]
+        {
+            0x54, 0x5A, 0x69, 0x66, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x54, 0x5A, 0x69, 0x66,
+            0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x0C, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0xFF, 0xFF, 0xF8, 0xE4, 0x00, 0x00, 0x00, 0x00, 0x0E, 0x10, 0x01, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x08, 0x00, 0x00, 0x0E, 0x10, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x4C,
+            0x4D, 0x54, 0x00, 0x2B, 0x30, 0x31, 0x00, 0x2B, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00,
+            // POSIX Rule
+            // 0x0A, 0x3C, 0x2B, 0x30, 0x30, 0x3E, 0x30, 0x3C, 0x2B, 0x30, 0x31,
+            // 0x3E, 0x2C, 0x30, 0x2F, 0x30, 0x2C, 0x4A, 0x33, 0x36, 0x35, 0x2F, 0x32, 0x35, 0x0A
+        };
+
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("<+00>0<+01>,0/0,J365/25", 1, 1, true)]
+        [InlineData("<+00>0<+01>,30/0,J365/25", 31, 1, true)]
+        [InlineData("<+00>0<+01>,31/0,J365/25", 1, 2, true)]
+        [InlineData("<+00>0<+01>,58/0,J365/25", 28, 2, true)]
+        [InlineData("<+00>0<+01>,59/0,J365/25", 0, 0, false)]
+        [InlineData("<+00>0<+01>,9999999/0,J365/25", 0, 0, false)]
+        [InlineData("<+00>0<+01>,A/0,J365/25", 0, 0, false)]
+        public static void NJulianRuleTest(string posixRule, int dayNumber, int monthNumber, bool shouldSucceed)
+        {
+            string zoneFilePath = Path.GetTempPath() + "dotnet_tz";
+            using (FileStream fs = new FileStream(zoneFilePath, FileMode.Create))
+            {
+                fs.Write(timeZoneFileContents.AsSpan());
+
+                // Append the POSIX rule
+                fs.WriteByte(0x0A);
+                foreach (char c in posixRule)
+                {
+                    fs.WriteByte((byte) c);
+                }
+                fs.WriteByte(0x0A);
+            }
+
+            ProcessStartInfo psi = new ProcessStartInfo() {  UseShellExecute = false };
+            psi.Environment.Add("TZ", zoneFilePath);
+
+            RemoteExecutor.Invoke((day, month, succeed) =>
+            {
+                bool expectedToSucceed = bool.Parse(succeed);
+                int d = int.Parse(day);
+                int m = int.Parse(month);
+
+                TimeZoneInfo.AdjustmentRule [] rules = TimeZoneInfo.Local.GetAdjustmentRules();
+
+                if (expectedToSucceed)
+                {
+                    Assert.Equal(1, rules.Length);
+                    Assert.Equal(d, rules[0].DaylightTransitionStart.Day);
+                    Assert.Equal(m, rules[0].DaylightTransitionStart.Month);
+                }
+                else
+                {
+                    Assert.Equal(0, rules.Length);
+                }
+            }, dayNumber.ToString(), monthNumber.ToString(), shouldSucceed.ToString(), new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
+
+            File.Delete(zoneFilePath);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2396,30 +2396,35 @@ namespace System.Tests
                 fs.WriteByte(0x0A);
             }
 
-            ProcessStartInfo psi = new ProcessStartInfo() {  UseShellExecute = false };
-            psi.Environment.Add("TZ", zoneFilePath);
-
-            RemoteExecutor.Invoke((day, month, succeed) =>
+            try
             {
-                bool expectedToSucceed = bool.Parse(succeed);
-                int d = int.Parse(day);
-                int m = int.Parse(month);
+                ProcessStartInfo psi = new ProcessStartInfo() {  UseShellExecute = false };
+                psi.Environment.Add("TZ", zoneFilePath);
 
-                TimeZoneInfo.AdjustmentRule [] rules = TimeZoneInfo.Local.GetAdjustmentRules();
-
-                if (expectedToSucceed)
+                RemoteExecutor.Invoke((day, month, succeed) =>
                 {
-                    Assert.Equal(1, rules.Length);
-                    Assert.Equal(d, rules[0].DaylightTransitionStart.Day);
-                    Assert.Equal(m, rules[0].DaylightTransitionStart.Month);
-                }
-                else
-                {
-                    Assert.Equal(0, rules.Length);
-                }
-            }, dayNumber.ToString(), monthNumber.ToString(), shouldSucceed.ToString(), new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
+                    bool expectedToSucceed = bool.Parse(succeed);
+                    int d = int.Parse(day);
+                    int m = int.Parse(month);
 
-            File.Delete(zoneFilePath);
+                    TimeZoneInfo.AdjustmentRule [] rules = TimeZoneInfo.Local.GetAdjustmentRules();
+
+                    if (expectedToSucceed)
+                    {
+                        Assert.Equal(1, rules.Length);
+                        Assert.Equal(d, rules[0].DaylightTransitionStart.Day);
+                        Assert.Equal(m, rules[0].DaylightTransitionStart.Month);
+                    }
+                    else
+                    {
+                        Assert.Equal(0, rules.Length);
+                    }
+                }, dayNumber.ToString(), monthNumber.ToString(), shouldSucceed.ToString(), new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
+            }
+            finally
+            {
+                try { File.Delete(zoneFilePath); } catch { } // don't fail the test if we couldn't delete the file.
+            }
         }
 
         [Fact]


### PR DESCRIPTION
On Linux the time zone files can include the rules posix format https://man7.org/linux/man-pages/man3/tzset.3.html. We already parse such format successfully except the Julian n day format. After investigating different Linux distro zone files for all zones, I found only `rhel` based distros (e.g. `RHEL`, `Centos`, and `Amazon Linux`) are using this Julian n rules for the following zones:

```
Africa\Casablanca: <+00>0<+01>,0/0,J365/25
Africa\El_Aaiun:   <+00>0<+01>,0/0,J365/25
```

Also, it is used only for convenience to specify January 1st date. From the experience with the time zone, I cannot think in any case that need to use this rule to specify dates after February 28. Considering that, we can handle this rule if the specified date in the rule would be from Jan 1 to Feb 28. 

So, this change is to allow parsing this rule and we'll only fail in case if getting dates past Feb 28 which is very uncommon and very unlikely be used in the future.

https://github.com/dotnet/runtime/issues/25933
