### PR TITLE
Return DiaSymReader library for cross-arch crossgen to Runtime package

### DIFF
--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -100,9 +100,7 @@ extern VerboseLevel g_CorCompileVerboseLevel;
 #elif defined(HOST_ARM)
 #define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm.dll")
 #elif defined(HOST_ARM64)
-// Use diasymreader until the package has an arm64 version - issue #7360
-//#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm64.dll")
-#define NATIVE_SYMBOL_READER_DLL W("diasymreader.dll")
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm64.dll")
 #endif
 
 typedef DPTR(PersistentInlineTrackingMapNGen) PTR_PersistentInlineTrackingMapNGen;

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -65,7 +65,6 @@
     <!-- DiaSymReader for the host architecture, which is used for [cross-]compilation -->
     <_diaSymArch>$(_hostArch)</_diaSymArch>
     <_diaSymReaderPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymArch).dll</_diaSymReaderPath>
-    <_diaSymReaderPathIfExists Condition="Exists('$(_diaSymReaderPath)')">$(_diaSymReaderPath)</_diaSymReaderPathIfExists>
 
     <!-- DiaSymReader for the target architecture, which is placed into the package -->
     <_diaSymTargetArch>$(TargetArchitecture)</_diaSymTargetArch>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
@@ -89,16 +89,16 @@
       <CoreCLRCrossTargetFiles PackOnly="true" />
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'clrjit' or '%(FileName)' == 'libclrjit'">
         <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'crossgen'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore')) and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <CoreCLRCrossTargetFiles Condition="'%(FileName)%(Extension)' == 'mscordbi.dll' and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
-        </CoreCLRCrossTargetFiles>
+      </CoreCLRCrossTargetFiles>
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles);@(CoreCLRCrossTargetFiles);" />
     </ItemGroup>
   </Target>
@@ -116,7 +116,6 @@
     <!-- DiaSymReader for the host architecture, which is used for [cross-]compilation -->
     <_diaSymArch>$(_hostArch)</_diaSymArch>
     <_diaSymReaderPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymArch).dll</_diaSymReaderPath>
-    <_diaSymReaderPathIfExists Condition="Exists('$(_diaSymReaderPath)')">$(_diaSymReaderPath)</_diaSymReaderPathIfExists>
 
     <!-- DiaSymReader for the target architecture, which is placed into the package -->
     <_diaSymTargetArch>$(TargetArchitecture)</_diaSymTargetArch>
@@ -124,8 +123,11 @@
     <_diaSymReaderTargetArchPath>$(PkgMicrosoft_DiaSymReader_Native)/runtimes/win/native/Microsoft.DiaSymReader.Native.$(_diaSymTargetArch).dll</_diaSymReaderTargetArchPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="Exists('$(_diaSymReaderTargetArchPath)')">
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
     <NativeRuntimeAsset Include="$(_diaSymReaderTargetArchPath)" />
+    <NativeRuntimeAsset Include="$(_diaSymReaderPath)" Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">
+      <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
+    </NativeRuntimeAsset>
   </ItemGroup>
 
   <!-- VS uses this file to show the target framework in the drop down. -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -37,12 +37,12 @@
     <ItemGroup Condition="'@(_crossTargetJit)' != '' and '@(_crossTargetCrossgen)' != ''">
       <CrossgenTool Include="@(_crossTargetCrossgen->ClearMetadata())"
                     JitPath="@(_crossTargetJit)"
-                    DiaSymReader="$(_diaSymReaderPathIfExists)" />
+                    DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup Condition="'@(_crossTargetJit)' == '' and '@(_crossTargetCrossgen)' == ''">
       <CrossgenTool Include="@(_crossgen->ClearMetadata())"
                     JitPath="@(_clrjit)"
-                    DiaSymReader="$(_diaSymReaderPathIfExists)" />
+                    DiaSymReader="$(_diaSymReaderPath)" />
     </ItemGroup>
     <ItemGroup>
       <Crossgen2Tool Include="$(Crossgen2Exe)" JitPath="$(JitLibrary)" />


### PR DESCRIPTION
Merge #50149 to preview3 branch.

### Customer Impact

The `Microsoft.NETCore.App.Runtime.win-arm` package misses the `Microsoft.DiaSymReader.Native.x86.dll` library required by the x86-hosted `crossgen.exe` in order to generate PDBs in the cross-architecture compilation scenario. Similarly, the `Microsoft.NETCore.App.Runtime.win-arm64` package misses the `Microsoft.DiaSymReader.Native.amd64.dll` library required by the x64-hosted `crossgen.exe`. This blocks integration to AspNetCore repo.

### Testing

The fix has been tested in the main branches of Runtime and AspNetCore repos.

### Risk

No known risk.