### PR TITLE
Binary search for nearest prime

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -71,7 +71,7 @@ namespace System.Collections
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinarySearchForPrime(int min, out int prime)
+        private static bool TryBinarySearchForPrime(int target, out int prime)
         {
             var primes = s_primes;
 
@@ -80,14 +80,14 @@ namespace System.Collections
             while (lo <= hi)
             {
                 int i = lo + ((hi - lo) >> 1);
-                var target = primes[i];
+                var mid = primes[i];
 
-                if (target == min)
+                if (mid == target)
                 {
-                    prime = target;
+                    prime = mid;
                     return true;
                 }
-                if (min < target)
+                if (target < mid)
                 {
                     lo = i + 1;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -57,11 +57,9 @@ namespace System.Collections
             if (min < 0)
                 throw new ArgumentException(SR.Arg_HTCapacityOverflow);
 
-            foreach (int prime in s_primes)
-            {
-                if (prime >= min)
-                    return prime;
-            }
+
+            if (TryBinarySearchForPrime(min, out int prime))
+                return prime;
 
             // Outside of our predefined table. Compute the hard way.
             for (int i = (min | 1); i < int.MaxValue; i += 2)
@@ -70,6 +68,43 @@ namespace System.Collections
                     return i;
             }
             return min;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinarySearchForPrime(int min, out int prime)
+        {
+            var primes = s_primes;
+
+            int lo = 0;
+            int hi = primes.Length - 1;
+            while (lo <= hi)
+            {
+                int i = lo + ((hi - lo) >> 1);
+                var target = primes[i];
+
+                if (target == min)
+                {
+                    prime = target;
+                    return true;
+                }
+                if (min < target)
+                {
+                    lo = i + 1;
+                }
+                else
+                {
+                    hi = i - 1;
+                }
+            }
+
+            if (lo >= primes.Length)
+            {
+                prime = default;
+                return false;
+            }
+
+            prime = primes[lo];
+            return true;
         }
 
         // Returns size of hashtable to grow to.

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -87,7 +87,7 @@ namespace System.Collections
                     prime = mid;
                     return true;
                 }
-                if (target < mid)
+                if (mid < target)
                 {
                     lo = i + 1;
                 }


### PR DESCRIPTION
- Saw this while looking at how dictionary does resizes while investigating a performance issue.

PS: I haven't done any performance testing or real testing as yet. I wanted to see if this made sense given that resizes normally start off with smaller numbers (its possible bin search is worse when starting off with smaller dictionary sizes).

cc @jkotas 