### PR TITLE
Propagate extra string data passed to Android instrumentation app as managed args

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/MainActivity.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends Activity
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
             @Override
             public void run() {
-                int retcode = MonoRunner.initialize(entryPointLibName, ctx);
+                int retcode = MonoRunner.initialize(entryPointLibName, new String[0], ctx);
                 textView.setText("Mono Runtime returned: " + retcode);
             }
         }, 1000);

--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.BufferedInputStream;
+import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -30,19 +31,14 @@ public class MonoRunner extends Instrumentation
 {
     static {
         // loadLibrary triggers JNI_OnLoad in these libs
-        try
-        {
-            // loadLibrary can throw an error here if OpenSSL bits aren't around. 
-            // We'll delete OpenSSL impl once we finish the transition to Android Crypto.
-            System.loadLibrary("System.Security.Cryptography.Native.OpenSsl");
-        } catch (java.lang.UnsatisfiedLinkError e) {
-            Log.e("DOTNET", e.getLocalizedMessage());
-        }
+        System.loadLibrary("System.Security.Cryptography.Native.OpenSsl");
         System.loadLibrary("monodroid");
     }
 
     static String entryPointLibName = "%EntryPointLibName%";
     static Bundle result = new Bundle();
+
+    private String[] argsToForward;
 
     @Override
     public void onCreate(Bundle arguments) {
@@ -52,14 +48,23 @@ public class MonoRunner extends Instrumentation
                 entryPointLibName = lib;
             }
 
+            ArrayList<String> argsList = new ArrayList<String>();
             for (String key : arguments.keySet()) {
                 if (key.startsWith("env:")) {
                     String envName = key.substring("env:".length());
                     String envValue = arguments.getString(key);
                     setEnv(envName, envValue);
                     Log.i("DOTNET", "env:" + envName + "=" + envValue);
+                } else {
+                    String val = arguments.getString(key);
+                    if (val != null) {
+                        argsList.add(key);
+                        argsList.add(val);
+                    }
                 }
             }
+
+            argsToForward = argsList.toArray(new String[argsList.size()]);
         }
 
         super.onCreate(arguments);
@@ -74,7 +79,7 @@ public class MonoRunner extends Instrumentation
         return docsPath.getAbsolutePath();
     }
 
-    public static int initialize(String entryPointLibName, Context context) {
+    public static int initialize(String entryPointLibName, String[] args, Context context) {
         String filesDir = context.getFilesDir().getAbsolutePath();
         String cacheDir = context.getCacheDir().getAbsolutePath();
         String docsDir = getDocsDir(context);
@@ -83,7 +88,7 @@ public class MonoRunner extends Instrumentation
         unzipAssets(context, filesDir, "assets.zip");
 
         Log.i("DOTNET", "MonoRunner initialize,, entryPointLibName=" + entryPointLibName);
-        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName);
+        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, args);
     }
 
     @Override
@@ -95,7 +100,7 @@ public class MonoRunner extends Instrumentation
             finish(1, null);
             return;
         }
-        int retcode = initialize(entryPointLibName, getContext());
+        int retcode = initialize(entryPointLibName, argsToForward, getContext());
 
         Log.i("DOTNET", "MonoRunner finished, return-code=" + retcode);
         result.putInt("return-code", retcode);
@@ -144,7 +149,7 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName);
+    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, String[] args);
 
     static native int setEnv(String key, String value);
 }

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -170,7 +170,7 @@ unhandled_exception_handler (MonoObject *exc, void *user_data)
     char *type_name = strdup_printf ("%s.%s", mono_class_get_namespace (type), mono_class_get_name (type));
     char *trace = mono_droid_fetch_exception_property_string (exc, "get_StackTrace", true);
     char *message = mono_droid_fetch_exception_property_string (exc, "get_Message", true);
-    
+
     LOG_ERROR("UnhandledException: %s %s %s", type_name, message, trace);
 
     free (trace);
@@ -194,7 +194,7 @@ void register_aot_modules (void);
 #endif
 
 int
-mono_droid_runtime_init (void)
+mono_droid_runtime_init (const char* executable, int managed_argc, char* managed_argv[])
 {
     // uncomment for debug output:
     //
@@ -215,7 +215,7 @@ mono_droid_runtime_init (void)
     const char* appctx_values[2];
     appctx_values[0] = ANDROID_RUNTIME_IDENTIFIER;
     appctx_values[1] = bundle_path;
-    
+
     monovm_initialize(2, appctx_keys, appctx_values);
 
     mono_debug_init (MONO_DEBUG_FORMAT_MONO);
@@ -234,7 +234,7 @@ mono_droid_runtime_init (void)
 #if FORCE_INTERPRETER
     LOG_INFO("Interp Enabled");
     mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP_ONLY);
-#elif FORCE_AOT    
+#elif FORCE_AOT
     register_aot_modules();
     mono_jit_set_aot_mode(MONO_AOT_MODE_FULL);
 #endif
@@ -245,10 +245,7 @@ mono_droid_runtime_init (void)
     assert (assembly);
     LOG_INFO ("Executable: %s", executable);
 
-    char *managed_argv [1];
-    managed_argv[0] = bundle_path;
-
-    int res = mono_jit_exec (mono_domain_get (), assembly, 1, managed_argv);
+    int res = mono_jit_exec (mono_domain_get (), assembly, managed_argc, managed_argv);
     LOG_INFO ("Exit code: %d.", res);
     return res;
 }
@@ -274,7 +271,7 @@ Java_net_dot_MonoRunner_setEnv (JNIEnv* env, jobject thiz, jstring j_key, jstrin
 }
 
 int
-Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName)
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jobjectArray j_args)
 {
     char file_dir[2048];
     char cache_dir[2048];
@@ -292,7 +289,27 @@ Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_
     setenv ("TMPDIR", cache_dir, true);
     setenv ("DOCSDIR", docs_dir, true);
 
-    return mono_droid_runtime_init ();
+    int args_len = (*env)->GetArrayLength(env, j_args);
+    int managed_argc = args_len + 1;
+    char** managed_argv = (char**)malloc(managed_argc * sizeof(char*));
+
+    managed_argv[0] = bundle_path;
+    for (int i = 0; i < args_len; ++i)
+    {
+        jstring j_arg = (*env)->GetObjectArrayElement(env, j_args, i);
+        managed_argv[i + 1] = (*env)->GetStringUTFChars(env, j_arg, NULL);
+    }
+
+    int res = mono_droid_runtime_init (executable, managed_argc, managed_argv);
+
+    for (int i = 0; i < args_len; ++i)
+    {
+        jstring j_arg = (*env)->GetObjectArrayElement(env, j_args, i);
+        (*env)->ReleaseStringUTFChars(env, j_arg, managed_argv[i + 1]);
+    }
+
+    free(managed_argv);
+    return res;
 }
 
 // called from C#


### PR DESCRIPTION
Pass along extra string data given to the Android instrumentation app (`MonoRunner`) as args to the managed application.

For example:
```bash
# adb
adb shell am instrument  -e -key1 value1 -e -key2 value2 -w <package_name>/<runner_class>

# xharness
dotnet xharness android test -i=<runner_class> -p=<package_name> -a=<apk_path> -arg=-key1=value1 -arg=-key2=value2
```
Arguments received by the managed application will be: `[ "-key1", "value1", "-key2", "value2" ]`

In combination with https://github.com/dotnet/xharness/pull/520, this should make for a better inner dev loop, allowing us to filter tests to run (e.g. run one specific test).

cc @steveisok @jkoritzinsky 