### PR TITLE
Use Length property instead of GetFileInformationByHandleEx for Seek(…

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/WindowsFileStreamStrategy.cs
@@ -186,7 +186,7 @@ namespace System.IO.Strategies
             long pos = origin switch
             {
                 SeekOrigin.Begin => offset,
-                SeekOrigin.End => FileStreamHelpers.GetFileLength(_fileHandle, _path) + offset,
+                SeekOrigin.End => Length + offset,
                 _ => _filePosition + offset // SeekOrigin.Current
             };
 


### PR DESCRIPTION
…SeekOrigin.End)

Continuation of https://github.com/dotnet/runtime/pull/49975.

Instead of always perform an expensive native call, we can take advantage of the caching logic in `WindowsFileStream.Length` which caches the result of `GetFileInformationByHandleEx` in memory when the file is locked.

Benchmark Results:

<details>

|       Method |           Toolchain | fileSize |      options |        Mean |     Error |    StdDev |      Median |         Min |         Max | Ratio | Allocated |
|------------- |-------------------- |--------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|------:|----------:|
|  SeekForward |   \base\CoreRun.exe |     1024 |         None |    44.25 us |  0.727 us |  0.680 us |    44.32 us |    42.80 us |    45.43 us |  1.00 |     224 B |
|  SeekForward |\feature\CoreRun.exe |     1024 |         None |    43.97 us |  0.468 us |  0.438 us |    43.97 us |    43.35 us |    44.59 us |  0.99 |     224 B |
|              |                     |          |              |             |           |           |             |             |             |       |           |
| SeekBackward |   \base\CoreRun.exe |     1024 |         None | 1,836.67 us | 34.760 us | 27.138 us | 1,830.33 us | 1,803.24 us | 1,909.43 us |  1.00 |     224 B |
| SeekBackward |\feature\CoreRun.exe |     1024 |         None |    46.98 us |  0.622 us |  0.551 us |    47.03 us |    45.66 us |    47.69 us |  0.03 |     224 B |
|              |                     |          |              |             |           |           |             |             |             |       |           |
|  SeekForward |   \base\CoreRun.exe |     1024 | Asynchronous |    44.77 us |  0.646 us |  0.605 us |    44.92 us |    43.81 us |    45.99 us |  1.00 |     272 B |
|  SeekForward |\feature\CoreRun.exe |     1024 | Asynchronous |    47.20 us |  0.874 us |  0.817 us |    47.01 us |    45.72 us |    48.95 us |  1.05 |     272 B |
|              |                     |          |              |             |           |           |             |             |             |       |           |
| SeekBackward |   \base\CoreRun.exe |     1024 | Asynchronous | 2,697.63 us | 31.490 us | 29.456 us | 2,697.93 us | 2,642.54 us | 2,760.08 us |  1.00 |     272 B |
| SeekBackward |\feature\CoreRun.exe |     1024 | Asynchronous |    50.21 us |  0.508 us |  0.475 us |    50.05 us |    49.59 us |    51.08 us |  0.02 |     272 B |

</details>