### PR TITLE
Support private SuperPMI MCH file stores

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -3053,6 +3053,7 @@ def process_base_jit_path_arg(coreclr_args):
     if coreclr_args.base_jit_path is not None:
         if not os.path.isfile(coreclr_args.base_jit_path):
             raise RuntimeError("Specified -base_jit_path does not point to a file")
+        coreclr_args.base_jit_path = os.path.abspath(coreclr_args.base_jit_path)
         return
 
     # We cache baseline jits under the following directory. Note that we can't create the full directory path


### PR DESCRIPTION
In addition to the default Azure Storage SuperPMI location,
support private data stores via the new `-private_store` argument
to `replay` and `asmdiffs`. Private stores are typically file
system locations, or, on Windows, UNC paths.

There already exists the `-mch_files` argument, which allows you
to use any specified set of MCH files. However, when specifying
`-mch_files`, only those files are used and the normal stores are
ignored.

The private store mechanism is more convenient in some scenarios,
as it treats the specified private stores equivalently to the default
Azure Storage store.

In addition, both private stores and `-mch_files` handle downloading
ZIP files, un-ZIPping, and caching their contents.

Finally, a new top-level command `upload-private` is introduced to
help create private stores by specifying a set of MCH files to
use. It ZIP compresses the files to upload.