### PR TITLE
Make DSACryptoServiceProvider set legal key sizes to most restrictive for platform

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Dsa.Tests
     public partial class DSAKeyGeneration
     {
         public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
+        public static bool HasSecondMinSize { get; } = GetHasSecondMinSize();
 
         [Fact]
         public static void VerifyDefaultKeySize_Fips186_2()
@@ -28,7 +29,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             GenerateKey(dsa => GetMin(dsa.LegalKeySizes));
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ConditionalFact(nameof(SupportsKeyGeneration), nameof(HasSecondMinSize))]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(dsa => GetSecondMin(dsa.LegalKeySizes));
@@ -117,6 +118,14 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
 
             return secondMin;
+        }
+
+        private static bool GetHasSecondMinSize()
+        {
+            using (DSA dsa = DSAFactory.Create())
+            {
+                return GetSecondMin(dsa.LegalKeySizes) != int.MaxValue;
+            }
         }
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -163,7 +163,17 @@ namespace System.Security.Cryptography.Dsa.Tests
             Assert.Throws<ObjectDisposedException>(
                 () =>
                 {
-                    key.KeySize = 576;
+                    try
+                    {
+                        key.KeySize = 576;
+                    }
+                    catch (CryptographicException) when (PlatformDetection.IsAndroid)
+                    {
+                        // DSACryptoServiceProvider on Android only supports 1024 and does an early check fo legal
+                        // key sizes, since it is more restrictive than the wrapped implementation. It will throw
+                        // CryptographicException. SignData should still throw ObjectDisposedException.
+                    }
+
                     SignData(key, data, HashAlgorithmName.SHA1);
                 });
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -167,11 +167,15 @@ namespace System.Security.Cryptography.Dsa.Tests
                     {
                         key.KeySize = 576;
                     }
-                    catch (CryptographicException) when (PlatformDetection.IsAndroid)
+                    catch (CryptographicException)
                     {
-                        // DSACryptoServiceProvider on Android only supports 1024 and does an early check fo legal
+                        // DSACryptoServiceProvider on Android only supports 1024 and does an early check for legal
                         // key sizes, since it is more restrictive than the wrapped implementation. It will throw
                         // CryptographicException. SignData should still throw ObjectDisposedException.
+                        if (!PlatformDetection.IsAndroid)
+                        {
+                            throw;
+                        }
                     }
 
                     SignData(key, data, HashAlgorithmName.SHA1);

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -12,26 +12,40 @@ namespace System.Security.Cryptography
     public sealed class DSACryptoServiceProvider : DSA, ICspAsymmetricAlgorithm
     {
         private const int SHA1_HASHSIZE = 20;
+        private const int DefaultKeySize = 1024;
 
         private readonly DSA _impl;
         private bool _publicOnly;
 
-        private static KeySizes[] s_legalKeySizes =
+        private static KeySizes[] s_legalKeySizesWindowsCsp =
         {
             new KeySizes(512, 1024, 64)  // Use the same values as Csp Windows because the _impl has different values (512, 3072, 64)
         };
 
-        public DSACryptoServiceProvider() : base()
+        private static KeySizes[] s_legalKeySizesAndroid =
         {
-            // This class wraps DSA
-            _impl = DSA.Create();
-            KeySize = 1024;
+            new KeySizes(1024, 1024, 0)  // Intersection of legal sizes on Android and Windows provider
+        };
+
+        public DSACryptoServiceProvider()
+            : this(DefaultKeySize)
+        {
         }
 
         public DSACryptoServiceProvider(int dwKeySize) : base()
         {
             if (dwKeySize < 0)
                 throw new ArgumentOutOfRangeException(nameof(dwKeySize), SR.ArgumentOutOfRange_NeedNonNegNum);
+
+            // Depending on the platform, _impl's legal key sizes may be more restrictive than Windows provider.
+            //   DSAAndroid : (1024, 3072, 1024)
+            //   DSAOpenSsl : (512, 3072, 64)
+            //   DSASecurityTransforms : (512, 1024, 64)
+            //   Windows CSP : (512, 1024, 64)
+            // Use the most restrictive legal key sizes
+            LegalKeySizesValue = OperatingSystem.IsAndroid()
+                ? s_legalKeySizesAndroid
+                : s_legalKeySizesWindowsCsp;
 
             // This class wraps DSA
             _impl = DSA.Create();
@@ -147,14 +161,14 @@ namespace System.Security.Cryptography
             set
             {
                 // Perform the check here because LegalKeySizes are more restrictive here than _impl
-                if (!value.IsLegalSize(s_legalKeySizes))
+                if (!value.IsLegalSize(this.LegalKeySizesValue!))
                     throw new CryptographicException(SR.Cryptography_InvalidKeySize);
 
                 _impl.KeySize = value;
             }
         }
 
-        public override KeySizes[] LegalKeySizes => s_legalKeySizes.CloneKeySizesArray();
+        public override KeySizes[] LegalKeySizes => base.LegalKeySizes;
 
         // PersistKeyInCsp has no effect in Unix
         public bool PersistKeyInCsp { get; set; }


### PR DESCRIPTION
The legal key sizes for DSA are more restrictive than on other platforms. Update `DSACryptoServiceProvider` to use the most restrictive sizes as the legal key sizes.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs