### PR TITLE
Make ModuleTests.ResolveField/Method actually test something

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -212,6 +212,7 @@ namespace System.Reflection.Tests
         public void ResolveMethod(MethodInfo t)
         {
             Assert.Equal(t, Module.ResolveMethod(t.MetadataToken));
+            throw new Exception();
         }
 
         public static IEnumerable<object[]> BadResolveMethods =>
@@ -241,6 +242,7 @@ namespace System.Reflection.Tests
         public void ResolveField(FieldInfo t)
         {
             Assert.Equal(t, Module.ResolveField(t.MetadataToken));
+            throw new Exception();
         }
 
         public static IEnumerable<object[]> BadResolveFields =>

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -205,7 +205,7 @@ namespace System.Reflection.Tests
         }
 
         public static IEnumerable<object[]> Methods =>
-            typeof(ModuleTests).GetMethods().Select(m => new object[] { m });
+            typeof(ModuleTests).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly).Select(m => new object[] { m });
 
         [Theory]
         [MemberData(nameof(Methods))]
@@ -234,7 +234,7 @@ namespace System.Reflection.Tests
         }
 
         public static IEnumerable<object[]> Fields =>
-            typeof(ModuleTests).GetFields().Select(f => new object[] { f });
+            typeof(ModuleTests).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly).Select(f => new object[] { f });
 
         [Theory]
         [MemberData(nameof(Fields))]

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -205,14 +205,13 @@ namespace System.Reflection.Tests
         }
 
         public static IEnumerable<object[]> Methods =>
-            Module.GetMethods().Select(m => new object[] { m });
+            typeof(ModuleTests).GetMethods().Select(m => new object[] { m });
 
         [Theory]
         [MemberData(nameof(Methods))]
         public void ResolveMethod(MethodInfo t)
         {
             Assert.Equal(t, Module.ResolveMethod(t.MetadataToken));
-            throw new Exception();
         }
 
         public static IEnumerable<object[]> BadResolveMethods =>
@@ -235,14 +234,13 @@ namespace System.Reflection.Tests
         }
 
         public static IEnumerable<object[]> Fields =>
-            Module.GetFields().Select(f => new object[] { f });
+            typeof(ModuleTests).GetFields().Select(f => new object[] { f });
 
         [Theory]
         [MemberData(nameof(Fields))]
         public void ResolveField(FieldInfo t)
         {
             Assert.Equal(t, Module.ResolveField(t.MetadataToken));
-            throw new Exception();
         }
 
         public static IEnumerable<object[]> BadResolveFields =>


### PR DESCRIPTION
There are no global fields/methods in the module so this wasn't testing anything.

Looks like the version of the runner used in testing doesn't consider this an error. The single file test runner does.