### PR TITLE
Fix SuperPMI handling of missing data for asm diffs

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -210,6 +210,7 @@ void ProcessChildStdOut(const CommandLine::Options& o,
                         int*                        jitted,
                         int*                        failed,
                         int*                        excluded,
+                        int*                        missing,
                         int*                        diffs,
                         bool*                       usageError)
 {
@@ -253,13 +254,13 @@ void ProcessChildStdOut(const CommandLine::Options& o,
         }
         else if (strncmp(buff, g_AllFormatStringFixedPrefix, strlen(g_AllFormatStringFixedPrefix)) == 0)
         {
-            int childLoaded = 0, childJitted = 0, childFailed = 0, childExcluded = 0;
+            int childLoaded = 0, childJitted = 0, childFailed = 0, childExcluded = 0, childMissing = 0;
             if (o.applyDiff)
             {
                 int childDiffs = 0;
                 int converted  = sscanf_s(buff, g_AsmDiffsSummaryFormatString, &childLoaded, &childJitted, &childFailed,
-                                         &childExcluded, &childDiffs);
-                if (converted != 5)
+                                         &childExcluded, &childMissing, &childDiffs);
+                if (converted != 6)
                 {
                     LogError("Couldn't parse status message: \"%s\"", buff);
                     continue;
@@ -269,8 +270,8 @@ void ProcessChildStdOut(const CommandLine::Options& o,
             else
             {
                 int converted =
-                    sscanf_s(buff, g_SummaryFormatString, &childLoaded, &childJitted, &childFailed, &childExcluded);
-                if (converted != 4)
+                    sscanf_s(buff, g_SummaryFormatString, &childLoaded, &childJitted, &childFailed, &childExcluded, &childMissing);
+                if (converted != 5)
                 {
                     LogError("Couldn't parse status message: \"%s\"", buff);
                     continue;
@@ -281,6 +282,7 @@ void ProcessChildStdOut(const CommandLine::Options& o,
             *jitted += childJitted;
             *failed += childFailed;
             *excluded += childExcluded;
+            *missing += childMissing;
         }
     }
 
@@ -616,14 +618,14 @@ int doParallelSuperPMI(CommandLine::Options& o)
 
         bool usageError = false; // variable to flag if we hit a usage error in SuperPMI
 
-        int loaded = 0, jitted = 0, failed = 0, excluded = 0, diffs = 0;
+        int loaded = 0, jitted = 0, failed = 0, excluded = 0, missing = 0, diffs = 0;
 
         // Read the stderr files and log them as errors
         // Read the stdout files and parse them for counts and log any MISSING or ISSUE errors
         for (int i = 0; i < o.workerCount; i++)
         {
             ProcessChildStdErr(arrStdErrorPath[i]);
-            ProcessChildStdOut(o, arrStdOutputPath[i], &loaded, &jitted, &failed, &excluded, &diffs, &usageError);
+            ProcessChildStdOut(o, arrStdOutputPath[i], &loaded, &jitted, &failed, &excluded, &missing, &diffs, &usageError);
             if (usageError)
                 break;
         }
@@ -644,11 +646,11 @@ int doParallelSuperPMI(CommandLine::Options& o)
         {
             if (o.applyDiff)
             {
-                LogInfo(g_AsmDiffsSummaryFormatString, loaded, jitted, failed, excluded, diffs);
+                LogInfo(g_AsmDiffsSummaryFormatString, loaded, jitted, failed, excluded, missing, diffs);
             }
             else
             {
-                LogInfo(g_SummaryFormatString, loaded, jitted, failed, excluded);
+                LogInfo(g_SummaryFormatString, loaded, jitted, failed, excluded, missing);
             }
         }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -25,8 +25,8 @@ extern int doParallelSuperPMI(CommandLine::Options& o);
 // There must be a single, fixed prefix common to all strings, to ease the determination of when
 // to parse the string fully.
 const char* const g_AllFormatStringFixedPrefix  = "Loaded ";
-const char* const g_SummaryFormatString         = "Loaded %d  Jitted %d  FailedCompile %d Excluded %d";
-const char* const g_AsmDiffsSummaryFormatString = "Loaded %d  Jitted %d  FailedCompile %d Excluded %d Diffs %d";
+const char* const g_SummaryFormatString         = "Loaded %d  Jitted %d  FailedCompile %d Excluded %d Missing %d";
+const char* const g_AsmDiffsSummaryFormatString = "Loaded %d  Jitted %d  FailedCompile %d Excluded %d Missing %d Diffs %d";
 
 //#define SuperPMI_ChewMemory 0x7FFFFFFF //Amount of address space to consume on startup
 
@@ -576,11 +576,11 @@ int __cdecl main(int argc, char* argv[])
     if (o.applyDiff)
     {
         LogInfo(g_AsmDiffsSummaryFormatString, loadedCount, jittedCount, failToReplayCount, excludedCount,
-                jittedCount - failToReplayCount - matchCount);
+                missingCount, jittedCount - failToReplayCount - matchCount);
     }
     else
     {
-        LogInfo(g_SummaryFormatString, loadedCount, jittedCount, failToReplayCount, excludedCount);
+        LogInfo(g_SummaryFormatString, loadedCount, jittedCount, failToReplayCount, excludedCount, missingCount);
     }
 
     st2.Stop();
@@ -607,7 +607,7 @@ int __cdecl main(int argc, char* argv[])
     {
         result = SpmiResult::Error;
     }
-    else if (o.applyDiff && matchCount != jittedCount)
+    else if (o.applyDiff && (matchCount != jittedCount - missingCount))
     {
         result = SpmiResult::Diffs;
     }


### PR DESCRIPTION
Adjust the error code determination for asm diffs to not report
diffs if all the compilation failures were due to missing data
in the MCH files.

Update the SuperPMI end status line to report the count of MC
compilation failures due to missing data (and adjust parallel
SuperPMI to handle it as well).

As a result, with `superpmi.py asmdiffs` you won't see the message
"Asm diffs" if all the failures were due to missing data.