### PR TITLE
Fix for field layout verification across version bubble boundary

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -401,7 +401,7 @@ namespace Internal.TypeSystem
             var offsets = new FieldAndOffset[numInstanceFields];
 
             // For types inheriting from another type, field offsets continue on from where they left off
-            LayoutInt cumulativeInstanceFieldPos = CalculateFieldOffsetForType(type, requiresAlign8: false);
+            LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type);
 
             var layoutMetadata = type.GetClassLayout();
 
@@ -445,7 +445,7 @@ namespace Internal.TypeSystem
             return computedLayout;
         }
 
-        protected virtual void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
+        protected virtual void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
         {
         }
 
@@ -551,7 +551,7 @@ namespace Internal.TypeSystem
             bool requiresAlign8 = !largestAlignmentRequired.IsIndeterminate && largestAlignmentRequired.AsInt > 4;
 
             // For types inheriting from another type, field offsets continue on from where they left off
-            LayoutInt cumulativeInstanceFieldPos = CalculateFieldOffsetForType(type, requiresAlign8);
+            LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type);
 
             // We've finished placing the fields into their appropriate arrays
             // The next optimization may place non-GC Pointers, so repurpose our
@@ -762,14 +762,14 @@ namespace Internal.TypeSystem
             return type.IsValueType && !type.IsPrimitive && !type.IsEnum;
         }
 
-        private LayoutInt CalculateFieldOffsetForType(DefType type, bool requiresAlign8)
+        public LayoutInt CalculateFieldBaseOffset(TypeDesc type)
         {
             LayoutInt cumulativeInstanceFieldPos = LayoutInt.Zero;
 
             if (!type.IsValueType && type.HasBaseType)
             {
                 cumulativeInstanceFieldPos = type.BaseType.InstanceByteCountUnaligned;
-                AlignBaseOffsetIfNecessary((MetadataType)type, ref cumulativeInstanceFieldPos, requiresAlign8 || type.BaseType.RequiresAlign8());
+                AlignBaseOffsetIfNecessary((MetadataType)type, ref cumulativeInstanceFieldPos);
             }
 
             return cumulativeInstanceFieldPos;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -859,6 +859,12 @@ namespace Internal.TypeSystem
         {
             SizeAndAlignment result;
 
+            // Pad the length of structs to be 1 if they are empty so we have no zero-length structures
+            if (type.IsValueType && instanceSize == LayoutInt.Zero)
+            {
+                instanceSize = LayoutInt.One;
+            }
+
             TargetDetails target = type.Context.Target;
 
             if (classLayoutSize != 0)

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -761,7 +761,7 @@ namespace Internal.TypeSystem
             return type.IsValueType && !type.IsPrimitive && !type.IsEnum;
         }
 
-        public LayoutInt CalculateBaseTypeSize(TypeDesc type)
+        public LayoutInt CalculateBaseTypeSize(MetadataType type)
         {
             LayoutInt baseTypeSize = LayoutInt.Zero;
 
@@ -769,14 +769,14 @@ namespace Internal.TypeSystem
             {
                 LayoutInt offsetBias = OffsetBias(type);
                 baseTypeSize = type.BaseType.InstanceByteCount + offsetBias;
-                AlignBaseOffsetIfNecessary((MetadataType)type, ref baseTypeSize);
+                AlignBaseOffsetIfNecessary(type, ref baseTypeSize);
                 baseTypeSize -= offsetBias;
             }
 
             return baseTypeSize;
         }
 
-        public LayoutInt CalculateFieldBaseOffset(TypeDesc type)
+        public LayoutInt CalculateFieldBaseOffset(MetadataType type)
         {
             LayoutInt cumulativeInstanceFieldPos = LayoutInt.Zero;
 
@@ -784,7 +784,7 @@ namespace Internal.TypeSystem
             {
                 LayoutInt offsetBias = OffsetBias(type);
                 cumulativeInstanceFieldPos = type.BaseType.InstanceByteCountUnaligned + offsetBias;
-                AlignBaseOffsetIfNecessary((MetadataType)type, ref cumulativeInstanceFieldPos);
+                AlignBaseOffsetIfNecessary(type, ref cumulativeInstanceFieldPos);
                 cumulativeInstanceFieldPos -= offsetBias;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -82,6 +82,12 @@ namespace ILCompiler
         public abstract bool IsInputBubble { get; }
 
         /// <summary>
+        /// Returns true when the base type and derived type don't reside in the same version bubble
+        /// in which case the runtime aligns the field base offset.
+        /// </summary>
+        public abstract bool NeedsAlignmentBetweenBaseTypeAndDerived(MetadataType baseType, MetadataType derivedType);
+
+        /// <summary>
         /// List of input modules to use for the compilation.
         /// </summary>
         public abstract IEnumerable<EcmaModule> CompilationModuleSet { get; }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         && !_fieldDesc.IsStatic
                         && !_fieldDesc.OwningType.IsValueType)
                     {
-                        baseOffset = (uint)_fieldDesc.OwningType.BaseTypeSize().AsInt;
+                        baseOffset = (uint)((MetadataType)_fieldDesc.OwningType).BaseTypeSize().AsInt;
                         if (!factory.CompilationModuleGroup.VersionsWithType(_fieldDesc.OwningType.BaseType))
                         {
                             fieldOffset -= baseOffset;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         && !_fieldDesc.IsStatic
                         && !_fieldDesc.OwningType.IsValueType)
                     {
-                        baseOffset = (uint)((MetadataType)_fieldDesc.OwningType).BaseTypeSize().AsInt;
+                        baseOffset = (uint)((MetadataType)_fieldDesc.OwningType).FieldBaseOffset().AsInt;
                         if (!factory.CompilationModuleGroup.VersionsWithType(_fieldDesc.OwningType.BaseType))
                         {
                             fieldOffset -= baseOffset;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -41,22 +41,30 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_fieldDesc);
                 SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
+                uint baseOffset = 0;
+                uint fieldOffset = (uint)_fieldDesc.Offset.AsInt;
 
                 if (_fixupKind == ReadyToRunFixupKind.Verify_FieldOffset)
                 {
                     TypeDesc baseType = _fieldDesc.OwningType.BaseType;
-                    if ((_fieldDesc.OwningType.BaseType != null) && !_fieldDesc.IsStatic && !_fieldDesc.OwningType.IsValueType)
+                    if ((_fieldDesc.OwningType.BaseType != null)
+                        && !_fieldDesc.IsStatic
+                        && !_fieldDesc.OwningType.IsValueType)
                     {
-                        dataBuilder.EmitUInt((uint)_fieldDesc.OwningType.FieldBaseOffset().AsInt);
+                        baseOffset = (uint)_fieldDesc.OwningType.FieldBaseOffset().AsInt;
+                        if (!factory.CompilationModuleGroup.VersionsWithType(_fieldDesc.OwningType.BaseType))
+                        {
+                            fieldOffset -= baseOffset;
+                            baseOffset = 0;
+                        }
                     }
-                    else
-                        dataBuilder.EmitUInt(0);
+                    dataBuilder.EmitUInt(baseOffset);
                 }
 
                 if ((_fixupKind == ReadyToRunFixupKind.Check_FieldOffset) ||
                     (_fixupKind == ReadyToRunFixupKind.Verify_FieldOffset))
                 {
-                    dataBuilder.EmitUInt((uint)_fieldDesc.Offset.AsInt);
+                    dataBuilder.EmitUInt(fieldOffset);
                 }
 
                 dataBuilder.EmitFieldSignature(_fieldDesc, innerContext);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -51,8 +51,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         && !_fieldDesc.IsStatic
                         && !_fieldDesc.OwningType.IsValueType)
                     {
-                        baseOffset = (uint)((MetadataType)_fieldDesc.OwningType).FieldBaseOffset().AsInt;
-                        if (!factory.CompilationModuleGroup.VersionsWithType(_fieldDesc.OwningType.BaseType))
+                        MetadataType owningType = (MetadataType)_fieldDesc.OwningType;
+                        baseOffset = (uint)owningType.FieldBaseOffset().AsInt;
+                        if (factory.CompilationModuleGroup.NeedsAlignmentBetweenBaseTypeAndDerived((MetadataType)baseType, owningType))
                         {
                             fieldOffset -= baseOffset;
                             baseOffset = 0;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         && !_fieldDesc.IsStatic
                         && !_fieldDesc.OwningType.IsValueType)
                     {
-                        baseOffset = (uint)_fieldDesc.OwningType.FieldBaseOffset().AsInt;
+                        baseOffset = (uint)_fieldDesc.OwningType.BaseTypeSize().AsInt;
                         if (!factory.CompilationModuleGroup.VersionsWithType(_fieldDesc.OwningType.BaseType))
                         {
                             fieldOffset -= baseOffset;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -267,8 +267,11 @@ namespace ILCompiler
             return ModuleToCompilationUnitIndex(module1) == ModuleToCompilationUnitIndex(module2);
         }
 
-        public bool NeedsAlignmentBetweenBaseTypeAndDerived(MetadataType baseType, MetadataType derivedType)
+        public override bool NeedsAlignmentBetweenBaseTypeAndDerived(MetadataType baseType, MetadataType derivedType)
         {
+            if (baseType.IsObject)
+                return false;
+
             if (!ModuleMatchesCompilationUnitIndex(derivedType.Module, baseType.Module) ||
                 TypeLayoutCompilationUnits(baseType).HasMultipleCompilationUnits)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -68,9 +68,9 @@ namespace ILCompiler
             }
         }
 
-        public LayoutInt CalculateBaseTypeSize(TypeDesc type) => _r2rFieldLayoutAlgorithm.CalculateBaseTypeSize(type);
+        public LayoutInt CalculateBaseTypeSize(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateBaseTypeSize(type);
 
-        public LayoutInt CalculateFieldBaseOffset(TypeDesc type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type);
+        public LayoutInt CalculateFieldBaseOffset(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type);
 
         public void SetCompilationGroup(ReadyToRunCompilationModuleGroupBase compilationModuleGroup)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -68,6 +68,8 @@ namespace ILCompiler
             }
         }
 
+        public LayoutInt CalculateBaseTypeSize(TypeDesc type) => _r2rFieldLayoutAlgorithm.CalculateBaseTypeSize(type);
+
         public LayoutInt CalculateFieldBaseOffset(TypeDesc type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type);
 
         public void SetCompilationGroup(ReadyToRunCompilationModuleGroupBase compilationModuleGroup)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -68,6 +68,8 @@ namespace ILCompiler
             }
         }
 
+        public LayoutInt CalculateFieldBaseOffset(TypeDesc type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type);
+
         public void SetCompilationGroup(ReadyToRunCompilationModuleGroupBase compilationModuleGroup)
         {
             _r2rFieldLayoutAlgorithm.SetCompilationGroup(compilationModuleGroup);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -68,7 +68,12 @@ namespace ILCompiler
             }
         }
 
-        public LayoutInt CalculateFieldBaseOffset(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type, type.RequiresAlign8());
+        /// <summary>
+        /// This is a rough equivalent of the CoreCLR runtime method ReadyToRunInfo::GetFieldBaseOffset.
+        /// In contrast to the auto field layout algorithm, this method unconditionally applies alignment
+        /// between base and derived class (even when they reside in the same version bubble).
+        /// </summary>
+        public LayoutInt CalculateFieldBaseOffset(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type, type.RequiresAlign8(), requiresAlignedBase: true);
 
         public void SetCompilationGroup(ReadyToRunCompilationModuleGroupBase compilationModuleGroup)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -68,9 +68,7 @@ namespace ILCompiler
             }
         }
 
-        public LayoutInt CalculateBaseTypeSize(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateBaseTypeSize(type);
-
-        public LayoutInt CalculateFieldBaseOffset(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type);
+        public LayoutInt CalculateFieldBaseOffset(MetadataType type) => _r2rFieldLayoutAlgorithm.CalculateFieldBaseOffset(type, type.RequiresAlign8());
 
         public void SetCompilationGroup(ReadyToRunCompilationModuleGroupBase compilationModuleGroup)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -821,7 +821,8 @@ namespace ILCompiler
         {
             if (requiresAlignedBase || _compilationGroup.NeedsAlignmentBetweenBaseTypeAndDerived(baseType: (MetadataType)type.BaseType, derivedType: type))
             {
-                LayoutInt alignment = new LayoutInt(requiresAlign8 || type.BaseType.RequiresAlign8() ? 8 : type.Context.Target.PointerSize);
+                bool use8Align = (requiresAlign8 || type.BaseType.RequiresAlign8()) && type.Context.Target.Architecture != TargetArchitecture.X86;
+                LayoutInt alignment = new LayoutInt(use8Align ? 8 : type.Context.Target.PointerSize);
                 baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -18,11 +18,6 @@ namespace ILCompiler
 {
     public static class ReadyToRunTypeExtensions
     {
-        public static LayoutInt BaseTypeSize(this MetadataType type)
-        {
-            return ((ReadyToRunCompilerContext)type.Context).CalculateBaseTypeSize(type);
-        }
-
         public static LayoutInt FieldBaseOffset(this MetadataType type)
         {
             return ((ReadyToRunCompilerContext)type.Context).CalculateFieldBaseOffset(type);
@@ -822,7 +817,7 @@ namespace ILCompiler
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.
         /// </summary>
-        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
+        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
         {
             DefType baseType = type.BaseType;
 
@@ -832,7 +827,7 @@ namespace ILCompiler
                 return;
             }
 
-            LayoutInt alignment = new LayoutInt(type.Context.Target.Architecture == TargetArchitecture.ARM ? 8 : type.Context.Target.PointerSize);
+            LayoutInt alignment = new LayoutInt(requiresAlign8 ? 8 : type.Context.Target.PointerSize);
             baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -835,7 +835,7 @@ namespace ILCompiler
 
             LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);
 
-            if (requiresAlign8)
+            if (requiresAlign8 || type.Context.Target.Architecture == TargetArchitecture.ARM)
             {
                 alignment = new LayoutInt(8);
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -20,13 +20,7 @@ namespace ILCompiler
     {
         public static LayoutInt FieldBaseOffset(this TypeDesc type)
         {
-            LayoutInt baseOffset = type.BaseType.InstanceByteCount;
-            if (type.RequiresAlign8())
-            {
-                baseOffset = LayoutInt.AlignUp(baseOffset, new LayoutInt(8), type.Context.Target);
-            }
-
-            return baseOffset;
+            return ((ReadyToRunCompilerContext)type.Context).CalculateFieldBaseOffset(type);
         }
     }
 
@@ -823,7 +817,7 @@ namespace ILCompiler
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.
         /// </summary>
-        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
+        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
         {
             DefType baseType = type.BaseType;
             
@@ -833,12 +827,7 @@ namespace ILCompiler
                 return;
             }
 
-            LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);
-
-            if (requiresAlign8 || type.Context.Target.Architecture == TargetArchitecture.ARM)
-            {
-                alignment = new LayoutInt(8);
-            }
+            LayoutInt alignment = new LayoutInt(type.Context.Target.Architecture == TargetArchitecture.ARM ? 8 : type.Context.Target.PointerSize);
             baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -18,6 +18,11 @@ namespace ILCompiler
 {
     public static class ReadyToRunTypeExtensions
     {
+        public static LayoutInt BaseTypeSize(this TypeDesc type)
+        {
+            return ((ReadyToRunCompilerContext)type.Context).CalculateBaseTypeSize(type);
+        }
+
         public static LayoutInt FieldBaseOffset(this TypeDesc type)
         {
             return ((ReadyToRunCompilerContext)type.Context).CalculateFieldBaseOffset(type);
@@ -820,7 +825,7 @@ namespace ILCompiler
         protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
         {
             DefType baseType = type.BaseType;
-            
+
             if (!_compilationGroup.NeedsAlignmentBetweenBaseTypeAndDerived(baseType: (MetadataType)baseType, derivedType: type))
             {
                 // The type is defined in the module that's currently being compiled and the type layout doesn't depend on other modules

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -817,18 +817,13 @@ namespace ILCompiler
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.
         /// </summary>
-        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
+        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8, bool requiresAlignedBase)
         {
-            DefType baseType = type.BaseType;
-
-            if (!_compilationGroup.NeedsAlignmentBetweenBaseTypeAndDerived(baseType: (MetadataType)baseType, derivedType: type))
+            if (requiresAlignedBase || _compilationGroup.NeedsAlignmentBetweenBaseTypeAndDerived(baseType: (MetadataType)type.BaseType, derivedType: type))
             {
-                // The type is defined in the module that's currently being compiled and the type layout doesn't depend on other modules
-                return;
+                LayoutInt alignment = new LayoutInt(requiresAlign8 ? 8 : type.Context.Target.PointerSize);
+                baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
             }
-
-            LayoutInt alignment = new LayoutInt(requiresAlign8 ? 8 : type.Context.Target.PointerSize);
-            baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
         }
 
         public static bool IsManagedSequentialType(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -821,7 +821,7 @@ namespace ILCompiler
         {
             if (requiresAlignedBase || _compilationGroup.NeedsAlignmentBetweenBaseTypeAndDerived(baseType: (MetadataType)type.BaseType, derivedType: type))
             {
-                LayoutInt alignment = new LayoutInt(requiresAlign8 ? 8 : type.Context.Target.PointerSize);
+                LayoutInt alignment = new LayoutInt(requiresAlign8 || type.BaseType.RequiresAlign8() ? 8 : type.Context.Target.PointerSize);
                 baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -18,12 +18,12 @@ namespace ILCompiler
 {
     public static class ReadyToRunTypeExtensions
     {
-        public static LayoutInt BaseTypeSize(this TypeDesc type)
+        public static LayoutInt BaseTypeSize(this MetadataType type)
         {
             return ((ReadyToRunCompilerContext)type.Context).CalculateBaseTypeSize(type);
         }
 
-        public static LayoutInt FieldBaseOffset(this TypeDesc type)
+        public static LayoutInt FieldBaseOffset(this MetadataType type)
         {
             return ((ReadyToRunCompilerContext)type.Context).CalculateFieldBaseOffset(type);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2336,7 +2336,7 @@ namespace Internal.JitInterface
                 }
 
                 // ENCODE_FIELD_BASE_OFFSET
-                int fieldBaseOffset = pMT.FieldBaseOffset().AsInt;
+                int fieldBaseOffset = ((MetadataType)pMT).FieldBaseOffset().AsInt;
                 Debug.Assert(pResult->offset >= (uint)fieldBaseOffset);
                 pResult->offset -= (uint)fieldBaseOffset;
                 pResult->fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE_WITH_BASE;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14107,6 +14107,14 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                 actualBaseOffset = ReadyToRunInfo::GetFieldBaseOffset(pEnclosingMT);
             }
 
+            if (baseOffset == 0)
+            {
+                // Relative verification of just the field offset when the base class
+                // is outside of the current R2R version bubble
+                actualFieldOffset -= actualBaseOffset;
+                actualBaseOffset = 0;
+            }
+
             if ((fieldOffset != actualFieldOffset) || (baseOffset != actualBaseOffset))
             {
                 // Verification failures are failfast events

--- a/src/tests/Regressions/coreclr/GitHub_49982/test49982.cs
+++ b/src/tests/Regressions/coreclr/GitHub_49982/test49982.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class Program
+{
+    private class MockEndPoint : EndPoint
+    {
+    }
+
+    private sealed class ExtendedSocketException : SocketException
+    {
+        private readonly EndPoint? _endPoint;
+
+        public ExtendedSocketException(EndPoint? endPoint)
+            : base(0)
+        {
+            _endPoint = endPoint;
+        }
+        
+        public bool EndPointEquals(EndPoint? endPoint)
+        {
+            return _endPoint == endPoint;
+        }
+    }
+
+    static bool TestExtendedSocketException()
+    {
+        EndPoint endPoint = new MockEndPoint();
+        ExtendedSocketException extendedSocketException = new ExtendedSocketException(endPoint);
+        Console.WriteLine("ExtendedSocketException: {0}", extendedSocketException.GetType());
+        return extendedSocketException.EndPointEquals(endPoint);
+    }
+
+    static int Main()
+    {
+        Console.WriteLine("Extended socket exception:");
+        return TestExtendedSocketException() ? 100 : 1;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_49982/test49982.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_49982/test49982.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- This is an explicit crossgen test -->
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Net.Sockets" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When verifying field offset consistency, we shouldn't be checking
base class size when the base class doesn't belong to the current
version bubble. I have fixed this by adding a special case for
the existing fixup encoding indicated by base class size being
zero; please let me know if you find it preferable to create
a new fixup type for this purpose instead. I have also created
a simple regression test that was previously failing when run
against the framework compiled with CG2 assembly by assembly.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/49982

/cc @dotnet/crossgen-contrib 