### PR TITLE
Allow bounded channel to be created with drop delegate

### DIFF
--- a/src/libraries/System.Threading.Channels/ref/System.Threading.Channels.cs
+++ b/src/libraries/System.Threading.Channels/ref/System.Threading.Channels.cs
@@ -23,6 +23,7 @@ namespace System.Threading.Channels
     {
         public static System.Threading.Channels.Channel<T> CreateBounded<T>(int capacity) { throw null; }
         public static System.Threading.Channels.Channel<T> CreateBounded<T>(System.Threading.Channels.BoundedChannelOptions options) { throw null; }
+        public static System.Threading.Channels.Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
         public static System.Threading.Channels.Channel<T> CreateUnbounded<T>() { throw null; }
         public static System.Threading.Channels.Channel<T> CreateUnbounded<T>(System.Threading.Channels.UnboundedChannelOptions options) { throw null; }
     }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -337,11 +337,12 @@ namespace System.Threading.Channels
 
                 BoundedChannel<T> parent = _parent;
 
-                bool releaseLock = true;
-                Monitor.Enter(parent.SyncObj);
+                bool releaseLock = false;
 
                 try
                 {
+                    Monitor.Enter(parent.SyncObj, ref releaseLock);
+
                     parent.AssertInvariants();
 
                     // If we're done writing, nothing more to do.
@@ -414,11 +415,12 @@ namespace System.Threading.Channels
                             parent._items.DequeueTail() :
                             parent._items.DequeueHead();
 
+                        parent._items.EnqueueTail(item);
+
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
                         parent._itemDropped?.Invoke(droppedItem);
 
-                        parent._items.EnqueueTail(item);
                         return true;
                     }
                 }
@@ -511,11 +513,12 @@ namespace System.Threading.Channels
 
                 BoundedChannel<T> parent = _parent;
 
-                bool releaseLock = true;
-                Monitor.Enter(parent.SyncObj);
+                bool releaseLock = false;
 
                 try
                 {
+                    Monitor.Enter(parent.SyncObj, ref releaseLock);
+
                     parent.AssertInvariants();
 
                     // If we're done writing, trying to write is an error.
@@ -604,11 +607,12 @@ namespace System.Threading.Channels
                             parent._items.DequeueTail() :
                             parent._items.DequeueHead();
 
+                        parent._items.EnqueueTail(item);
+
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
                         parent._itemDropped?.Invoke(droppedItem);
 
-                        parent._items.EnqueueTail(item);
                         return default;
                     }
                 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Channels
     {
         /// <summary>The mode used when the channel hits its bound.</summary>
         private readonly BoundedChannelFullMode _mode;
-        /// <summary>The delegate that will be called when channel hits its bound and item is being dropped from channel.</summary>
+        /// <summary>The delegate that will be invoked when the channel hits its bound and an item is dropped from the channel.</summary>
         private readonly Action<T>? _itemDropped;
         /// <summary>Task signaled when the channel has completed.</summary>
         private readonly TaskCompletionSource _completion;
@@ -42,7 +42,7 @@ namespace System.Threading.Channels
         /// <param name="bufferedCapacity">The positive bounded capacity for the channel.</param>
         /// <param name="mode">The mode used when writing to a full channel.</param>
         /// <param name="runContinuationsAsynchronously">Whether to force continuations to be executed asynchronously.</param>
-        /// <param name="itemDropped">Delegate that will be called when item is being dropped from channel. See <see cref="BoundedChannelFullMode"/>.</param>
+        /// <param name="itemDropped">Delegate that will be invoked when an item is dropped from the channel. See <see cref="BoundedChannelFullMode"/>.</param>
         internal BoundedChannel(int bufferedCapacity, BoundedChannelFullMode mode, bool runContinuationsAsynchronously, Action<T>? itemDropped)
         {
             Debug.Assert(bufferedCapacity > 0);
@@ -338,7 +338,6 @@ namespace System.Threading.Channels
                 BoundedChannel<T> parent = _parent;
 
                 bool releaseLock = false;
-
                 try
                 {
                     Monitor.Enter(parent.SyncObj, ref releaseLock);
@@ -514,7 +513,6 @@ namespace System.Threading.Channels
                 BoundedChannel<T> parent = _parent;
 
                 bool releaseLock = false;
-
                 try
                 {
                     Monitor.Enter(parent.SyncObj, ref releaseLock);

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -338,11 +338,10 @@ namespace System.Threading.Channels
                 BoundedChannel<T> parent = _parent;
 
                 bool releaseLock = true;
+                Monitor.Enter(parent.SyncObj);
 
                 try
                 {
-                    Monitor.Enter(parent.SyncObj);
-
                     parent.AssertInvariants();
 
                     // If we're done writing, nothing more to do.
@@ -404,7 +403,7 @@ namespace System.Threading.Channels
                         // but say we added it.
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
-                        _parent._itemDropped?.Invoke(item);
+                        parent._itemDropped?.Invoke(item);
                         return true;
                     }
                     else
@@ -417,9 +416,8 @@ namespace System.Threading.Channels
 
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
-                        _parent._itemDropped?.Invoke(droppedItem);
+                        parent._itemDropped?.Invoke(droppedItem);
 
-                        // and enque the new item
                         parent._items.EnqueueTail(item);
                         return true;
                     }
@@ -512,12 +510,12 @@ namespace System.Threading.Channels
                 AsyncOperation<bool>? waitingReadersTail = null;
 
                 BoundedChannel<T> parent = _parent;
+
                 bool releaseLock = true;
+                Monitor.Enter(parent.SyncObj);
 
                 try
                 {
-                    Monitor.Enter(parent.SyncObj);
-
                     parent.AssertInvariants();
 
                     // If we're done writing, trying to write is an error.
@@ -595,7 +593,7 @@ namespace System.Threading.Channels
                         // Ignore the item but say we accepted it.
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
-                        _parent._itemDropped?.Invoke(item);
+                        parent._itemDropped?.Invoke(item);
                         return default;
                     }
                     else
@@ -608,7 +606,7 @@ namespace System.Threading.Channels
 
                         Monitor.Exit(parent.SyncObj);
                         releaseLock = false;
-                        _parent._itemDropped?.Invoke(droppedItem);
+                        parent._itemDropped?.Invoke(droppedItem);
 
                         parent._items.EnqueueTail(item);
                         return default;

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Channels
     {
         /// <summary>The mode used when the channel hits its bound.</summary>
         private readonly BoundedChannelFullMode _mode;
-        /// <summary>The mode used when the channel hits its bound.</summary>
+        /// <summary>The delegate that will be called when channel hits its bound and item is being dropped from channel.</summary>
         private readonly Action<T>? _itemDropped;
         /// <summary>Task signaled when the channel has completed.</summary>
         private readonly TaskCompletionSource _completion;

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -287,6 +287,23 @@ namespace System.Threading.Channels
                 _waiterSingleton = new AsyncOperation<bool>(runContinuationsAsynchronously: true, pooled: true);
             }
 
+            private struct DropItem
+            {
+                internal T Item { get; private set; }
+                internal bool HasValue { get; private set; }
+
+                internal static readonly DropItem None = new DropItem { HasValue = false };
+
+                internal static DropItem Create(T itemToDrop)
+                {
+                    return new DropItem
+                    {
+                        HasValue = true,
+                        Item = itemToDrop,
+                    };
+                }
+            }
+
             public override bool TryComplete(Exception? error)
             {
                 BoundedChannel<T> parent = _parent;
@@ -336,86 +353,98 @@ namespace System.Threading.Channels
                 AsyncOperation<bool>? waitingReadersTail = null;
 
                 BoundedChannel<T> parent = _parent;
-                lock (parent.SyncObj)
+                DropItem dropitem = DropItem.None;
+
+                try
                 {
-                    parent.AssertInvariants();
-
-                    // If we're done writing, nothing more to do.
-                    if (parent._doneWriting != null)
+                    lock (parent.SyncObj)
                     {
-                        return false;
-                    }
+                        parent.AssertInvariants();
 
-                    // Get the number of items in the channel currently.
-                    int count = parent._items.Count;
-
-                    if (count == 0)
-                    {
-                        // There are no items in the channel, which means we may have blocked/waiting readers.
-
-                        // If there are any blocked readers, find one that's not canceled
-                        // and store it to complete outside of the lock, in case it has
-                        // continuations that'll run synchronously
-                        while (!parent._blockedReaders.IsEmpty)
+                        // If we're done writing, nothing more to do.
+                        if (parent._doneWriting != null)
                         {
-                            AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
-                            {
-                                blockedReader = r;
-                                break;
-                            }
+                            return false;
                         }
 
-                        if (blockedReader == null)
+                        // Get the number of items in the channel currently.
+                        int count = parent._items.Count;
+
+                        if (count == 0)
                         {
-                            // If there wasn't a blocked reader, then store the item. If no one's waiting
-                            // to be notified about a 0-to-1 transition, we're done.
+                            // There are no items in the channel, which means we may have blocked/waiting readers.
+
+                            // If there are any blocked readers, find one that's not canceled
+                            // and store it to complete outside of the lock, in case it has
+                            // continuations that'll run synchronously
+                            while (!parent._blockedReaders.IsEmpty)
+                            {
+                                AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
+                                if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
+                                {
+                                    blockedReader = r;
+                                    break;
+                                }
+                            }
+
+                            if (blockedReader == null)
+                            {
+                                // If there wasn't a blocked reader, then store the item. If no one's waiting
+                                // to be notified about a 0-to-1 transition, we're done.
+                                parent._items.EnqueueTail(item);
+                                waitingReadersTail = parent._waitingReadersTail;
+                                if (waitingReadersTail == null)
+                                {
+                                    return true;
+                                }
+                                parent._waitingReadersTail = null;
+                            }
+                        }
+                        else if (count < parent._bufferedCapacity)
+                        {
+                            // There's room in the channel.  Since we're not transitioning from 0-to-1 and
+                            // since there's room, we can simply store the item and exit without having to
+                            // worry about blocked/waiting readers.
                             parent._items.EnqueueTail(item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
-                            {
-                                return true;
-                            }
-                            parent._waitingReadersTail = null;
+                            return true;
                         }
-                    }
-                    else if (count < parent._bufferedCapacity)
-                    {
-                        // There's room in the channel.  Since we're not transitioning from 0-to-1 and
-                        // since there's room, we can simply store the item and exit without having to
-                        // worry about blocked/waiting readers.
-                        parent._items.EnqueueTail(item);
-                        return true;
-                    }
-                    else if (parent._mode == BoundedChannelFullMode.Wait)
-                    {
-                        // The channel is full and we're in a wait mode.
-                        // Simply exit and let the caller know we didn't write the data.
-                        return false;
-                    }
-                    else if (parent._mode == BoundedChannelFullMode.DropWrite)
-                    {
-                        // The channel is full.  Just ignore the item being added
-                        // but say we added it.
-                        _parent._itemDropped?.Invoke(item);
-                        return true;
-                    }
-                    else
-                    {
-                        // The channel is full, and we're in a dropping mode.
-                        // Drop either the oldest or the newest and write the new item.
-                        if (parent._mode == BoundedChannelFullMode.DropNewest)
+                        else if (parent._mode == BoundedChannelFullMode.Wait)
                         {
-                            var droppedItem = parent._items.DequeueTail();
-                            _parent._itemDropped?.Invoke(droppedItem);
+                            // The channel is full and we're in a wait mode.
+                            // Simply exit and let the caller know we didn't write the data.
+                            return false;
+                        }
+                        else if (parent._mode == BoundedChannelFullMode.DropWrite)
+                        {
+                            // The channel is full.  Just ignore the item being added
+                            // but say we added it.
+                            dropitem = DropItem.Create(item);
+                            return true;
                         }
                         else
                         {
-                            var droppedItem = parent._items.DequeueHead();
-                            _parent._itemDropped?.Invoke(droppedItem);
+                            // The channel is full, and we're in a dropping mode.
+                            // Drop either the oldest or the newest and write the new item.
+                            if (parent._mode == BoundedChannelFullMode.DropNewest)
+                            {
+                                var droppedItem = parent._items.DequeueTail();
+                                dropitem = DropItem.Create(droppedItem);
+                            }
+                            else
+                            {
+                                var droppedItem = parent._items.DequeueHead();
+                                dropitem = DropItem.Create(droppedItem);
+                            }
+                            parent._items.EnqueueTail(item);
+                            return true;
                         }
-                        parent._items.EnqueueTail(item);
-                        return true;
+                    }
+                }
+                finally
+                {
+                    if (dropitem.HasValue)
+                    {
+                        _parent._itemDropped?.Invoke(dropitem.Item);
                     }
                 }
 
@@ -499,102 +528,114 @@ namespace System.Threading.Channels
                 AsyncOperation<bool>? waitingReadersTail = null;
 
                 BoundedChannel<T> parent = _parent;
-                lock (parent.SyncObj)
+                DropItem dropItem = DropItem.None;
+
+                try
                 {
-                    parent.AssertInvariants();
-
-                    // If we're done writing, trying to write is an error.
-                    if (parent._doneWriting != null)
+                    lock (parent.SyncObj)
                     {
-                        return new ValueTask(Task.FromException(ChannelUtilities.CreateInvalidCompletionException(parent._doneWriting)));
-                    }
+                        parent.AssertInvariants();
 
-                    // Get the number of items in the channel currently.
-                    int count = parent._items.Count;
-
-                    if (count == 0)
-                    {
-                        // There are no items in the channel, which means we may have blocked/waiting readers.
-
-                        // If there are any blocked readers, find one that's not canceled
-                        // and store it to complete outside of the lock, in case it has
-                        // continuations that'll run synchronously
-                        while (!parent._blockedReaders.IsEmpty)
+                        // If we're done writing, trying to write is an error.
+                        if (parent._doneWriting != null)
                         {
-                            AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
-                            {
-                                blockedReader = r;
-                                break;
-                            }
+                            return new ValueTask(Task.FromException(ChannelUtilities.CreateInvalidCompletionException(parent._doneWriting)));
                         }
 
-                        if (blockedReader == null)
+                        // Get the number of items in the channel currently.
+                        int count = parent._items.Count;
+
+                        if (count == 0)
                         {
-                            // If there wasn't a blocked reader, then store the item. If no one's waiting
-                            // to be notified about a 0-to-1 transition, we're done.
+                            // There are no items in the channel, which means we may have blocked/waiting readers.
+
+                            // If there are any blocked readers, find one that's not canceled
+                            // and store it to complete outside of the lock, in case it has
+                            // continuations that'll run synchronously
+                            while (!parent._blockedReaders.IsEmpty)
+                            {
+                                AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
+                                if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
+                                {
+                                    blockedReader = r;
+                                    break;
+                                }
+                            }
+
+                            if (blockedReader == null)
+                            {
+                                // If there wasn't a blocked reader, then store the item. If no one's waiting
+                                // to be notified about a 0-to-1 transition, we're done.
+                                parent._items.EnqueueTail(item);
+                                waitingReadersTail = parent._waitingReadersTail;
+                                if (waitingReadersTail == null)
+                                {
+                                    return default;
+                                }
+                                parent._waitingReadersTail = null;
+                            }
+                        }
+                        else if (count < parent._bufferedCapacity)
+                        {
+                            // There's room in the channel.  Since we're not transitioning from 0-to-1 and
+                            // since there's room, we can simply store the item and exit without having to
+                            // worry about blocked/waiting readers.
                             parent._items.EnqueueTail(item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
-                            {
-                                return default;
-                            }
-                            parent._waitingReadersTail = null;
+                            return default;
                         }
-                    }
-                    else if (count < parent._bufferedCapacity)
-                    {
-                        // There's room in the channel.  Since we're not transitioning from 0-to-1 and
-                        // since there's room, we can simply store the item and exit without having to
-                        // worry about blocked/waiting readers.
-                        parent._items.EnqueueTail(item);
-                        return default;
-                    }
-                    else if (parent._mode == BoundedChannelFullMode.Wait)
-                    {
-                        // The channel is full and we're in a wait mode.  We need to queue a writer.
-
-                        // If we're able to use the singleton writer, do so.
-                        if (!cancellationToken.CanBeCanceled)
+                        else if (parent._mode == BoundedChannelFullMode.Wait)
                         {
-                            VoidAsyncOperationWithData<T> singleton = _writerSingleton;
-                            if (singleton.TryOwnAndReset())
+                            // The channel is full and we're in a wait mode.  We need to queue a writer.
+
+                            // If we're able to use the singleton writer, do so.
+                            if (!cancellationToken.CanBeCanceled)
                             {
-                                singleton.Item = item;
-                                parent._blockedWriters.EnqueueTail(singleton);
-                                return singleton.ValueTask;
+                                VoidAsyncOperationWithData<T> singleton = _writerSingleton;
+                                if (singleton.TryOwnAndReset())
+                                {
+                                    singleton.Item = item;
+                                    parent._blockedWriters.EnqueueTail(singleton);
+                                    return singleton.ValueTask;
+                                }
                             }
-                        }
 
-                        // Otherwise, queue a new writer.
-                        var writer = new VoidAsyncOperationWithData<T>(runContinuationsAsynchronously: true, cancellationToken);
-                        writer.Item = item;
-                        parent._blockedWriters.EnqueueTail(writer);
-                        return writer.ValueTask;
-                    }
-                    else if (parent._mode == BoundedChannelFullMode.DropWrite)
-                    {
-                        // The channel is full and we're in ignore mode.
-                        // Ignore the item but say we accepted it.
-                        _parent._itemDropped?.Invoke(item);
-                        return default;
-                    }
-                    else
-                    {
-                        // The channel is full, and we're in a dropping mode.
-                        // Drop either the oldest or the newest and write the new item.
-                        if (parent._mode == BoundedChannelFullMode.DropNewest)
+                            // Otherwise, queue a new writer.
+                            var writer = new VoidAsyncOperationWithData<T>(runContinuationsAsynchronously: true, cancellationToken);
+                            writer.Item = item;
+                            parent._blockedWriters.EnqueueTail(writer);
+                            return writer.ValueTask;
+                        }
+                        else if (parent._mode == BoundedChannelFullMode.DropWrite)
                         {
-                            var droppedItem = parent._items.DequeueTail();
-                            _parent._itemDropped?.Invoke(droppedItem);
+                            // The channel is full and we're in ignore mode.
+                            // Ignore the item but say we accepted it.
+                            dropItem = DropItem.Create(item);
+                            return default;
                         }
                         else
                         {
-                            var droppedItem = parent._items.DequeueHead();
-                            _parent._itemDropped?.Invoke(droppedItem);
+                            // The channel is full, and we're in a dropping mode.
+                            // Drop either the oldest or the newest and write the new item.
+                            if (parent._mode == BoundedChannelFullMode.DropNewest)
+                            {
+                                var droppedItem = parent._items.DequeueTail();
+                                dropItem = DropItem.Create(droppedItem);
+                            }
+                            else
+                            {
+                                var droppedItem = parent._items.DequeueHead();
+                                dropItem = DropItem.Create(droppedItem);
+                            }
+                            parent._items.EnqueueTail(item);
+                            return default;
                         }
-                        parent._items.EnqueueTail(item);
-                        return default;
+                    }
+                }
+                finally
+                {
+                    if (dropItem.HasValue)
+                    {
+                        _parent._itemDropped?.Invoke(dropItem.Item);
                     }
                 }
 

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
@@ -44,11 +44,6 @@ namespace System.Threading.Channels
         /// <returns>The created channel.</returns>
         public static Channel<T> CreateBounded<T>(BoundedChannelOptions options)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
             return CreateBounded<T>(options, itemDropped: null);
         }
 

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
@@ -35,10 +35,10 @@ namespace System.Threading.Channels
                 throw new ArgumentOutOfRangeException(nameof(capacity));
             }
 
-            return new BoundedChannel<T>(capacity, BoundedChannelFullMode.Wait, runContinuationsAsynchronously: true);
+            return new BoundedChannel<T>(capacity, BoundedChannelFullMode.Wait, runContinuationsAsynchronously: true, itemDropped: null);
         }
 
-        /// <summary>Creates a channel with the specified maximum capacity.</summary>
+        /// <summary>Creates a channel subject to the provided options.</summary>
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <param name="options">Options that guide the behavior of the channel.</param>
         /// <returns>The created channel.</returns>
@@ -49,7 +49,22 @@ namespace System.Threading.Channels
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations);
+            return new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations, itemDropped: null);
+        }
+
+        /// <summary>Creates a channel subject to the provided options.</summary>
+        /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
+        /// <param name="options">Options that guide the behavior of the channel.</param>
+        /// <param name="itemDropped">Delegate that will be called when item is being dropped from channel. See <see cref="BoundedChannelFullMode"/>.</param>
+        /// <returns>The created channel.</returns>
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations, itemDropped);
         }
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
@@ -49,7 +49,7 @@ namespace System.Threading.Channels
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations, itemDropped: null);
+            return CreateBounded<T>(options, itemDropped: null);
         }
 
         /// <summary>Creates a channel subject to the provided options.</summary>

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -297,7 +297,7 @@ namespace System.Threading.Channels.Tests
             var secondWriteTask = c.Writer.WriteAsync(2);
             Assert.False(secondWriteTask.IsCompleted);
 
-            // Read from chanell to free up space
+            // Read from channel to free up space
             var readItem = await c.Reader.ReadAsync();
             // Second write should complete
             await secondWriteTask;
@@ -380,7 +380,7 @@ namespace System.Threading.Channels.Tests
 
                 dropDelegateCalled = true;
 
-                // Dropped delegate should not be called while holding the channel synchronisation lock.
+                // Dropped delegate should not be called while holding the channel lock.
                 // Verify this by trying to write into the channel from different thread.
                 // If lock is held during callback, this should effecitvely cause deadlock.
                 var mres = new ManualResetEventSlim();

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -360,8 +360,8 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(10, droppedItems.Count);
         }
 
-        [Theory]
-        [MemberData(nameof(ChannelDropModes))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [MemberData(nameof(ChannelDropModes))]        
         public void DroppedDelegateCalledAfterLockReleased_SyncWrites(BoundedChannelFullMode boundedChannelFullMode)
         {
             Channel<int> c = null;
@@ -399,8 +399,8 @@ namespace System.Threading.Channels.Tests
             Assert.True(dropDelegateCalled);
         }
 
-        [Theory]
-        [MemberData(nameof(ChannelDropModes))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [MemberData(nameof(ChannelDropModes))]        
         public async Task DroppedDelegateCalledAfterLockReleased_AsyncWrites(BoundedChannelFullMode boundedChannelFullMode)
         {
             Channel<int> c = null;

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -386,7 +386,7 @@ namespace System.Threading.Channels.Tests
                 var mres = new ManualResetEventSlim();
                 ThreadPool.QueueUserWorkItem(delegate
                 {
-                    c.Writer.TryWrite(11);
+                    c.Writer.TryWrite(3);
                     mres.Set();
                 });
 

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -21,7 +21,7 @@ namespace System.Threading.Channels.Tests
 
         public static IEnumerable<object[]> ChannelDropModes()
         {
-            foreach (var mode in Enum.GetValues(typeof(BoundedChannelFullMode)).Cast<BoundedChannelFullMode>())
+            foreach (BoundedChannelFullMode mode in Enum.GetValues(typeof(BoundedChannelFullMode)))
             {
                 if (mode != BoundedChannelFullMode.Wait)
                 {
@@ -266,7 +266,7 @@ namespace System.Threading.Channels.Tests
         [MemberData(nameof(ChannelDropModes))]
         public void DroppedDelegateIsNull_SyncWrites(BoundedChannelFullMode boundedChannelFullMode)
         {
-            var c = Channel.CreateBounded<int>(new BoundedChannelOptions(1) { FullMode = boundedChannelFullMode }, itemDropped: null);
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(1) { FullMode = boundedChannelFullMode }, itemDropped: null);
 
             Assert.True(c.Writer.TryWrite(5));
             Assert.True(c.Writer.TryWrite(5));
@@ -276,7 +276,7 @@ namespace System.Threading.Channels.Tests
         [MemberData(nameof(ChannelDropModes))]
         public async Task DroppedDelegateIsNull_AsyncWrites(BoundedChannelFullMode boundedChannelFullMode)
         {
-            var c = Channel.CreateBounded<int>(new BoundedChannelOptions(1) { FullMode = boundedChannelFullMode }, itemDropped: null);
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(1) { FullMode = boundedChannelFullMode }, itemDropped: null);
 
             await c.Writer.WriteAsync(5);
             await c.Writer.WriteAsync(5);


### PR DESCRIPTION
Fixes #36522 
Add additional CreateBounded overload with delegate parameter that will be called when item is being dropped from channel
Added unit tests