### PR TITLE
 Question: should we exclude to-be-fired timers when updating shortest wait duration of native timer?

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
@@ -115,7 +115,7 @@ namespace System.Threading
                             continue;
                         }
 
-                        if (waitDurationMs < shortestWaitDurationMs)
+                        if (waitDurationMs > 0 && waitDurationMs < shortestWaitDurationMs)
                         {
                             shortestWaitDurationMs = (int)waitDurationMs;
                         }


### PR DESCRIPTION
Hi, in TimerQueue.Portable.cs, shortestWaitDurationMs will be updated if waitDurationMs is less,  but what if the waitDurationMs is less than 0(since it's possible a timer is delayed)? As the [doc](https://docs.microsoft.com/en-us/dotnet/api/system.threading.waithandle.waitone?view=net-5.0#System_Threading_WaitHandle_WaitOne_System_Int32_) said, WaitOne only accept -1 as a valid negative number,  ArgumentOutOfRangeException will be thrown if values is a negative number other than -1.  So, in my view, the native timer thread will probably quit if the negative wait duration other than -1 occurred. Since the to-be-fired timers is queued to thread pool immediately, a small tweak is made to update shortest wait duration when waitDurationMs is greater than zero.
 I'm new to the repository and not 100% sure the change is right or  wrong, you're free to reject the PR.