### PR TITLE
ensure MetadataReader fast path works with every FileStream on every OS

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultLanguage>en-US</DefaultLanguage>
@@ -15,9 +15,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
-             Link="Common\Interop\Windows\Interop.Libraries.cs" />
+             Link="Common\Interop\Windows\Interop.Libraries.cs"
+             Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)' "/>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs"
-             Link="Common\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs" />
+             Link="Common\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs"
+             Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)' "/>
     <Compile Include="System\Reflection\Internal\Utilities\PinnedObject.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" Condition="'$(TargetFramework)' != 'netstandard1.1'" />
     <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.netstandard1.1.cs" Condition="'$(TargetFramework)' == 'netstandard1.1'" />

--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -102,8 +102,9 @@
     <Compile Include="System\Reflection\Internal\Utilities\EmptyArray.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.cs" Condition="$(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('net4'))" />
     <Compile Include="System\Reflection\Internal\Utilities\EncodingHelper.netcoreapp.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
-    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.cs" Condition="'$(TargetFramework)' != 'netstandard1.1'" />
+    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.netcoreapp.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
     <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.netstandard1.1.cs" Condition="'$(TargetFramework)' == 'netstandard1.1'" />
+    <Compile Include="System\Reflection\Internal\Utilities\FileStreamReadLightUp.netstandard2.0.cs" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
     <Compile Include="System\Reflection\Internal\Utilities\Hash.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ImmutableByteArrayInterop.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\ImmutableMemoryStream.cs" />

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -76,7 +76,7 @@ namespace System.Reflection.Internal
             {
                 stream.Seek(start, SeekOrigin.Begin);
 
-                if (!isFileStream || !FileStreamReadLightUp.TryReadFile(stream, block.Pointer, start, size))
+                if (!isFileStream || !FileStreamReadLightUp.TryReadFile(stream, block.Pointer, size))
                 {
                     stream.CopyTo(block.Pointer, size);
                 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -78,7 +78,7 @@ namespace System.Reflection.Internal
 
                 int bytesRead = 0;
 
-                if (!isFileStream || !FileStreamReadLightUp.TryReadFile(stream, block.Pointer, size, out bytesRead))
+                if (!isFileStream || (bytesRead = FileStreamReadLightUp.ReadFile(stream, block.Pointer, size)) != size)
                 {
                     stream.CopyTo(block.Pointer + bytesRead, size - bytesRead);
                 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -76,9 +76,11 @@ namespace System.Reflection.Internal
             {
                 stream.Seek(start, SeekOrigin.Begin);
 
-                if (!isFileStream || !FileStreamReadLightUp.TryReadFile(stream, block.Pointer, size))
+                int bytesRead = 0;
+
+                if (!isFileStream || !FileStreamReadLightUp.TryReadFile(stream, block.Pointer, size, out bytesRead))
                 {
-                    stream.CopyTo(block.Pointer, size);
+                    stream.CopyTo(block.Pointer + bytesRead, size - bytesRead);
                 }
 
                 fault = false;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+
+namespace System.Reflection.Internal
+{
+    internal static class FileStreamReadLightUp
+    {
+        internal static bool IsFileStream(Stream stream) => stream is FileStream;
+
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
+            => stream.Read(new Span<byte>(buffer, size)) == size;
+    }
+}

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
@@ -9,11 +9,7 @@ namespace System.Reflection.Internal
     {
         internal static bool IsFileStream(Stream stream) => stream is FileStream;
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
-        {
-            bytesRead = stream.Read(new Span<byte>(buffer, size));
-
-            return bytesRead == size;
-        }
+        internal static unsafe int ReadFile(Stream stream, byte* buffer, int size)
+            => stream.Read(new Span<byte>(buffer, size));
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netcoreapp.cs
@@ -9,7 +9,11 @@ namespace System.Reflection.Internal
     {
         internal static bool IsFileStream(Stream stream) => stream is FileStream;
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
-            => stream.Read(new Span<byte>(buffer, size)) == size;
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
+        {
+            bytesRead = stream.Read(new Span<byte>(buffer, size));
+
+            return bytesRead == size;
+        }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -86,21 +86,22 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
         {
             if (readFileNotAvailable)
             {
+                bytesRead = 0;
                 return false;
             }
 
             SafeHandle handle = GetSafeFileHandle(stream);
             if (handle == null)
             {
+                bytesRead = 0;
                 return false;
             }
 
             int result;
-            int bytesRead;
 
             try
             {
@@ -109,6 +110,7 @@ namespace System.Reflection.Internal
             catch
             {
                 readFileNotAvailable = true;
+                bytesRead = 0;
                 return false;
             }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -86,45 +86,29 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
+        internal static unsafe int ReadFile(Stream stream, byte* buffer, int size)
         {
             if (readFileNotAvailable)
             {
-                bytesRead = 0;
-                return false;
+                return 0;
             }
 
             SafeHandle handle = GetSafeFileHandle(stream);
             if (handle == null)
             {
-                bytesRead = 0;
-                return false;
+                return 0;
             }
-
-            int result;
 
             try
             {
-                result = Interop.Kernel32.ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                int result = Interop.Kernel32.ReadFile(handle, buffer, size, out int bytesRead, IntPtr.Zero);
+                return result == 0 ? 0 : bytesRead;
             }
             catch
             {
                 readFileNotAvailable = true;
-                bytesRead = 0;
-                return false;
+                return 0;
             }
-
-            if (result == 0 || bytesRead != size)
-            {
-                // We used to throw here, but this is where we land if the FileStream was
-                // opened with useAsync: true, which is currently the default on .NET Core.
-                // https://github.com/dotnet/corefx/pull/987 filed to look in to how best to
-                // handle this, but in the meantime, we'll fall back to the slower code path
-                // just as in the case where the native API is unavailable in the current platform.
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -86,7 +86,7 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, long start, int size)
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
         {
             if (readFileNotAvailable)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
@@ -36,34 +36,21 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
+        internal static unsafe int ReadFile(Stream stream, byte* buffer, int size)
         {
             if (!IsReadFileAvailable)
             {
-                bytesRead = 0;
-                return false;
+                return 0;
             }
 
             SafeHandle? handle = GetSafeFileHandle(stream);
             if (handle == null)
             {
-                bytesRead = 0;
-                return false;
+                return 0;
             }
 
-            int result = Interop.Kernel32.ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
-
-            if (result == 0 || bytesRead != size)
-            {
-                // We used to throw here, but this is where we land if the FileStream was
-                // opened with useAsync: true, which is currently the default on .NET Core.
-                // https://github.com/dotnet/corefx/pull/987 filed to look in to how best to
-                // handle this, but in the meantime, we'll fall back to the slower code path
-                // just as in the case where the native API is unavailable in the current platform.
-                return false;
-            }
-
-            return true;
+            int result = Interop.Kernel32.ReadFile(handle, buffer, size, out int bytesRead, IntPtr.Zero);
+            return result == 0 ? 0 : bytesRead;
         }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
@@ -36,20 +36,22 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size, out int bytesRead)
         {
             if (!IsReadFileAvailable)
             {
+                bytesRead = 0;
                 return false;
             }
 
             SafeHandle? handle = GetSafeFileHandle(stream);
             if (handle == null)
             {
+                bytesRead = 0;
                 return false;
             }
 
-            int result = Interop.Kernel32.ReadFile(handle, buffer, size, out int bytesRead, IntPtr.Zero);
+            int result = Interop.Kernel32.ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
 
             if (result == 0 || bytesRead != size)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard2.0.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -9,12 +8,7 @@ namespace System.Reflection.Internal
 {
     internal static class FileStreamReadLightUp
     {
-        private static bool IsReadFileAvailable =>
-#if NETCOREAPP
-            OperatingSystem.IsWindows();
-#else
-            Path.DirectorySeparatorChar == '\\';
-#endif
+        private static bool IsReadFileAvailable => Path.DirectorySeparatorChar == '\\';
 
         internal static bool IsFileStream(Stream stream) => stream is FileStream;
 
@@ -42,7 +36,7 @@ namespace System.Reflection.Internal
             return handle;
         }
 
-        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, long start, int size)
+        internal static unsafe bool TryReadFile(Stream stream, byte* buffer, int size)
         {
             if (!IsReadFileAvailable)
             {


### PR DESCRIPTION
This code predates me, but according to my understanding:

1. We had a Windows-specific optimization:

https://github.com/dotnet/runtime/blob/49e5d17b128287ca71a7ed8df223749b801852ec/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs#L12-L17

2. That was calling `ReadFile` syscall:

https://github.com/dotnet/runtime/blob/49e5d17b128287ca71a7ed8df223749b801852ec/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs#L58

3. That was working only for `sync` `FileStream`s:

https://github.com/dotnet/runtime/blob/49e5d17b128287ca71a7ed8df223749b801852ec/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs#L62-L66

Based on the comment from #14276

>  Perhaps, this is the right opportunity to define a portable FileStream.Read overload that reads to unmanaged memory?

It seems that this code was created before we have added a `Stream.Read(Span)` overload that allows for reading from a file to an unmanaged memory buffer. 

Moreover, I think that partial reads were not handled properly, as in cases when `bytesRead != requestedSize` the `block.Pointer` was not incremented properly:

https://github.com/dotnet/runtime/blob/79ae74f5ca5c8a6fe3a48935e85bd7374959c570/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs#L79-L81

fixes #14276