### PR TITLE
Rename CreateInstanceT_StructWithoutDefaultConstructor_ThrowsMissingMethodException test

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ActivatorTests.Generic.cs
+++ b/src/libraries/System.Runtime/tests/System/ActivatorTests.Generic.cs
@@ -53,7 +53,7 @@ namespace System.Tests
             Assert.Throws<MissingMethodException>(() => Activator.CreateInstance<StructWithPrivateDefaultConstructor>());
 
         [Fact]
-        public void CreateInstanceT_StructWithoutDefaultConstructor_ThrowsMissingMethodException() =>
+        public void CreateInstanceT_StructWithoutDefaultConstructor_InvokesConstructor() =>
             Activator.CreateInstance<StructWithoutDefaultConstructor>();
 
         [Fact]


### PR DESCRIPTION
This doesn't throw an exception, so the test shouldn't be named "ThrowsMissingMethodException"