### PR TITLE
Ensure System.Resources.Extensions targets are applied transitively

### DIFF
--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -60,6 +60,7 @@
     <WriteLinesToFile File="$(_packageTargetsFile)" Overwrite="true" Lines="$(_packageTargetsFileContent)" />
     <ItemGroup>
       <FilesToPackage Include="$(_packageTargetsFile)" TargetPath="build/$(TargetFramework)" TargetFramework="$(TargetFramework)" />
+      <FilesToPackage Include="$(_packageTargetsFile)" TargetPath="buildTransitive/$(TargetFramework)" TargetFramework="$(TargetFramework)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Copy targets to buildTransitive so that they will be applied from
transitive package/project references.  We maintain build folder so that
old nuget clients can still get the build targets.

Fixes https://github.com/dotnet/runtime/issues/50286