### PR TITLE
Add ConfigurationKeyNameAttribute to binder and updated tests.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Configuration
         public static string GetConnectionString(this Microsoft.Extensions.Configuration.IConfiguration configuration, string name) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationSection GetRequiredSection(this Microsoft.Extensions.Configuration.IConfiguration configuration, string key) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property)]
     public sealed partial class ConfigurationKeyNameAttribute : System.Attribute
     {
         public ConfigurationKeyNameAttribute(string name) { }

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
@@ -4,17 +4,8 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System;
-
 namespace Microsoft.Extensions.Configuration
 {
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ConfigurationKeyNameAttribute : Attribute
-    {
-        public ConfigurationKeyNameAttribute(string name) => Name = name;
-
-        public string Name { get; }
-    }
     public static partial class ConfigurationExtensions
     {
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder Add<TSource>(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<TSource> configureSource) where TSource : Microsoft.Extensions.Configuration.IConfigurationSource, new() { throw null; }
@@ -23,6 +14,12 @@ namespace Microsoft.Extensions.Configuration
         public static bool Exists(this Microsoft.Extensions.Configuration.IConfigurationSection section) { throw null; }
         public static string GetConnectionString(this Microsoft.Extensions.Configuration.IConfiguration configuration, string name) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationSection GetRequiredSection(this Microsoft.Extensions.Configuration.IConfiguration configuration, string key) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    public sealed partial class ConfigurationKeyNameAttribute : System.Attribute
+    {
+        public ConfigurationKeyNameAttribute(string name) { }
+        public string Name { get { throw null; } }
     }
     public static partial class ConfigurationPath
     {

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
@@ -4,8 +4,17 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Extensions.Configuration
 {
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ConfigurationKeyNameAttribute : Attribute
+    {
+        public ConfigurationKeyNameAttribute(string name) => Name = name;
+
+        public string Name { get; }
+    }
     public static partial class ConfigurationExtensions
     {
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder Add<TSource>(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<TSource> configureSource) where TSource : Microsoft.Extensions.Configuration.IConfigurationSource, new() { throw null; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Extensions.Configuration
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ConfigurationKeyNameAttribute : Attribute
     {
-        public ConfigurationKeyNameAttribute()
-        {
-        }
-
         public ConfigurationKeyNameAttribute(string name) => Name = name;
 
         public string Name { get; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.Configuration
 {
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property)]
     public sealed class ConfigurationKeyNameAttribute : Attribute
     {
         public ConfigurationKeyNameAttribute(string name) => Name = name;

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Configuration
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ConfigurationKeyNameAttribute : Attribute
+    {
+        public ConfigurationKeyNameAttribute()
+        {
+        }
+
+        public ConfigurationKeyNameAttribute(string name) => Name = name;
+
+        public string Name { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -593,11 +593,13 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(property));
             }
 
+            // Check for a custom property name used for configuration key binding
             foreach (var attributeData in property.GetCustomAttributesData())
             {
                 if (attributeData.AttributeType != typeof(ConfigurationKeyNameAttribute) ||
                     attributeData.ConstructorArguments.Count == 0)
                 {
+                    // ConfigurationKeyName expected to have a single string constructor argument
                     continue;
                 }
 
@@ -605,14 +607,18 @@ namespace Microsoft.Extensions.Configuration
                 if (constructorArgument.ArgumentType != typeof(string) ||
                     constructorArgument.Value == null)
                 {
-                    continue;
+                    // First argument didn't contain the expected string value
+                    break;
                 }
 
-                string value = constructorArgument.Value.ToString();
-                if (!string.IsNullOrWhiteSpace(value))
+                string name = constructorArgument.Value.ToString();
+                if (!string.IsNullOrWhiteSpace(name))
                 {
-                    return value;
+                    return name;
                 }
+
+                // No custom string "name" provided - we're done here.
+                break;
             }
 
             return property.Name;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -596,29 +596,19 @@ namespace Microsoft.Extensions.Configuration
             // Check for a custom property name used for configuration key binding
             foreach (var attributeData in property.GetCustomAttributesData())
             {
-                if (attributeData.AttributeType != typeof(ConfigurationKeyNameAttribute) ||
-                    attributeData.ConstructorArguments.Count == 0)
+                if (attributeData.AttributeType != typeof(ConfigurationKeyNameAttribute))
                 {
-                    // ConfigurationKeyName expected to have a single string constructor argument
                     continue;
                 }
 
-                var constructorArgument = attributeData.ConstructorArguments.First();
-                if (constructorArgument.ArgumentType != typeof(string) ||
-                    constructorArgument.Value == null)
-                {
-                    // First argument didn't contain the expected string value
-                    break;
-                }
+                // Assumes ConfiguratKeyName constructor first arg is a string key name
+                string name = attributeData
+                    .ConstructorArguments
+                    .First()
+                    .Value?
+                    .ToString();
 
-                string name = constructorArgument.Value.ToString();
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    return name;
-                }
-
-                // No custom string "name" provided - we're done here.
-                break;
+                return !string.IsNullOrWhiteSpace(name) ? name : property.Name;
             }
 
             return property.Name;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -593,7 +593,6 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(property));
             }
 
-
             // Check for a custom property name used for configuration key binding
             foreach (var attributeData in property.GetCustomAttributesData())
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            propertyValue = GetPropertyValue(property, instance, config, options, null);
+            propertyValue = GetPropertyValue(property, instance, config, options);
 
             if (propertyValue != null && hasSetter)
             {
@@ -576,21 +576,14 @@ namespace Microsoft.Extensions.Configuration
             return allProperties;
         }
 
-        private static object GetPropertyValue(PropertyInfo property, object instance, IConfiguration config, BinderOptions options, object defaultValue)
+        private static object GetPropertyValue(PropertyInfo property, object instance, IConfiguration config, BinderOptions options)
         {
-            try
-            {
-                string propertyName = GetPropertyName(property);
-                return BindInstance(
-                    property.PropertyType,
-                    property.GetValue(instance),
-                    config.GetSection(propertyName),
-                    options) ?? defaultValue;
-            }
-            catch
-            {
-                return defaultValue;
-            }
+            string propertyName = GetPropertyName(property);
+            return BindInstance(
+                property.PropertyType,
+                property.GetValue(instance),
+                config.GetSection(propertyName),
+                options);
         }
 
         private static string GetPropertyName(MemberInfo property)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -601,7 +601,13 @@ namespace Microsoft.Extensions.Configuration
                     continue;
                 }
 
-                // Assumes ConfigurationKeyName constructor first arg is a string key name
+                // Ensure ConfigurationKeyName constructor signature matches expectations
+                if (attributeData.ConstructorArguments.Count != 1)
+                {
+                    break;
+                }
+
+                // Assumes ConfigurationKeyName constructor first arg is the string key name
                 string name = attributeData
                     .ConstructorArguments[0]
                     .Value?

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -593,6 +593,7 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(property));
             }
 
+
             // Check for a custom property name used for configuration key binding
             foreach (var attributeData in property.GetCustomAttributesData())
             {
@@ -601,7 +602,7 @@ namespace Microsoft.Extensions.Configuration
                     continue;
                 }
 
-                // Assumes ConfiguratKeyName constructor first arg is a string key name
+                // Assumes (ConfigurationKeyName constructor first arg is a string key name
                 string name = attributeData
                     .ConstructorArguments
                     .First()

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -604,8 +604,7 @@ namespace Microsoft.Extensions.Configuration
 
                 // Assumes ConfigurationKeyName constructor first arg is a string key name
                 string name = attributeData
-                    .ConstructorArguments
-                    .First()
+                    .ConstructorArguments[0]
                     .Value?
                     .ToString();
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Extensions.Configuration
                     continue;
                 }
 
-                // Assumes (ConfigurationKeyName constructor first arg is a string key name
+                // Assumes ConfigurationKeyName constructor first arg is a string key name
                 string name = attributeData
                     .ConstructorArguments
                     .First()

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -205,7 +205,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Null(options.Section.Value);
         }
 
-
         [Fact]
         public void CanBindAttributesIConfigurationSection()
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             internal string InternalProperty { get; set; }
             protected string ProtectedProperty { get; set; }
 
-
             [ConfigurationKeyName("Named_Property")]
             public string NamedProperty { get; set; }
 
@@ -206,33 +205,19 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
-        public void CanBindAttributesIConfigurationSection()
+        public void CanBindConfigurationKeyNameAttributes()
         {
             var dic = new Dictionary<string, string>
             {
-                {"Section:Integer", "-2"},
-                {"Section:Boolean", "TRUe"},
-                {"Section:Nested:Integer", "11"},
-                {"Section:Virtual", "Sup"},
-                {"Section:Named_Property", "Yo"},
+                {"Named_Property", "Yo"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
             var config = configurationBuilder.Build();
 
-            var options = config.Get<ConfigurationInterfaceOptions>();
-
-            var childOptions = options.Section.Get<DerivedOptions>();
-
-            Assert.True(childOptions.Boolean);
-            Assert.Equal(-2, childOptions.Integer);
-            Assert.Equal(11, childOptions.Nested.Integer);
-            Assert.Equal("Derived:Sup", childOptions.Virtual);
-            Assert.Equal("Yo", childOptions.NamedProperty);
-
-            Assert.Equal("Section", options.Section.Key);
-            Assert.Equal("Section", options.Section.Path);
-            Assert.Null(options.Section.Value);
+            var options = config.Get<ComplexOptions>();
+            
+            Assert.Equal("Yo", options.NamedProperty);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
-using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -37,7 +36,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
 
             [ConfigurationKeyName("Named_Property")]
-            [DataMember(Name = "Named_Property")]
             public string NamedProperty { get; set; }
 
             protected string ProtectedPrivateSet { get; private set; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -33,6 +34,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             private string PrivateProperty { get; set; }
             internal string InternalProperty { get; set; }
             protected string ProtectedProperty { get; set; }
+
+
+            [ConfigurationKeyName("Named_Property")]
+            [DataMember(Name = "Named_Property")]
+            public string NamedProperty { get; set; }
 
             protected string ProtectedPrivateSet { get; private set; }
 
@@ -198,6 +204,37 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("Section", options.Section.Path);
             Assert.Equal("DerivedSection", childOptions.DerivedSection.Key);
             Assert.Equal("Section:DerivedSection", childOptions.DerivedSection.Path);
+            Assert.Null(options.Section.Value);
+        }
+
+
+        [Fact]
+        public void CanBindAttributesIConfigurationSection()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Section:Integer", "-2"},
+                {"Section:Boolean", "TRUe"},
+                {"Section:Nested:Integer", "11"},
+                {"Section:Virtual", "Sup"},
+                {"Section:Named_Property", "Yo"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ConfigurationInterfaceOptions>();
+
+            var childOptions = options.Section.Get<DerivedOptions>();
+
+            Assert.True(childOptions.Boolean);
+            Assert.Equal(-2, childOptions.Integer);
+            Assert.Equal(11, childOptions.Nested.Integer);
+            Assert.Equal("Derived:Sup", childOptions.Virtual);
+            Assert.Equal("Yo", childOptions.NamedProperty);
+
+            Assert.Equal("Section", options.Section.Key);
+            Assert.Equal("Section", options.Section.Path);
             Assert.Null(options.Section.Value);
         }
 


### PR DESCRIPTION
API implementation of https://github.com/dotnet/runtime/issues/36010

- Add `ConfigurationKeyName` attribute to the Configuration Binder project
- Update Configuration Binder to use key name from the new attribute in binding property values
- Add test using `ConfigurationKeyName` attribute to map the configuration dictionary key