### PR TITLE
Move NonDisposedSocket_SafeHandlesCollected to a non-parallel test collection

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -747,21 +747,6 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndAccept(null));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
-        {
-            TimeSpan timeout = TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout);
-            List<WeakReference> handles = await CreateHandlesAsync(clientAsync).WaitAsync(timeout);
-            await RetryHelper.ExecuteAsync(() => Task.Run(() =>
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Assert.Equal(0, handles.Count(h => h.IsAlive));
-            })).WaitAsync(timeout);
-        }
-
         [Fact]
         public void SocketWithDanglingReferenceDoesntHangFinalizerThread()
         {
@@ -776,6 +761,25 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             bool dummy = false;
             socket.SafeHandle.DangerousAddRef(ref dummy);
+        }
+    }
+
+    [Collection(nameof(NoParallelTests))]
+    public class DisposedSocketTestsNonParallel
+    {
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
+        {
+            TimeSpan timeout = TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout);
+            List<WeakReference> handles = await CreateHandlesAsync(clientAsync).WaitAsync(timeout);
+            await RetryHelper.ExecuteAsync(() => Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Assert.Equal(0, handles.Count(h => h.IsAlive));
+            })).WaitAsync(timeout);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Attempt to fix #50068.

The hang/timeout happens in `CreateHandlesAsync(clientAsync : true)`, which means we have trouble creating 100 connected socket pairs asynchronously on the CI machines, while running all the other tests in parallel.

While this might be a sign of a product bug in unlucky case, it's orthogonal to what `NonDisposedSocket_SafeHandlesCollected` is testing. I recommend to open a separate issue for the `CreateHandlesAsync` timeout after/if this PR is merged.

/cc @geoffkizer @wfurt 