### PR TITLE
[release/5.0] Fix pointer tearing in JIT_MemSet helper on ARM64

### DIFF
--- a/src/coreclr/src/vm/arm64/crthelpers.S
+++ b/src/coreclr/src/vm/arm64/crthelpers.S
@@ -12,7 +12,7 @@
 LEAF_ENTRY JIT_MemSet, _TEXT
     cbz x2, LOCAL_LABEL(JIT_MemSet_ret)
 
-    strb w1, [x0]
+    ldrb wzr, [x0]
 
     b C_PLTFUNC(memset)
 
@@ -23,7 +23,7 @@ LEAF_END_MARKED JIT_MemSet, _TEXT
 LEAF_ENTRY JIT_MemCpy, _TEXT
     cbz x2, LOCAL_LABEL(JIT_MemCpy_ret)
 
-    strb wzr, [x0]
+    ldrb wzr, [x0]
     ldrb wzr, [x1]
 
     b C_PLTFUNC(memcpy)


### PR DESCRIPTION
Fixes #49859

## Customer Impact

Intermittent crash during background GC on Linux ARM64. Customer app experiencing crash multiple times per day due to this issue.

## Description

The crash is caused by pointer tearing in JIT_MemSet helper (more details https://github.com/dotnet/runtime/issues/49859#issuecomment-807917101). The fix is to update the helper to use the pattern used on other platforms.

## Regression?

No. Bug introduce during initial Linux ARM64 port.

## Risk (see taxonomy)

Low. Customer verified that the fix works.