### PR TITLE
[mono][aot] Handle out of range indexes in the generated get_method () functions, they can happen since mini-llvm.c and aot-compiler.c can compute different table sizes.

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3403,6 +3403,7 @@ sort_methods (MonoAotModule *amodule)
 	msort_method_addresses (methods, method_indexes, methods_len);
 	for (int i = 0; i < methods_len -1; ++i)
 		g_assert (methods [i] <= methods [i + 1]);
+
 	amodule->sorted_methods_len = methods_len;
 	if (mono_atomic_cas_ptr ((gpointer*)&amodule->sorted_methods, methods, NULL) != NULL)
 		/* Somebody got in before us */

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -2854,7 +2854,7 @@ emit_get_method (MonoLLVMModule *module)
 {
 	LLVMModuleRef lmodule = module->lmodule;
 	LLVMValueRef func, switch_ins, m;
-	LLVMBasicBlockRef entry_bb, fail_bb, bb, code_start_bb, code_end_bb;
+	LLVMBasicBlockRef entry_bb, fail_bb, bb, code_start_bb, code_end_bb, main_bb;
 	LLVMBasicBlockRef *bbs = NULL;
 	LLVMTypeRef rtype;
 	LLVMBuilderRef builder = LLVMCreateBuilder ();
@@ -2874,12 +2874,13 @@ emit_get_method (MonoLLVMModule *module)
 
 	rtype = LLVMPointerType (LLVMInt8Type (), 0);
 
+	int table_len = module->max_method_idx + 1;
+
 	if (emit_table) {
 		LLVMTypeRef table_type;
 		LLVMValueRef *table_elems;
 		char *table_name;
 
-		int table_len = module->max_method_idx + 1;
 		table_type = LLVMArrayType (rtype, table_len);
 		table_name = g_strdup_printf ("%s_method_table", module->global_prefix);
 		table = LLVMAddGlobal (lmodule, table_type, table_name);
@@ -2926,13 +2927,21 @@ emit_get_method (MonoLLVMModule *module)
 
 	if (emit_table) {
 		/*
+		 * Because table_len is computed using the method indexes available for us, it
+		 * might not include methods which are not compiled because of AOT profiles.
+		 * So table_len can be smaller than info->nmethods. Add a bounds check because
+		 * of that.
 		 * switch (index) {
 		 * case -1: return code_start;
 		 * case -2: return code_end;
-		 * default: return method_table [index];
+		 * default: return index < table_len ? method_table [index] : 0;
 		 */
-		LLVMBasicBlockRef default_bb = LLVMAppendBasicBlock (func, "DEFAULT");
-		LLVMPositionBuilderAtEnd (builder, default_bb);
+		fail_bb = LLVMAppendBasicBlock (func, "FAIL");
+		LLVMPositionBuilderAtEnd (builder, fail_bb);
+		LLVMBuildRet (builder, LLVMBuildIntToPtr (builder, LLVMConstInt (LLVMInt32Type (), 0, FALSE), rtype, ""));
+
+		main_bb = LLVMAppendBasicBlock (func, "MAIN");
+		LLVMPositionBuilderAtEnd (builder, main_bb);
 		LLVMValueRef base = table;
 		LLVMValueRef indexes [2];
 		indexes [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
@@ -2940,6 +2949,11 @@ emit_get_method (MonoLLVMModule *module)
 		LLVMValueRef addr = LLVMBuildGEP (builder, base, indexes, 2, "");
 		LLVMValueRef res = mono_llvm_build_load (builder, addr, "", FALSE);
 		LLVMBuildRet (builder, res);
+
+		LLVMBasicBlockRef default_bb = LLVMAppendBasicBlock (func, "DEFAULT");
+		LLVMPositionBuilderAtEnd (builder, default_bb);
+		LLVMValueRef cmp = LLVMBuildICmp (builder, LLVMIntSGE, LLVMGetParam (func, 0), LLVMConstInt (LLVMInt32Type (), table_len, FALSE), "");
+		LLVMBuildCondBr (builder, cmp, fail_bb, main_bb);
 
 		LLVMPositionBuilderAtEnd (builder, entry_bb);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50202.