### PR TITLE
JIT: Convert UNBOX helpers to BBJ_THROW

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15970,6 +15970,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     op1 = gtNewHelperCallNode(helper, TYP_VOID, gtNewCallArgs(op2, op1));
 
+                    // In this case helper call is a fallback to throw an exception.
+                    op1->AsCall()->gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN;
+
                     op1 = new (this, GT_COLON) GenTreeColon(TYP_VOID, gtNewNothingNode(), op1);
                     op1 = gtNewQmarkNode(TYP_VOID, condBox, op1);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -18034,6 +18034,12 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         }
         Statement* trueStmt = fgNewStmtFromTree(trueExpr, stmt->GetILOffsetX());
         fgInsertStmtAtEnd(thenBlock, trueStmt);
+
+        // Convert the whole block to BBJ_THROW if trueExpr is a no-return call
+        if (trueExpr->IsCall() && trueExpr->AsCall()->IsNoReturn())
+        {
+            fgConvertBBToThrowBB(thenBlock);
+        }
     }
 
     // Assign the falseExpr into the dst or tmp, insert in elseBlock
@@ -18045,6 +18051,12 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         }
         Statement* falseStmt = fgNewStmtFromTree(falseExpr, stmt->GetILOffsetX());
         fgInsertStmtAtEnd(elseBlock, falseStmt);
+
+        // Convert the whole block to BBJ_THROW if falseExpr is a no-return call
+        if (falseExpr->IsCall() && falseExpr->AsCall()->IsNoReturn())
+        {
+            fgConvertBBToThrowBB(elseBlock);
+        }
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
Example:
```csharp
int Test(object o) => (int)o;
```
Current codegen:
```asm
; Method Program:Test(System.Object):int
G_M40916_IG01:             
       56                   push     rsi
       4883EC20             sub      rsp, 32
       488BF1               mov      rsi, rcx
						;; bbWeight=1    PerfScore 1.50
G_M40916_IG02:             
       48BA509C44E8F97F0000 mov      rdx, 0x7FF9E8449C50
       483916               cmp      qword ptr [rsi], rdx
       7412                 je       SHORT G_M40916_IG04
						;; bbWeight=1    PerfScore 3.25
G_M40916_IG03:            
       488BD6               mov      rdx, rsi
       48B9509C44E8F97F0000 mov      rcx, 0x7FF9E8449C50
       E8AF7AACFF           call     CORINFO_HELP_UNBOX
						;; bbWeight=0.25 PerfScore 0.38
G_M40916_IG04:            
       8B4608               mov      eax, dword ptr [rsi+8]
						;; bbWeight=1    PerfScore 2.00
G_M40916_IG05:             
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      
						;; bbWeight=1    PerfScore 1.75
; Total bytes of code: 50
```
New codegen:
```asm
; Method Program:Test(System.Object):int
G_M40916_IG01:       
       4883EC28             sub      rsp, 40
						;; bbWeight=1    PerfScore 0.25
G_M40916_IG02:              
       48B8509C44E8F97F0000 mov      rax, 0x7FF9E8449C50
       483901               cmp      qword ptr [rcx], rax
       7508                 jne      SHORT G_M40916_IG05
						;; bbWeight=1    PerfScore 3.25
G_M40916_IG03:              
       8B4108               mov      eax, dword ptr [rcx+8]
						;; bbWeight=1    PerfScore 2.00
G_M40916_IG04:              
       4883C428             add      rsp, 40
       C3                   ret      
						;; bbWeight=1    PerfScore 1.25
G_M40916_IG05:         
       488BD1               mov      rdx, rcx
       48B9509C44E8F97F0000 mov      rcx, 0x7FF9E8449C50
       E8AB7AACFF           call     CORINFO_HELP_UNBOX
       CC                   int3     
						;; bbWeight=0    PerfScore 0.00
; Total bytes of code: 46
```
Jit-diff (-f --crossgen):
```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 33504668
Total bytes of diff: 33508029
Total bytes of delta: 3361 (0.01% of base)
    diff is a regression.


Top file regressions (bytes):
        2802 : System.Linq.Expressions.dasm (0.10% of base)
        1076 : Newtonsoft.Json.dasm (0.18% of base)
         918 : Microsoft.VisualBasic.Core.dasm (0.22% of base)
         423 : System.Private.CoreLib.dasm (0.01% of base)
         311 : System.Data.Common.dasm (0.03% of base)
         173 : System.Reflection.Metadata.dasm (0.05% of base)
         112 : System.CodeDom.dasm (0.07% of base)
         105 : System.Data.OleDb.dasm (0.04% of base)
          75 : System.Collections.Immutable.dasm (0.03% of base)
          73 : System.Resources.Extensions.dasm (0.23% of base)
          73 : System.Management.dasm (0.02% of base)
          73 : System.Resources.Writer.dasm (0.93% of base)
          68 : Microsoft.CSharp.dasm (0.02% of base)
          65 : Microsoft.Extensions.Logging.Console.dasm (0.40% of base)
          59 : FSharp.Core.dasm (0.01% of base)
          52 : System.ComponentModel.Annotations.dasm (0.14% of base)
          50 : System.Private.Xml.Linq.dasm (0.04% of base)
          49 : System.DirectoryServices.dasm (0.01% of base)
          47 : Microsoft.CodeAnalysis.dasm (0.01% of base)
          41 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)

Top file improvements (bytes):
       -1199 : System.Text.Json.dasm (-0.23% of base)
        -952 : System.Private.Xml.dasm (-0.03% of base)
        -256 : System.ComponentModel.TypeConverter.dasm (-0.12% of base)
        -160 : System.DirectoryServices.Protocols.dasm (-0.20% of base)
        -151 : System.Configuration.ConfigurationManager.dasm (-0.05% of base)
         -96 : System.Security.AccessControl.dasm (-0.15% of base)
         -88 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -82 : System.Speech.dasm (-0.02% of base)
         -70 : System.Net.Sockets.dasm (-0.04% of base)
         -58 : System.Data.Odbc.dasm (-0.03% of base)
         -51 : System.Net.Http.dasm (-0.01% of base)
         -43 : System.Runtime.Caching.dasm (-0.08% of base)
         -37 : System.Security.Principal.Windows.dasm (-0.10% of base)
         -34 : System.Collections.Specialized.dasm (-0.15% of base)
         -34 : System.Drawing.Common.dasm (-0.01% of base)
         -34 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -24 : System.Net.Mail.dasm (-0.01% of base)
         -15 : Microsoft.Extensions.FileSystemGlobbing.dasm (-0.07% of base)
         -12 : System.IO.Ports.dasm (-0.03% of base)
         -12 : System.Text.RegularExpressions.dasm (-0.01% of base)

93 total files with Code Size differences (41 improved, 52 regressed), 178 unchanged.

Top method regressions (bytes):
        4467 ( 0.41% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(InterpretedFrame):int:this (3375 methods)
         210 ( 0.42% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
         201 ( 4.45% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValue(JsonWriter,int,Object)
         199 (10.96% of base) : System.Data.OleDb.dasm - ColumnBinding:Value(Object):this
         198 ( 4.27% of base) : Newtonsoft.Json.dasm - JsonWriter:WriteValueAsync(JsonWriter,int,Object,CancellationToken):Task
         161 ( 3.38% of base) : System.Data.Common.dasm - SqlConvert:ChangeTypeForXML(Object,Type):Object
         100 ( 5.31% of base) : System.Private.CoreLib.dasm - CustomAttributeBuilder:EmitValue(BinaryWriter,Type,Object)
          97 ( 3.28% of base) : System.Data.Common.dasm - SqlConvert:ChangeType2(Object,int,Type,IFormatProvider):Object
          95 ( 4.71% of base) : Newtonsoft.Json.dasm - JValue:Compare(int,Object,Object):int
          87 ( 6.05% of base) : Newtonsoft.Json.dasm - JsonConvert:ToString(Object):String
          85 ( 6.15% of base) : System.Data.Common.dasm - SqlConvert:ConvertToSqlDouble(Object):SqlDouble
          83 ( 1.66% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.IComparable.CompareTo(Object):int:this (15 methods)
          80 ( 0.47% of base) : System.Data.Common.dasm - BinaryNode:EvalBinaryOp(int,ExpressionNode,ExpressionNode,DataRow,int,ref):Object:this
          79 ( 6.31% of base) : System.Private.DataContractSerialization.dasm - XmlWriterDelegator:WriteAnyType(Object,Type):this
          76 ( 0.73% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.Collections.IStructuralComparable.CompareTo(Object,IComparer):int:this (15 methods)
          75 ( 2.45% of base) : FSharp.Core.dasm - Display:leafFormatter(FormatOptions,Object):TaggedText
          75 ( 2.01% of base) : System.Private.CoreLib.dasm - ValueTuple`2:System.Collections.IStructuralComparable.CompareTo(Object,IComparer):int:this (15 methods)
          75 ( 0.94% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.Collections.IStructuralEquatable.Equals(Object,IEqualityComparer):bool:this (15 methods)
          75 ( 4.93% of base) : System.Resources.Extensions.dasm - PreserializedResourceWriter:WriteValue(int,Object,BinaryWriter):this
          75 ( 6.17% of base) : System.Data.Common.dasm - SqlConvert:ConvertToSqlSingle(Object):SqlSingle

Top method improvements (bytes):
        -861 (-1.35% of base) : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
        -563 (-26.23% of base) : System.Text.Json.dasm - JsonConverter`1:WriteWithQuotesAsObject(Utf8JsonWriter,Object,JsonSerializerOptions,byref):this (20 methods)
        -512 (-24.32% of base) : System.Text.Json.dasm - JsonConverter`1:TryWriteAsObject(Utf8JsonWriter,Object,JsonSerializerOptions,byref):bool:this (20 methods)
        -279 (-2.98% of base) : System.Private.CoreLib.dasm - EqualityComparer`1:System.Collections.IEqualityComparer.Equals(Object,Object):bool:this (39 methods)
        -268 (-16.71% of base) : System.Text.Json.dasm - JsonPropertyInfo`1:SetExtensionDictionaryAsObject(Object,Object):this (20 methods)
        -251 (-6.07% of base) : System.Private.Xml.dasm - XmlUntypedStringConverter:ToArray(ref,IXmlNamespaceResolver):ref:this (16 methods)
        -239 (-2.73% of base) : System.Private.CoreLib.dasm - Comparer`1:System.Collections.IComparer.Compare(Object,Object):int:this (33 methods)
        -202 (-10.42% of base) : System.Private.Xml.dasm - XmlILOptimizerVisitor:FoldArithmetic(int,QilLiteral,QilLiteral):QilNode:this
        -192 (-20.17% of base) : System.Private.DataContractSerialization.dasm - DataNode`1:set_Value(Object):this (17 methods)
        -168 (-31.28% of base) : System.Data.Common.dasm - BigIntegerStorage:ConvertToBigInteger(Object,IFormatProvider):BigInteger
        -144 (-1.42% of base) : System.Private.Xml.dasm - XmlListConverter:ToArray(Object,IXmlNamespaceResolver):ref:this (16 methods)
        -116 (-2.57% of base) : System.Data.Common.dasm - FunctionNode:EvalFunction(int,ref,DataRow,int):Object:this
        -110 (-6.03% of base) : System.Private.Xml.dasm - ParticleContentValidator:BuildTransitionTable(BitSet,ref,int):ref:this
        -102 (-5.78% of base) : System.DirectoryServices.Protocols.dasm - DirectoryControl:TransformControls(ref)
        -101 (-3.92% of base) : System.Private.Xml.dasm - RangeContentValidator:ValidateElement(XmlQualifiedName,ValidationState,byref):Object:this
         -80 (-2.72% of base) : System.Data.Common.dasm - DataTable:DeserializeTableSchema(SerializationInfo,StreamingContext,bool):this
         -63 (-4.68% of base) : System.Private.CoreLib.dasm - List`1:System.Collections.IList.set_Item(int,Object):this (8 methods)
         -63 (-4.68% of base) : System.Private.CoreLib.dasm - List`1:System.Collections.IList.Insert(int,Object):this (8 methods)
         -63 (-3.08% of base) : System.Speech.dasm - StreamMarshaler:ReadArray(ref,int):this (7 methods)
         -60 (-2.65% of base) : System.DirectoryServices.Protocols.dasm - BerConverter:Encode(String,ref):ref

Top method regressions (percentages):
          13 (25.49% of base) : System.Runtime.CompilerServices.Unsafe.dasm - Unsafe:Unbox(Object):byref
          13 (24.07% of base) : System.Private.DataContractSerialization.dasm - ReflectionReader:ObjectToKeyValuePairGetKey(Object):Object
          13 (23.64% of base) : System.Private.DataContractSerialization.dasm - ReflectionReader:ObjectToKeyValuePairGetValue(Object):Object
          10 (12.82% of base) : Microsoft.Extensions.DependencyInjection.dasm - <>c__3`3:<RunOnEmptyStack>b__3_0(Object):__Canon:this
          10 (12.82% of base) : System.Linq.Expressions.dasm - <>c__5`3:<RunOnEmptyStack>b__5_0(Object):__Canon:this
          10 (12.66% of base) : System.Linq.Expressions.dasm - <>c__3`2:<RunOnEmptyStack>b__3_0(Object):Object:this
          10 (12.20% of base) : System.Linq.Expressions.dasm - <>c__6`4:<RunOnEmptyStack>b__6_0(Object):__Canon:this
          10 (12.05% of base) : System.Linq.Expressions.dasm - <>c__4`3:<RunOnEmptyStack>b__4_0(Object):Object:this
          25 (11.68% of base) : System.Linq.Expressions.dasm - LeftShiftInt32:Run(InterpretedFrame):int:this
          25 (11.68% of base) : System.Linq.Expressions.dasm - RightShiftInt32:Run(InterpretedFrame):int:this
         199 (10.96% of base) : System.Data.OleDb.dasm - ColumnBinding:Value(Object):this
          40 (10.67% of base) : System.Linq.Expressions.dasm - AndBoolean:Run(InterpretedFrame):int:this
          72 (10.56% of base) : System.Diagnostics.EventLog.dasm - NativeWrapper:EvtSetChannelConfigProperty(EventLogHandle,int,Object)
          38 (10.05% of base) : System.Linq.Expressions.dasm - OrBoolean:Run(InterpretedFrame):int:this
          14 ( 8.92% of base) : System.Linq.Expressions.dasm - NegateCheckedInt32:Run(InterpretedFrame):int:this
          19 ( 8.41% of base) : System.Linq.Expressions.dasm - AndInt32:Run(InterpretedFrame):int:this
          19 ( 8.41% of base) : System.Linq.Expressions.dasm - ExclusiveOrInt32:Run(InterpretedFrame):int:this
          19 ( 8.41% of base) : System.Linq.Expressions.dasm - OrInt32:Run(InterpretedFrame):int:this
          44 ( 8.04% of base) : System.Linq.Expressions.dasm - ToUnderlying:Convert(Object):Object:this
          30 ( 7.59% of base) : System.Text.Json.dasm - EnumConverter`1:ConvertToUInt64(Object):long

Top method improvements (percentages):
         -23 (-32.39% of base) : System.Private.Xml.dasm - DurationFacetsChecker:MatchEnumeration(Object,ArrayList,XmlSchemaDatatype):bool:this
        -168 (-31.28% of base) : System.Data.Common.dasm - BigIntegerStorage:ConvertToBigInteger(Object,IFormatProvider):BigInteger
         -30 (-29.41% of base) : System.Private.Xml.dasm - LogicalExpr:cmpNumberNumber(int,Object,Object):bool
         -40 (-28.57% of base) : System.Private.Xml.dasm - LogicalExpr:cmpBoolNumberO(int,Object,Object):bool
         -24 (-26.37% of base) : System.Security.AccessControl.dasm - AccessRule`1:.ctor(IdentityReference,__Canon,int):this
         -24 (-26.37% of base) : System.Security.AccessControl.dasm - AuditRule`1:.ctor(IdentityReference,__Canon,int):this
        -563 (-26.23% of base) : System.Text.Json.dasm - JsonConverter`1:WriteWithQuotesAsObject(Utf8JsonWriter,Object,JsonSerializerOptions,byref):this (20 methods)
         -26 (-25.24% of base) : System.Security.AccessControl.dasm - AccessRule`1:.ctor(IdentityReference,__Canon,int,int,int):this
         -26 (-25.24% of base) : System.Security.AccessControl.dasm - AuditRule`1:.ctor(IdentityReference,__Canon,int,int,int):this
        -512 (-24.32% of base) : System.Text.Json.dasm - JsonConverter`1:TryWriteAsObject(Utf8JsonWriter,Object,JsonSerializerOptions,byref):bool:this (20 methods)
         -15 (-23.81% of base) : System.Data.Common.dasm - DataKey:Equals(Object):bool:this
         -23 (-22.77% of base) : System.Security.Cryptography.X509Certificates.dasm - FindPal:ConfirmedCast(Object):DateTime
         -30 (-22.39% of base) : System.Private.Xml.dasm - LogicalExpr:cmpBoolBoolO(int,Object,Object):bool
         -12 (-21.82% of base) : System.Data.Common.dasm - AutoIncrementInt64:set_Current(Object):this
         -12 (-20.34% of base) : System.Drawing.Common.dasm - TriState:Equals(Object):bool:this
        -192 (-20.17% of base) : System.Private.DataContractSerialization.dasm - DataNode`1:set_Value(Object):this (17 methods)
         -15 (-18.99% of base) : System.ComponentModel.TypeConverter.dasm - Int32Converter:ToString(Object,NumberFormatInfo):String:this
         -15 (-18.99% of base) : System.ComponentModel.TypeConverter.dasm - UInt32Converter:ToString(Object,NumberFormatInfo):String:this
         -15 (-18.75% of base) : System.ComponentModel.TypeConverter.dasm - ByteConverter:ToString(Object,NumberFormatInfo):String:this
         -15 (-18.75% of base) : System.ComponentModel.TypeConverter.dasm - UInt16Converter:ToString(Object,NumberFormatInfo):String:this

1655 total methods with Code Size differences (823 improved, 832 regressed), 200195 unchanged.
```