### PR TITLE
[AndroidCrypto] Make SslStreamCertificateContext treat an empty chain as not finding intermediates

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -38,47 +38,46 @@ namespace System.Net.Security
                     NetEventSource.Error(null, $"Failed to build chain for {target.Subject}");
                 }
 
-                if (chain.ChainElements.Count == 0)
-                {
-                    // Some platforms (e.g. Android) can't ignore all verification and will return zero
-                    // certificates on failure to build a chain. Treat this as not finding any intermediates.
-                    return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>());
-                }
-
                 int count = chain.ChainElements.Count - 1;
-#pragma warning disable 0162 // Disable unreachable code warning. TrimRootCertificate is const bool = false on some platforms
-                if (TrimRootCertificate)
+
+                // Some platforms (e.g. Android) can't ignore all verification and will return zero
+                // certificates on failure to build a chain. Treat this as not finding any intermediates.
+                if (count >= 0)
                 {
-                    count--;
-                    foreach (X509ChainStatus status in chain.ChainStatus)
+#pragma warning disable 0162 // Disable unreachable code warning. TrimRootCertificate is const bool = false on some platforms
+                    if (TrimRootCertificate)
                     {
-                        if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                        count--;
+                        foreach (X509ChainStatus status in chain.ChainStatus)
                         {
-                            // The last cert isn't a root cert
-                            count++;
-                            break;
+                            if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                            {
+                                // The last cert isn't a root cert
+                                count++;
+                                break;
+                            }
                         }
                     }
-                }
 #pragma warning restore 0162
 
-                // Count can be zero for a self-signed certificate, or a cert issued directly from a root.
-                if (count > 0 && chain.ChainElements.Count > 1)
-                {
-                    intermediates = new X509Certificate2[count];
-                    for (int i = 0; i < count; i++)
+                    // Count can be zero for a self-signed certificate, or a cert issued directly from a root.
+                    if (count > 0 && chain.ChainElements.Count > 1)
                     {
-                        intermediates[i] = chain.ChainElements[i + 1].Certificate;
+                        intermediates = new X509Certificate2[count];
+                        for (int i = 0; i < count; i++)
+                        {
+                            intermediates[i] = chain.ChainElements[i + 1].Certificate;
+                        }
                     }
-                }
 
-                // Dispose the copy of the target cert.
-                chain.ChainElements[0].Certificate.Dispose();
+                    // Dispose the copy of the target cert.
+                    chain.ChainElements[0].Certificate.Dispose();
 
-                // Dispose the last cert, if we didn't include it.
-                for (int i = count + 1; i < chain.ChainElements.Count; i++)
-                {
-                    chain.ChainElements[i].Certificate.Dispose();
+                    // Dispose the last cert, if we didn't include it.
+                    for (int i = count + 1; i < chain.ChainElements.Count; i++)
+                    {
+                        chain.ChainElements[i].Certificate.Dispose();
+                    }
                 }
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -38,6 +38,13 @@ namespace System.Net.Security
                     NetEventSource.Error(null, $"Failed to build chain for {target.Subject}");
                 }
 
+                if (chain.ChainElements.Count == 0)
+                {
+                    // Some platforms (e.g. Android) can't ignore all verification and will return zero
+                    // certificates on failure to build a chain. Treat this as not finding any intermediates.
+                    return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>());
+                }
+
                 int count = chain.ChainElements.Count - 1;
 #pragma warning disable 0162 // Disable unreachable code warning. TrimRootCertificate is const bool = false on some platforms
                 if (TrimRootCertificate)


### PR DESCRIPTION
Android can't bypass all verification when building a chain and will return an empty chain in those cases. This change makes `SslStreamCertificateContext` treat an empty chain as not finding intermediates.

This should unblock the initial failures with Android + System.Net.Security (and get to the `NotImplementedException`s we currently have for Android).

cc @wfurt @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs