### PR TITLE
Print reason why EH Var was not enregistered

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -459,10 +459,6 @@ public:
 
     unsigned char lvDisqualifyForEhWriteThru : 1; // tracks variable that are disqualified from register candidancy
 
-#ifdef DEBUG
-    unsigned char lvDisqualifyEHVarReason = 'H';
-#endif
-
 #if ASSERTION_PROP
     unsigned char lvDisqualify : 1;   // variable is no longer OK for add copy optimization
     unsigned char lvVolatileHint : 1; // hint for AssertionProp
@@ -544,6 +540,10 @@ public:
     unsigned char lvFieldCnt; //  Number of fields in the promoted VarDsc.
     unsigned char lvFldOffset;
     unsigned char lvFldOrdinal;
+
+#ifdef DEBUG
+    unsigned char lvDisqualifyEHVarReason = 'H';
+#endif
 
 #if FEATURE_MULTIREG_ARGS
     regNumber lvRegNumForSlot(unsigned slotNum)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -460,7 +460,7 @@ public:
     unsigned char lvDisqualifyForEhWriteThru : 1; // tracks variable that are disqualified from register candidancy
 
 #ifdef DEBUG
-    unsigned char lvDisqualifyEHVarReason = ' ';
+    unsigned char lvDisqualifyEHVarReason = 'H';
 #endif
 
 #if ASSERTION_PROP

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -459,6 +459,10 @@ public:
 
     unsigned char lvDisqualifyForEhWriteThru : 1; // tracks variable that are disqualified from register candidancy
 
+#ifdef DEBUG
+    unsigned char lvDisqualifyEHVarReason = ' ';
+#endif
+
 #if ASSERTION_PROP
     unsigned char lvDisqualify : 1;   // variable is no longer OK for add copy optimization
     unsigned char lvVolatileHint : 1; // hint for AssertionProp

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4086,22 +4086,72 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
                 bool bbIsReturn            = block->bbJumpKind == BBJ_RETURN;
                 bool needsExplicitZeroInit = fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn);
 
-                if (varDsc->lvEhWriteThruCandidate || needsExplicitZeroInit)
-                {
-                    varDsc->lvEhWriteThruCandidate     = false;
-                    varDsc->lvDisqualifyForEhWriteThru = true;
-                }
-                else
-                {
-#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
-                    // such variable. In future, need to enable enregisteration for such variables.
-                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
-#endif
-                    {
-                        varDsc->lvEhWriteThruCandidate = true;
-                    }
-                }
+//                if (varDsc->lvEhWriteThruCandidate/* && needsExplicitZeroInit*/)
+//                {
+//#ifdef DEBUG
+//                    varDsc->lvDisqualifyEHVarReason = 'M'; //needsExplicitZeroInit ? 'Z' : 'M';
+//#endif // DEBUG
+//                    varDsc->lvEhWriteThruCandidate     = false;
+//                    varDsc->lvDisqualifyForEhWriteThru = true;
+//                }
+//                else
+//                {
+//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+//                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
+//                    // such variable. In future, need to enable enregisteration for such variables.
+//                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
+//#endif
+//                    {
+//                        varDsc->lvEhWriteThruCandidate = true;
+//                    }
+//                }
+
+
+//                if (needsExplicitZeroInit)
+//                {
+//                    if (varDsc->lvEhWriteThruCandidate)
+//                    {
+//                        varDsc->lvEhWriteThruCandidate = false;
+//                        varDsc->lvDisqualifyForEhWriteThru = true;
+//#ifdef DEBUG
+//                        // Needs explicit zero and it is already defined once.
+//                        varDsc->lvDisqualifyEHVarReason = 'Z';
+//#endif // DEBUG
+//                    }
+//                    else
+//                    {
+//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+//                        // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
+//                        // such variable. In future, need to enable enregisteration for such variables.
+//                        if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
+//#endif
+//                        {
+//                            varDsc->lvEhWriteThruCandidate = true;
+//                        }
+//                    }
+//                }
+//                else if (varDsc->lvEhWriteThruCandidate)
+//                {
+//                    varDsc->lvEhWriteThruCandidate     = false;
+//                    varDsc->lvDisqualifyForEhWriteThru = true;
+//#ifdef DEBUG
+//                    // This is a multi-definition variable
+//                    varDsc->lvDisqualifyEHVarReason = 'M';
+//#endif // DEBUG
+//
+//                }
+//                else
+//                {
+//                    // first definition
+//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+//                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
+//                    // such variable. In future, need to enable enregisteration for such variables.
+//                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
+//#endif
+//                    {
+//                        varDsc->lvEhWriteThruCandidate = true;
+//                    }
+//                }
             }
         }
 
@@ -7354,7 +7404,14 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         }
         if (lvaEnregEHVars && varDsc->lvLiveInOutOfHndlr)
         {
-            printf("H");
+            if (varDsc->lvDisqualifyEHVarReason != ' ')
+            {
+                printf("%c", varDsc->lvDisqualifyEHVarReason);
+            }
+            else
+            {
+                 printf("H");
+            }
         }
         if (varDsc->lvLclFieldExpr)
         {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4092,7 +4092,8 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
                     if (needsExplicitZeroInit)
                     {
                         varDsc->lvDisqualifyEHVarReason = 'Z';
-                        JITDUMP("EH Var V%02u needs explicit zero init. Disqualified as a register candidate.\n", lclNum);
+                        JITDUMP("EH Var V%02u needs explicit zero init. Disqualified as a register candidate.\n",
+                                lclNum);
                     }
                     else
                     {
@@ -7369,14 +7370,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         }
         if (lvaEnregEHVars && varDsc->lvLiveInOutOfHndlr)
         {
-            if (varDsc->lvDisqualifyEHVarReason != ' ')
-            {
-                printf("%c", varDsc->lvDisqualifyEHVarReason);
-            }
-            else
-            {
-                 printf("H");
-            }
+            printf("%c", varDsc->lvDisqualifyEHVarReason);
         }
         if (varDsc->lvLclFieldExpr)
         {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4086,72 +4086,37 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
                 bool bbIsReturn            = block->bbJumpKind == BBJ_RETURN;
                 bool needsExplicitZeroInit = fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn);
 
-//                if (varDsc->lvEhWriteThruCandidate/* && needsExplicitZeroInit*/)
-//                {
-//#ifdef DEBUG
-//                    varDsc->lvDisqualifyEHVarReason = 'M'; //needsExplicitZeroInit ? 'Z' : 'M';
-//#endif // DEBUG
-//                    varDsc->lvEhWriteThruCandidate     = false;
-//                    varDsc->lvDisqualifyForEhWriteThru = true;
-//                }
-//                else
-//                {
-//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-//                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
-//                    // such variable. In future, need to enable enregisteration for such variables.
-//                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
-//#endif
-//                    {
-//                        varDsc->lvEhWriteThruCandidate = true;
-//                    }
-//                }
+                if (varDsc->lvEhWriteThruCandidate || needsExplicitZeroInit)
+                {
+#ifdef DEBUG
+                    if (needsExplicitZeroInit)
+                    {
+                        varDsc->lvDisqualifyEHVarReason = 'Z';
+                        JITDUMP("EH Var V%02u needs explicit zero init. Disqualified as a register candidate.\n", lclNum);
+                    }
+                    else
+                    {
+                        varDsc->lvDisqualifyEHVarReason = 'M';
+                        JITDUMP("EH Var V%02u has multiple definitions. Disqualified as a register candidate.\n",
+                                lclNum);
+                    }
 
-
-//                if (needsExplicitZeroInit)
-//                {
-//                    if (varDsc->lvEhWriteThruCandidate)
-//                    {
-//                        varDsc->lvEhWriteThruCandidate = false;
-//                        varDsc->lvDisqualifyForEhWriteThru = true;
-//#ifdef DEBUG
-//                        // Needs explicit zero and it is already defined once.
-//                        varDsc->lvDisqualifyEHVarReason = 'Z';
-//#endif // DEBUG
-//                    }
-//                    else
-//                    {
-//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-//                        // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
-//                        // such variable. In future, need to enable enregisteration for such variables.
-//                        if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
-//#endif
-//                        {
-//                            varDsc->lvEhWriteThruCandidate = true;
-//                        }
-//                    }
-//                }
-//                else if (varDsc->lvEhWriteThruCandidate)
-//                {
-//                    varDsc->lvEhWriteThruCandidate     = false;
-//                    varDsc->lvDisqualifyForEhWriteThru = true;
-//#ifdef DEBUG
-//                    // This is a multi-definition variable
-//                    varDsc->lvDisqualifyEHVarReason = 'M';
-//#endif // DEBUG
-//
-//                }
-//                else
-//                {
-//                    // first definition
-//#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-//                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
-//                    // such variable. In future, need to enable enregisteration for such variables.
-//                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
-//#endif
-//                    {
-//                        varDsc->lvEhWriteThruCandidate = true;
-//                    }
-//                }
+#endif // DEBUG
+                    varDsc->lvEhWriteThruCandidate     = false;
+                    varDsc->lvDisqualifyForEhWriteThru = true;
+                }
+                else
+                {
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                    // TODO-CQ: If the varType needs partial callee save, conservatively do not enregister
+                    // such variable. In future, need to enable enregisteration for such variables.
+                    if (!varTypeNeedsPartialCalleeSave(varDsc->lvType))
+#endif
+                    {
+                        varDsc->lvEhWriteThruCandidate = true;
+                        JITDUMP("Marking EH Var V%02u as a register candidate.\n", lclNum);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
While visiting dumps/disasm, it is valuable to see the reason why EH var didn't get enregistered. In addition to existing reasons, there are are 2 more possibilities:
- It has multiple definition
- It needs explicit zero initialization