### PR TITLE
Use a smart pointer to prevent Zap memory leak

### DIFF
--- a/src/coreclr/zap/zapper.cpp
+++ b/src/coreclr/zap/zapper.cpp
@@ -121,8 +121,6 @@ STDAPI CreatePDBWorker(LPCWSTR pwzAssemblyPath, LPCWSTR pwzPlatformAssembliesPat
 
     BEGIN_ENTRYPOINT_NOTHROW;
 
-    Zapper* zap = NULL;
-
     EX_TRY
     {
         GetCompileInfo()->SetIsGeneratingNgenPDB(TRUE);
@@ -130,7 +128,7 @@ STDAPI CreatePDBWorker(LPCWSTR pwzAssemblyPath, LPCWSTR pwzPlatformAssembliesPat
         NGenOptions ngo = {0};
         ngo.dwSize = sizeof(NGenOptions);
 
-        zap = Zapper::NewZapper(&ngo);
+        NewHolder<Zapper> zap(Zapper::NewZapper(&ngo));
 
 #if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
         zap->SetDontLoadJit();


### PR DESCRIPTION
We allocate a Zap in CreatePDBWorker, but we never deallocate it. Assuming the object instance is no longer needed, this fixes a memory leak.