### PR TITLE
ignore empty domain for digets auth

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
@@ -33,7 +33,6 @@ namespace System.Net.Http.Functional.Tests
         private async Task CreateAndValidateRequest(HttpClientHandler handler, Uri url, HttpStatusCode expectedStatusCode, ICredentials credentials)
         {
             handler.Credentials = credentials;
-
             using (HttpClient client = CreateHttpClient(handler))
             using (HttpResponseMessage response = await client.GetAsync(url))
             {
@@ -93,6 +92,13 @@ namespace System.Net.Http.Functional.Tests
                 // Unauthorized on WinHttpHandler
                 yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256, nonce=\"testnonce\"", true };
                 yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256-SESS, nonce=\"testnonce\", qop=\"auth\"", true };
+            }
+
+            // Add tests cases for empty values that are not mandatory
+            if (!IsWinHttpHandler)
+            {
+                yield return new object[] { "Digest realm=\"testrealm\",nonce=\"6afd170437eb5144258b308f7c491d96\",opaque=\"\",stale=FALSE,algorithm=MD5,qop=\"auth\"", true };
+                yield return new object[] { "Digest realm=\"testrealm\", domain=\"\", nonce=\"NA42+vpOFQd1GwCyVRZuhhy+jDn4BMRl\", algorithm=MD5, qop=\"auth\", stale=false", true };
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -403,9 +403,13 @@ namespace System.Net.Http
 
                     // Get the value.
                     string? value = GetNextValue(challenge, parsedIndex, MustValueBeQuoted(key), out parsedIndex);
+                    if (value == null)
+                        break;
+
                     // Ensure value is valid.
-                    if (string.IsNullOrEmpty(value)
-                        && (value == null || (!key.Equals(Opaque, StringComparison.OrdinalIgnoreCase) && !key.Equals(Domain, StringComparison.OrdinalIgnoreCase))))
+                    // Opaque and Domain can have empty string
+                    if (value == string.Empty &&
+                       (!key.Equals(Opaque, StringComparison.OrdinalIgnoreCase) && !key.Equals(Domain, StringComparison.OrdinalIgnoreCase)))
                         break;
 
                     // Add the key-value pair to Parameters.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -18,6 +18,7 @@ namespace System.Net.Http
         private const string Qop = "qop";
         private const string Auth = "auth";
         private const string AuthInt = "auth-int";
+        private const string Domain = "domain";
         private const string Nonce = "nonce";
         private const string NC = "nc";
         private const string Realm = "realm";
@@ -404,7 +405,7 @@ namespace System.Net.Http
                     string? value = GetNextValue(challenge, parsedIndex, MustValueBeQuoted(key), out parsedIndex);
                     // Ensure value is valid.
                     if (string.IsNullOrEmpty(value)
-                        && (value == null || !key.Equals(Opaque, StringComparison.OrdinalIgnoreCase)))
+                        && (value == null || (!key.Equals(Opaque, StringComparison.OrdinalIgnoreCase) && !key.Equals(Domain, StringComparison.OrdinalIgnoreCase))))
                         break;
 
                     // Add the key-value pair to Parameters.


### PR DESCRIPTION
rfc7616 suggest that missing or empty should be treated equally.

```
  domain

      A quoted, space-separated list of URIs, as specified in [RFC3986],
      that define the protection space.  If a URI is a path-absolute, it
      is relative to the canonical root URL.  (See Section 2.2 of
      [RFC7235].)  An absolute-URI in this list may refer to a different
      server than the web-origin [RFC6454].  The client can use this
      list to determine the set of URIs for which the same
      authentication information may be sent: any URI that has a URI in
      this list as a prefix (after both have been made absolute) MAY be
      assumed to be in the same protection space.  If this parameter is
      omitted or its value is empty, the client SHOULD assume that the
      protection space consists of all URIs on the web-origin.
```

fixes  #50283
