### PR TITLE
[wasm] Copy native ICU libraries to native bin dir

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -127,14 +127,15 @@
       <SystemNativeDir>$(RepoRoot)src\libraries\Native\Unix\System.Native</SystemNativeDir>
     </PropertyGroup>
     <ItemGroup>
+      <ICULibNativeFiles Include="$(ICULibDir)/libicuuc.a;
+                                  $(ICULibDir)/libicui18n.a" />
       <MonoLibFiles Include="$(MonoArtifactsPath)libmono-ee-interp.a;
                              $(MonoArtifactsPath)libmonosgen-2.0.a;
                              $(MonoArtifactsPath)libmono-ilgen.a;
                              $(MonoArtifactsPath)libmono-icall-table.a;
                              $(NativeBinDir)libSystem.Native.a;
-                             $(NativeBinDir)libSystem.IO.Compression.Native.a;
-                             $(ICULibDir)/libicuuc.a;
-                             $(ICULibDir)/libicui18n.a" />
+                             $(NativeBinDir)libSystem.IO.Compression.Native.a" />
+      <MonoLibFiles Include="@(ICULibNativeFiles)" />
       <PInvokeTableFile Include="$(WasmObjDir)\pinvoke-table.h" />
       <ICULibFiles Include="$(ICULibDir)/*.dat" />
     </ItemGroup>
@@ -194,7 +195,7 @@
           DestinationFolder="$(NativeBinDir)src"
           SkipUnchangedFiles="true" />
 
-    <Copy SourceFiles="@(ICULibFiles)"
+    <Copy SourceFiles="@(ICULibFiles);@(ICULibNativeFiles)"
           DestinationFolder="$(NativeBinDir)"
           SkipUnchangedFiles="true" />
 


### PR DESCRIPTION
We were missing these in built artifacts on windows, resulting in this
error, when building wasm projects:

    Compiling native assets with emcc. This may take a while ...
    emcc: error: C:\...\artifacts\bin\microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\native\libicuuc.a: No such file or directory ("C:\Users\rodo\git\winwasm2\artifacts\bin\microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\native\libicuuc.a" was expected to be an input file, based on the commandline arguments provided)