### PR TITLE
Revert "Fix release builds with latest VS dogfood (#49948)"

### DIFF
--- a/src/coreclr/EmptyProps.props
+++ b/src/coreclr/EmptyProps.props
@@ -5,13 +5,4 @@
      in the root of the source tree. In particular this was necessary to compile DacTableGen, which is currently compiled
      against .NET Framework.
      -->
-
-  <!-- Workaround for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1295929/ -->
-  <!-- Unset IncrementalLinkDatabaseFile when incremental linking is explicitly disabled -->
-  <ItemDefinitionGroup Condition="'$(LinkIncremental)'=='false'">
-    <Link>
-      <IncrementalLinkDatabaseFile/>
-    </Link>
-  </ItemDefinitionGroup>
-
 </Project>


### PR DESCRIPTION
This reverts commit 3961d91812c997af18ff1ebbdac53bcc4d84fb02.

This workaround is no longer needed.