### PR TITLE
Clean up string formatting in a variety of places

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1,11 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Reflection
 {
@@ -439,15 +440,33 @@ namespace System.Reflection
         #region Object Override
         public override string ToString()
         {
-            string ctorArgs = "";
-            for (int i = 0; i < ConstructorArguments.Count; i++)
-                ctorArgs += string.Format(i == 0 ? "{0}" : ", {0}", ConstructorArguments[i]);
+            var vsb = new ValueStringBuilder(stackalloc char[256]);
 
-            string namedArgs = "";
-            for (int i = 0; i < NamedArguments.Count; i++)
-                namedArgs += string.Format(i == 0 && ctorArgs.Length == 0 ? "{0}" : ", {0}", NamedArguments[i]);
+            vsb.Append('[');
+            vsb.Append(Constructor.DeclaringType!.FullName);
+            vsb.Append('(');
 
-            return string.Format("[{0}({1}{2})]", Constructor.DeclaringType!.FullName, ctorArgs, namedArgs);
+            bool first = true;
+
+            int count = ConstructorArguments.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (!first) vsb.Append(", ");
+                vsb.Append(ConstructorArguments[i].ToString());
+                first = false;
+            }
+
+            count = NamedArguments.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (!first) vsb.Append(", ");
+                vsb.Append(NamedArguments[i].ToString());
+                first = false;
+            }
+
+            vsb.Append(")]");
+
+            return vsb.ToString();
         }
         public override int GetHashCode() => base.GetHashCode();
         public override bool Equals(object? obj) => obj == (object)this;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -557,9 +557,6 @@ namespace System.Reflection
         private int m_hr;
         internal MetadataException(int hr) { m_hr = hr; }
 
-        public override string ToString()
-        {
-            return string.Format("MetadataException HResult = {0:x}.", m_hr);
-        }
+        public override string ToString() => $"MetadataException HResult = {m_hr:x}.";
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
@@ -71,7 +71,7 @@ internal static partial class Interop
             }
 
             // Couldn't get a message, so manufacture one.
-            return string.Format("Unknown error (0x{0:x})", errorCode);
+            return $"Unknown error (0x{errorCode:x})";
         }
 
         private static string GetAndTrimString(Span<char> buffer)

--- a/src/libraries/Common/src/System/Net/WebSockets/WebSocketValidate.cs
+++ b/src/libraries/Common/src/System/Net/WebSockets/WebSocketValidate.cs
@@ -58,7 +58,7 @@ namespace System.Net.WebSockets
                 char ch = subProtocol[i];
                 if (ch < 0x21 || ch > 0x7e)
                 {
-                    invalidChar = string.Format(CultureInfo.InvariantCulture, "[{0}]", (int)ch);
+                    invalidChar = $"[{(int)ch}]";
                     break;
                 }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
@@ -15,10 +15,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
         private readonly string[] _memberNames;
         private readonly object[] _memberValues;
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "<enum '{0}'>", TypeName);
-        }
+        public override string ToString() => $"<enum '{TypeName}'>";
 
         internal ComTypeEnumDesc(ComTypes.ITypeInfo typeInfo, ComTypeLibDesc typeLibDesc) :
             base(typeInfo, typeLibDesc)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeLibDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeLibDesc.cs
@@ -32,10 +32,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             _classes = new LinkedList<ComTypeClassDesc>();
         }
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "<type library {0}>", Name);
-        }
+        public override string ToString() => $"<type library {Name}>";
 
         public string Documentation
         {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DispCallable.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DispCallable.cs
@@ -19,10 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             DispId = dispId;
         }
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "<bound dispmethod {0}>", MemberName);
-        }
+        public override string ToString() => $"<bound dispmethod {MemberName}>";
 
         public IDispatchComObject DispatchComObject { get; }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 typeName = "IDispatch";
             }
 
-            return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", RuntimeCallableWrapper.ToString(), typeName);
+            return $"{RuntimeCallableWrapper.ToString()} ({typeName})";
         }
 
         public ComTypeDesc ComTypeDesc

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
@@ -281,10 +281,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "Variant ({0})", VariantType);
-        }
+        public override string ToString() => $"Variant ({VariantType})";
 
         public void SetAsIConvertible(IConvertible value)
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                     {
                         // "/SomeSwitch" is equivalent to "--SomeSwitch" when interpreting switch mappings
                         // So we do a conversion to simplify later processing
-                        currentArg = string.Format("--{0}", currentArg.Substring(1));
+                        currentArg = $"--{currentArg.Substring(1)}";
                         keyStartIndex = 2;
                     }
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -94,8 +94,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
                 {
                     // This shouldn't happen. The parameter name isn't supposed to contain wild card.
                     throw new InvalidOperationException(
-                        string.Format("More than one sub directories are found under {0} with name {1}.",
-                            _directoryInfo.FullName, name));
+                        $"More than one sub directories are found under {_directoryInfo.FullName} with name {name}.");
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/MatcherContext.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/MatcherContext.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal
             }
             else
             {
-                return string.Format("{0}/{1}", left, right);
+                return $"{left}/{right}";
             }
         }
 

--- a/src/libraries/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
+++ b/src/libraries/Microsoft.Win32.Primitives/src/System/ComponentModel/Win32Exception.cs
@@ -87,7 +87,7 @@ namespace System.ComponentModel
             string className = GetType().ToString();
             StringBuilder s = new StringBuilder(className);
             string nativeErrorString = NativeErrorCode < 0
-                ? string.Format(CultureInfo.InvariantCulture, "0x{0:X8}", NativeErrorCode)
+                ? $"0x{NativeErrorCode:X8}"
                 : NativeErrorCode.ToString(CultureInfo.InvariantCulture);
             if (HResult == E_FAIL)
             {

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -668,9 +668,7 @@ namespace Microsoft.Win32
 
             IntPtr hInstance = Interop.Kernel32.GetModuleHandle(null);
 
-            s_className = string.Format(
-                ".NET-BroadcastEventWindow.{0:x}.0",
-                AppDomain.CurrentDomain.GetHashCode());
+            s_className = $".NET-BroadcastEventWindow.{AppDomain.CurrentDomain.GetHashCode():x}.0";
 
             fixed (char* className = s_className)
             {

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -453,7 +453,7 @@ namespace Microsoft.XmlSerializer.Generator
         private void WriteHeader()
         {
             // do not localize Copyright header
-            Console.WriteLine(string.Format(CultureInfo.CurrentCulture, ".NET Xml Serialization Generation Utility, Version {0}]", ThisAssembly.InformationalVersion));
+            Console.WriteLine($".NET Xml Serialization Generation Utility, Version {ThisAssembly.InformationalVersion}]");
         }
 
         private void WriteHelp()

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -217,7 +217,7 @@ namespace System.Collections.Immutable
             get
             {
                 var self = this;
-                return self.IsDefault ? "Uninitialized" : string.Format(CultureInfo.CurrentCulture, "Length = {0}", self.Length);
+                return self.IsDefault ? "Uninitialized" : $"Length = {self.Length}";
             }
         }
 

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
@@ -173,14 +173,8 @@ namespace System.ComponentModel.Composition.Hosting
             }
         }
 
-        private string GetDisplayName()
-        {
-            return string.Format(CultureInfo.CurrentCulture,
-                                "{0} (Path=\"{1}\") (PrivateProbingPath=\"{2}\")",   // NOLOC
-                                GetType().Name,
-                                AppDomain.CurrentDomain.BaseDirectory,
-                                AppDomain.CurrentDomain.RelativeSearchPath);
-        }
+        private string GetDisplayName() =>
+            $"{GetType().Name} (Path=\"{AppDomain.CurrentDomain.BaseDirectory}\") (PrivateProbingPath=\"{AppDomain.CurrentDomain.RelativeSearchPath}\")";   // NOLOC
 
         /// <summary>
         ///     Returns a string representation of the directory catalog.

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
@@ -540,13 +540,8 @@ namespace System.ComponentModel.Composition.Hosting
             }
         }
 
-        private string GetDisplayName()
-        {
-            return string.Format(CultureInfo.CurrentCulture,
-                                "{0} (Assembly=\"{1}\")",   // NOLOC
-                                GetType().Name,
-                                Assembly.FullName);
-        }
+        private string GetDisplayName() =>
+            $"{GetType().Name} (Assembly=\"{Assembly.FullName}\")";   // NOLOC
 
         private static Assembly LoadAssembly(string codeBase)
         {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/DirectoryCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/DirectoryCatalog.cs
@@ -732,13 +732,8 @@ namespace System.ComponentModel.Composition.Hosting
             }
         }
 
-        private string GetDisplayName()
-        {
-            return string.Format(CultureInfo.CurrentCulture,
-                                "{0} (Path=\"{1}\")",   // NOLOC
-                                GetType().Name,
-                                _path);
-        }
+        private string GetDisplayName() =>
+            $"{GetType().Name} (Path=\"{_path}\")";   // NOLOC
 
         private string[] GetFiles()
         {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/MetadataViewGenerator.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/MetadataViewGenerator.cs
@@ -67,7 +67,7 @@ namespace System.ComponentModel.Composition
 
         private static readonly Lock _lock = new Lock();
         private static readonly Dictionary<Type, MetadataViewFactory> _metadataViewFactories = new Dictionary<Type, MetadataViewFactory>();
-        private static readonly AssemblyName ProxyAssemblyName = new AssemblyName(string.Format(CultureInfo.InvariantCulture, "MetadataViewProxies_{0}", Guid.NewGuid()));
+        private static readonly AssemblyName ProxyAssemblyName = new AssemblyName($"MetadataViewProxies_{Guid.NewGuid()}");
         private static ModuleBuilder? transparentProxyModuleBuilder;
 
         private static readonly Type[] CtorArgumentTypes = new Type[] { typeof(IDictionary<string, object>) };
@@ -193,7 +193,7 @@ namespace System.ComponentModel.Composition
 
             var proxyModuleBuilder = GetProxyModuleBuilder(requiresCritical);
             proxyTypeBuilder = proxyModuleBuilder.DefineType(
-                string.Format(CultureInfo.InvariantCulture, "_proxy_{0}_{1}", viewType.FullName, Guid.NewGuid()),
+                $"_proxy_{viewType.FullName}_{Guid.NewGuid()}",
                 TypeAttributes.Public,
                 typeof(object),
                 interfaces);
@@ -214,7 +214,7 @@ namespace System.ComponentModel.Composition
             // Implement interface properties
             foreach (PropertyInfo propertyInfo in viewType.GetAllProperties())
             {
-                string fieldName = string.Format(CultureInfo.InvariantCulture, "_{0}_{1}", propertyInfo.Name, Guid.NewGuid());
+                string fieldName = $"_{propertyInfo.Name}_{Guid.NewGuid()}";
 
                 // Cache names and type for exception
                 string propertyName = propertyInfo.Name;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ContractBasedImportDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ContractBasedImportDefinition.cs
@@ -371,11 +371,11 @@ namespace System.ComponentModel.Composition.Primitives
         {
             var sb = new StringBuilder();
 
-            sb.Append(string.Format("\n\tContractName\t{0}", ContractName));
-            sb.Append(string.Format("\n\tRequiredTypeIdentity\t{0}", RequiredTypeIdentity));
+            sb.Append("\n\tContractName\t").Append(ContractName);
+            sb.Append("\n\tRequiredTypeIdentity\t").Append(RequiredTypeIdentity);
             if (_requiredCreationPolicy != CreationPolicy.Any)
             {
-                sb.Append(string.Format("\n\tRequiredCreationPolicy\t{0}", RequiredCreationPolicy));
+                sb.Append("\n\tRequiredCreationPolicy\t").Append(RequiredCreationPolicy);
             }
 
             if (_requiredMetadata.Any())
@@ -383,7 +383,7 @@ namespace System.ComponentModel.Composition.Primitives
                 sb.Append("\n\tRequiredMetadata");
                 foreach (KeyValuePair<string, Type> metadataItem in _requiredMetadata)
                 {
-                    sb.Append(string.Format("\n\t\t{0}\t({1})", metadataItem.Key, metadataItem.Value));
+                    sb.Append("\n\t\t").Append(metadataItem.Key).Append("\t(").Append(metadataItem.Value).Append(')');
                 }
             }
             return sb.ToString();

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionMemberExportDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionMemberExportDefinition.cs
@@ -78,12 +78,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
             return ExportingLazyMember.ToReflectionMember();
         }
 
-        private string GetDisplayName()
-        {
-            return string.Format(CultureInfo.CurrentCulture,
-                   "{0} (ContractName=\"{1}\")",    // NOLOC
-                   ToReflectionMember().GetDisplayName(),
-                   ContractName);
-        }
+        private string GetDisplayName() =>
+            $"{ToReflectionMember().GetDisplayName()} (ContractName=\"{ContractName}\")";    // NOLOC
     }
 }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionMemberImportDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionMemberImportDefinition.cs
@@ -43,13 +43,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
             get { return _importingLazyMember; }
         }
 
-        protected override string GetDisplayName()
-        {
-            return string.Format(
-                CultureInfo.CurrentCulture,
-                "{0} (ContractName=\"{1}\")",    // NOLOC
-                ImportingLazyMember.ToReflectionMember().GetDisplayName(),
-                ContractName);
-        }
+        protected override string GetDisplayName() =>
+            $"{ImportingLazyMember.ToReflectionMember().GetDisplayName()} (ContractName=\"{ContractName}\")";    // NOLOC
     }
 }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionParameter.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionParameter.cs
@@ -31,14 +31,8 @@ namespace System.ComponentModel.Composition.ReflectionModel
             get { return UnderlyingParameter.Name; }
         }
 
-        public override string GetDisplayName()
-        {
-            return string.Format(
-                CultureInfo.CurrentCulture,
-                "{0} (Parameter=\"{1}\")",  // NOLOC
-                UnderlyingParameter.Member.GetDisplayName(),
-                UnderlyingParameter.Name);
-        }
+        public override string GetDisplayName() =>
+            $"{UnderlyingParameter.Member.GetDisplayName()} (Parameter=\"{UnderlyingParameter.Name}\")";  // NOLOC
 
         public override Type ReturnType
         {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionParameterImportDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionParameterImportDefinition.cs
@@ -45,12 +45,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
         protected override string GetDisplayName()
         {
             ParameterInfo parameter = ImportingLazyParameter.GetNotNullValue("parameter");
-            return string.Format(
-                CultureInfo.CurrentCulture,
-                "{0} (Parameter=\"{1}\", ContractName=\"{2}\")",  // NOLOC
-                parameter.Member.GetDisplayName(),
-                parameter.Name,
-                ContractName);
+            return $"{parameter.Member.GetDisplayName()} (Parameter=\"{parameter.Name}\", ContractName=\"{ContractName}\")";  // NOLOC
         }
     }
 }

--- a/src/libraries/System.Composition.Hosting/src/System/Composition/Hosting/Util/Formatters.cs
+++ b/src/libraries/System.Composition.Hosting/src/System/Composition/Hosting/Util/Formatters.cs
@@ -47,7 +47,7 @@ namespace System.Composition.Hosting.Util
 
             var name = closedGenericType.Name.Substring(0, closedGenericType.Name.IndexOf('`'));
             var args = closedGenericType.GenericTypeArguments.Select(t => Format(t));
-            return string.Format("{0}<{1}>", name, string.Join(", ", args));
+            return $"{name}<{string.Join(", ", args)}>";
         }
     }
 }

--- a/src/libraries/System.Composition.Runtime/src/System/Composition/Hosting/Core/CompositionContract.cs
+++ b/src/libraries/System.Composition.Runtime/src/System/Composition/Hosting/Core/CompositionContract.cs
@@ -110,7 +110,7 @@ namespace System.Composition.Hosting.Core
             if (_metadataConstraints != null)
                 result += string.Format(" {{ {0} }}",
                     string.Join(SR.Formatter_ListSeparatorWithSpace,
-                        _metadataConstraints.Select(kv => string.Format("{0} = {1}", kv.Key, Formatters.Format(kv.Value)))));
+                        _metadataConstraints.Select(kv => $"{kv.Key} = {Formatters.Format(kv.Value)}")));
 
             return result;
         }

--- a/src/libraries/System.Composition.Runtime/src/System/Composition/Runtime/Util/Formatters.cs
+++ b/src/libraries/System.Composition.Runtime/src/System/Composition/Runtime/Util/Formatters.cs
@@ -36,7 +36,7 @@ namespace System.Composition.Runtime.Util
             Debug.Assert(closedGenericType.IsConstructedGenericType);
             var name = closedGenericType.Name.Substring(0, closedGenericType.Name.IndexOf('`'));
             IEnumerable<string> args = closedGenericType.GenericTypeArguments.Select(t => Format(t));
-            return string.Format("{0}<{1}>", name, string.Join(SR.Formatter_ListSeparatorWithSpace, args));
+            return $"{name}<{string.Join(SR.Formatter_ListSeparatorWithSpace, args)}>";
         }
     }
 }

--- a/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolCounters.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolCounters.cs
@@ -259,7 +259,7 @@ namespace System.Data.ProviderBase
             // to PERFMON.  They recommend that we translate them as shown below, to
             // prevent problems.
 
-            result = string.Format(null, "{0}[{1}]", instanceName, pid);
+            result = $"{instanceName}[{pid}]";
             result = result.Replace('(', '[').Replace(')', ']').Replace('#', '_').Replace('/', '_').Replace('\\', '_');
 
             // counter instance name cannot be greater than 127
@@ -272,13 +272,10 @@ namespace System.Data.ProviderBase
                 const string insertString = "[...]";
                 int firstPartLength = (CounterInstanceNameMaxLength - insertString.Length) / 2;
                 int lastPartLength = CounterInstanceNameMaxLength - firstPartLength - insertString.Length;
-                result = string.Format(null, "{0}{1}{2}",
-                    result.Substring(0, firstPartLength),
-                    insertString,
-                    result.Substring(result.Length - lastPartLength, lastPartLength));
+                result = $"{result.Substring(0, firstPartLength)}{insertString}{result.Substring(result.Length - lastPartLength, lastPartLength)}";
 
                 Debug.Assert(result.Length == CounterInstanceNameMaxLength,
-                    string.Format(null, "wrong calculation of the instance name: expected {0}, actual: {1}", CounterInstanceNameMaxLength, result.Length));
+                    $"wrong calculation of the instance name: expected {CounterInstanceNameMaxLength}, actual: {result.Length}");
             }
 
             return result;

--- a/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
@@ -126,20 +126,18 @@ namespace System.Diagnostics
         //
         private bool GetVersionInfoForCodePage(IntPtr memIntPtr, string codepage)
         {
-            string template = "\\\\StringFileInfo\\\\{0}\\\\{1}";
-
-            _companyName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "CompanyName"));
-            _fileDescription = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileDescription"));
-            _fileVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "FileVersion"));
-            _internalName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "InternalName"));
-            _legalCopyright = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalCopyright"));
-            _originalFilename = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "OriginalFilename"));
-            _productName = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductName"));
-            _productVersion = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "ProductVersion"));
-            _comments = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "Comments"));
-            _legalTrademarks = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "LegalTrademarks"));
-            _privateBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "PrivateBuild"));
-            _specialBuild = GetFileVersionString(memIntPtr, string.Format(CultureInfo.InvariantCulture, template, codepage, "SpecialBuild"));
+            _companyName = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\CompanyName");
+            _fileDescription = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\FileDescription");
+            _fileVersion = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\FileVersion");
+            _internalName = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\InternalName");
+            _legalCopyright = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\LegalCopyright");
+            _originalFilename = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\OriginalFilename");
+            _productName = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\ProductName");
+            _productVersion = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\ProductVersion");
+            _comments = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\Comments");
+            _legalTrademarks = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\LegalTrademarks");
+            _privateBuild = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\PrivateBuild");
+            _specialBuild = GetFileVersionString(memIntPtr, $"\\\\StringFileInfo\\\\{codepage}\\\\SpecialBuild");
 
             _language = GetFileVersionLanguage(memIntPtr);
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1355,7 +1355,7 @@ namespace System.Diagnostics
                 string processName = ProcessName;
                 if (processName.Length != 0)
                 {
-                    return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", base.ToString(), processName);
+                    return $"{base.ToString()} ({processName})";
                 }
             }
             return base.ToString();

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
@@ -390,7 +390,7 @@ namespace System.Diagnostics
 
         private void WriteHeader(string source, TraceEventType eventType, int id)
         {
-            Write(string.Format(CultureInfo.InvariantCulture, "{0} {1}: {2} : ", source, eventType.ToString(), id.ToString(CultureInfo.InvariantCulture)));
+            Write($"{source} {eventType.ToString()}: {id.ToString(CultureInfo.InvariantCulture)} : ");
         }
 
         private void WriteFooter(TraceEventCache? eventCache)

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -1824,12 +1824,7 @@ namespace System.DirectoryServices.AccountManagement
 
             try
             {
-                string path = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "LDAP://{0}/{1}",
-                    string.IsNullOrEmpty(this.UserSuppliedServerName) ? this.DnsHostName : this.UserSuppliedServerName,
-                    this.ContextBasePartitionDN
-                    );
+                string path = $"LDAP://{(string.IsNullOrEmpty(this.UserSuppliedServerName) ? this.DnsHostName : this.UserSuppliedServerName)}/{this.ContextBasePartitionDN}";
 
                 defaultNCDirEntry = SDSUtils.BuildDirectoryEntry(path, this.credentials, this.authTypes);
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Font.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Font.Unix.cs
@@ -65,7 +65,7 @@ namespace System.Drawing
             int status = Gdip.GdipCreateFont(new HandleRef(this, family.NativeFamily), emSize, style, unit, out _nativeFont);
 
             if (status == Gdip.FontStyleNotFound)
-                throw new ArgumentException(string.Format("Style {0} isn't supported by font {1}.", style.ToString(), familyName));
+                throw new ArgumentException($"Style {style.ToString()} isn't supported by font {familyName}.");
 
             Gdip.CheckStatus(status);
         }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -262,16 +262,8 @@ namespace System.Drawing
         /// <summary>
         /// Returns a human-readable string representation of this <see cref='Font'/>.
         /// </summary>
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "[{0}: Name={1}, Size={2}, Units={3}, GdiCharSet={4}, GdiVerticalFont={5}]",
-                                    GetType().Name,
-                                    FontFamily.Name,
-                                    _fontSize,
-                                    (int)_fontUnit,
-                                    _gdiCharSet,
-                                    _gdiVerticalFont);
-        }
+        public override string ToString() =>
+            $"[{GetType().Name}: Name={FontFamily.Name}, Size={_fontSize}, Units={(int)_fontUnit}, GdiCharSet={_gdiCharSet}, GdiVerticalFont={_gdiVerticalFont}]";
 
         // This is used by SystemFonts when constructing a system Font objects.
         internal void SetSystemFontName(string systemFontName) => _systemFontName = systemFontName;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -401,13 +401,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitLambda<T>(Expression<T> node)
         {
-            Out(
-                string.Format(CultureInfo.CurrentCulture,
-                    ".Lambda {0}<{1}>",
-                    GetLambdaName(node),
-                    node.Type.ToString()
-                )
-            );
+            Out($".Lambda {GetLambdaName(node)}<{node.Type}>");
 
             if (_lambdas == null)
             {
@@ -471,17 +465,11 @@ namespace System.Linq.Expressions
             }
             else if ((value is string) && node.Type == typeof(string))
             {
-                Out(string.Format(
-                    CultureInfo.CurrentCulture,
-                    "\"{0}\"",
-                    value));
+                Out($"\"{value}\"");
             }
             else if ((value is char) && node.Type == typeof(char))
             {
-                Out(string.Format(
-                    CultureInfo.CurrentCulture,
-                    "'{0}'",
-                    value));
+                Out($"'{value}'");
             }
             else if ((value is int) && node.Type == typeof(int)
               || (value is bool) && node.Type == typeof(bool))
@@ -498,11 +486,7 @@ namespace System.Linq.Expressions
                 }
                 else
                 {
-                    Out(string.Format(
-                        CultureInfo.CurrentCulture,
-                        ".Constant<{0}>({1})",
-                        node.Type.ToString(),
-                        value));
+                    Out($".Constant<{node.Type}>({value})");
                 }
             }
             return node;
@@ -994,7 +978,7 @@ namespace System.Linq.Expressions
             // last expression's type in the block.
             if (node.Type != node.GetExpression(node.ExpressionCount - 1).Type)
             {
-                Out(string.Format(CultureInfo.CurrentCulture, "<{0}>", node.Type.ToString()));
+                Out($"<{node.Type}>");
             }
 
             VisitDeclarations(node.Variables);
@@ -1149,7 +1133,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitExtension(Expression node)
         {
-            Out(string.Format(CultureInfo.CurrentCulture, ".Extension<{0}>", node.GetType().ToString()));
+            Out($".Extension<{node.GetType()}>");
 
             if (node.CanReduce)
             {
@@ -1165,22 +1149,14 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitDebugInfo(DebugInfoExpression node)
         {
-            Out(string.Format(
-                CultureInfo.CurrentCulture,
-                ".DebugInfo({0}: {1}, {2} - {3}, {4})",
-                node.Document.FileName,
-                node.StartLine,
-                node.StartColumn,
-                node.EndLine,
-                node.EndColumn)
-            );
+            Out($".DebugInfo({node.Document.FileName}: {node.StartLine}, {node.StartColumn} - {node.EndLine}, {node.EndColumn})");
             return node;
         }
 
 
         private void DumpLabel(LabelTarget target)
         {
-            Out(string.Format(CultureInfo.CurrentCulture, ".LabelTarget {0}:", GetLabelTargetName(target)));
+            Out($".LabelTarget {GetLabelTargetName(target)}:");
         }
 
         private string GetLabelTargetName(LabelTarget target)
@@ -1198,13 +1174,7 @@ namespace System.Linq.Expressions
 
         private void WriteLambda(LambdaExpression lambda)
         {
-            Out(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    ".Lambda {0}<{1}>",
-                    GetLambdaName(lambda),
-                    lambda.Type.ToString())
-            );
+            Out($".Lambda {GetLambdaName(lambda)}<{lambda.Type}>");
 
             VisitDeclarations(lambda.Parameters);
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -381,16 +381,7 @@ namespace System.Linq.Expressions
 
         protected internal override Expression VisitDebugInfo(DebugInfoExpression node)
         {
-            string s = string.Format(
-                CultureInfo.CurrentCulture,
-                "<DebugInfo({0}: {1}, {2}, {3}, {4})>",
-                node.Document.FileName,
-                node.StartLine,
-                node.StartColumn,
-                node.EndLine,
-                node.EndColumn
-            );
-            Out(s);
+            Out($"<DebugInfo({node.Document.FileName}: {node.StartLine}, {node.StartColumn}, {node.EndLine}, {node.EndColumn})>");
             return node;
         }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -3101,7 +3101,7 @@ namespace System.Linq.Expressions.Interpreter
                     break;
             }
             Debug.Assert(_instructions.CurrentStackDepth == startingStackDepth + (expr.Type == typeof(void) ? 0 : 1),
-                string.Format("{0} vs {1} for {2}", _instructions.CurrentStackDepth, startingStackDepth + (expr.Type == typeof(void) ? 0 : 1), expr.NodeType));
+                $"{_instructions.CurrentStackDepth} vs {startingStackDepth + (expr.Type == typeof(void) ? 0 : 1)} for {expr.NodeType}");
         }
 
         private void Compile(Expression expr)

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -506,7 +506,7 @@ namespace System.Buffers
                 }
             }
 
-            return string.Format("System.Buffers.ReadOnlySequence<{0}>[{1}]", typeof(T).Name, Length);
+            return $"System.Buffers.ReadOnlySequence<{typeof(T).Name}>[{Length}]";
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -208,8 +208,7 @@ namespace System.Net.Http
             Debug.Assert(_chunkedMode);
             Debug.Assert(count > 0);
 
-            string chunkSizeString = string.Format("{0:x}\r\n", count);
-            byte[] chunkSize = Encoding.UTF8.GetBytes(chunkSizeString);
+            byte[] chunkSize = Encoding.UTF8.GetBytes($"{count:x}\r\n");
 
             await InternalWriteDataAsync(chunkSize, 0, chunkSize.Length, token).ConfigureAwait(false);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_CALLBACK_STATUS_GETPROXYFORURL_COMPLETE => "STATUS_GETPROXYFORURL_COMPLETE",
                 Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE => "STATUS_CLOSE_COMPLETE",
                 Interop.WinHttp.WINHTTP_CALLBACK_STATUS_SHUTDOWN_COMPLETE => "STATUS_SHUTDOWN_COMPLETE",
-                _ => string.Format("0x{0:X}", status),
+                _ => $"0x{status:X}",
             };
     }
 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -451,11 +451,9 @@ namespace System.Net
                 response.StatusCode = status;
                 response.ContentType = "text/html";
                 string? description = HttpStatusDescription.Get(status);
-                string str;
-                if (msg != null)
-                    str = string.Format("<h1>{0} ({1})</h1>", description, msg);
-                else
-                    str = string.Format("<h1>{0}</h1>", description);
+                string str = msg != null ?
+                    $"<h1>{description} ({msg})</h1>" :
+                    $"<h1>{description}</h1>";
 
                 byte[] error = Encoding.Default.GetBytes(str);
                 response.Close(error, false);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -195,7 +195,7 @@ namespace System.Net
             if (colon >= 0)
                 host = host.Substring(0, colon);
 
-            string base_uri = string.Format("{0}://{1}:{2}", RequestScheme, host, LocalEndPoint!.Port);
+            string base_uri = $"{RequestScheme}://{host}:{LocalEndPoint!.Port}";
 
             if (!Uri.TryCreate(base_uri + path, UriKind.Absolute, out _requestUri))
             {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
@@ -129,11 +129,8 @@ namespace System.Net
         }
 
         private static byte[] s_crlf = new byte[] { 13, 10 };
-        private static byte[] GetChunkSizeBytes(int size, bool final)
-        {
-            string str = string.Format("{0:x}\r\n{1}", size, final ? "\r\n" : "");
-            return Encoding.ASCII.GetBytes(str);
-        }
+        private static byte[] GetChunkSizeBytes(int size, bool final) =>
+            Encoding.ASCII.GetBytes($"{size:x}\r\n{(final ? "\r\n" : "")}");
 
         internal void InternalWrite(byte[] buffer, int offset, int count)
         {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/ServiceNameStore.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/ServiceNameStore.cs
@@ -118,8 +118,7 @@ namespace System.Net
             string normalizedHost = constructedUri.GetComponents(
                 UriComponents.NormalizedHost, UriFormat.SafeUnescaped);
 
-            string normalizedServiceName = string.Format(CultureInfo.InvariantCulture,
-                "{0}{1}{2}{3}", prefix, normalizedHost, port, distinguisher);
+            string normalizedServiceName = prefix + normalizedHost + port + distinguisher;
 
             // Don't return the new one unless we absolutely have to.  It may have only changed casing.
             if (inputServiceName.Equals(normalizedServiceName, StringComparison.OrdinalIgnoreCase))

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -926,9 +926,7 @@ namespace System.Net
                             if (decodedOutgoingBlob != null)
                             {
                                 // Prefix SPNEGO token/NTLM challenge with scheme per RFC 4559, MS-NTHT
-                                outBlob = string.Format("{0} {1}",
-                                    headerScheme == AuthenticationSchemes.Ntlm ? NegotiationInfoClass.NTLM : NegotiationInfoClass.Negotiate,
-                                    Convert.ToBase64String(decodedOutgoingBlob));
+                                outBlob = $"{(headerScheme == AuthenticationSchemes.Ntlm ? NegotiationInfoClass.NTLM : NegotiationInfoClass.Negotiate)} {Convert.ToBase64String(decodedOutgoingBlob)}";
                             }
 
                             if (!error)

--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -216,7 +216,7 @@ namespace System
             {
                 return (_object is string str) ? str.Substring(_index, _length) : Span.ToString();
             }
-            return string.Format("System.Memory<{0}>[{1}]", typeof(T).Name, _length);
+            return $"System.Memory<{typeof(T).Name}>[{_length}]";
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
@@ -652,12 +652,7 @@ namespace System.Numerics
         /// <summary>Returns a string that represents this matrix.</summary>
         /// <returns>The string representation of this matrix.</returns>
         /// <remarks>The numeric values in the returned string are formatted by using the conventions of the current culture. For example, for the en-US culture, the returned string might appear as <c>{ {M11:1.1 M12:1.2} {M21:2.1 M22:2.2} {M31:3.1 M32:3.2} }</c>.</remarks>
-        public override readonly string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "{{ {{M11:{0} M12:{1}}} {{M21:{2} M22:{3}}} {{M31:{4} M32:{5}}} }}",
-                                 M11, M12,
-                                 M21, M22,
-                                 M31, M32);
-        }
+        public override readonly string ToString() =>
+            $"{{ {{M11:{M11} M12:{M12}}} {{M21:{M21} M22:{M22}}} {{M31:{M31} M32:{M32}}} }}";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -2256,14 +2256,8 @@ namespace System.Numerics
         /// <summary>Returns a string that represents this matrix.</summary>
         /// <returns>The string representation of this matrix.</returns>
         /// <remarks>The numeric values in the returned string are formatted by using the conventions of the current culture. For example, for the en-US culture, the returned string might appear as <c>{ {M11:1.1 M12:1.2 M13:1.3 M14:1.4} {M21:2.1 M22:2.2 M23:2.3 M24:2.4} {M31:3.1 M32:3.2 M33:3.3 M34:3.4} {M41:4.1 M42:4.2 M43:4.3 M44:4.4} }</c>.</remarks>
-        public override readonly string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "{{ {{M11:{0} M12:{1} M13:{2} M14:{3}}} {{M21:{4} M22:{5} M23:{6} M24:{7}}} {{M31:{8} M32:{9} M33:{10} M34:{11}}} {{M41:{12} M42:{13} M43:{14} M44:{15}}} }}",
-                                 M11, M12, M13, M14,
-                                 M21, M22, M23, M24,
-                                 M31, M32, M33, M34,
-                                 M41, M42, M43, M44);
-        }
+        public override readonly string ToString() =>
+            $"{{ {{M11:{M11} M12:{M12} M13:{M13} M14:{M14}}} {{M21:{M21} M22:{M22} M23:{M23} M24:{M24}}} {{M31:{M31} M32:{M32} M33:{M33} M34:{M34}}} {{M41:{M41} M42:{M42} M43:{M43} M44:{M44}}} }}";
 
         private struct CanonicalBasis
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.cs
@@ -321,10 +321,7 @@ namespace System.Numerics
         /// <summary>Returns the string representation of this plane object.</summary>
         /// <returns>A string that represents this <see cref="System.Numerics.Plane" /> object.</returns>
         /// <remarks>The string representation of a <see cref="System.Numerics.Plane" /> object use the formatting conventions of the current culture to format the numeric values in the returned string. For example, a <see cref="System.Numerics.Plane" /> object whose string representation is formatted by using the conventions of the en-US culture might appear as <c>{Normal:&lt;1.1, 2.2, 3.3&gt; D:4.4}</c>.</remarks>
-        public override readonly string ToString()
-        {
-            CultureInfo ci = CultureInfo.CurrentCulture;
-            return string.Format(ci, "{{Normal:{0} D:{1}}}", Normal.ToString(), D.ToString(ci));
-        }
+        public override readonly string ToString() =>
+            $"{{Normal:{Normal.ToString()} D:{D.ToString()}}}";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.cs
@@ -635,9 +635,7 @@ namespace System.Numerics
         /// <summary>Returns a string that represents this quaternion.</summary>
         /// <returns>The string representation of this quaternion.</returns>
         /// <remarks>The numeric values in the returned string are formatted by using the conventions of the current culture. For example, for the en-US culture, the returned string might appear as <c>{X:1.1 Y:2.2 Z:3.3 W:4.4}</c>.</remarks>
-        public override readonly string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "{{X:{0} Y:{1} Z:{2} W:{3}}}", X, Y, Z, W);
-        }
+        public override readonly string ToString() =>
+            $"{{X:{X} Y:{Y} Z:{Z} W:{W}}}";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -145,7 +145,7 @@ namespace System
             {
                 return (_object is string str) ? str.Substring(_index, _length) : Span.ToString();
             }
-            return string.Format("System.ReadOnlyMemory<{0}>[{1}]", typeof(T).Name, _length);
+            return $"System.ReadOnlyMemory<{typeof(T).Name}>[{_length}]";
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -319,7 +319,7 @@ namespace System
             {
                 return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _pointer.Value), _length));
             }
-            return string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
+            return $"System.ReadOnlySpan<{typeof(T).Name}>[{_length}]";
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -260,7 +260,7 @@ namespace System.Reflection
                 if (s_loadfile.TryGetValue(normalizedPath, out result))
                     return result;
 
-                AssemblyLoadContext alc = new IndividualAssemblyLoadContext(string.Format("Assembly.LoadFile({0})", normalizedPath));
+                AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);
                 s_loadfile.Add(normalizedPath, result);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
@@ -45,7 +45,7 @@ namespace System.Reflection
             if (m_memberInfo == null)
                 return base.ToString()!;
 
-            return string.Format("{0} = {1}", MemberInfo.Name, TypedValue.ToString(ArgumentType != typeof(object)));
+            return $"{MemberInfo.Name} = {TypedValue.ToString(ArgumentType != typeof(object))}";
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ExceptionHandlingClause.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ExceptionHandlingClause.cs
@@ -16,11 +16,7 @@ namespace System.Reflection
         public virtual int FilterOffset => throw new InvalidOperationException(SR.Arg_EHClauseNotFilter);
         public virtual Type? CatchType => null;
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentUICulture,
-                "Flags={0}, TryOffset={1}, TryLength={2}, HandlerOffset={3}, HandlerLength={4}, CatchType={5}",
-                Flags, TryOffset, TryLength, HandlerOffset, HandlerLength, CatchType);
-        }
+        public override string ToString() =>
+            $"Flags={Flags}, TryOffset={TryOffset}, TryLength={TryLength}, HandlerOffset={HandlerOffset}, HandlerLength={HandlerLength}, CatchType={CatchType}";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -399,7 +399,7 @@ namespace System
             {
                 return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _pointer.Value), _length));
             }
-            return string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
+            return $"System.Span<{typeof(T).Name}>[{_length}]";
         }
 
         /// <summary>

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
@@ -773,7 +773,7 @@ namespace System.Xml
                             else
                             {
                                 DiagnosticUtility.DebugAssert(byteOffset + actualByteCount < bytes.Length,
-                                    string.Format("byteOffset {0} + actualByteCount {1} MUST BE < bytes.Length {2}", byteOffset, actualByteCount, bytes.Length));
+                                    $"byteOffset {byteOffset} + actualByteCount {actualByteCount} MUST BE < bytes.Length {bytes.Length}");
 
                                 // Request a few more bytes to get at least one character
                                 actualCharCount = decoder.GetChars(bytes, byteOffset + actualByteCount, 1, chars, charOffset);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataAggregator.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataAggregator.cs
@@ -28,7 +28,7 @@ namespace System.Reflection.Metadata.Ecma335
 
             public override string ToString()
             {
-                return string.Format("+0x{0:x} ~0x{1:x}", AggregateInserts, Updates);
+                return $"+0x{AggregateInserts:x} ~0x{Updates:x}";
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/CacheMemoryMonitor.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/CacheMemoryMonitor.cs
@@ -224,9 +224,7 @@ namespace System.Runtime.Caching
                 }
 
 #if PERF
-                Debug.WriteLine(string.Format("CacheMemoryMonitor.GetPercentToTrim: percent={0:N}, lastTrimPercent={1:N}{Environment.NewLine}",
-                                                    percent,
-                                                    lastTrimPercent));
+                Debug.WriteLine($"CacheMemoryMonitor.GetPercentToTrim: percent={percent:N}, lastTrimPercent={lastTrimPercent:N}{Environment.NewLine}");
 #endif
             }
             return percent;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -606,7 +606,7 @@ namespace System.Numerics
             {
                 if (fmt == 'g' || fmt == 'G' || fmt == 'r' || fmt == 'R')
                 {
-                    formatSpan = formatString = digits > 0 ? string.Format("D{0}", digits) : "D";
+                    formatSpan = formatString = digits > 0 ? $"D{digits}" : "D";
                 }
 
                 if (targetSpan)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -388,20 +388,11 @@ namespace System.Numerics
             return finalHash;
         }
 
-        public override string ToString()
-        {
-            return string.Format(CultureInfo.CurrentCulture, "({0}, {1})", m_real, m_imaginary);
-        }
+        public override string ToString() => $"({m_real}, {m_imaginary})";
 
-        public string ToString(string? format)
-        {
-            return string.Format(CultureInfo.CurrentCulture, "({0}, {1})", m_real.ToString(format, CultureInfo.CurrentCulture), m_imaginary.ToString(format, CultureInfo.CurrentCulture));
-        }
+        public string ToString(string? format) => ToString(format, null);
 
-        public string ToString(IFormatProvider? provider)
-        {
-            return string.Format(provider, "({0}, {1})", m_real, m_imaginary);
-        }
+        public string ToString(IFormatProvider? provider) => ToString(null, provider);
 
         public string ToString(string? format, IFormatProvider? provider)
         {

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
@@ -237,7 +237,7 @@ namespace System.Security.Cryptography.Xml
                 keyName = key.GetHashCode().ToString("x8", CultureInfo.InvariantCulture);
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "{0}#{1}", key.GetType().Name, keyName);
+            return $"{key.GetType().Name}#{keyName}";
         }
 
         /// <summary>
@@ -247,9 +247,7 @@ namespace System.Security.Cryptography.Xml
         {
             Debug.Assert(o != null, "o != null");
 
-            return string.Format(CultureInfo.InvariantCulture,
-                                 "{0}#{1}", o.GetType().Name,
-                                 o.GetHashCode().ToString("x8", CultureInfo.InvariantCulture));
+            return $"{o.GetType().Name}#{o.GetHashCode().ToString("x8", CultureInfo.InvariantCulture)}";
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -197,10 +197,7 @@ namespace System.Threading.Tasks.Dataflow
                 {
                     var displaySource = _source as IDebuggerDisplay;
                     var displayTarget = _target as IDebuggerDisplay;
-                    return string.Format("{0} Source=\"{1}\", Target=\"{2}\"",
-                        Common.GetNameForDebugger(this),
-                        displaySource != null ? displaySource.Content : _source,
-                        displayTarget != null ? displayTarget.Content : _target);
+                    return $"{Common.GetNameForDebugger(this)} Source=\"{(displaySource != null ? displaySource.Content : _source)}\", Target=\"{(displayTarget != null ? displayTarget.Content : _target)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
@@ -726,10 +723,7 @@ namespace System.Threading.Tasks.Dataflow
                 get
                 {
                     var displayTarget = _target as IDebuggerDisplay;
-                    return string.Format("{0} Message={1}, Target=\"{2}\"",
-                        Common.GetNameForDebugger(this),
-                        _messageValue,
-                        displayTarget != null ? displayTarget.Content : _target);
+                    return $"{Common.GetNameForDebugger(this)} Message={_messageValue}, Target=\"{(displayTarget != null ? displayTarget.Content : _target)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
@@ -1365,14 +1359,8 @@ namespace System.Threading.Tasks.Dataflow
             Task IDataflowBlock.Completion { get { throw new NotSupportedException(SR.NotSupported_MemberNotNeeded); } }
 
             /// <summary>The data to display in the debugger display attribute.</summary>
-            private object DebuggerDisplayContent
-            {
-                get
-                {
-                    return string.Format("{0} IsCompleted={1}",
-                        Common.GetNameForDebugger(this), base.Task.IsCompleted);
-                }
-            }
+            private object DebuggerDisplayContent => $"{Common.GetNameForDebugger(this)} IsCompleted={base.Task.IsCompleted}";
+
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
             object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
         }
@@ -1559,14 +1547,8 @@ namespace System.Threading.Tasks.Dataflow
             Task IDataflowBlock.Completion { get { throw new NotSupportedException(SR.NotSupported_MemberNotNeeded); } }
 
             /// <summary>The data to display in the debugger display attribute.</summary>
-            private object DebuggerDisplayContent
-            {
-                get
-                {
-                    return string.Format("{0} IsCompleted={1}",
-                        Common.GetNameForDebugger(this), base.Task.IsCompleted);
-                }
-            }
+            private object DebuggerDisplayContent => $"{Common.GetNameForDebugger(this)} IsCompleted={base.Task.IsCompleted}";
+
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
             object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
         }
@@ -1685,10 +1667,7 @@ namespace System.Threading.Tasks.Dataflow
                 {
                     var displayTarget = _target as IDebuggerDisplay;
                     var displaySource = _source as IDebuggerDisplay;
-                    return string.Format("{0} Target=\"{1}\", Source=\"{2}\"",
-                        Common.GetNameForDebugger(this),
-                        displayTarget != null ? displayTarget.Content : _target,
-                        displaySource != null ? displaySource.Content : _source);
+                    return $"{Common.GetNameForDebugger(this)} Target=\"{(displayTarget != null ? displayTarget.Content : _target)}\", Source=\"{(displaySource != null ? displaySource.Content : _source)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
@@ -2222,14 +2201,8 @@ namespace System.Threading.Tasks.Dataflow
             Task IDataflowBlock.Completion { get { throw new NotSupportedException(SR.NotSupported_MemberNotNeeded); } }
 
             /// <summary>The data to display in the debugger display attribute.</summary>
-            private object DebuggerDisplayContent
-            {
-                get
-                {
-                    return string.Format("{0} IsCompleted={1}",
-                        Common.GetNameForDebugger(this), base.Task.IsCompleted);
-                }
-            }
+            private object DebuggerDisplayContent => $"{Common.GetNameForDebugger(this)} IsCompleted={base.Task.IsCompleted}";
+
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
             object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
         }
@@ -2411,9 +2384,7 @@ namespace System.Threading.Tasks.Dataflow
                 get
                 {
                     var displaySource = _source as IDebuggerDisplay;
-                    return string.Format("Observers={0}, Block=\"{1}\"",
-                        _observersState.Observers.Count,
-                        displaySource != null ? displaySource.Content : _source);
+                    return $"Observers={_observersState.Observers.Count}, Block=\"{(displaySource != null ? displaySource.Content : _source)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
@@ -2671,8 +2642,7 @@ namespace System.Threading.Tasks.Dataflow
                 get
                 {
                     var displayTarget = _target as IDebuggerDisplay;
-                    return string.Format("Block=\"{0}\"",
-                        displayTarget != null ? displayTarget.Content : _target);
+                    return $"Block=\"{(displayTarget != null ? displayTarget.Content : _target)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
@@ -307,15 +307,9 @@ namespace System.Threading.Tasks.Dataflow
         }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, InputCount={1}",
-                    Common.GetNameForDebugger(this, _defaultTarget != null ? _defaultTarget.DataflowBlockOptions : _spscTarget!.DataflowBlockOptions),
-                    InputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{(Common.GetNameForDebugger(this, _defaultTarget != null ? _defaultTarget.DataflowBlockOptions : _spscTarget!.DataflowBlockOptions))}, InputCount={InputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
@@ -178,16 +178,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, BatchSize={1}, OutputCount={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    BatchSize,
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, BatchSize={BatchSize}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -1170,8 +1163,7 @@ namespace System.Threading.Tasks.Dataflow
                 get
                 {
                     var displayBatch = _owningBatch as IDebuggerDisplay;
-                    return string.Format("Block=\"{0}\"",
-                        displayBatch != null ? displayBatch.Content : _owningBatch);
+                    return $"Block=\"{(displayBatch != null ? displayBatch.Content : _owningBatch)}\"";
                 }
             }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
@@ -208,16 +208,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, BatchSize={1}, OutputCount={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    BatchSize,
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, BatchSize={BatchSize}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -472,16 +465,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, BatchSize={1}, OutputCount={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    BatchSize,
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, BatchSize={BatchSize}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -642,15 +628,9 @@ namespace System.Threading.Tasks.Dataflow.Internal
         Task IDataflowBlock.Completion { get { throw new NotSupportedException(SR.NotSupported_MemberNotNeeded); } }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0} InputCount={1}",
-                    Common.GetNameForDebugger(this),
-                    _messages.Count);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this)} InputCount={_messages.Count}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
@@ -443,16 +443,8 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, HasValue={1}, Value={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    HasValueForDebugger,
-                    ValueForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent => $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, HasValue={HasValueForDebugger}, Value={ValueForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -1200,8 +1192,7 @@ namespace System.Threading.Tasks.Dataflow
                 get
                 {
                     var displaySource = _owningSource as IDebuggerDisplay;
-                    return string.Format("Block=\"{0}\"",
-                        displaySource != null ? displaySource.Content : _owningSource);
+                    return $"Block=\"{(displaySource != null ? displaySource.Content : _owningSource)}\"";
                 }
             }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
@@ -425,15 +425,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, Count={1}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    CountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, Count={CountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
@@ -187,15 +187,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, OutputCount={1}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -420,15 +414,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0} OutputCount={1}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)} OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 
@@ -961,10 +949,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             get
             {
                 var displayJoin = _sharedResources._ownerJoin as IDebuggerDisplay;
-                return string.Format("{0} InputCount={1}, Join=\"{2}\"",
-                    Common.GetNameForDebugger(this),
-                    InputCountForDebugger,
-                    displayJoin != null ? displayJoin.Content : _sharedResources._ownerJoin);
+                return $"{Common.GetNameForDebugger(this)} InputCount={InputCountForDebugger}, Join=\"{(displayJoin != null ? displayJoin.Content : _sharedResources._ownerJoin)}\"";
             }
         }
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
@@ -1456,8 +1441,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             get
             {
                 var displayJoin = _ownerJoin as IDebuggerDisplay;
-                return string.Format("Block=\"{0}\"",
-                    displayJoin != null ? displayJoin.Content : _ownerJoin);
+                return $"Block=\"{(displayJoin != null ? displayJoin.Content : _ownerJoin)}\"";
             }
         }
     }

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
@@ -394,16 +394,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, InputCount={1}, OutputCount={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    InputCountForDebugger,
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, InputCount={InputCountForDebugger}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -627,16 +627,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _source.DataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, InputCount={1}, OutputCount={2}",
-                    Common.GetNameForDebugger(this, _source.DataflowBlockOptions),
-                    InputCountForDebugger,
-                    OutputCountForDebugger);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _source.DataflowBlockOptions)}, InputCount={InputCountForDebugger}, OutputCount={OutputCountForDebugger}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
@@ -511,14 +511,9 @@ namespace System.Threading.Tasks.Dataflow
         public override string ToString() { return Common.GetNameForDebugger(this, _dataflowBlockOptions); }
 
         /// <summary>The data to display in the debugger display attribute.</summary>
-        private object DebuggerDisplayContent
-        {
-            get
-            {
-                return string.Format("{0}, HasValue={1}, Value={2}",
-                    Common.GetNameForDebugger(this, _dataflowBlockOptions), HasValue, Value);
-            }
-        }
+        private object DebuggerDisplayContent =>
+            $"{Common.GetNameForDebugger(this, _dataflowBlockOptions)}, HasValue={HasValue}, Value={Value}";
+
         /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>
         object IDebuggerDisplay.Content { get { return DebuggerDisplayContent; } }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -983,8 +983,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             get
             {
                 var displaySource = _owningSource as IDebuggerDisplay;
-                return string.Format("Block=\"{0}\"",
-                    displaySource != null ? displaySource.Content : _owningSource);
+                return $"Block=\"{(displaySource != null ? displaySource.Content : _owningSource)}\"";
             }
         }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
@@ -377,8 +377,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             get
             {
                 var displayTarget = _owningTarget as IDebuggerDisplay;
-                return string.Format("Block=\"{0}\"",
-                    displayTarget != null ? displayTarget.Content : _owningTarget);
+                return $"Block=\"{(displayTarget != null ? displayTarget.Content : _owningTarget)}\"";
             }
         }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -822,8 +822,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             get
             {
                 var displayTarget = _owningTarget as IDebuggerDisplay;
-                return string.Format("Block=\"{0}\"",
-                    displayTarget != null ? displayTarget.Content : _owningTarget);
+                return $"Block=\"{(displayTarget != null ? displayTarget.Content : _owningTarget)}\"";
             }
         }
 

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/TargetRegistry.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/TargetRegistry.cs
@@ -365,10 +365,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 {
                     var displaySource = _owningSource as IDebuggerDisplay;
                     var displayTarget = _target as IDebuggerDisplay;
-                    return string.Format("{0} Source=\"{1}\", Target=\"{2}\"",
-                        Common.GetNameForDebugger(this),
-                        displaySource != null ? displaySource.Content : _owningSource,
-                        displayTarget != null ? displayTarget.Content : _target);
+                    return $"{Common.GetNameForDebugger(this)} Source=\"{(displaySource != null ? displaySource.Content : _owningSource)}\", Target=\"{(displayTarget != null ? displayTarget.Content : _target)}\"";
                 }
             }
             /// <summary>Gets the data to display in the debugger display attribute for this instance.</summary>


### PR DESCRIPTION
Mostly just replacing string.Format calls with equivalent interpolated string uses.  In some cases, I replaced lots of string creations with a StringBuilder or equivalent.