### PR TITLE
Fix cross compilation of XmlSerializer.Generator tests

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -8,8 +8,8 @@
   <PropertyGroup>
     <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
     <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
-    <GeneratorCommand Condition="'$(TargetOS)' == 'windows'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
-    <GeneratorCommand Condition="'$(TargetOS)' != 'windows'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">


### PR DESCRIPTION
Executing commands wants to know what the current OS is, not what the compilation target OS is.

With this change `build.cmd libs.tests -os Linux` finishes with no errors.