### PR TITLE
Fix PriorityQueue not deleting references to dequeued elements

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -555,25 +555,25 @@ namespace System.Collections.Generic
         /// </summary>
         private void RemoveRootNode()
         {
-            // The idea is to replace the root node by the very last
-            // node and shorten the array by one.
-            int lastNodeIndex = _size - 1;
-            (TElement Element, TPriority Priority) lastNode = _nodes[lastNodeIndex];
+            int lastNodeIndex = --_size;
+            _version++;
+
+            if (lastNodeIndex > 0)
+            {
+                (TElement Element, TPriority Priority) lastNode = _nodes[lastNodeIndex];
+                if (_comparer == null)
+                {
+                    MoveDownDefaultComparer(lastNode, 0);
+                }
+                else
+                {
+                    MoveDownCustomComparer(lastNode, 0);
+                }
+            }
+
             if (RuntimeHelpers.IsReferenceOrContainsReferences<(TElement, TPriority)>())
             {
                 _nodes[lastNodeIndex] = default;
-            }
-
-            _size--;
-            _version++;
-
-            if (_comparer == null)
-            {
-                MoveDownDefaultComparer(lastNode, 0);
-            }
-            else
-            {
-                MoveDownCustomComparer(lastNode, 0);
             }
         }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -625,6 +625,7 @@ namespace System.Collections.Generic
             // a similar optimization as in the insertion sort.
 
             Debug.Assert(_comparer is null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
 
             (TElement Element, TPriority Priority)[] nodes = _nodes;
 
@@ -656,6 +657,7 @@ namespace System.Collections.Generic
             // a similar optimization as in the insertion sort.
 
             Debug.Assert(_comparer is not null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
 
             IComparer<TPriority> comparer = _comparer;
             (TElement Element, TPriority Priority)[] nodes = _nodes;
@@ -689,6 +691,7 @@ namespace System.Collections.Generic
             // for this value to drop in. Similar optimization as in the insertion sort.
 
             Debug.Assert(_comparer is null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
 
             (TElement Element, TPriority Priority)[] nodes = _nodes;
             int size = _size;
@@ -736,6 +739,7 @@ namespace System.Collections.Generic
             // for this value to drop in. Similar optimization as in the insertion sort.
 
             Debug.Assert(_comparer is not null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
 
             IComparer<TPriority> comparer = _comparer;
             (TElement Element, TPriority Priority)[] nodes = _nodes;


### PR DESCRIPTION
Fix #50114.

The private `RemoveRootNode()` method does not handle heaps of size 1 correctly, reinserting the dequeued element back into the buffer. While not impacting functional correctness, it can result in references not being removed from the queue.