### PR TITLE
Dispose the ContentFileProvider when the host is disposed

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Extensions.Hosting
         private HostBuilderContext _hostBuilderContext;
         private HostingEnvironment _hostingEnvironment;
         private IServiceProvider _appServices;
+        private PhysicalFileProvider _defaultProvider;
 
         /// <summary>
         /// A central location for sharing state between components during the host building process.
@@ -162,7 +163,7 @@ namespace Microsoft.Extensions.Hosting
                 _hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name;
             }
 
-            _hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath);
+            _hostingEnvironment.ContentRootFileProvider = _defaultProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath);
         }
 
         private string ResolveContentRootPath(string contentRootPath, string basePath)
@@ -219,6 +220,8 @@ namespace Microsoft.Extensions.Hosting
             services.AddSingleton<IHost>(_ =>
             {
                 return new Internal.Host(_appServices,
+                    _hostingEnvironment,
+                    _defaultProvider,
                     _appServices.GetRequiredService<IHostApplicationLifetime>(),
                     _appServices.GetRequiredService<ILogger<Internal.Host>>(),
                     _appServices.GetRequiredService<IHostLifetime>(),

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -18,13 +19,23 @@ namespace Microsoft.Extensions.Hosting.Internal
         private readonly IHostLifetime _hostLifetime;
         private readonly ApplicationLifetime _applicationLifetime;
         private readonly HostOptions _options;
+        private readonly IHostEnvironment _hostEnvironment;
+        private readonly PhysicalFileProvider _defaultProvider;
         private IEnumerable<IHostedService> _hostedServices;
 
-        public Host(IServiceProvider services, IHostApplicationLifetime applicationLifetime, ILogger<Host> logger,
-            IHostLifetime hostLifetime, IOptions<HostOptions> options)
+        public Host(IServiceProvider services,
+                    IHostEnvironment hostEnvironment,
+                    PhysicalFileProvider defaultProvider,
+                    IHostApplicationLifetime applicationLifetime,
+                    ILogger<Host> logger,
+                    IHostLifetime hostLifetime,
+                    IOptions<HostOptions> options)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
             _applicationLifetime = (applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime))) as ApplicationLifetime;
+            _hostEnvironment = hostEnvironment;
+            _defaultProvider = defaultProvider;
+
             if (_applicationLifetime is null)
             {
                 throw new ArgumentException("Replacing IHostApplicationLifetime is not supported.", nameof(applicationLifetime));
@@ -131,14 +142,34 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         public async ValueTask DisposeAsync()
         {
-            switch (Services)
+            // The user didn't change the ContentRootFileProvider instance, we can dispose it
+            if (ReferenceEquals(_hostEnvironment.ContentRootFileProvider, _defaultProvider))
             {
-                case IAsyncDisposable asyncDisposable:
-                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
-                    break;
-                case IDisposable disposable:
-                    disposable.Dispose();
-                    break;
+                // Dispose the content provider
+                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(false);
+            }
+            else
+            {
+                // In the rare case that the user replaced the ContentRootFileProvider, dispose it and the one
+                // we originally created
+                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(false);
+                await DisposeAsync(_defaultProvider).ConfigureAwait(false);
+            }
+
+            // Dispose the service provider
+            await DisposeAsync(Services).ConfigureAwait(false);
+
+            static async ValueTask DisposeAsync(object o)
+            {
+                switch (o)
+                {
+                    case IAsyncDisposable asyncDisposable:
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        break;
+                    case IDisposable disposable:
+                        disposable.Dispose();
+                        break;
+                }
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting.Fakes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.Extensions.Hosting.Tests
@@ -532,6 +533,20 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Fact]
+        public void DisposingHostDisposesContentFileProvider()
+        {
+            var host = new HostBuilder()
+                .Build();
+
+            var env = host.Services.GetRequiredService<IHostEnvironment>();
+            var fileProvider = new FakeFileProvider();
+            env.ContentRootFileProvider = fileProvider;
+
+            host.Dispose();
+            Assert.True(fileProvider.Disposed);
+        }
+
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34580", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void HostServicesSameServiceProviderAsInHostBuilder()
         {
@@ -542,6 +557,15 @@ namespace Microsoft.Extensions.Hosting.Tests
             var field = type.GetField("_appServices", BindingFlags.Instance | BindingFlags.NonPublic)!;
             var appServicesFromHostBuilder = (IServiceProvider)field.GetValue(hostBuilder)!;
             Assert.Same(appServicesFromHostBuilder, host.Services);
+        }
+
+        private class FakeFileProvider : IFileProvider, IDisposable
+        {
+            public bool Disposed { get; set; }
+            public void Dispose() { Disposed = true; }
+            public IDirectoryContents GetDirectoryContents(string subpath) => throw new NotImplementedException();
+            public IFileInfo GetFileInfo(string subpath) => throw new NotImplementedException();
+            public IChangeToken Watch(string filter) => throw new NotImplementedException();
         }
 
         private class ServiceC


### PR DESCRIPTION
- Today we don't and it results in a leak when hosts are created and destroyed.

Contributes to https://github.com/dotnet/aspnetcore/issues/31125

Fixed https://github.com/dotnet/runtime/issues/36550