### PR TITLE
Remove unnecessary delegate/closure allocations from PollForValues

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -271,10 +271,9 @@ namespace System.Diagnostics.Tracing
             // We cache these outside of the scope of s_counterGroupLock because
             // calling into the callbacks can cause a re-entrancy into CounterGroup.Enable()
             // and result in a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
-            List<Action> onTimers = new List<Action>();
+            var onTimers = new List<CounterGroup>();
             while (true)
             {
-                onTimers.Clear();
                 int sleepDurationInMilliseconds = int.MaxValue;
                 lock (s_counterGroupLock)
                 {
@@ -284,7 +283,7 @@ namespace System.Diagnostics.Tracing
                         DateTime now = DateTime.UtcNow;
                         if (counterGroup._nextPollingTimeStamp < now + new TimeSpan(0, 0, 0, 0, 1))
                         {
-                            onTimers.Add(() => counterGroup.OnTimer());
+                            onTimers.Add(counterGroup);
                         }
 
                         int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - now).TotalMilliseconds);
@@ -292,10 +291,11 @@ namespace System.Diagnostics.Tracing
                         sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
                     }
                 }
-                foreach (Action onTimer in onTimers)
+                foreach (CounterGroup onTimer in onTimers)
                 {
-                    onTimer.Invoke();
+                    onTimer.OnTimer();
                 }
+                onTimers.Clear();
                 if (sleepDurationInMilliseconds == int.MaxValue)
                 {
                     sleepDurationInMilliseconds = -1; // WaitOne uses -1 to mean infinite


### PR DESCRIPTION
It allocates a delegate/closure for each counter group each time the loop runs.

cc: @sywhang 