### PR TITLE
Fix leak of app variable on assert in hostpolicy

### DIFF
--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -894,6 +894,8 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     {
         // This should really never happen, but fail gracefully if it does anyway.
         assert(false);
+        delete app;
+        app = nullptr;
         trace::error(_X("Failed to initialize empty runtime config for the component."));
         return StatusCode::InvalidConfigFile;
     }


### PR DESCRIPTION
This was caught by a static analyzer that pointed out that if the assert is hit and the method returns, app is never deallocated.