### PR TITLE
Several WebProxy-related fixes

### DIFF
--- a/src/libraries/System.Net.WebProxy/src/System.Net.WebProxy.csproj
+++ b/src/libraries/System.Net.WebProxy/src/System.Net.WebProxy.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Net\IWebProxyScript.cs" />
     <Compile Include="System\Net\WebProxy.cs" />
+    <Compile Condition="'$(TargetsBrowser)' == 'true'" Include="System\Net\WebProxy.Browser.cs" />
+    <Compile Condition="'$(TargetsBrowser)' != 'true'" Include="System\Net\WebProxy.NonBrowser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Net.NameResolution" />
@@ -15,5 +17,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.RegularExpressions" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.Browser.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.Browser.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace System.Net
+{
+    public partial class WebProxy : IWebProxy, ISerializable
+    {
+        private bool IsLocal(Uri host)
+        {
+            if (host.IsLoopback)
+            {
+                return true;
+            }
+
+            string hostString = host.Host;
+            return
+                !IPAddress.TryParse(hostString, out _) &&
+                !hostString.Contains('.');
+        }
+    }
+}

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonBrowser.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonBrowser.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.NetworkInformation;
+using System.Runtime.Serialization;
+using System.Threading;
+
+namespace System.Net
+{
+    public partial class WebProxy : IWebProxy, ISerializable
+    {
+        private static volatile string? s_domainName;
+        private static volatile IPAddress[]? s_localAddresses;
+        private static int s_networkChangeRegistered;
+
+        private bool IsLocal(Uri host)
+        {
+            if (host.IsLoopback)
+            {
+                return true;
+            }
+
+            string hostString = host.Host;
+
+            if (IPAddress.TryParse(hostString, out IPAddress? hostAddress))
+            {
+                EnsureNetworkChangeRegistration();
+                IPAddress[] localAddresses = s_localAddresses ??= Dns.GetHostEntry(Dns.GetHostName()).AddressList;
+                return Array.IndexOf(localAddresses, hostAddress) != -1;
+            }
+
+            // No dot?  Local.
+            int dot = hostString.IndexOf('.');
+            if (dot == -1)
+            {
+                return true;
+            }
+
+            // If it matches the primary domain, it's local (whether or not the hostname matches).
+            EnsureNetworkChangeRegistration();
+            string local = s_domainName ??= "." + IPGlobalProperties.GetIPGlobalProperties().DomainName;
+            return
+                local.Length == (hostString.Length - dot) &&
+                string.Compare(local, 0, hostString, dot, local.Length, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        /// <summary>Ensures we've registered with NetworkChange to clear out statically-cached state upon a network change notification.</summary>
+        private static void EnsureNetworkChangeRegistration()
+        {
+            if (s_networkChangeRegistered == 0)
+            {
+                Register();
+
+                static void Register()
+                {
+                    if (Interlocked.Exchange(ref s_networkChangeRegistered, 1) != 0)
+                    {
+                        return;
+                    }
+
+                    // Clear out cached state when we get notification of a network-related change.
+                    NetworkChange.NetworkAddressChanged += (s, e) =>
+                    {
+                        s_domainName = null;
+                        s_localAddresses = null;
+                    };
+                    NetworkChange.NetworkAvailabilityChanged += (s, e) =>
+                    {
+                        s_domainName = null;
+                        s_localAddresses = null;
+                    };
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Split browser from non-browser to avoid CA1416 suppressions, UnsupportedOSPlatform attributes, and PNSEs when used from browser
- Cache domain name and local addresses for use in IsLocal, along with clearing of the caches upon network change detection
- Removing redundant IPAddress.IsLoopback check that's covered by previous Uri.IsLoopback check
- Change IsMatchInBypassList to use string interpolation, such that the non-default port case will get better implicitly with C# 10 interpolated string improvements

Contributes to (or fixes, we don't know if or what the issue there is yet) https://github.com/dotnet/runtime/issues/50323
Fixes https://github.com/dotnet/runtime/issues/43751

```C#
private WebProxy _proxy = new WebProxy("http://myproxy", true);
private Uri _uri1 = new Uri("https://dot.net");
private Uri _uri2 = new Uri("https://104.215.148.63");

[Benchmark]
public bool IsBypassedName() => _proxy.IsBypassed(_uri1);
[Benchmark]
public bool IsBypassedIP() => _proxy.IsBypassed(_uri2);
```

|         Method |         Toolchain |          Mean | Ratio | Allocated |
|--------------- |------------------ |--------------:|------:|----------:|
| IsBypassedName | \main\corerun.exe |      67.53 ns |  1.00 |      24 B |
| IsBypassedName |   \pr\corerun.exe |      50.16 ns |  0.74 |         - |
|                |                   |               |       |           |
|   IsBypassedIP | \main\corerun.exe | 262,327.94 ns | 1.000 |     984 B |
|   IsBypassedIP |   \pr\corerun.exe |     146.56 ns | 0.001 |      40 B |
