### PR TITLE
Always call CloseHandle in AsmMan::EmitManifest

### DIFF
--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -1000,8 +1000,9 @@ HRESULT AsmMan::EmitManifest()
                             m_fMResNew[m_dwMResNum] = TRUE;
                             m_dwMResNum++;
                         }
-                        CloseHandle(hFile);
                     }
+
+                    CloseHandle(hFile);
                 }
             }
             if(fOK || ((Assembler*)m_pAssembler)->OnErrGo)


### PR DESCRIPTION
Unless it's an ERROR_INVALID_HANDLE.

Otherwise, we can leak the file handle.