### PR TITLE
Move publishing off hosted ADO machines, again

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -55,12 +55,15 @@ try {
       $optionalParams.Add($SigningValidationAdditionalParameters) | Out-Null
     }
   }
-
+  # note the custom branch to work around https://github.com/dotnet/arcade/issues/6987 .  Try to keep this rebased off master if publishing changes
+  
+  Write-Host "Using Arcade branch master-workaround-publishing-issue to work around disk space issues with alternate build pool.  Will be lost on Arcade updates as this is in eng common.  Contact dnceng for questions."
+  
   & $darc add-build-to-channel `
   --id $buildId `
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
-  --source-branch main `
+  --source-branch master-workaround-publishing-issue `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/48855 again after this was overwritten by an Arcade update. ([Example](https://dev.azure.com/dnceng/internal/_build/results?buildId=1062805&view=logs&s=0d7db6e4-c533-50c8-77c7-b1b9fc049ed6) of a failed publish.)