### PR TITLE
Fix CoreCLR runtime in the presence of 1-file composite images

### DIFF
--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -635,16 +635,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
         // In multi-assembly composite images, per assembly sections are stored next to their core headers.
         m_pCompositeInfo = pNativeImage->GetReadyToRunInfo();
         m_pComposite = m_pCompositeInfo->GetComponentInfo();
-        if (pNativeImage->GetComponentAssemblyCount() == 1)
-        {
-            // When there's just 1 component assembly in the composite image, we're skipping the
-            // assembly headers and store all sections directly in the main R2R header.
-            m_component = *m_pComposite;
-        }
-        else
-        {
-            m_component = ReadyToRunCoreInfo(m_pComposite->GetLayout(), pNativeImage->GetComponentAssemblyHeader(pModule->GetSimpleName()));
-        }
+        m_component = ReadyToRunCoreInfo(m_pComposite->GetLayout(), pNativeImage->GetComponentAssemblyHeader(pModule->GetSimpleName()));
         m_isComponentAssembly = true;
     }
     else


### PR DESCRIPTION
I hit this while creating a regression test for the issue #49982.
In the initial composite R2R design I proposed slightly different
organization of the header tables when the composite image
only comprises a single file; later on I removed this special
casing as it was confusing and making the format more complicated
but apparently I forgot to fix this runtime bit. When there's a
composite image with only one component in it, we weren't properly
initializing the component header table and so we were unable to
resolve any R2R methods for the composite image.

Thanks

Tomas

/cc @dotnet/crossgen-contrib