### PR TITLE
Specify the Size of List<T> Instances in InvokeTypeInfo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
@@ -22,9 +22,9 @@ namespace System.Diagnostics.Tracing
     /// </summary>
     internal sealed class EventPayload : IDictionary<string, object?>
     {
-        internal EventPayload(List<string> payloadNames, List<object?> payloadValues)
+        internal EventPayload(string[] payloadNames, object?[] payloadValues)
         {
-            Debug.Assert(payloadNames.Count == payloadValues.Count);
+            Debug.Assert(payloadNames.Length == payloadValues.Length);
 
             m_names = payloadNames;
             m_values = payloadValues;
@@ -88,7 +88,7 @@ namespace System.Diagnostics.Tracing
             return false;
         }
 
-        public int Count => m_names.Count;
+        public int Count => m_names.Length;
 
         public bool IsReadOnly => true;
 
@@ -142,8 +142,8 @@ namespace System.Diagnostics.Tracing
         }
 
 #region private
-        private readonly List<string> m_names;
-        private readonly List<object?> m_values;
+        private readonly string[] m_names;
+        private readonly object?[] m_values;
 #endregion
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
@@ -77,13 +77,13 @@ namespace System.Diagnostics.Tracing
         {
             if (this.properties != null)
             {
-                var membersNames = new List<string>(this.properties.Length);
-                var membersValues = new List<object?>(this.properties.Length);
+                var membersNames = new string[this.properties.Length];
+                var membersValues = new object?[this.properties.Length];
                 for (int i = 0; i < this.properties.Length; i++)
                 {
                     object? propertyValue = properties[i].propertyInfo.GetValue(value);
-                    membersNames.Add(properties[i].name);
-                    membersValues.Add(properties[i].typeInfo.GetData(propertyValue));
+                    membersNames[i] = properties[i].name;
+                    membersValues[i] = properties[i].typeInfo.GetData(propertyValue);
                 }
                 return new EventPayload(membersNames, membersValues);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
@@ -77,8 +77,8 @@ namespace System.Diagnostics.Tracing
         {
             if (this.properties != null)
             {
-                var membersNames = new List<string>();
-                var membersValues = new List<object?>();
+                var membersNames = new List<string>(this.properties.Length);
+                var membersValues = new List<object?>(this.properties.Length);
                 for (int i = 0; i < this.properties.Length; i++)
                 {
                     object? propertyValue = properties[i].propertyInfo.GetValue(value);


### PR DESCRIPTION
These allocations are showing up in some of the traces that I've been collecting recently.  Since the size of these `List<T>` instances is known, we can pre-allocate them.  This won't help for small instances, but for anything larger than 4, which is the current `DefaultSize`, this will eliminate resizing.