### PR TITLE
Wrap ArgumentException with CryptographicException for incorrect key in EnvelopedCms

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -296,6 +296,6 @@
     <value>Certificate already present in the collection.</value>
   </data>
   <data name="Cryptography_Cms_InvalidSymmetricKey" xml:space="preserve">
-    <value>The key in enveloped message is not valid or could not be decoded.</value>
+    <value>The key in the enveloped message is not valid or could not be decoded.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -295,4 +295,7 @@
   <data name="Cryptography_Cms_CertificateAlreadyInCollection" xml:space="preserve">
     <value>Certificate already present in the collection.</value>
   </data>
+  <data name="Cryptography_Cms_InvalidSymmetricKey" xml:space="preserve">
+    <value>The key in enveloped message is not valid or could not be decoded.</value>
+  </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 "864801650304012A0410C85C553A73E9B55F98752E1133ACA645801099B22DFF" +
 "6A9D8984F8B3F63079CE9265";
                 EnvelopedCms ecms = new EnvelopedCms();
-                ecms.Decode(Convert.FromHexString(encryptedContent));
+                ecms.Decode(encryptedContent.HexToByteArray());
                 Assert.ThrowsAny<CryptographicException>(() => ecms.Decrypt(new X509Certificate2Collection(wrongRecipient)));
             }
         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
@@ -68,6 +68,31 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        public static void DecryptSuccesfullyWithWrongKeyProducesInvalidSymmetricKey()
+        {
+            using (X509Certificate2 wrongRecipient = Certificates.RSAKeyTransfer5_ExplicitSkiOfRSAKeyTransfer4.TryGetCertificateWithPrivateKey())
+            {
+                string encryptedContent =
+"3082018806092A864886F70D010703A082017930820175020102318201303082" +
+"012C0201028014B46B61938FF9864BD8494B3937DA19C9F06FA8D3300D06092A" +
+"864886F70D0101010500048201008198CBAFF1C67EE634C7A32C356729F996BC" +
+"E4125EE353B220A792CCFD37855B50E05916CC8EC6E25EF62B35B29620C8BF76" +
+"144032854D14E3E19B613C15A26E376A2014AD3AD492F80A92F0D61910B6C416" +
+"867985279CF4E26CDED351AFB84CE9E1BC105899280DB6B782688CE6B04B7003" +
+"E4C53B580DD2F21A71B973C2AB70E61F1AFBDD2616FE0101BB02BCDA14881CEC" +
+"037032C91FE803C76D91FA5E0A802ECB2FB2BBE71C8567F58B5B74638CD9765E" +
+"F658172AAD423963784C5BE49AC01682751796F0AFE4943373981FC074F24640" +
+"901201AD6884415788FC18721ECB201A60A7FE5859FF61DA8BB21D0D23593D28" +
+"86896886D3507906DB58FB056953303C06092A864886F70D010701301D060960" +
+"864801650304012A0410C85C553A73E9B55F98752E1133ACA645801099B22DFF" +
+"6A9D8984F8B3F63079CE9265";
+                EnvelopedCms ecms = new EnvelopedCms();
+                ecms.Decode(Convert.FromHexString(encryptedContent));
+                Assert.ThrowsAny<CryptographicException>(() => ecms.Decrypt(new X509Certificate2Collection(wrongRecipient)));
+            }
+        }
+
+        [Fact]
         public static void DecryptUsingCertificateWithSameSubjectKeyIdentifierButDifferentKeyPair()
         {
             using (X509Certificate2 recipientCert = Certificates.RSAKeyTransfer4_ExplicitSki.GetCertificate())


### PR DESCRIPTION
If an incorrect asymmetric key is used to decrypt a symmetric key in enveloped data, and the decryption is successful but produces an invalid symmetric key, wrap that as a CryptographicException.

Closes #50222.