### PR TITLE
Loop inversion throughput improvements

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9394,7 +9394,7 @@ public:
     const char* compGetTieringName(bool wantShortName = false) const;
     const char* compGetStressMessage() const;
 
-    codeOptimize compCodeOpt()
+    codeOptimize compCodeOpt() const
     {
 #if 0
         // Switching between size & speed has measurable throughput impact


### PR DESCRIPTION
A few minor changes that should improve throughput:
1. Move the `fgIsForwardBranch` check lower, after all the
cheaper checks, since it does a linear walk of the basic
block list.
2. Don't do a tree walk to count shared static helpers if we
already know it's cheap enough to do the optimization.

Also, removed the not-too-useful `optFindLoopTermTest`,
and added more use of FMT_WT.