### PR TITLE
[release/5.0] When marshalling a layout class, fall-back to dynamically marshalling the type if it doesn't match the static type in the signature.

### DIFF
--- a/src/coreclr/src/vm/corelib.h
+++ b/src/coreclr/src/vm/corelib.h
@@ -491,6 +491,7 @@ DEFINE_FIELD(MARSHAL,               SYSTEM_MAX_DBCS_CHAR_SIZE,         SystemMax
 DEFINE_METHOD(MARSHAL,              STRUCTURE_TO_PTR,                  StructureToPtr,                SM_Obj_IntPtr_Bool_RetVoid)
 DEFINE_METHOD(MARSHAL,              PTR_TO_STRUCTURE,                  PtrToStructure,                SM_IntPtr_Obj_RetVoid)
 DEFINE_METHOD(MARSHAL,              DESTROY_STRUCTURE,                 DestroyStructure,              SM_IntPtr_Type_RetVoid)
+DEFINE_METHOD(MARSHAL,              SIZEOF_TYPE,                       SizeOf,                        SM_Type_RetInt)
 
 DEFINE_CLASS(NATIVELIBRARY, Interop, NativeLibrary)
 DEFINE_METHOD(NATIVELIBRARY,        LOADLIBRARYCALLBACKSTUB, LoadLibraryCallbackStub, SM_Str_AssemblyBase_Bool_UInt_RetIntPtr)

--- a/src/coreclr/src/vm/corelib.h
+++ b/src/coreclr/src/vm/corelib.h
@@ -488,6 +488,10 @@ DEFINE_METHOD(MARSHAL,              ALLOC_CO_TASK_MEM,                 AllocCoTa
 DEFINE_METHOD(MARSHAL,              FREE_CO_TASK_MEM,                  FreeCoTaskMem,                 SM_IntPtr_RetVoid)
 DEFINE_FIELD(MARSHAL,               SYSTEM_MAX_DBCS_CHAR_SIZE,         SystemMaxDBCSCharSize)
 
+DEFINE_METHOD(MARSHAL,              STRUCTURE_TO_PTR,                  StructureToPtr,                SM_Obj_IntPtr_Bool_RetVoid)
+DEFINE_METHOD(MARSHAL,              PTR_TO_STRUCTURE,                  PtrToStructure,                SM_IntPtr_Obj_RetVoid)
+DEFINE_METHOD(MARSHAL,              DESTROY_STRUCTURE,                 DestroyStructure,              SM_IntPtr_Type_RetVoid)
+
 DEFINE_CLASS(NATIVELIBRARY, Interop, NativeLibrary)
 DEFINE_METHOD(NATIVELIBRARY,        LOADLIBRARYCALLBACKSTUB, LoadLibraryCallbackStub, SM_Str_AssemblyBase_Bool_UInt_RetIntPtr)
 

--- a/src/coreclr/src/vm/ilmarshalers.cpp
+++ b/src/coreclr/src/vm/ilmarshalers.cpp
@@ -2466,11 +2466,11 @@ void ILBlittablePtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslIL
     UINT uNativeSize = m_pargs->m_pMT->GetNativeSize();
     int fieldDef = pslILEmit->GetToken(CoreLibBinder::GetField(FIELD__RAW_DATA__DATA));
 
-    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
-    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
-
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
+
+    ILCodeLabel* isNotMatchingTypeLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, isNotMatchingTypeLabel);
 
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitLDFLDA(fieldDef);                            // dest

--- a/src/coreclr/src/vm/ilmarshalers.cpp
+++ b/src/coreclr/src/vm/ilmarshalers.cpp
@@ -2149,14 +2149,30 @@ void ILLayoutClassPtrMarshalerBase::EmitConvertSpaceCLRToNative(ILCodeStream* ps
 
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
+    ILCodeLabel* pTypeMismatchedLabel = pslILEmit->NewCodeLabel();
+    bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, pTypeMismatchedLabel);
+    DWORD sizeLocal = pslILEmit->NewLocal(LocalDesc(ELEMENT_TYPE_I4));
+
     pslILEmit->EmitLDC(uNativeSize);
+    if (emittedTypeCheck)
+    {
+        ILCodeLabel* pHaveSizeLabel = pslILEmit->NewCodeLabel();
+        pslILEmit->EmitBR(pHaveSizeLabel);
+        pslILEmit->EmitLabel(pTypeMismatchedLabel);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitCALL(METHOD__OBJECT__GET_TYPE, 1, 1);
+        pslILEmit->EmitCALL(METHOD__MARSHAL__SIZEOF_TYPE, 1, 1);
+        pslILEmit->EmitLabel(pHaveSizeLabel);
+    }
+    pslILEmit->EmitSTLOC(sizeLocal);
+    pslILEmit->EmitLDLOC(sizeLocal);
     pslILEmit->EmitCALL(METHOD__MARSHAL__ALLOC_CO_TASK_MEM, 1, 1);
     pslILEmit->EmitDUP();           // for INITBLK
     EmitStoreNativeValue(pslILEmit);
 
     // initialize local block we just allocated
     pslILEmit->EmitLDC(0);
-    pslILEmit->EmitLDC(uNativeSize);
+    pslILEmit->EmitLDLOC(sizeLocal);
     pslILEmit->EmitINITBLK();
 
     pslILEmit->EmitLabel(pNullRefLabel);
@@ -2180,15 +2196,30 @@ void ILLayoutClassPtrMarshalerBase::EmitConvertSpaceCLRToNativeTemp(ILCodeStream
 
         EmitLoadManagedValue(pslILEmit);
         pslILEmit->EmitBRFALSE(pNullRefLabel);
+        ILCodeLabel* pTypeMismatchedLabel = pslILEmit->NewCodeLabel();
+        bool emittedTypeCheck = EmitExactTypeCheck(pslILEmit, pTypeMismatchedLabel);
+        DWORD sizeLocal = pslILEmit->NewLocal(LocalDesc(ELEMENT_TYPE_I4));
 
         pslILEmit->EmitLDC(uNativeSize);
+        if (emittedTypeCheck)
+        {
+            ILCodeLabel* pHaveSizeLabel = pslILEmit->NewCodeLabel();
+            pslILEmit->EmitBR(pHaveSizeLabel);
+            pslILEmit->EmitLabel(pTypeMismatchedLabel);
+            EmitLoadManagedValue(pslILEmit);
+            pslILEmit->EmitCALL(METHOD__OBJECT__GET_TYPE, 1, 1);
+            pslILEmit->EmitCALL(METHOD__MARSHAL__SIZEOF_TYPE, 1, 1);
+            pslILEmit->EmitLabel(pHaveSizeLabel);
+        }
+        pslILEmit->EmitSTLOC(sizeLocal);
+        pslILEmit->EmitLDLOC(sizeLocal);
         pslILEmit->EmitLOCALLOC();
         pslILEmit->EmitDUP();           // for INITBLK
         EmitStoreNativeValue(pslILEmit);
 
         // initialize local block we just allocated
         pslILEmit->EmitLDC(0);
-        pslILEmit->EmitLDC(uNativeSize);
+        pslILEmit->EmitLDLOC(sizeLocal);
         pslILEmit->EmitINITBLK();
 
         pslILEmit->EmitLabel(pNullRefLabel);

--- a/src/coreclr/src/vm/ilmarshalers.cpp
+++ b/src/coreclr/src/vm/ilmarshalers.cpp
@@ -2297,6 +2297,8 @@ void ILLayoutClassPtrMarshalerBase::EmitClearNativeTemp(ILCodeStream* pslILEmit)
 
 bool ILLayoutClassPtrMarshalerBase::EmitExactTypeCheck(ILCodeStream* pslILEmit, ILCodeLabel* isNotMatchingTypeLabel)
 {
+    STANDARD_VM_CONTRACT;
+
     if (m_pargs->m_pMT->IsSealed())
     {
         // If the provided type cannot be derived from, then we don't need to emit the type check.
@@ -2497,7 +2499,7 @@ bool ILBlittablePtrMarshaler::CanMarshalViaPinning()
     return IsCLRToNative(m_dwMarshalFlags) &&
         !IsByref(m_dwMarshalFlags) &&
         !IsFieldMarshal(m_dwMarshalFlags) &&
-        m_pargs->m_pMT->IsSealed(); // We can't marshal via pinning if we might need to marshal differently at runtime.
+        m_pargs->m_pMT->IsSealed(); // We can't marshal via pinning if we might need to marshal differently at runtime. See calls to EmitExactTypeCheck where we check the runtime type of the object being marshalled.
 }
 
 void ILBlittablePtrMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)

--- a/src/coreclr/src/vm/ilmarshalers.h
+++ b/src/coreclr/src/vm/ilmarshalers.h
@@ -2915,6 +2915,7 @@ protected:
     bool NeedsClearNative() override;
     void EmitClearNative(ILCodeStream* pslILEmit) override;
     void EmitClearNativeTemp(ILCodeStream* pslILEmit) override;
+    bool EmitExactTypeCheck(ILCodeStream* pslILEmit, ILCodeLabel* isNotMatchingTypeLabel);
 };
 
 class ILLayoutClassPtrMarshaler : public ILLayoutClassPtrMarshalerBase

--- a/src/coreclr/src/vm/metasig.h
+++ b/src/coreclr/src/vm/metasig.h
@@ -604,6 +604,10 @@ DEFINE_METASIG_T(SM(Array_Int_Array_Int_Int_RetVoid, C(ARRAY) i C(ARRAY) i i, v)
 DEFINE_METASIG_T(SM(Array_Int_Obj_RetVoid, C(ARRAY) i j, v))
 DEFINE_METASIG_T(SM(Array_Int_PtrVoid_RetRefObj, C(ARRAY) i P(v), r(j)))
 
+DEFINE_METASIG(SM(Obj_IntPtr_Bool_RetVoid, j I F, v))
+DEFINE_METASIG(SM(IntPtr_Obj_RetVoid, I j, v))
+DEFINE_METASIG_T(SM(IntPtr_Type_RetVoid, I C(TYPE), v))
+
 // Undefine macros in case we include the file again in the compilation unit
 
 #undef  DEFINE_METASIG

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -1231,7 +1231,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
     m_pMT                           = NULL;
     m_pMD                           = pMD;
     m_onInstanceMethod              = onInstanceMethod;
-    // For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
+    // [Compat] For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
     BOOL outImpliesInOut            = FALSE;
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -1231,6 +1231,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
     m_pMT                           = NULL;
     m_pMD                           = pMD;
     m_onInstanceMethod              = onInstanceMethod;
+    // For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
+    BOOL outImpliesInOut            = FALSE;
 
 #ifdef FEATURE_COMINTEROP
     m_fDispItf                      = FALSE;
@@ -2007,6 +2009,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_BLITTABLE_LAYOUTCLASS : MARSHAL_TYPE_BLITTABLEPTR;
                     m_args.m_pMT = m_pMT;
+                    outImpliesInOut = TRUE;
                 }
                 else if (m_pMT->HasLayout())
                 {
@@ -2532,6 +2535,12 @@ lExit:
                 m_out = FALSE;
             }
 
+        }
+
+        // For marshalers that expect [Out] behavior to match [In, Out] behavior, update that here.
+        if (m_out && outImpliesInOut)
+        {
+            m_in = TRUE;
         }
     }
 

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -1231,8 +1231,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
     m_pMT                           = NULL;
     m_pMD                           = pMD;
     m_onInstanceMethod              = onInstanceMethod;
-    // [Compat] For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [Out].
-    BOOL outImpliesInOut            = FALSE;
+    // [Compat] For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [In], [Out], or not marked with either.
+    BOOL byValAlwaysInOut           = FALSE;
 
 #ifdef FEATURE_COMINTEROP
     m_fDispItf                      = FALSE;
@@ -2009,7 +2009,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_BLITTABLE_LAYOUTCLASS : MARSHAL_TYPE_BLITTABLEPTR;
                     m_args.m_pMT = m_pMT;
-                    outImpliesInOut = TRUE;
+                    byValAlwaysInOut = TRUE;
                 }
                 else if (m_pMT->HasLayout())
                 {
@@ -2517,10 +2517,16 @@ lExit:
             }
         }
 
-        // If neither IN nor OUT are true, this signals the URT to use the default
-        // rules.
-        if (!m_in && !m_out)
+        if (!m_byref && byValAlwaysInOut)
         {
+            // Some marshalers expect [In, Out] behavior with [In], [Out], or no directional attributes.
+            m_in = TRUE;
+            m_out = TRUE;
+        }
+        else if (!m_in && !m_out)
+        {
+            // If neither IN nor OUT are true, this signals the URT to use the default
+            // rules.
             if (m_byref ||
                  (mtype == ELEMENT_TYPE_CLASS
                   && !(sig.IsStringType(pModule, pTypeContext))
@@ -2535,12 +2541,6 @@ lExit:
                 m_out = FALSE;
             }
 
-        }
-
-        // For marshalers that expect [Out] behavior to match [In, Out] behavior, update that here.
-        if (m_out && outImpliesInOut)
-        {
-            m_in = TRUE;
         }
     }
 

--- a/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
+++ b/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
@@ -78,21 +78,13 @@ DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleExpLayoutClassByRef(ExpClass* p)
 }
 
 extern "C"
-DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleBlittableSeqLayoutClassByRef(BlittableClass* p)
+DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleBlittableSeqLayoutClass_UpdateField(BlittableClass* p)
 {
     if(p->a != 10)
     {
         printf("FAIL: p->a=%d\n", p->a);
         return FALSE;
     }
-    return TRUE;
-}
-
-extern "C"
-DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleBlittableSeqLayoutClassByOutAttr(BlittableClass* p)
-{
-    if(!SimpleBlittableSeqLayoutClassByRef(p))
-        return FALSE;
 
     p->a++;
     return TRUE;

--- a/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
+++ b/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
@@ -5,7 +5,16 @@
 #include <xplatform.h>
 
 typedef void *voidPtr;
- 
+
+struct EmptyBase
+{
+};
+
+struct DerivedSeqClass : public EmptyBase
+{
+    int a;
+};
+
 struct SeqClass
 {
     int a;
@@ -14,7 +23,7 @@ struct SeqClass
 };
 
 struct ExpClass
-{ 
+{
     int a;
     int padding; //padding needs to be added here as we have added 8 byte offset.
     union
@@ -41,6 +50,17 @@ DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleSeqLayoutClassByRef(SeqClass* p)
     if((p->a != 0) || (p->b) || strcmp(p->str, "before") != 0)
     {
         printf("FAIL: p->a=%d, p->b=%s, p->str=%s\n", p->a, p->b ? "true" : "false", p->str);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+extern "C"
+DLL_EXPORT BOOL STDMETHODCALLTYPE DerivedSeqLayoutClassByRef(EmptyBase* p, int expected)
+{
+    if(((DerivedSeqClass*)p)->a != expected)
+    {
+        printf("FAIL: p->a=%d, expected %d\n", ((DerivedSeqClass*)p)->a, expected);
         return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
Port of #50137, #50655, and #50735 to release/5.0

When we switched the struct marshalling system to be IL based, we accidentally stopped checking if the passed in object matched the type in the signature in the "layout class" case (where we have a sequential or explicit layout `class` type). This causes failures to marshal the derived types correctly since only the base type ends up being marshalled.

## Customer Impact

Without this change, developers need to manually marshal their types. An internal team (Halo) has worked around this by manually marshalling their types, but would prefer to remove this workaround.

## Regression?

This was a regression from .NET Core 3.1.

See #49857

## Testing

Tests for both the fix and backwards compatibility are included with this change.

## Risk

Medium. This change affects marshalling of layout classes.