### PR TITLE
Fix incorrect optimization of Activator.CreateInstance

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
@@ -19,7 +19,7 @@ namespace Internal.IL
                 && method.Name == "CreateInstance")
             {
                 TypeDesc type = method.Instantiation[0];
-                if (type.IsValueType && type.GetDefaultConstructor() == null)
+                if (type.IsValueType && type.GetParameterlessConstructor() == null)
                 {
                     // Replace the body with implementation that just returns "default"
                     MethodDesc createDefaultInstance = method.OwningType.GetKnownMethod("CreateDefaultInstance", method.GetTypicalMethodDefinition().Signature);


### PR DESCRIPTION
We should not return "default" if there's a private parameterless constructor. GetDefaultConstructor only returns the default constructor in the C# sense (public parameterless ctor on a non-abstract class).