### PR TITLE
Make it possible to condition tests on line number support

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -76,6 +76,8 @@ namespace System
 
             }
         }
+        
+        public static bool IsLineNumbersSupported => !IsBrowser;
 
         public static bool IsInContainer => GetIsInContainer();
         public static bool SupportsComInterop => IsWindows && IsNotMonoRuntime; // matches definitions in clr.featuredefines.props

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -77,7 +77,7 @@ namespace System
             }
         }
         
-        public static bool IsLineNumbersSupported => !IsBrowser;
+        public static bool IsLineNumbersSupported => true;
 
         public static bool IsInContainer => GetIsInContainer();
         public static bool SupportsComInterop => IsWindows && IsNotMonoRuntime; // matches definitions in clr.featuredefines.props

--- a/src/libraries/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ExceptionTests.cs
@@ -151,7 +151,15 @@ namespace System.Tests
         {
             try
             {
-                const string frameParserRegex = @"\s+at\s.+\.(?<memberName>[^(.]+)\([^)]*\)\sin\s(?<filePath>.*)\:line\s(?<lineNumber>[\d]+)";
+                string frameParserRegex;
+                if (PlatformDetection.IsLineNumbersSupported)
+                {
+                    frameParserRegex = @"\s+at\s.+\.(?<memberName>[^(.]+)\([^)]*\)\sin\s(?<filePath>.*)\:line\s(?<lineNumber>[\d]+)";
+                }
+                else
+                {
+                    frameParserRegex = @"\s+at\s.+\.(?<memberName>[^(.]+)";
+                }
 
                 using (var sr = new StringReader(reportedCallStack))
                 {
@@ -162,8 +170,12 @@ namespace System.Tests
                     var match = Regex.Match(frame, frameParserRegex);
                     Assert.True(match.Success);
                     Assert.Equal(expectedStackFrame.CallerMemberName, match.Groups["memberName"].Value);
-                    Assert.Equal(expectedStackFrame.SourceFilePath, match.Groups["filePath"].Value);
-                    Assert.Equal(expectedStackFrame.SourceLineNumber, Convert.ToInt32(match.Groups["lineNumber"].Value));
+                    
+                    if (PlatformDetection.IsLineNumbersSupported)
+                    {
+                        Assert.Equal(expectedStackFrame.SourceFilePath, match.Groups["filePath"].Value);
+                        Assert.Equal(expectedStackFrame.SourceLineNumber, Convert.ToInt32(match.Groups["lineNumber"].Value));
+                    }
                 }
             }
             catch


### PR DESCRIPTION
I assume this will come in handy for e.g. Browser scenarios (either just AOT or interpreted too).

The entire test is currently disabled on Mono everywhere so it's probably not immediately useful here but I reckon this change doesn't need to sit in the NativeAOT branch.