### PR TITLE
Fix unintended closure in RsaPaddingProcessor.OpenProcessor

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -32,9 +32,9 @@ namespace System.Security.Cryptography
         {
             return s_hashSizes.GetOrAdd(
                 hashAlgorithm,
-                alg =>
+                static hashAlgorithm =>
                 {
-                    using (HashProviderCng hashProvider = new HashProviderCng(alg.Name!, null))
+                    using (HashProviderCng hashProvider = new HashProviderCng(hashAlgorithm.Name!, null))
                     {
                         return hashProvider.HashSizeInBytes;
                     }

--- a/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography
         {
             return s_lookup.GetOrAdd(
                 hashAlgorithmName,
-                alg =>
+                static hashAlgorithmName =>
                 {
                     using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
                     {


### PR DESCRIPTION
The change in RsaPaddingProcessor.cs is the fix.
The change in RSACng.SignVerify.cs is for consistency / future-proofing.