### PR TITLE
Fix buffering bug

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -539,7 +539,10 @@ namespace System.IO.Strategies
                         source.Slice(0, numBytes).CopyTo(_buffer!.AsSpan(_writePos));
                         _writePos += numBytes;
                         source = source.Slice(numBytes);
-                        arraySegment = arraySegment.Array != null ? arraySegment.Slice(numBytes) : arraySegment;
+                        if (arraySegment.Array != null)
+                        {
+                            arraySegment = arraySegment.Slice(numBytes);
+                        }
                     }
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -539,6 +539,7 @@ namespace System.IO.Strategies
                         source.Slice(0, numBytes).CopyTo(_buffer!.AsSpan(_writePos));
                         _writePos += numBytes;
                         source = source.Slice(numBytes);
+                        arraySegment = arraySegment.Array != null ? arraySegment.Slice(numBytes) : arraySegment;
                     }
                 }
 


### PR DESCRIPTION
private `ReadSpan` and `WriteSpan` methods of the `BufferedFileStreamStrategy` accept both a `Span` and an `ArraySegment` for reasons described here:

https://github.com/dotnet/runtime/blob/cf842f10d5fc2f26cd973adfe338c9835caa1b8c/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs#L203-L206

The bug that I've discovered while working on #50166 was that the `Span` was getting sliced, while `ArraySegment` was not. This was causing a serious bug (but the new strategy was not enabled yet so we are safe):

https://github.com/dotnet/runtime/blob/cf842f10d5fc2f26cd973adfe338c9835caa1b8c/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs#L538-L542

Read is free of this bug as the ArraySegment is properly sliced using `n`:

https://github.com/dotnet/runtime/blob/cf842f10d5fc2f26cd973adfe338c9835caa1b8c/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs#L258-L260

I've added a failing tests to the `FileStream` conformance tests:

```log
[xUnit.net 00:00:08.68]     System.IO.Tests.BufferedAsyncFileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(mode: SyncArray) [FAIL]
  Failed System.IO.Tests.BufferedAsyncFileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(mode: SyncArray) [13 ms]
  Error Message:
   Assert.Equal() Failure
Expected: 51
Actual:   52
  Stack Trace:
     at System.IO.Tests.FileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(ReadWriteMode mode) in C:\Projects\runtime\src\libraries\System.IO.FileSystem\tests\FileStream\FileStreamConformanceTests.cs:line 128
--- End of stack trace from previous location ---
[xUnit.net 00:00:08.76]     System.IO.Tests.BufferedSyncFileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(mode: SyncArray) [FAIL]
  Failed System.IO.Tests.BufferedSyncFileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(mode: SyncArray) [3 ms]
  Error Message:
   Assert.Equal() Failure
Expected: 51
Actual:   52
  Stack Trace:
     at System.IO.Tests.FileStreamStandaloneConformanceTests.NoDataIsLostWhenWritingToFile(ReadWriteMode mode) in C:\Projects\runtime\src\libraries\System.IO.FileSystem\tests\FileStream\FileStreamConformanceTests.cs:line 128
--- End of stack trace from previous location ---
```