### PR TITLE
expose alloc data on dbi

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4787,6 +4787,17 @@ VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread)
     }
 }
 
+void DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread        vmThread, 
+                                             DacThreadAllocInfo* threadAllocInfo)
+{
+    DD_ENTER_MAY_THROW;
+
+    Thread * pThread = vmThread.GetDacPtr();
+    gc_alloc_context* allocContext = pThread->GetAllocContext();
+    threadAllocInfo->m_allocBytesSOH = (ULONG)(allocContext->alloc_bytes - (allocContext->alloc_limit - allocContext->alloc_ptr));
+    threadAllocInfo->m_allocBytesUOH = (ULONG)allocContext->alloc_bytes_uoh;
+}
+
 // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
 // according to the CorDebugThreadState.
 void DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread        vmThread,

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -783,6 +783,9 @@ public:
     // Return the object handle for the managed Thread object corresponding to the specified thread.
     VMPTR_OBJECTHANDLE GetThreadObject(VMPTR_Thread vmThread);
 
+    // Get the alocated bytes for this thread.
+    void GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo);
+
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
     // according to the CorDebugThreadState.
     void SetDebugState(VMPTR_Thread        vmThread,

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1065,6 +1065,17 @@ public:
 
     virtual
     VMPTR_OBJECTHANDLE GetThreadObject(VMPTR_Thread vmThread) = 0;
+    
+    //
+    // Get the allocation info corresponding to the specified thread.
+    //
+    // Arguments:
+    //    vmThread - the specified thread
+    //    threadAllocInfo - the allocated bytes from SOH and UOH so far on this thread
+    //
+
+    virtual
+    void GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo) = 0;
 
     //
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -784,5 +784,12 @@ struct MSLAYOUT DacSharedReJitInfo
     CORDB_ADDRESS  m_rgInstrumentedMapEntries;
 };
 
+// These represent the allocated bytes so far on the thread.
+struct MSLAYOUT DacThreadAllocInfo
+{
+    ULONG m_allocBytesSOH;
+    ULONG m_allocBytesUOH;
+};
+
 #include "dacdbistructures.inl"
 #endif // DACDBISTRUCTURES_H_


### PR DESCRIPTION
we are already exposing this data for sos, should make this available for debuggers to use as well. it's very lightweight and would be very useful for things like showing exactly how many bytes were allocated on the thread between 2 breakpoints.