### PR TITLE
Include the iOS, Android, and macCatalyst supported platforms

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -35,7 +35,14 @@
   <PropertyGroup Condition="'$(TargetsAnyOS)' == 'true' and !$(TargetFrameworks.Contains('$(TargetFramework)-Browser'))">
       <CrossPlatformAndHasNoBrowserTarget>true</CrossPlatformAndHasNoBrowserTarget>
   </PropertyGroup>
-  
+
+  <!-- Enables warnings for Android, iOS, and macCatalyst for all builds -->
+  <ItemGroup>
+    <SupportedPlatform Include="Android" />
+    <SupportedPlatform Include="iOS" />
+    <SupportedPlatform Include="macCatalyst" />
+  </ItemGroup>
+
   <!-- Enables browser warnings for cross platform or Browser targeted builds -->
   <ItemGroup Condition="('$(TargetsBrowser)' == 'true' or '$(CrossPlatformAndHasNoBrowserTarget)' == 'true') and '$(IsTestProject)' != 'true'">
     <SupportedPlatform Include="browser"/>
@@ -45,7 +52,7 @@
   <ItemGroup Condition="'$(TargetstvOS)' == 'true' and '$(IsTestProject)' != 'true'">
     <SupportedPlatform Include="tvos"/>
   </ItemGroup>
-  
+
   <ItemGroup>
     <_unsupportedOSPlatforms Include="$(UnsupportedOSPlatforms)" />
   </ItemGroup>


### PR DESCRIPTION
With dotnet/sdk#16489, we are removing `iOS`, `Android`, and `macCatalyst` from the default set of supported platforms that will be checked by the Platform Compatibility Analyzer. We intend to reintroduce those platforms into a default set with scoping to cover libraries; that will be handled by dotnet/sdk#16488. To ensure no gap in coverage of these platforms in `dotnet/runtime` though, this change explicitly adds those platforms back into our own build. These platforms are added in unconditionally as they were in the SDK default so that we maintain full continuity of that coverage.