### PR TITLE
[wasm] Fix order of include paths, to have the obj dir first

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -194,7 +194,6 @@
     <PlatformManifestFileEntry Include="corebindings.c" IsNative="true" />
     <PlatformManifestFileEntry Include="driver.c" IsNative="true" />
     <PlatformManifestFileEntry Include="pinvoke.c" IsNative="true" />
-    <PlatformManifestFileEntry Include="pinvoke-table.h" IsNative="true" />
     <PlatformManifestFileEntry Include="pinvoke.h" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-flags.txt" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-version.txt" IsNative="true" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -144,7 +144,7 @@ icu-files: $(wildcard $(ICU_LIBDIR)/*.dat) $(ICU_LIBDIR)/libicuuc.a $(ICU_LIBDIR
 source-files: runtime/driver.c runtime/pinvoke.c runtime/corebindings.c runtime/binding_support.js runtime/dotnet_support.js runtime/library_mono.js $(SYSTEM_NATIVE_LIBDIR)/pal_random.js | $(NATIVE_BIN_DIR)/src
 	cp $^ $(NATIVE_BIN_DIR)/src
 
-header-files: runtime/pinvoke.h $(BUILDS_OBJ_DIR)/pinvoke-table.h | $(NATIVE_BIN_DIR)/include/wasm
+header-files: runtime/pinvoke.h | $(NATIVE_BIN_DIR)/include/wasm
 	cp $^ $(NATIVE_BIN_DIR)/include/wasm
 
 # Helper targets

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -421,7 +421,6 @@
       <_WasmPInvokeModules Include="libSystem.IO.Compression.Native" />
       <_WasmPInvokeModules Include="libSystem.Globalization.Native" />
    </ItemGroup>
-   <!--This pinvoke-table.h will be used instead of the one in the runtime pack because of -I$(_WasmIntermediateOutputPath) -->
    <PInvokeTableGenerator
      Modules="@(_WasmPInvokeModules)"
      Assemblies="@(_WasmAssembliesInternal)"

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -471,8 +471,8 @@
 
    <ItemGroup>
      <_EmccIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
-     <_EmccIncludePaths Include="$(_WasmIncludeDir)mono-2.0" />
-     <_EmccIncludePaths Include="$(_WasmIncludeDir)wasm" />
+     <_EmccIncludePaths Include="$(_WasmRuntimePackIncludeDir)mono-2.0" />
+     <_EmccIncludePaths Include="$(_WasmRuntimePackIncludeDir)wasm" />
    </ItemGroup>
 
    <PropertyGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -470,19 +470,16 @@
    <Error Condition="'$(RunAOTCompilation)' == 'true' and @(_BitcodeFile->Count()) != @(_AOTAssemblies->Count())"
           Text="Bug: Number of aot assemblies doesn't match the number of generated bitcode files. BitcodeFiles: @(_BitcodeFile->Count()) vs Assemblies: @(_AOTAssemblies->Count())" />
 
+   <ItemGroup>
+     <_EmccIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
+     <_EmccIncludePaths Include="$(_WasmIncludeDir)mono-2.0" />
+     <_EmccIncludePaths Include="$(_WasmIncludeDir)wasm" />
+   </ItemGroup>
+
    <PropertyGroup>
      <EmccCFlags>$(EmccFlags) -DCORE_BINDINGS -DGEN_PINVOKE=1</EmccCFlags>
+     <EmccCFlags>$(EmccCFlags) @(_EmccIncludePaths -> '&quot;-I%(Identity)&quot;', ' ')</EmccCFlags>
      <EmccCFlags Condition="'$(WasmNativeDebugSymbols)' == 'true'">$(EmccCFlags) -g</EmccCFlags>
-
-     <!--
-          For path c:\foo\bar\ quoting would make it "c:\foo\bar\"
-          .. which escapes the closing quote. So, instead make it
-            c:\foo\bar\ -> "c:\foo\bar\."
-     -->
-     <EmccCFlags Condition="$(_WasmIntermediateOutputPath.EndsWith('\')) ">$(EmccCFlags) "-I$(_WasmIntermediateOutputPath)."</EmccCFlags>
-     <EmccCFlags Condition="!$(_WasmIntermediateOutputPath.EndsWith('\'))">$(EmccCFlags) "-I$(_WasmIntermediateOutputPath)"</EmccCFlags>
-
-     <EmccCFlags>$(EmccCFlags) &quot;-I$(_WasmRuntimePackIncludeDir)mono-2.0&quot; &quot;-I$(_WasmRuntimePackIncludeDir)wasm&quot;</EmccCFlags>
 
      <EmccLDFlags>$(EmccFlags) -s TOTAL_MEMORY=536870912</EmccLDFlags>
      <_WasmOptCommand>$([MSBuild]::NormalizePath('$(EmSdkUpstreamBinPath)', 'wasm-opt$(_ExeExt)'))</_WasmOptCommand>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -180,7 +180,7 @@
           Lines="$(ActualEmccVersion)"
           Overwrite="true" />
 
-    <Copy SourceFiles="$(MonoObjDir)\pinvoke-table.h;runtime\pinvoke.h"
+    <Copy SourceFiles="runtime\pinvoke.h"
           DestinationFolder="$(NativeBinDir)\include\wasm"
           SkipUnchangedFiles="true" />
     


### PR DESCRIPTION
this regressed recently, and we started using `pinvoke-table.h`, and
`icall-table.h` from the runtime pack instead of from the obj dir.

To fix:
- `pinvoke-table.h` should not be included in the runtime pack anyway, so remove that
- Fix the order of the include paths