### PR TITLE
[mono] Remove domain lock

### DIFF
--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -605,13 +605,7 @@ exit:
 gboolean
 mono_domain_owns_vtable_slot (MonoDomain *domain, gpointer vtable_slot)
 {
-	gboolean res;
-	MonoMemoryManager *memory_manager = mono_mem_manager_get_ambient ();
-
-	mono_mem_manager_lock (memory_manager);
-	res = mono_mempool_contains_addr (memory_manager->mp, vtable_slot);
-	mono_mem_manager_unlock (memory_manager);
-	return res;
+	return mono_mem_manager_mp_contains_addr (mono_mem_manager_get_ambient (), vtable_slot);
 }
 
 gboolean

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -256,13 +256,6 @@ typedef struct _MonoJitCodeHash MonoJitCodeHash;
 
 struct _MonoDomain {
 	/*
-	 * This lock must never be taken before the loader lock,
-	 * i.e. if both are taken by the same thread, the loader lock
-	 * must taken first.
-	 */
-	MonoCoopMutex    lock;
-
-	/*
 	 * keep all the managed objects close to each other for the precise GC
 	 * For the Boehm GC we additionally keep close also other GC-tracked pointers.
 	 */
@@ -319,9 +312,6 @@ mono_domain_assemblies_unlock (MonoDomain *domain)
 }
 
 typedef MonoDomain* (*MonoLoadFunc) (const char *filename, const char *runtime_version);
-
-void mono_domain_lock (MonoDomain *domain);
-void mono_domain_unlock (MonoDomain *domain);
 
 void
 mono_install_runtime_load  (MonoLoadFunc func);

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -315,8 +315,6 @@ mono_domain_create (void)
 
 	domain->domain_assemblies = NULL;
 
-	mono_coop_mutex_init_recursive (&domain->lock);
-
 	mono_coop_mutex_init_recursive (&domain->assemblies_lock);
 
 	mono_appdomains_lock ();
@@ -1254,18 +1252,6 @@ const MonoRuntimeInfo*
 mono_get_runtime_info (void)
 {
 	return current_runtime;
-}
-
-void
-mono_domain_lock (MonoDomain *domain)
-{
-	mono_locks_coop_acquire (&domain->lock, DomainLock);
-}
-
-void
-mono_domain_unlock (MonoDomain *domain)
-{
-	mono_locks_coop_release (&domain->lock, DomainLock);
 }
 
 GPtrArray*

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -86,7 +86,6 @@ struct _MonoAssemblyLoadContext {
 };
 
 struct _MonoMemoryManager {
-	MonoDomain *domain;
 	// Whether the MemoryManager can be unloaded on netcore; should only be set at creation
 	gboolean collectible;
 	// Whether this is a singleton or generic MemoryManager

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -98,9 +98,14 @@ struct _MonoMemoryManager {
 	// Currently unused, we take the domain lock instead
 	MonoCoopMutex lock;
 
-	MonoMemPool *mp;
+	// Private, don't access directly
+	MonoMemPool *_mp;
 	MonoCodeManager *code_mp;
 	LockFreeMempool *lock_free_mp;
+
+	// Protects access to _mp
+	// Non-coop, non-recursive
+	mono_mutex_t mp_mutex;
 
 	GPtrArray *class_vtable_array;
 	GHashTable *generic_virtual_cases;
@@ -238,13 +243,7 @@ void *
 mono_mem_manager_alloc (MonoMemoryManager *memory_manager, guint size);
 
 void *
-mono_mem_manager_alloc_nolock (MonoMemoryManager *memory_manager, guint size);
-
-void *
 mono_mem_manager_alloc0 (MonoMemoryManager *memory_manager, guint size);
-
-void *
-mono_mem_manager_alloc0_nolock (MonoMemoryManager *memory_manager, guint size);
 
 gpointer
 mono_mem_manager_alloc0_lock_free (MonoMemoryManager *memory_manager, guint size);
@@ -270,6 +269,9 @@ mono_mem_manager_strdup (MonoMemoryManager *memory_manager, const char *s);
 
 void
 mono_mem_manager_free_debug_info (MonoMemoryManager *memory_manager);
+
+gboolean
+mono_mem_manager_mp_contains_addr (MonoMemoryManager *memory_manager, gpointer addr);
 
 G_END_DECLS
 

--- a/src/mono/mono/metadata/lock-tracer.h
+++ b/src/mono/mono/metadata/lock-tracer.h
@@ -15,7 +15,6 @@ typedef enum {
 	InvalidLock = 0,
 	LoaderLock,
 	ImageDataLock,
-	DomainLock,
 	DomainAssembliesLock,
 	DomainJitCodeHashLock,
 	IcallLock,

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -95,7 +95,6 @@ memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
 {
 	MonoDomain *domain = mono_get_root_domain ();
 
-	memory_manager->domain = domain;
 	memory_manager->freeing = FALSE;
 
 	mono_coop_mutex_init_recursive (&memory_manager->lock);
@@ -218,15 +217,13 @@ mono_mem_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, gbo
 void
 mono_mem_manager_lock (MonoMemoryManager *memory_manager)
 {
-	//mono_coop_mutex_lock (&memory_manager->lock);
-	mono_domain_lock (memory_manager->domain);
+	mono_coop_mutex_lock (&memory_manager->lock);
 }
 
 void
 mono_mem_manager_unlock (MonoMemoryManager *memory_manager)
 {
-	//mono_coop_mutex_unlock (&memory_manager->lock);
-	mono_domain_unlock (memory_manager->domain);
+	mono_coop_mutex_unlock (&memory_manager->lock);
 }
 
 static inline void

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -99,8 +99,9 @@ memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
 	memory_manager->freeing = FALSE;
 
 	mono_coop_mutex_init_recursive (&memory_manager->lock);
+	mono_os_mutex_init (&memory_manager->mp_mutex);
 
-	memory_manager->mp = mono_mempool_new ();
+	memory_manager->_mp = mono_mempool_new ();
 	memory_manager->code_mp = mono_code_manager_new ();
 	memory_manager->lock_free_mp = lock_free_mempool_new ();
 
@@ -183,15 +184,15 @@ memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
 	mono_coop_mutex_destroy (&memory_manager->lock);
 
 	if (debug_unload) {
-		mono_mempool_invalidate (memory_manager->mp);
+		mono_mempool_invalidate (memory_manager->_mp);
 		mono_code_manager_invalidate (memory_manager->code_mp);
 	} else {
 #ifndef DISABLE_PERFCOUNTERS
 		/* FIXME: use an explicit subtraction method as soon as it's available */
-		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (memory_manager->mp));
+		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (memory_manager->_mp));
 #endif
-		mono_mempool_destroy (memory_manager->mp);
-		memory_manager->mp = NULL;
+		mono_mempool_destroy (memory_manager->_mp);
+		memory_manager->_mp = NULL;
 		mono_code_manager_destroy (memory_manager->code_mp);
 		memory_manager->code_mp = NULL;
 	}
@@ -228,25 +229,31 @@ mono_mem_manager_unlock (MonoMemoryManager *memory_manager)
 	mono_domain_unlock (memory_manager->domain);
 }
 
+static inline void
+alloc_lock (MonoMemoryManager *memory_manager)
+{
+	mono_os_mutex_lock (&memory_manager->mp_mutex);
+}
+
+static inline void
+alloc_unlock (MonoMemoryManager *memory_manager)
+{
+	mono_os_mutex_unlock (&memory_manager->mp_mutex);
+}
+
 void *
 mono_mem_manager_alloc (MonoMemoryManager *memory_manager, guint size)
 {
 	void *res;
 
-	mono_mem_manager_lock (memory_manager);
-	res = mono_mem_manager_alloc_nolock (memory_manager, size);
-	mono_mem_manager_unlock (memory_manager);
-
-	return res;
-}
-
-void *
-mono_mem_manager_alloc_nolock (MonoMemoryManager *memory_manager, guint size)
-{
+	alloc_lock (memory_manager);
 #ifndef DISABLE_PERFCOUNTERS
 	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
-	return mono_mempool_alloc (memory_manager->mp, size);
+	res = mono_mempool_alloc (memory_manager->_mp, size);
+	alloc_unlock (memory_manager);
+
+	return res;
 }
 
 void *
@@ -254,20 +261,14 @@ mono_mem_manager_alloc0 (MonoMemoryManager *memory_manager, guint size)
 {
 	void *res;
 
-	mono_mem_manager_lock (memory_manager);
-	res = mono_mem_manager_alloc0_nolock (memory_manager, size);
-	mono_mem_manager_unlock (memory_manager);
-
-	return res;
-}
-
-void *
-mono_mem_manager_alloc0_nolock (MonoMemoryManager *memory_manager, guint size)
-{
+	alloc_lock (memory_manager);
 #ifndef DISABLE_PERFCOUNTERS
 	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
-	return mono_mempool_alloc0 (memory_manager->mp, size);
+	res = mono_mempool_alloc0 (memory_manager->_mp, size);
+	alloc_unlock (memory_manager);
+
+	return res;
 }
 
 char*
@@ -275,10 +276,21 @@ mono_mem_manager_strdup (MonoMemoryManager *memory_manager, const char *s)
 {
 	char *res;
 
-	mono_mem_manager_lock (memory_manager);
-	res = mono_mempool_strdup (memory_manager->mp, s);
-	mono_mem_manager_unlock (memory_manager);
+	alloc_lock (memory_manager);
+	res = mono_mempool_strdup (memory_manager->_mp, s);
+	alloc_unlock (memory_manager);
 
+	return res;
+}
+
+gboolean
+mono_mem_manager_mp_contains_addr (MonoMemoryManager *memory_manager, gpointer addr)
+{
+	gboolean res;
+
+	alloc_lock (memory_manager);
+	res = mono_mempool_contains_addr (memory_manager->_mp, addr);
+	alloc_unlock (memory_manager);
 	return res;
 }
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1468,7 +1468,7 @@ static MonoImtBuilderEntry*
 get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_slot);
 
 /*
- * LOCKING: requires the loader and domain locks.
+ * LOCKING: assume the loader lock is held
  *
 */
 static void
@@ -1626,7 +1626,9 @@ build_imt (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_interf
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
+	mono_loader_lock ();
 	build_imt_slots (klass, vt, imt, extra_interfaces, -1);
+	mono_loader_unlock ();
 }
 
 /**
@@ -1636,7 +1638,7 @@ build_imt (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_interf
  * Fill the given \p imt_slot in the IMT table of \p vtable with
  * a trampoline or a trampoline for the case of collisions.
  * This is part of the internal mono API.
- * LOCKING: Take the domain lock.
+ * LOCKING: Take the loader lock.
  */
 void
 mono_vtable_build_imt_slot (MonoVTable* vtable, int imt_slot)
@@ -1652,12 +1654,10 @@ mono_vtable_build_imt_slot (MonoVTable* vtable, int imt_slot)
 	 * Update and heck needs to ahppen inside the proper domain lock, as all
 	 * the changes made to a MonoVTable.
 	 */
-	mono_loader_lock (); /*FIXME build_imt_slots requires the loader lock.*/
-	mono_domain_lock (vtable->domain);
+	mono_loader_lock ();
 	/* we change the slot only if it wasn't changed from the generic imt trampoline already */
 	if (!callbacks.imt_entry_inited (vtable, imt_slot))
 		build_imt_slots (vtable->klass, vtable, imt, NULL, imt_slot);
-	mono_domain_unlock (vtable->domain);
 	mono_loader_unlock ();
 }
 
@@ -1684,9 +1684,8 @@ get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_sl
 
   	GenericVirtualCase *list;
  	MonoImtBuilderEntry *entries;
-	MonoDomain *domain = mono_get_root_domain ();
 
- 	mono_domain_lock (domain);
+	mono_mem_manager_lock (mem_manager);
  	if (!mem_manager->generic_virtual_cases)
  		mem_manager->generic_virtual_cases = g_hash_table_new (mono_aligned_addr_hash, NULL);
  
@@ -1709,7 +1708,7 @@ get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_sl
  		entries = entry;
  	}
  
- 	mono_domain_unlock (domain);
+	mono_mem_manager_unlock (mem_manager);
  
  	/* FIXME: Leaking memory ? */
  	return entries;
@@ -1740,10 +1739,11 @@ mono_method_add_generic_virtual_invocation (MonoVTable *vtable,
 	GenericVirtualCase *gvc, *list;
 	MonoImtBuilderEntry *entries;
 	GPtrArray *sorted;
-	MonoDomain *domain = mono_get_root_domain ();
 	MonoMemoryManager *mem_manager = m_class_get_mem_manager (vtable->klass);
 
-	mono_domain_lock (domain);
+	mono_loader_lock ();
+
+	mono_mem_manager_lock (mem_manager);
 	if (!mem_manager->generic_virtual_cases)
 		mem_manager->generic_virtual_cases = g_hash_table_new (mono_aligned_addr_hash, NULL);
 
@@ -1774,6 +1774,8 @@ mono_method_add_generic_virtual_invocation (MonoVTable *vtable,
 
 		num_added++;
 	}
+
+	mono_mem_manager_unlock (mem_manager);
 
 	if (++gvc->count == THUNK_THRESHOLD) {
 		gpointer *old_thunk = (void **)*vtable_slot;
@@ -1812,7 +1814,7 @@ mono_method_add_generic_virtual_invocation (MonoVTable *vtable,
 		}
 	}
 
-	mono_domain_unlock (domain);
+	mono_loader_unlock ();
 }
 
 static MonoVTable *mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error);
@@ -2173,7 +2175,6 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 		MonoReflectionTypeHandle vt_type = mono_type_get_object_handle (m_class_get_byval_arg (klass), error);
 		vt->type = MONO_HANDLE_RAW (vt_type);
 		if (!is_ok (error)) {
-			mono_domain_unlock (domain);
 			mono_loader_unlock ();
 			MONO_PROFILER_RAISE (vtable_failed, (vt));
 			goto return_null;

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -3853,7 +3853,6 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	reflection_setup_internal_class (ref_tb, error);
 	mono_error_assert_ok (error);
 
-	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_tb);
 	MonoType *type = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionType, ref_tb), type);
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
 

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -3860,14 +3860,9 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, ref_tb, cattrs);
 	mono_save_custom_attrs (klass->image, klass, MONO_HANDLE_RAW (cattrs)); /* FIXME use handles */
 
-	/* 
-	 * we need to lock the domain because the lock will be taken inside
-	 * So, we need to keep the locking order correct.
-	 */
 	mono_loader_lock ();
-	mono_domain_lock (domain);
+
 	if (klass->wastypebuilder) {
-		mono_domain_unlock (domain);
 		mono_loader_unlock ();
 
 		return mono_type_get_object_handle (m_class_get_byval_arg (klass), error);
@@ -3957,7 +3952,6 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 		goto_if_nok (error, failure);
 	}
 
-	mono_domain_unlock (domain);
 	mono_loader_unlock ();
 
 	if (klass->enumtype && !mono_class_is_valid_enum (klass)) {
@@ -3975,7 +3969,6 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 failure:
 	mono_class_set_type_load_failure (klass, "TypeBuilder could not create runtime class due to: %s", mono_error_get_message (error));
 	klass->wastypebuilder = TRUE;
-	mono_domain_unlock (domain);
 	mono_loader_unlock ();
 failure_unlocked:
 	return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3800,10 +3800,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 	}
 
 	if (!cfg->compile_aot && !(flags & JIT_FLAG_DISCARD_RESULTS)) {
-		MonoDomain *domain = mono_get_root_domain ();
-		mono_domain_lock (domain);
 		mono_jit_info_table_add (cfg->jit_info);
-		mono_domain_unlock (domain);
 
 		if (cfg->method->dynamic) {
 			MonoJitMemoryManager *jit_mm = (MonoJitMemoryManager*)cfg->jit_mm;
@@ -3963,7 +3960,6 @@ mono_jit_compile_method_inner (MonoMethod *method, int opt, MonoError *error)
 	MonoException *ex = NULL;
 	gint64 start;
 	MonoMethod *prof_method, *shared;
-	MonoDomain *target_domain = mono_get_root_domain ();
 
 	error_init (error);
 
@@ -4034,7 +4030,7 @@ mono_jit_compile_method_inner (MonoMethod *method, int opt, MonoError *error)
 		shared = NULL;
 	}
 
-	mono_domain_lock (target_domain);
+	mono_loader_lock ();
 
 	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
 		g_printf ("Printing runtime stats at method: %s\n", mono_method_get_full_name (method));
@@ -4081,7 +4077,7 @@ mono_jit_compile_method_inner (MonoMethod *method, int opt, MonoError *error)
 	mono_emit_jit_map (jinfo);
 	mono_emit_jit_dump (jinfo, code);
 #endif
-	mono_domain_unlock (target_domain);
+	mono_loader_unlock ();
 
 	if (!is_ok (error))
 		return NULL;


### PR DESCRIPTION
* Avoid double locking the loader+domain lock, its not needed.
* Use the mem manager lock and the loader lock in a few places instead of
  the domain lock.
* Use lock free code in mono_jit_runtime_invoke ().
* Avoid locking around mono_jit_info_table_add (), it does locking itself.