### PR TITLE
Free up IGCToCLR memory on error returns

### DIFF
--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -190,14 +190,6 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
         return __HRESULT_FROM_WIN32(err);
     }
 
-    // a standalone GC dispatches virtually on GCToEEInterface, so we must instantiate
-    // a class for the GC to use.
-    IGCToCLR* gcToClr = new (nothrow) standalone::GCToEEInterface();
-    if (!gcToClr)
-    {
-        return E_OUTOFMEMORY;
-    }
-
     g_gc_load_status = GC_LOAD_STATUS_DONE_LOAD;
     GC_VersionInfoFunction versionInfo = (GC_VersionInfoFunction)GetProcAddress(hMod, "GC_VersionInfo");
     if (!versionInfo)
@@ -234,6 +226,14 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
         return __HRESULT_FROM_WIN32(err);
     }
 
+    // a standalone GC dispatches virtually on GCToEEInterface, so we must instantiate
+    // a class for the GC to use.
+    IGCToCLR* gcToClr = new (nothrow) standalone::GCToEEInterface();
+    if (!gcToClr)
+    {
+        return E_OUTOFMEMORY;
+    }
+
     g_gc_load_status = GC_LOAD_STATUS_GET_INITIALIZE;
     IGCHeap* heap;
     IGCHandleManager* manager;
@@ -252,6 +252,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
     }
     else
     {
+        delete gcToClr;
         LOG((LF_GC, LL_FATALERROR, "GC initialization failed with HR = 0x%X\n", initResult));
     }
 


### PR DESCRIPTION
We can return early in case of error and accidentally forget to release the memory allocated on the heap. Using a smart pointer isn't a real option because we transfer over memory ownership to another class on the success path.