### PR TITLE
Fix swapped args in AssemblySpec::AssemblyNameInit

### DIFF
--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -564,7 +564,7 @@ void AssemblySpec::AssemblyNameInit(ASSEMBLYNAMEREF* pAsmName, PEImage* pImageIn
     {
         DWORD dwMachine, dwKind;
 
-        pImageInfo->GetPEKindAndMachine(&dwMachine,&dwKind);
+        pImageInfo->GetPEKindAndMachine(&dwKind, &dwMachine);
 
         MethodDescCallSite setPA(METHOD__ASSEMBLY_NAME__SET_PROC_ARCH_INDEX);
 


### PR DESCRIPTION
GetPEKindAndMachine takes two arguments, a kind and a machine, in that order:

    $ ag GetPEKindAndMachine
    ...
    src/coreclr/vm/pefile.cpp
    181:    peFile->GetPEKindAndMachine(&peKind, &actualMachineType);
    1688:void PEFile::GetPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachine)
    1723:    GetILimage()->GetPEKindAndMachine(pdwKind, pdwMachine);

    src/coreclr/vm/peimage.h
    383:    void GetPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachine);
    ...

But this code swaps the arguments:

    pImageInfo->GetPEKindAndMachine(&dwMachine,&dwKind);

Fix that.