### PR TITLE
Fix waits on iOS

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_threading.c
+++ b/src/libraries/Native/Unix/System.Native/pal_threading.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>
+#include <sys/time.h>
 
 #if defined(TARGET_OSX)
 // So we can use the declaration of pthread_cond_timedwait_relative_np
@@ -169,13 +170,25 @@ int32_t SystemNative_LowLevelMonitor_TimedWait(LowLevelMonitor *monitor, int32_t
 #if HAVE_CLOCK_GETTIME_NSEC_NP
     timeoutTimeSpec.tv_sec = timeoutMilliseconds / 1000;
     timeoutTimeSpec.tv_nsec = (timeoutMilliseconds % 1000) * 1000 * 1000;
+
     error = pthread_cond_timedwait_relative_np(&monitor->Condition, &monitor->Mutex, &timeoutTimeSpec);
 #else
+#if HAVE_CLOCK_MONOTONIC
     error = clock_gettime(CLOCK_MONOTONIC, &timeoutTimeSpec);
     assert(error == 0);
+#else
+    struct timeval tv;
+
+    error = gettimeofday(&tv, NULL);
+    assert(error == 0);
+
+    timeoutTimeSpec.tv_sec = tv.tv_sec;
+    timeoutTimeSpec.tv_nsec = tv.tv_usec * 1000;
+#endif
     uint64_t nanoseconds = (uint64_t)timeoutMilliseconds * 1000 * 1000 + (uint64_t)timeoutTimeSpec.tv_nsec;
     timeoutTimeSpec.tv_sec += nanoseconds / (1000 * 1000 * 1000);
     timeoutTimeSpec.tv_nsec = nanoseconds % (1000 * 1000 * 1000);
+
     error = pthread_cond_timedwait(&monitor->Condition, &monitor->Mutex, &timeoutTimeSpec);
 #endif
     assert(error == 0 || error == ETIMEDOUT);


### PR DESCRIPTION
I don't understand why `CLOCK_MONOTONIC` doesn't work even in newer simulators here, but this will at least fix the problem for now.

Fixes https://github.com/dotnet/runtime/issues/50245