### PR TITLE
Add a missing fclose in jitutils MethodSet constructor

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1707,6 +1707,11 @@ MethodSet::MethodSet(const WCHAR* filename, HostAllocator alloc) : m_pInfos(null
         }
     }
 
+    if (fclose(methodSetFile))
+    {
+        JITDUMP("Unable to close %ws\n", filename);
+    }
+
     if (m_pInfos == nullptr)
     {
         JITDUMP("No methods read from %ws\n", filename);


### PR DESCRIPTION
The file methodSetFile is never used outside of the constructor, but the file is never closed, leaking a resource handle. Lets close it manually.