### PR TITLE
Return DiaSymReader library for cross-arch crossgen to Runtime package

### DIFF
--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -100,9 +100,7 @@ extern VerboseLevel g_CorCompileVerboseLevel;
 #elif defined(HOST_ARM)
 #define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm.dll")
 #elif defined(HOST_ARM64)
-// Use diasymreader until the package has an arm64 version - issue #7360
-//#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm64.dll")
-#define NATIVE_SYMBOL_READER_DLL W("diasymreader.dll")
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm64.dll")
 #endif
 
 typedef DPTR(PersistentInlineTrackingMapNGen) PTR_PersistentInlineTrackingMapNGen;

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -65,7 +65,6 @@
     <!-- DiaSymReader for the host architecture, which is used for [cross-]compilation -->
     <_diaSymArch>$(_hostArch)</_diaSymArch>
     <_diaSymReaderPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymArch).dll</_diaSymReaderPath>
-    <_diaSymReaderPathIfExists Condition="Exists('$(_diaSymReaderPath)')">$(_diaSymReaderPath)</_diaSymReaderPathIfExists>
 
     <!-- DiaSymReader for the target architecture, which is placed into the package -->
     <_diaSymTargetArch>$(TargetArchitecture)</_diaSymTargetArch>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
@@ -89,16 +89,16 @@
       <CoreCLRCrossTargetFiles PackOnly="true" />
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'clrjit' or '%(FileName)' == 'libclrjit'">
         <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'crossgen'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore')) and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="'%(FileName)%(Extension)' == 'mscordbi.dll' and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles);@(CoreCLRCrossTargetFiles);" />
     </ItemGroup>
   </Target>
@@ -116,7 +116,6 @@
     <!-- DiaSymReader for the host architecture, which is used for [cross-]compilation -->
     <_diaSymArch>$(_hostArch)</_diaSymArch>
     <_diaSymReaderPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymArch).dll</_diaSymReaderPath>
-    <_diaSymReaderPathIfExists Condition="Exists('$(_diaSymReaderPath)')">$(_diaSymReaderPath)</_diaSymReaderPathIfExists>
 
     <!-- DiaSymReader for the target architecture, which is placed into the package -->
     <_diaSymTargetArch>$(TargetArchitecture)</_diaSymTargetArch>
@@ -124,8 +123,11 @@
     <_diaSymReaderTargetArchPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymTargetArch).dll</_diaSymReaderTargetArchPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="Exists('$(_diaSymReaderTargetArchPath)')">
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
     <NativeRuntimeAsset Include="$(_diaSymReaderTargetArchPath)" />
+    <NativeRuntimeAsset Include="$(_diaSymReaderPath)" Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">
+      <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
+    </NativeRuntimeAsset>
   </ItemGroup>
 
   <!-- VS uses this file to show the target framework in the drop down. -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -37,12 +37,12 @@
     <ItemGroup Condition="'@(_crossTargetJit)' != '' and '@(_crossTargetCrossgen)' != ''">
       <CrossgenTool Include="@(_crossTargetCrossgen->ClearMetadata())"
                     JitPath="@(_crossTargetJit)"
-                    DiaSymReader="$(_diaSymReaderPathIfExists)" />
+                    DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup Condition="'@(_crossTargetJit)' == '' and '@(_crossTargetCrossgen)' == ''">
       <CrossgenTool Include="@(_crossgen->ClearMetadata())"
                     JitPath="@(_clrjit)"
-                    DiaSymReader="$(_diaSymReaderPathIfExists)" />
+                    DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup>
       <Crossgen2Tool Include="$(Crossgen2Exe)" JitPath="$(JitLibrary)" />


### PR DESCRIPTION
The `Microsoft.NETCore.App.Runtime.win-arm` package ships x86 and ARM versions of `crossgen.exe`, which require the corresponding versions of the `Microsoft.DiaSymReader.Native.*.dll` library. While .NET Core 3.1 and .NET 5 releases contained three different architectures for the DiaSymReader library (x86, amd64, and arm), changes made in .NET 6 caused to ship only the architecture used for cross-compilation, i.e. x86. PR #49739 replaced it with the native architecture (arm), which fixed the native compilation scenario, but broke the cross-architecture compilation scenario.

This PR returns `Microsoft.DiaSymReader.Native.x86.dll` to the `win-arm` package; however, this time it is placed in the `runtimes\x86_arm\native` directory for cross-compilation libraries rather than the `runtimes\win-arm\native` directory for native libraries.

Below is the list of DiaSymReader library architectures shipped with different versions of the `win-arm` package. All package versions contain ARM-hosted `crossgen.exe` in the `tools` directory and x86-hosted `crossgen.exe` in the `tools\x86_arm` directory.

- v5.0.4 and earlier: **x86**, **amd64**, and **arm** (amd64 is not needed) in the `runtimes\win-arm\native` directory.
- v6.0.0-preview.1 and preview.2: **x86** in the `runtimes\win-arm\native` directory.
- Unofficial v6.0.0-preview.3 builds after #49739: **arm** in the `runtimes\win-arm\native` directory.
- With this PR: **arm** in the `runtimes\win-arm\native` directory and **x86** in the `runtimes\x86_arm\native` directory.

_Everything said above also applies to the `win-arm64` package, which ships x64 and ARM64 versions of `crossgen.exe`._ While .NET 5 releases contained three different architectures for the DiaSymReader library (x86, amd64, and arm, but no arm64), changes made in .NET 6 caused to ship only the architecture used for cross-compilation, i.e. amd64. PR #49739 replaced it with the native architecture (arm64), which fixed the native compilation scenario (together with the `ceeload.h` fix in this PR), but broke the cross-architecture compilation scenario.

This PR returns `Microsoft.DiaSymReader.Native.amd64.dll` to the `win-arm64` package; however, this time it is placed in the `runtimes\x64_arm64\native` directory for cross-compilation libraries rather than the `runtimes\win-arm64\native` directory for native libraries.

Below is the list of DiaSymReader library architectures shipped with different versions of the `win-arm64` package. All package versions contain ARM64-hosted `crossgen.exe` in the `tools` directory and x64-hosted `crossgen.exe` in the `tools\x64_arm64` directory.

- v5.0.4 and earlier: **x86**, **amd64**, and **arm** (x86 is not needed) in the `runtimes\win-arm64\native` directory.
- v6.0.0-preview.1 and preview.2: **amd64** in the `runtimes\win-arm64\native` directory.
- Unofficial v6.0.0-preview.3 builds after #49739: **arm64** in the `runtimes\win-arm64\native` directory.
- With this PR: **arm64** in the `runtimes\win-arm64\native` directory and **amd64** in the `runtimes\x64_arm64\native` directory.


