### PR TITLE
Add ExceptionDispatchInfo.SetRemoteStackTrace

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace System
 {
@@ -323,40 +322,9 @@ namespace System
                 _remoteStackTraceString, _ipForWatsonBuckets, _watsonBuckets);
         }
 
-        [StackTraceHidden]
-        internal void SetCurrentStackTrace()
-        {
-            if (!CanSetRemoteStackTrace())
-            {
-                return; // early-exit
-            }
-
-            // Store the current stack trace into the "remote" stack trace, which was originally introduced to support
-            // remoting of exceptions cross app-domain boundaries, and is thus concatenated into Exception.StackTrace
-            // when it's retrieved.
-            var sb = new StringBuilder(256);
-            new StackTrace(fNeedFileInfo: true).ToString(System.Diagnostics.StackTrace.TraceFormat.TrailingNewLine, sb);
-            sb.AppendLine(SR.Exception_EndStackTraceFromPreviousThrow);
-            _remoteStackTraceString = sb.ToString();
-        }
-
-        [StackTraceHidden]
-        internal void SetRemoteStackTrace(string stackTrace)
-        {
-            if (!CanSetRemoteStackTrace())
-            {
-                return; // early-exit
-            }
-
-            // Store the provided text into the "remote" stack trace, following the same format SetCurrentStackTrace
-            // would have generated.
-            _remoteStackTraceString = stackTrace + Environment.NewLineConst + SR.Exception_EndStackTraceFromPreviousThrow + Environment.NewLineConst;
-        }
-
         // Returns true if setting the _remoteStackTraceString field is legal, false if not (immutable exception).
         // A false return value means the caller should early-exit the operation.
         // Can also throw InvalidOperationException if a stack trace is already set or if object has been thrown.
-        [StackTraceHidden]
         private bool CanSetRemoteStackTrace()
         {
             // If this is a preallocated singleton exception, silently skip the operation,

--- a/src/libraries/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Exception.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace System
 {
@@ -197,5 +198,34 @@ namespace System
         public new Type GetType() => base.GetType();
 
         partial void RestoreRemoteStackTrace(SerializationInfo info, StreamingContext context);
+
+        [StackTraceHidden]
+        internal void SetCurrentStackTrace()
+        {
+            if (!CanSetRemoteStackTrace())
+            {
+                return; // early-exit
+            }
+
+            // Store the current stack trace into the "remote" stack trace, which was originally introduced to support
+            // remoting of exceptions cross app-domain boundaries, and is thus concatenated into Exception.StackTrace
+            // when it's retrieved.
+            var sb = new StringBuilder(256);
+            new StackTrace(fNeedFileInfo: true).ToString(System.Diagnostics.StackTrace.TraceFormat.TrailingNewLine, sb);
+            sb.AppendLine(SR.Exception_EndStackTraceFromPreviousThrow);
+            _remoteStackTraceString = sb.ToString();
+        }
+
+        internal void SetRemoteStackTrace(string stackTrace)
+        {
+            if (!CanSetRemoteStackTrace())
+            {
+                return; // early-exit
+            }
+
+            // Store the provided text into the "remote" stack trace, following the same format SetCurrentStackTrace
+            // would have generated.
+            _remoteStackTraceString = stackTrace + Environment.NewLineConst + SR.Exception_EndStackTraceFromPreviousThrow + Environment.NewLineConst;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.ExceptionServices
         /// <summary>Stores the current stack trace into the specified <see cref="Exception"/> instance.</summary>
         /// <param name="source">The unthrown <see cref="Exception"/> instance.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument was null.</exception>
-        /// <exception cref="InvalidOperationException">The <paramref name="source"/> argument was previously thrown or previously had a stack trace stored into it..</exception>
+        /// <exception cref="InvalidOperationException">The <paramref name="source"/> argument was previously thrown or previously had a stack trace stored into it.</exception>
         /// <returns>The <paramref name="source"/> exception instance.</returns>
         [StackTraceHidden]
         public static Exception SetCurrentStackTrace(Exception source)
@@ -76,6 +76,37 @@ namespace System.Runtime.ExceptionServices
             }
 
             source.SetCurrentStackTrace();
+
+            return source;
+        }
+
+        /// <summary>
+        /// Stores the provided stack trace into the specified <see cref="Exception"/> instance.
+        /// </summary>
+        /// <param name="source">The unthrown <see cref="Exception"/> instance.</param>
+        /// <param name="stackTrace">The stack trace string to persist within <paramref name="source"/>.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="source"/> or <paramref name="stackTrace"/> argument was null.</exception>
+        /// <exception cref="InvalidOperationException">The <paramref name="source"/> argument was previously thrown or previously had a stack trace stored into it.</exception>
+        /// <returns>The <paramref name="source"/> exception instance.</returns>
+        /// <remarks>
+        /// This method populates the <see cref="Exception.StackTrace"/> property from an arbitrary string value.
+        /// The typical use case is the transmission of <see cref="Exception" /> objects across processes with high fidelity,
+        /// allowing preservation of the exception object's stack trace information. .NET does not attempt to parse the
+        /// provided string value. The caller is responsible for normalizing line endings if required.
+        /// </remarks>
+        [StackTraceHidden]
+        public static Exception SetRemoteStackTrace(Exception source, string stackTrace)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (stackTrace is null)
+            {
+                throw new ArgumentNullException(nameof(stackTrace));
+            }
+
+            source.SetRemoteStackTrace(stackTrace);
 
             return source;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
@@ -84,17 +84,17 @@ namespace System.Runtime.ExceptionServices
         /// Stores the provided stack trace into the specified <see cref="Exception"/> instance.
         /// </summary>
         /// <param name="source">The unthrown <see cref="Exception"/> instance.</param>
-        /// <param name="stackTrace">The stack trace string to persist within <paramref name="source"/>.</param>
+        /// <param name="stackTrace">The stack trace string to persist within <paramref name="source"/>. This is normally acquired
+        /// from the <see cref="Exception.StackTrace"/> property from the remote exception instance.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> or <paramref name="stackTrace"/> argument was null.</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> argument was previously thrown or previously had a stack trace stored into it.</exception>
         /// <returns>The <paramref name="source"/> exception instance.</returns>
         /// <remarks>
         /// This method populates the <see cref="Exception.StackTrace"/> property from an arbitrary string value.
-        /// The typical use case is the transmission of <see cref="Exception" /> objects across processes with high fidelity,
+        /// The typical use case is the transmission of <see cref="Exception"/> objects across processes with high fidelity,
         /// allowing preservation of the exception object's stack trace information. .NET does not attempt to parse the
         /// provided string value. The caller is responsible for normalizing line endings if required.
         /// </remarks>
-        [StackTraceHidden]
         public static Exception SetRemoteStackTrace(Exception source, string stackTrace)
         {
             if (source is null)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9753,6 +9753,7 @@ namespace System.Runtime.ExceptionServices
         public System.Exception SourceException { get { throw null; } }
         public static System.Runtime.ExceptionServices.ExceptionDispatchInfo Capture(System.Exception source) { throw null; }
         public static System.Exception SetCurrentStackTrace(System.Exception source) { throw null; }
+        public static System.Exception SetRemoteStackTrace(System.Exception source, string stackTrace) { throw null; }
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         public void Throw() => throw null;
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]

--- a/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
@@ -29,23 +29,27 @@ namespace System.Runtime.ExceptionServices.Tests
         }
 
         [Fact]
-        public static void SetCurrentStackTrace_Invalid_Throws()
+        public static void SetCurrentOrRemoteStackTrace_Invalid_Throws()
         {
             Exception e;
 
             // Null argument
             e = null;
             AssertExtensions.Throws<ArgumentNullException>("source", () => ExceptionDispatchInfo.SetCurrentStackTrace(e));
+            AssertExtensions.Throws<ArgumentNullException>("source", () => ExceptionDispatchInfo.SetRemoteStackTrace(e, "Hello"));
+            AssertExtensions.Throws<ArgumentNullException>("stackTrace", () => ExceptionDispatchInfo.SetRemoteStackTrace(new Exception(), stackTrace: null));
 
             // Previously set current stack
             e = new Exception();
             ExceptionDispatchInfo.SetCurrentStackTrace(e);
             Assert.Throws<InvalidOperationException>(() => ExceptionDispatchInfo.SetCurrentStackTrace(e));
+            Assert.Throws<InvalidOperationException>(() => ExceptionDispatchInfo.SetRemoteStackTrace(e, "Hello"));
 
             // Previously thrown
             e = new Exception();
             try { throw e; } catch { }
             Assert.Throws<InvalidOperationException>(() => ExceptionDispatchInfo.SetCurrentStackTrace(e));
+            Assert.Throws<InvalidOperationException>(() => ExceptionDispatchInfo.SetRemoteStackTrace(e, "Hello"));
         }
 
         [Fact]
@@ -55,12 +59,29 @@ namespace System.Runtime.ExceptionServices.Tests
 
             e = new Exception();
             ABCDEFGHIJKLMNOPQRSTUVWXYZ(e);
-            Assert.Contains(nameof(ABCDEFGHIJKLMNOPQRSTUVWXYZ), e.StackTrace);
+            Assert.Contains(nameof(ABCDEFGHIJKLMNOPQRSTUVWXYZ), e.StackTrace, StringComparison.Ordinal);
 
             e = new Exception();
             ABCDEFGHIJKLMNOPQRSTUVWXYZ(e);
             try { throw e; } catch { }
-            Assert.Contains(nameof(ABCDEFGHIJKLMNOPQRSTUVWXYZ), e.StackTrace);
+            Assert.Contains(nameof(ABCDEFGHIJKLMNOPQRSTUVWXYZ), e.StackTrace, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public static void SetRemoteStackTrace_IncludedInExceptionStackTrace()
+        {
+            Exception e;
+
+            e = new Exception();
+            Assert.Same(e, ExceptionDispatchInfo.SetRemoteStackTrace(e, "pumpkin-anaconda-maritime")); // 3 randomly selected words
+            Assert.Contains("pumpkin-anaconda-maritime", e.StackTrace, StringComparison.Ordinal);
+            Assert.DoesNotContain("pumpkin-anaconda-maritime", new StackTrace(e).ToString(), StringComparison.Ordinal); // we shouldn't attempt to parse it in a StackTrace object
+
+            e = new Exception();
+            Assert.Same(e, ExceptionDispatchInfo.SetRemoteStackTrace(e, "pumpkin-anaconda-maritime"));
+            try { throw e; } catch { }
+            Assert.Contains("pumpkin-anaconda-maritime", e.StackTrace, StringComparison.Ordinal);
+            Assert.DoesNotContain("pumpkin-anaconda-maritime", new StackTrace(e).ToString(), StringComparison.Ordinal);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]

--- a/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -106,10 +106,7 @@ namespace System
         internal void SetCurrentStackTrace()
         {
             // Check to see if the exception already has a stack set in it.
-            if (_traceIPs != null || _stackTraceString != null || _remoteStackTraceString != null)
-            {
-                ThrowHelper.ThrowInvalidOperationException();
-            }
+            ThrowIfStackTraceAlreadyExists();
 
             // Store the current stack trace into the "remote" stack trace, which was originally introduced to support
             // remoting of exceptions cross app-domain boundaries, and is thus concatenated into Exception.StackTrace
@@ -118,6 +115,26 @@ namespace System
             new StackTrace(fNeedFileInfo: true).ToString(Diagnostics.StackTrace.TraceFormat.TrailingNewLine, sb);
             sb.AppendLine(SR.Exception_EndStackTraceFromPreviousThrow);
             _remoteStackTraceString = sb.ToString();
+        }
+
+        [StackTraceHidden]
+        internal void SetRemoteStackTrace()
+        {
+            // Check to see if the exception already has a stack set in it.
+            ThrowIfStackTraceAlreadyExists();
+
+            // Store the provided text into the "remote" stack trace, following the same format SetCurrentStackTrace
+            // would have generated.
+            _remoteStackTraceString = stackTrace + Environment.NewLineConst + SR.Exception_EndStackTraceFromPreviousThrow + Environment.NewLineConst;
+        }
+
+        [StackTraceHidden]
+        private void ThrowIfStackTraceAlreadyExists()
+        {
+            if (_traceIPs != null || _stackTraceString != null || _remoteStackTraceString != null)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
         }
 
         private string? CreateSourceName()

--- a/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -118,7 +118,7 @@ namespace System
         }
 
         [StackTraceHidden]
-        internal void SetRemoteStackTrace()
+        internal void SetRemoteStackTrace(string stackTrace)
         {
             // Check to see if the exception already has a stack set in it.
             ThrowIfStackTraceAlreadyExists();


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/50044.

The approved API (see https://github.com/dotnet/runtime/issues/50044#issuecomment-805161306) returns `bool`, which is clearly a mistake given that we wanted to make it a non-try method just like its sibling _SetCurrentStackTrace_. So for this PR, I made the method return `Exception`, just like its sibling. I believe this follows the spirit of what the API review intended.

It's too difficult for me to test the "immutable agile exception" case, so I didn't. That's going to have to remain within the purview of code review.

Also took this time to do some minor cleanup of existing devdoc and unit tests. Nothing too fancy.

/cc @ReubenBond