### PR TITLE
[debugger] Removing call to jit_done to help debug multithread

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2564,7 +2564,6 @@ lookup_start:
 		g_assert (vtable);
 		if (!mono_runtime_class_init_full (vtable, error))
 			return NULL;
-		MONO_PROFILER_RAISE (jit_done, (method, info));
 
 		code = MINI_ADDR_TO_FTNPTR (info->code_start);
 		return mono_create_ftnptr (code);


### PR DESCRIPTION
It was causing a side effect on Unity, I will study it again while implement multithread on icordebug.

Reverting part of this PR https://github.com/mono/mono/pull/19103
Mirror of this PR https://github.com/mono/mono/pull/20970