### PR TITLE
[wasm] Add targets to run samples

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -17,4 +17,13 @@
     </PropertyGroup>
     <Exec Command="$(_Dotnet) publish /p:TargetArchitecture=wasm /p:TargetOS=Browser $(_AOTFlag) $(_SampleProject)" />
   </Target>
+  <Target Name="RunSampleWithV8" DependsOnTargets="BuildSampleInTree">
+    <Exec Command="cd bin/$(Configuration)/AppBundle &amp;&amp; v8 --expose_wasm runtime.js -- $(DOTNET_MONO_LOG_LEVEL) --run Wasm.Console.Sample.dll" IgnoreExitCode="true" />
+  </Target>
+  <Target Name="CheckServe">
+    <Exec Command="dotnet tool install -g dotnet-serve" IgnoreExitCode="true" />
+  </Target>
+  <Target Name="RunSampleWithBrowser" DependsOnTargets="BuildSampleInTree;CheckServe">
+    <Exec Command="$(_Dotnet) serve -o -d:bin/Release/AppBundle -p:8000" IgnoreExitCode="true" YieldDuringToolExecution="true" />
+  </Target>
 </Project>

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -5,4 +5,16 @@
     </ItemGroup>
   </Target>
   <Import Project="$(MonoProjectRoot)\wasm\build\WasmApp.InTree.targets" />
+
+  <Target Name="BuildSampleInTree"
+      Inputs="Program.cs"
+      Outputs="bin/$(Configuration)/AppBundle/dotnet.wasm">
+    <PropertyGroup>
+      <_ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</_ScriptExt>
+      <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>
+      <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
+      <_AOTFlag Condition="'$(RunAOTCompilation)' != ''">/p:RunAOTCompilation=$(RunAOTCompilation)</_AOTFlag>
+    </PropertyGroup>
+    <Exec Command="$(_Dotnet) publish /p:TargetArchitecture=wasm /p:TargetOS=Browser $(_AOTFlag) $(_SampleProject)" />
+  </Target>
 </Project>

--- a/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
+++ b/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
@@ -7,4 +7,16 @@
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="index.html" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <_SampleProject>Wasm.Browser.Sample.csproj</_SampleProject>
+  </PropertyGroup>
+
+  <Target Name="CheckServe">
+    <Exec Command="dotnet tool install -g dotnet-serve" IgnoreExitCode="true" />
+  </Target>
+
+  <Target Name="RunSample" DependsOnTargets="BuildSampleInTree;CheckServe">
+    <Exec Command="$(_Dotnet) serve -o -d:bin/Release/AppBundle -p:8000" IgnoreExitCode="true" YieldDuringToolExecution="true" />
+  </Target>
 </Project>

--- a/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
+++ b/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
@@ -12,11 +12,5 @@
     <_SampleProject>Wasm.Browser.Sample.csproj</_SampleProject>
   </PropertyGroup>
 
-  <Target Name="CheckServe">
-    <Exec Command="dotnet tool install -g dotnet-serve" IgnoreExitCode="true" />
-  </Target>
-
-  <Target Name="RunSample" DependsOnTargets="BuildSampleInTree;CheckServe">
-    <Exec Command="$(_Dotnet) serve -o -d:bin/Release/AppBundle -p:8000" IgnoreExitCode="true" YieldDuringToolExecution="true" />
-  </Target>
+  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowser" />
 </Project>

--- a/src/mono/sample/wasm/console/Wasm.Console.Sample.csproj
+++ b/src/mono/sample/wasm/console/Wasm.Console.Sample.csproj
@@ -9,7 +9,5 @@
     <_SampleProject>Wasm.Console.Sample.csproj</_SampleProject>
   </PropertyGroup>
 
-  <Target Name="RunSample" DependsOnTargets="BuildSampleInTree">
-    <Exec Command="cd bin/$(Configuration)/AppBundle &amp;&amp; v8 --expose_wasm runtime.js -- $(DOTNET_MONO_LOG_LEVEL) --run Wasm.Console.Sample.dll" IgnoreExitCode="true" />
-  </Target>
+  <Target Name="RunSample" DependsOnTargets="RunSampleWithV8" />
 </Project>

--- a/src/mono/sample/wasm/console/Wasm.Console.Sample.csproj
+++ b/src/mono/sample/wasm/console/Wasm.Console.Sample.csproj
@@ -4,4 +4,12 @@
     <WasmMainJSPath>$(MonoProjectRoot)\wasm\runtime-test.js</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_SampleProject>Wasm.Console.Sample.csproj</_SampleProject>
+  </PropertyGroup>
+
+  <Target Name="RunSample" DependsOnTargets="BuildSampleInTree">
+    <Exec Command="cd bin/$(Configuration)/AppBundle &amp;&amp; v8 --expose_wasm runtime.js -- $(DOTNET_MONO_LOG_LEVEL) --run Wasm.Console.Sample.dll" IgnoreExitCode="true" />
+  </Target>
 </Project>

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -114,3 +114,5 @@ The samples in `src/mono/sample/wasm` can be build and run like this:
 * browser TestMeaning sample
 
 `dotnet build /t:RunSample browser/Wasm.Browser.Sample.csproj`
+
+To build and run the samples with AOT, add `/p:RunAOTCompilation=true` to the above command lines.

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -102,3 +102,15 @@ To run a test with `FooBar` in the name:
 (See https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit for filter options)
 
 Additional arguments for `dotnet test` can be passed via `TEST_ARGS`. Though only one of `TEST_ARGS`, or `TEST_FILTER` can be used at a time.
+
+## Run samples
+
+The samples in `src/mono/sample/wasm` can be build and run like this:
+
+* console Hello world sample
+
+`dotnet build /t:RunSample console/Wasm.Console.Sample.csproj`
+
+* browser TestMeaning sample
+
+`dotnet build /t:RunSample browser/Wasm.Browser.Sample.csproj`


### PR DESCRIPTION
Add `RunSample` and `BuildSampleInTree` targets.

Mention how to run the samples in the README