### PR TITLE
Add OutputRID to RID graph during source build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,7 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
+    <add key="ericstj-staging" value="https://www.myget.org/F/ericstj-staging/api/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21167.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21167.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21167.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21167.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-ericstj-032321.5</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21167.3</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21167.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21167.3</MicrosoftDotNetVersionToolsTasksVersion>

--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
@@ -5,14 +5,25 @@
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>
+    <InferRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(InferRuntimeIdentifiers);$(OutputRID)</InferRuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <File Include="runtime.json" />
+    <File Condition="'$(InferRuntimeIdentifiers)' == ''" Include="runtime.json" />
+    <File Condition="'$(InferRuntimeIdentifiers)' != ''" Include="$(IntermediateOutputPath)runtime.json" />
     <!-- make this package installable and noop in a packages.config-based project -->
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
-  </ItemGroup>
+  </ItemGroup>  
+
+  <Target Name="GenerateRuntimeJsonWithInferredRids" Condition="'$(InferRuntimeIdentifiers)' != ''" BeforeTargets="CreatePackage">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
+                          InferRuntimeIdentifiers="$(InferRuntimeIdentifiers)"
+                          RuntimeJson="$(IntermediateOutputPath)runtime.json"
+                          UpdateRuntimeFiles="True" />
+  </Target>
+
   <Import Project="runtimeGroups.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
Also support the addition of RIDs through InferRuntimeIdentifiers.

Fixes https://github.com/dotnet/runtime/issues/48507
cc @omajid

Needs https://github.com/dotnet/arcade/pull/7141 (current staged in side-channel feed)