### PR TITLE
When marshalling a layout class, fall-back to dynamically marshalling the type if it doesn't match the static type in the signature.

### DIFF
--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -477,6 +477,10 @@ DEFINE_METHOD(MARSHAL,              ALLOC_CO_TASK_MEM,                 AllocCoTa
 DEFINE_METHOD(MARSHAL,              FREE_CO_TASK_MEM,                  FreeCoTaskMem,                 SM_IntPtr_RetVoid)
 DEFINE_FIELD(MARSHAL,               SYSTEM_MAX_DBCS_CHAR_SIZE,         SystemMaxDBCSCharSize)
 
+DEFINE_METHOD(MARSHAL,              STRUCTURE_TO_PTR,                  StructureToPtr,                SM_Obj_IntPtr_Bool_RetVoid)
+DEFINE_METHOD(MARSHAL,              PTR_TO_STRUCTURE,                  PtrToStructure,                SM_IntPtr_Obj_RetVoid)
+DEFINE_METHOD(MARSHAL,              DESTROY_STRUCTURE,                 DestroyStructure,              SM_IntPtr_Type_RetVoid)
+
 DEFINE_CLASS(NATIVELIBRARY, Interop, NativeLibrary)
 DEFINE_METHOD(NATIVELIBRARY,        LOADLIBRARYCALLBACKSTUB, LoadLibraryCallbackStub, SM_Str_AssemblyBase_Bool_UInt_RetIntPtr)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -480,6 +480,7 @@ DEFINE_FIELD(MARSHAL,               SYSTEM_MAX_DBCS_CHAR_SIZE,         SystemMax
 DEFINE_METHOD(MARSHAL,              STRUCTURE_TO_PTR,                  StructureToPtr,                SM_Obj_IntPtr_Bool_RetVoid)
 DEFINE_METHOD(MARSHAL,              PTR_TO_STRUCTURE,                  PtrToStructure,                SM_IntPtr_Obj_RetVoid)
 DEFINE_METHOD(MARSHAL,              DESTROY_STRUCTURE,                 DestroyStructure,              SM_IntPtr_Type_RetVoid)
+DEFINE_METHOD(MARSHAL,              SIZEOF_TYPE,                       SizeOf,                        SM_Type_RetInt)
 
 DEFINE_CLASS(NATIVELIBRARY, Interop, NativeLibrary)
 DEFINE_METHOD(NATIVELIBRARY,        LOADLIBRARYCALLBACKSTUB, LoadLibraryCallbackStub, SM_Str_AssemblyBase_Bool_UInt_RetIntPtr)

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -2261,7 +2261,22 @@ void ILLayoutClassPtrMarshalerBase::EmitClearNativeTemp(ILCodeStream* pslILEmit)
     }
 }
 
+bool ILLayoutClassPtrMarshalerBase::EmitExactTypeCheck(ILCodeStream* pslILEmit, ILCodeLabel* isNotMatchingTypeLabel)
+{
+    if (m_pargs->m_pMT->IsSealed())
+    {
+        // If the provided type cannot be derived from, then we don't need to emit the type check.
+        return false;
+    }
+    EmitLoadManagedValue(pslILEmit);
+    pslILEmit->EmitCALL(METHOD__OBJECT__GET_TYPE, 1, 1);
+    pslILEmit->EmitLDTOKEN(pslILEmit->GetToken(m_pargs->m_pMT));
+    pslILEmit->EmitCALL(METHOD__TYPE__GET_TYPE_FROM_HANDLE, 1, 1);
+    pslILEmit->EmitCALLVIRT(pslILEmit->GetToken(CoreLibBinder::GetMethod(METHOD__OBJECT__EQUALS)), 1, 1);
+    pslILEmit->EmitBRFALSE(isNotMatchingTypeLabel);
 
+    return true;
+}
 
 void ILLayoutClassPtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit)
 {
@@ -2278,6 +2293,9 @@ void ILLayoutClassPtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* psl
     pslILEmit->EmitLDC(uNativeSize);
     pslILEmit->EmitINITBLK();
 
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
+
     MethodDesc* pStructMarshalStub = NDirect::CreateStructMarshalILStub(m_pargs->m_pMT);
 
     EmitLoadManagedValue(pslILEmit);
@@ -2287,6 +2305,18 @@ void ILLayoutClassPtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* psl
     EmitLoadCleanupWorkList(pslILEmit);
 
     pslILEmit->EmitCALL(pslILEmit->GetToken(pStructMarshalStub), 4, 0);
+
+    if (emittedTypeCheck)
+    {
+        pslILEmit->EmitBR(pNullRefLabel);
+
+        pslILEmit->EmitLabel(isNotMatchingTypeLabel);
+        EmitLoadManagedValue(pslILEmit);
+        EmitLoadNativeValue(pslILEmit);
+        pslILEmit->EmitLDC(0);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__STRUCTURE_TO_PTR, 3, 0);
+    }
+
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
@@ -2299,6 +2329,9 @@ void ILLayoutClassPtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* psl
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
 
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
+
     MethodDesc* pStructMarshalStub = NDirect::CreateStructMarshalILStub(m_pargs->m_pMT);
 
     EmitLoadManagedValue(pslILEmit);
@@ -2308,12 +2341,25 @@ void ILLayoutClassPtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* psl
     EmitLoadCleanupWorkList(pslILEmit);
 
     pslILEmit->EmitCALL(pslILEmit->GetToken(pStructMarshalStub), 4, 0);
+    if (emittedTypeCheck)
+    {
+        pslILEmit->EmitBR(pNullRefLabel);
+
+        pslILEmit->EmitLabel(isNotMatchingTypeLabel);
+        EmitLoadNativeValue(pslILEmit);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__PTR_TO_STRUCTURE, 2, 0);
+    }
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
 void ILLayoutClassPtrMarshaler::EmitClearNativeContents(ILCodeStream * pslILEmit)
 {
     STANDARD_VM_CONTRACT;
+
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    ILCodeLabel* cleanedUpLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
 
     MethodDesc* pStructMarshalStub = NDirect::CreateStructMarshalILStub(m_pargs->m_pMT);
 
@@ -2324,6 +2370,19 @@ void ILLayoutClassPtrMarshaler::EmitClearNativeContents(ILCodeStream * pslILEmit
     EmitLoadCleanupWorkList(pslILEmit);
 
     pslILEmit->EmitCALL(pslILEmit->GetToken(pStructMarshalStub), 4, 0);
+
+    if (emittedTypeCheck)
+    {
+        pslILEmit->EmitBR(cleanedUpLabel);
+
+        pslILEmit->EmitLabel(isNotMatchingTypeLabel);
+        EmitLoadNativeValue(pslILEmit);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitCALL(METHOD__OBJECT__GET_TYPE, 1, 1);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__DESTROY_STRUCTURE, 2, 0);
+    }
+
+    pslILEmit->EmitLabel(cleanedUpLabel);
 }
 
 
@@ -2338,6 +2397,9 @@ void ILBlittablePtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslIL
     EmitLoadNativeValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
 
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
+
     EmitLoadNativeValue(pslILEmit);                             // dest
 
     EmitLoadManagedValue(pslILEmit);
@@ -2346,6 +2408,17 @@ void ILBlittablePtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslIL
     pslILEmit->EmitLDC(uNativeSize);                            // size
 
     pslILEmit->EmitCPBLK();
+
+    if (emittedTypeCheck)
+    {
+        pslILEmit->EmitBR(pNullRefLabel);
+
+        pslILEmit->EmitLabel(isNotMatchingTypeLabel);
+        EmitLoadManagedValue(pslILEmit);
+        EmitLoadNativeValue(pslILEmit);
+        pslILEmit->EmitLDC(0);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__STRUCTURE_TO_PTR, 3, 0);
+    }
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
@@ -2356,6 +2429,9 @@ void ILBlittablePtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslIL
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
     UINT uNativeSize = m_pargs->m_pMT->GetNativeSize();
     int fieldDef = pslILEmit->GetToken(CoreLibBinder::GetField(FIELD__RAW_DATA__DATA));
+
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
 
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
@@ -2368,12 +2444,26 @@ void ILBlittablePtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslIL
     pslILEmit->EmitLDC(uNativeSize);                            // size
 
     pslILEmit->EmitCPBLK();
+
+    if (emittedTypeCheck)
+    {
+        pslILEmit->EmitBR(pNullRefLabel);
+
+        pslILEmit->EmitLabel(isNotMatchingTypeLabel);
+        EmitLoadNativeValue(pslILEmit);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__PTR_TO_STRUCTURE, 2, 0);
+    }
+
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
 bool ILBlittablePtrMarshaler::CanMarshalViaPinning()
 {
-    return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags) && !IsFieldMarshal(m_dwMarshalFlags);
+    return IsCLRToNative(m_dwMarshalFlags) &&
+        !IsByref(m_dwMarshalFlags) &&
+        !IsFieldMarshal(m_dwMarshalFlags) &&
+        m_pargs->m_pMT->IsSealed(); // We can't marshal via pinning if we might need to marshal differently at runtime.
 }
 
 void ILBlittablePtrMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -2297,6 +2297,8 @@ void ILLayoutClassPtrMarshalerBase::EmitClearNativeTemp(ILCodeStream* pslILEmit)
 
 bool ILLayoutClassPtrMarshalerBase::EmitExactTypeCheck(ILCodeStream* pslILEmit, ILCodeLabel* isNotMatchingTypeLabel)
 {
+    STANDARD_VM_CONTRACT;
+
     if (m_pargs->m_pMT->IsSealed())
     {
         // If the provided type cannot be derived from, then we don't need to emit the type check.
@@ -2497,7 +2499,7 @@ bool ILBlittablePtrMarshaler::CanMarshalViaPinning()
     return IsCLRToNative(m_dwMarshalFlags) &&
         !IsByref(m_dwMarshalFlags) &&
         !IsFieldMarshal(m_dwMarshalFlags) &&
-        m_pargs->m_pMT->IsSealed(); // We can't marshal via pinning if we might need to marshal differently at runtime.
+        m_pargs->m_pMT->IsSealed(); // We can't marshal via pinning if we might need to marshal differently at runtime. See calls to EmitExactTypeCheck where we check the runtime type of the object being marshalled.
 }
 
 void ILBlittablePtrMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)

--- a/src/coreclr/vm/ilmarshalers.h
+++ b/src/coreclr/vm/ilmarshalers.h
@@ -2791,6 +2791,7 @@ protected:
     bool NeedsClearNative() override;
     void EmitClearNative(ILCodeStream* pslILEmit) override;
     void EmitClearNativeTemp(ILCodeStream* pslILEmit) override;
+    bool EmitExactTypeCheck(ILCodeStream* pslILEmit, ILCodeLabel* isNotMatchingTypeLabel);
 };
 
 class ILLayoutClassPtrMarshaler : public ILLayoutClassPtrMarshalerBase

--- a/src/coreclr/vm/metasig.h
+++ b/src/coreclr/vm/metasig.h
@@ -592,6 +592,10 @@ DEFINE_METASIG_T(SM(Array_Int_Array_Int_Int_RetVoid, C(ARRAY) i C(ARRAY) i i, v)
 DEFINE_METASIG_T(SM(Array_Int_Obj_RetVoid, C(ARRAY) i j, v))
 DEFINE_METASIG_T(SM(Array_Int_PtrVoid_RetRefObj, C(ARRAY) i P(v), r(j)))
 
+DEFINE_METASIG(SM(Obj_IntPtr_Bool_RetVoid, j I F, v))
+DEFINE_METASIG(SM(IntPtr_Obj_RetVoid, I j, v))
+DEFINE_METASIG_T(SM(IntPtr_Type_RetVoid, I C(TYPE), v))
+
 // Undefine macros in case we include the file again in the compilation unit
 
 #undef  DEFINE_METASIG

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -1133,7 +1133,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
     CorElementType corElemType      = ELEMENT_TYPE_END;
     m_pMT                           = NULL;
     m_pMD                           = pMD;
-    // For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
+    // [Compat] For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
     BOOL outImpliesInOut            = FALSE;
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -1133,6 +1133,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
     CorElementType corElemType      = ELEMENT_TYPE_END;
     m_pMT                           = NULL;
     m_pMD                           = pMD;
+    // For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
+    BOOL outImpliesInOut            = FALSE;
 
 #ifdef FEATURE_COMINTEROP
     m_fDispItf                      = FALSE;
@@ -1877,6 +1879,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_BLITTABLE_LAYOUTCLASS : MARSHAL_TYPE_BLITTABLEPTR;
                     m_args.m_pMT = m_pMT;
+                    outImpliesInOut = TRUE;
                 }
                 else if (m_pMT->HasLayout())
                 {
@@ -2386,7 +2389,12 @@ lExit:
                 m_in = TRUE;
                 m_out = FALSE;
             }
+        }
 
+        // For marshalers that expect [Out] behavior to match [In, Out] behavior, update that here.
+        if (m_out && outImpliesInOut)
+        {
+            m_in = TRUE;
         }
     }
 

--- a/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
+++ b/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
@@ -5,7 +5,16 @@
 #include <xplatform.h>
 
 typedef void *voidPtr;
- 
+
+struct EmptyBase
+{
+};
+
+struct DerivedSeqClass : public EmptyBase
+{
+    int a;
+};
+
 struct SeqClass
 {
     int a;
@@ -14,7 +23,7 @@ struct SeqClass
 };
 
 struct ExpClass
-{ 
+{
     int a;
     int padding; //padding needs to be added here as we have added 8 byte offset.
     union
@@ -41,6 +50,17 @@ DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleSeqLayoutClassByRef(SeqClass* p)
     if((p->a != 0) || (p->b) || strcmp(p->str, "before") != 0)
     {
         printf("FAIL: p->a=%d, p->b=%s, p->str=%s\n", p->a, p->b ? "true" : "false", p->str);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+extern "C"
+DLL_EXPORT BOOL STDMETHODCALLTYPE DerivedSeqLayoutClassByRef(EmptyBase* p, int expected)
+{
+    if(((DerivedSeqClass*)p)->a != expected)
+    {
+        printf("FAIL: p->a=%d, expected %d\n", ((DerivedSeqClass*)p)->a, expected);
         return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
When we switched the struct marshalling system to be IL based, we accidentally stopped checking if the passed in object matched the type in the signature in the "layout class" case (where we have a sequential or explicit layout `class` type). This causes failures to marshal the derived types correctly since only the base type ends up being marshalled.

This PR fixes the regression by falling back to dynamically marshalling the object if the runtime type does not match the declared type.

Fixes #49857