### PR TITLE
Add list of prerequisites for Gentoo

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -57,7 +57,7 @@ libssl-dev libnuma-dev libkrb5-dev zlib1g-dev ninja-build
 ```
 
 You now have all the required components.
-
+*Unsupported OSes*:
 In case you have Gentoo you can run following commands:
 
 ```

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -57,3 +57,9 @@ libssl-dev libnuma-dev libkrb5-dev zlib1g-dev ninja-build
 ```
 
 You now have all the required components.
+
+In case you have Gentoo you can run following commands:
+
+```
+emerge --ask clang dev-util/lttng-ust app-crypt/mit-krb5
+```


### PR DESCRIPTION
I have fairly vanilla Gentoo with desktop environment, and these are only packages which I have to install in order to build runtime using `./build.sh`.