### PR TITLE
Make CLOCK_MONOTONIC handling more precise in pal_threading.c

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_threading.c
+++ b/src/libraries/Native/Unix/System.Native/pal_threading.c
@@ -173,7 +173,7 @@ int32_t SystemNative_LowLevelMonitor_TimedWait(LowLevelMonitor *monitor, int32_t
 
     error = pthread_cond_timedwait_relative_np(&monitor->Condition, &monitor->Mutex, &timeoutTimeSpec);
 #else
-#if HAVE_CLOCK_MONOTONIC
+#if HAVE_PTHREAD_CONDATTR_SETCLOCK && HAVE_CLOCK_MONOTONIC
     error = clock_gettime(CLOCK_MONOTONIC, &timeoutTimeSpec);
     assert(error == 0);
 #else


### PR DESCRIPTION
The root cause of the problem in https://github.com/dotnet/runtime/pull/50388 turned out to be because we do not have `pthread_condattr_setclock(..., CLOCK_MONOTONIC);` on iOS.
This caused the timeout argument for `pthread_cond_timedwait` to be interpreted as an _absolute system time_ (in seconds since the Unix epoch), however the value we got back from `clock_gettime(CLOCK_MONOTONIC, ...)` was actually some value based on the uptime of the system.
Since the uptime is much smaller than the system time the wait immediately returned.

Harden the handling by adding a check for `HAVE_PTHREAD_CONDATTR_SETCLOCK` like we already do in `SystemNative_LowLevelMonitor_Create()`