### PR TITLE
Propagate XUnitMethodName/XUnitClassName properties to Android test runner

### DIFF
--- a/eng/testing/AndroidRunnerTemplate.sh
+++ b/eng/testing/AndroidRunnerTemplate.sh
@@ -10,7 +10,7 @@ TEST_NAME=$4
 XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
 
 if [ -n "$5" ]; then
-    EXPECTED_EXIT_CODE="--expected-exit-code $5"
+    ADDITIONAL_ARGS=${@:5}
 fi
 
 cd $EXECUTION_DIR
@@ -41,7 +41,7 @@ $HARNESS_RUNNER android test                \
     --app="$EXECUTION_DIR/bin/$TEST_NAME.apk" \
     --output-directory="$XHARNESS_OUT" \
     --timeout=1800 \
-    $EXPECTED_EXIT_CODE
+    $ADDITIONAL_ARGS
 
 _exitCode=$?
 

--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -13,7 +13,7 @@ XCODE_PATH=$(xcode-select -p)/../..
 
 if [ -n "$5" ]; then
     XHARNESS_CMD="run"
-    EXPECTED_EXIT_CODE="--expected-exit-code $5"
+    ADDITIONAL_ARGS=${@:5}
 fi
 
 if [[ "$TARGET_OS" == "MacCatalyst" ]]; then TARGET=maccatalyst; fi
@@ -62,7 +62,7 @@ $HARNESS_RUNNER apple $XHARNESS_CMD    \
     --targets="$TARGET" \
     --xcode="$XCODE_PATH"   \
     --output-directory="$XHARNESS_OUT" \
-    $EXPECTED_EXIT_CODE
+    $ADDITIONAL_ARGS
 
 _exitCode=$?
 

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -50,6 +50,16 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AdditionalXHarnessArguments Condition="'$(ExpectedExitCode)' != ''">--expected-exit-code $(ExpectedExitCode)</AdditionalXHarnessArguments>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Android'">
+    <!-- The -arg flag for xharness passes the arguments along to the instrumentation app -->
+    <AdditionalXHarnessArguments Condition="'$(XUnitMethodName)' != ''">$(AdditionalXHarnessArguments) --arg=-m=$(XUnitMethodName)</AdditionalXHarnessArguments>
+    <AdditionalXHarnessArguments Condition="'$(XUnitClassName)' != ''">$(AdditionalXHarnessArguments) --arg=-c=$(XUnitClassName)</AdditionalXHarnessArguments>
+  </PropertyGroup>
+
   <UsingTask Condition="'$(RunAOTCompilation)' == 'true'" TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
   <Import Condition="'$(RunAOTCompilation)' == 'true'" Project="$(MonoAOTCompilerDir)MonoAOTCompiler.props" />
 

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -96,7 +96,7 @@
       <RunTestsCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                   $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">$(RunTestsCommand) --runtime-path "$(TestHostRootPath.TrimEnd('\/'))"</RunTestsCommand>
       <RunTestsCommand Condition="'$(TestRspFile)' != '' and '$(RuntimeFlavor)' != 'Mono'">$(RunTestsCommand) --rsp-file "$(TestRspFile)"</RunTestsCommand>
-      <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture) $(TargetOS) $(TestProjectName) $(ExpectedExitCode)</RunTestsCommand>
+      <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture) $(TargetOS) $(TestProjectName) $(AdditionalXHarnessArguments)</RunTestsCommand>
       <RunTestsCommand Condition="'$(TargetOS)' == 'Browser'">"$(RunScriptOutputPath)" $(JSEngine) $(AssemblyName).dll $(Scenario)</RunTestsCommand>
     </PropertyGroup>
 


### PR DESCRIPTION
In combination with dotnet/xharness#520, this should allow filtering tests through msbuild properties. For example:
```
dotnet build <repo_root>\src\libraries\<project>\tests /t:Test /p:XunitMethodName=<fully_qualified_method_name>
```

Without the xharness change, this change should be benign - additional data would be passed to the Android test app, but nothing would be done with it.

cc @steveisok @jkoritzinsky 