### PR TITLE
Handle casts done via helpers and fold overflow operations in value numbering

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -248,6 +248,7 @@ if (CLR_CMAKE_TARGET_WIN32)
     valuenumtype.h
     varset.h
     vartype.h
+    vartypesdef.h
   )
 
   if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_ARM)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4986,6 +4986,9 @@ GenTree* Compiler::optExtractSideEffListFromConst(GenTree* tree)
         bool ignoreRoot = true;
 
         gtExtractSideEffList(tree, &sideEffList, GTF_SIDE_EFFECT, ignoreRoot);
+
+        JITDUMP("Extracted side effects from a constant tree [%06u]:\n", tree->gtTreeID);
+        DISPTREE(sideEffList);
     }
 
     return sideEffList;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14419,8 +14419,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     case GT_CAST:
 
                         if (tree->gtOverflow() &&
-                            ((op1->TypeIs(TYP_DOUBLE) &&
-                              CheckedOps::CastFromDoubleOverflows(d1, tree->CastToType())) ||
+                            ((op1->TypeIs(TYP_DOUBLE) && CheckedOps::CastFromDoubleOverflows(d1, tree->CastToType())) ||
                              (op1->TypeIs(TYP_FLOAT) &&
                               CheckedOps::CastFromDoubleOverflows(forceCastToFloat(d1), tree->CastToType()))))
                         {
@@ -15265,7 +15264,7 @@ INTEGRAL_OVF:
     }
 
     var_types type = genActualType(tree->TypeGet());
-    op1 = type == TYP_LONG ? gtNewLconNode(0) : gtNewIconNode(0);
+    op1            = type == TYP_LONG ? gtNewLconNode(0) : gtNewIconNode(0);
     if (vnStore != nullptr)
     {
         op1->gtVNPair.SetBoth(vnStore->VNZeroForType(type));
@@ -15282,18 +15281,16 @@ INTEGRAL_OVF:
     assert(op1 != nullptr);
 
     op2 = op1;
-    op1 = gtNewHelperCallNode(CORINFO_HELP_OVERFLOW, TYP_VOID,
-        gtNewCallArgs(gtNewIconNode(compCurBB->bbTryIndex)));
+    op1 = gtNewHelperCallNode(CORINFO_HELP_OVERFLOW, TYP_VOID, gtNewCallArgs(gtNewIconNode(compCurBB->bbTryIndex)));
 
     // op1 is a call to the JIT helper that throws an Overflow exception.
     // Attach the ExcSet for VNF_OverflowExc(Void) to this call.
 
     if (vnStore != nullptr)
     {
-        op1->gtVNPair =
-            vnStore->VNPWithExc(ValueNumPair(ValueNumStore::VNForVoid(), ValueNumStore::VNForVoid()),
-                vnStore->VNPExcSetSingleton(
-                    vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnStore->VNPForVoid())));
+        op1->gtVNPair = vnStore->VNPWithExc(ValueNumPair(ValueNumStore::VNForVoid(), ValueNumStore::VNForVoid()),
+                                            vnStore->VNPExcSetSingleton(vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc,
+                                                                                               vnStore->VNPForVoid())));
     }
 
     tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), op1, op2);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14848,7 +14848,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     i1 >>= (i2 & 0x1f);
                     break;
                 case GT_RSZ:
-                    /* logical shift -> make it unsigned to not propagate the sign bit */
+                    // logical shift -> make it unsigned to not propagate the sign bit.
                     i1 = UINT32(i1) >> (i2 & 0x1f);
                     break;
                 case GT_ROL:
@@ -15168,7 +15168,6 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                     if (tree->gtOverflow() && lval2 != 0)
                     {
-
                         if (tree->IsUnsigned())
                         {
                             UINT64 ultemp = ltemp;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14753,66 +14753,28 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                 case GT_ADD:
                     itemp = i1 + i2;
-                    if (tree->gtOverflow())
+                    if (tree->gtOverflow() && CheckedOps::IntAddOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            if (INT64(UINT32(itemp)) != INT64(UINT32(i1)) + INT64(UINT32(i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
-                        else
-                        {
-                            if (INT64(INT32(itemp)) != INT64(INT32(i1)) + INT64(INT32(i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
+                        goto INT_OVF;
                     }
                     i1       = itemp;
                     fieldSeq = GetFieldSeqStore()->Append(op1->AsIntCon()->gtFieldSeq, op2->AsIntCon()->gtFieldSeq);
                     break;
                 case GT_SUB:
                     itemp = i1 - i2;
-                    if (tree->gtOverflow())
+                    if (tree->gtOverflow() && CheckedOps::IntSubOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            if (INT64(UINT32(itemp)) != ((INT64)((UINT32)i1) - (INT64)((UINT32)i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
-                        else
-                        {
-                            if (INT64(INT32(itemp)) != INT64(INT32(i1)) - INT64(INT32(i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
+                        goto INT_OVF;
                     }
                     i1 = itemp;
                     break;
                 case GT_MUL:
                     itemp = i1 * i2;
-                    if (tree->gtOverflow())
+                    if (tree->gtOverflow() && CheckedOps::IntMulOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            if (INT64(UINT32(itemp)) != ((INT64)((UINT32)i1) * (INT64)((UINT32)i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
-                        else
-                        {
-                            if (INT64(INT32(itemp)) != INT64(INT32(i1)) * INT64(INT32(i2)))
-                            {
-                                goto INT_OVF;
-                            }
-                        }
+                        goto INT_OVF;
                     }
+
                     // For the very particular case of the "constant array index" pseudo-field, we
                     // assume that multiplication is by the field width, and preserves that field.
                     // This could obviously be made more robust by a more complicated set of annotations...
@@ -15109,108 +15071,28 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                 case GT_ADD:
                     ltemp = lval1 + lval2;
-
-                LNG_ADD_CHKOVF:
-                    // For the SIGNED case - If there is one positive and one negative operand, there can be no overflow.
-                    // If both are positive, the result has to be positive, and similary for negatives.
-                    //
-                    // For the UNSIGNED case - If a UINT32 operand is bigger than the result then OVF.
-
-                    if (tree->gtOverflow())
+                    if (tree->gtOverflow() && CheckedOps::LongAddOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            if ((UINT64(lval1) > UINT64(ltemp)) || (UINT64(lval2) > UINT64(ltemp)))
-                            {
-                                goto LNG_OVF;
-                            }
-                        }
-                        else if (((lval1 < 0) == (lval2 < 0)) && ((lval1 < 0) != (ltemp < 0)))
-                        {
-                            goto LNG_OVF;
-                        }
+                        goto LNG_OVF;
                     }
                     lval1 = ltemp;
                     break;
 
                 case GT_SUB:
                     ltemp = lval1 - lval2;
-                    if (tree->gtOverflow())
+                    if (tree->gtOverflow() && CheckedOps::LongSubOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            if (UINT64(lval2) > UINT64(lval1))
-                            {
-                                goto LNG_OVF;
-                            }
-                        }
-                        else
-                        {
-                            // If both operands are +ve or both are -ve, there can be no
-                            // overflow. Else use the logic for : lval1 + (-lval2).
-
-                            if ((lval1 < 0) != (lval2 < 0))
-                            {
-                                if (lval2 == INT64_MIN)
-                                {
-                                    goto LNG_OVF;
-                                }
-                                lval2 = -lval2;
-                                goto LNG_ADD_CHKOVF;
-                            }
-                        }
+                        goto LNG_OVF;
                     }
                     lval1 = ltemp;
                     break;
 
                 case GT_MUL:
                     ltemp = lval1 * lval2;
-
-                    if (tree->gtOverflow() && lval2 != 0)
+                    if (tree->gtOverflow() && CheckedOps::LongMulOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        if (tree->IsUnsigned())
-                        {
-                            UINT64 ultemp = ltemp;
-                            UINT64 ulval1 = lval1;
-                            UINT64 ulval2 = lval2;
-                            if ((ultemp / ulval2) != ulval1)
-                            {
-                                goto LNG_OVF;
-                            }
-                        }
-                        else
-                        {
-                            // This does a multiply and then reverses it.  This test works great except for MIN_INT *
-                            //-1.  In that case we mess up the sign on ltmp.  Make sure to double check the sign.
-                            // if either is 0, then no overflow.
-                            if (lval1 != 0) // lval2 checked above.
-                            {
-                                if (((lval1 < 0) == (lval2 < 0)) && (ltemp < 0))
-                                {
-                                    goto LNG_OVF;
-                                }
-                                if (((lval1 < 0) != (lval2 < 0)) && (ltemp > 0))
-                                {
-                                    goto LNG_OVF;
-                                }
-
-                                // TODO-Amd64-Unix: Remove the code that disables optimizations for this method when the
-                                // clang
-                                // optimizer is fixed and/or the method implementation is refactored in a simpler code.
-                                // There is a bug in the clang-3.5 optimizer. The issue is that in release build the
-                                // optimizer is mistyping (or just wrongly decides to use 32 bit operation for a corner
-                                // case of MIN_LONG) the args of the (ltemp / lval2) to int (it does a 32 bit div
-                                // operation instead of 64 bit.). For the case of lval1 and lval2 equal to MIN_LONG
-                                // (0x8000000000000000) this results in raising a SIGFPE.
-                                // Optimizations disabled for now. See compiler.h.
-                                if ((ltemp / lval2) != lval1)
-                                {
-                                    goto LNG_OVF;
-                                }
-                            }
-                        }
+                        goto LNG_OVF;
                     }
-
                     lval1 = ltemp;
                     break;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14141,8 +14141,6 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
 #endif
 GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 {
-    unsigned kind = tree->OperKind();
-
     SSIZE_T       i1, i2, itemp;
     INT64         lval1, lval2, ltemp;
     float         f1, f2;
@@ -14150,9 +14148,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
     var_types     switchType;
     FieldSeqNode* fieldSeq = FieldSeqStore::NotAField(); // default unless we override it when folding
 
-    assert(kind & (GTK_UNOP | GTK_BINOP));
+    assert(tree->OperIsUnary() || tree->OperIsBinary());
 
-    GenTree* op1 = tree->AsOp()->gtOp1;
+    GenTree* op1 = tree->gtGetOp1();
     GenTree* op2 = tree->gtGetOp2IfPresent();
 
     if (!opts.OptEnabled(CLFLG_CONSTANTFOLD))
@@ -14160,61 +14158,49 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
         return tree;
     }
 
-    if (tree->OperGet() == GT_NOP)
+    if (tree->OperIs(GT_NOP, GT_ALLOCOBJ, GT_RUNTIMELOOKUP))
     {
         return tree;
     }
 
 #ifdef FEATURE_SIMD
-    if (tree->OperGet() == GT_SIMD)
+    if (tree->OperIs(GT_SIMD))
     {
         return tree;
     }
 #endif // FEATURE_SIMD
 #ifdef FEATURE_HW_INTRINSICS
-    if (tree->OperGet() == GT_HWINTRINSIC)
+    if (tree->OperIs(GT_HWINTRINSIC))
     {
         return tree;
     }
 #endif
 
-    if (tree->gtOper == GT_ALLOCOBJ)
+    if (tree->OperIsUnary())
     {
-        return tree;
-    }
+        assert(op1->OperIsConst());
 
-    if (tree->gtOper == GT_RUNTIMELOOKUP)
-    {
-        return tree;
-    }
-
-    if (kind & GTK_UNOP)
-    {
-        assert(op1->OperKind() & GTK_CONST);
-
-        switch (op1->gtType)
+        switch (op1->TypeGet())
         {
             case TYP_INT:
 
-                /* Fold constant INT unary operator */
+                // Fold constant INT unary operator.
 
                 if (!op1->AsIntCon()->ImmedValCanBeFolded(this, tree->OperGet()))
                 {
                     return tree;
                 }
 
-                i1 = (int)op1->AsIntCon()->gtIconVal;
+                i1 = (INT32)op1->AsIntCon()->IconValue();
 
                 // If we fold a unary oper, then the folded constant
-                // is considered a ConstantIndexField if op1 was one
-                //
-
+                // is considered a ConstantIndexField if op1 was one.
                 if ((op1->AsIntCon()->gtFieldSeq != nullptr) && op1->AsIntCon()->gtFieldSeq->IsConstantIndexFieldSeq())
                 {
                     fieldSeq = op1->AsIntCon()->gtFieldSeq;
                 }
 
-                switch (tree->gtOper)
+                switch (tree->OperGet())
                 {
                     case GT_NOT:
                         i1 = ~i1;
@@ -14244,7 +14230,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                             case TYP_SHORT:
                                 itemp = INT32(INT16(i1));
                             CHK_OVF:
-                                if (tree->gtOverflow() && ((itemp != i1) || ((tree->gtFlags & GTF_UNSIGNED) && i1 < 0)))
+                                if (tree->gtOverflow() && ((itemp != i1) || (tree->IsUnsigned() && (i1 < 0))))
                                 {
                                     goto INT_OVF;
                                 }
@@ -14277,14 +14263,14 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_INT;
 
                             case TYP_UINT:
-                                if (!(tree->gtFlags & GTF_UNSIGNED) && tree->gtOverflow() && i1 < 0)
+                                if (!tree->IsUnsigned() && tree->gtOverflow() && (i1 < 0))
                                 {
                                     goto INT_OVF;
                                 }
                                 goto CNS_INT;
 
                             case TYP_INT:
-                                if ((tree->gtFlags & GTF_UNSIGNED) && tree->gtOverflow() && i1 < 0)
+                                if (tree->IsUnsigned() && tree->gtOverflow() && (i1 < 0))
                                 {
                                     goto INT_OVF;
                                 }
@@ -14317,7 +14303,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_LONG;
 
                             case TYP_FLOAT:
-                                if (tree->gtFlags & GTF_UNSIGNED)
+                                if (tree->IsUnsigned())
                                 {
                                     f1 = forceCastToFloat(UINT32(i1));
                                 }
@@ -14329,7 +14315,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_DOUBLE;
 
                             case TYP_DOUBLE:
-                                if (tree->gtFlags & GTF_UNSIGNED)
+                                if (tree->IsUnsigned())
                                 {
                                     d1 = (double)UINT32(i1);
                                 }
@@ -14353,7 +14339,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             case TYP_LONG:
 
-                /* Fold constant LONG unary operator */
+                // Fold constant LONG unary operator.
 
                 if (!op1->AsIntConCommon()->ImmedValCanBeFolded(this, tree->OperGet()))
                 {
@@ -14362,7 +14348,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                 lval1 = op1->AsIntConCommon()->LngValue();
 
-                switch (tree->gtOper)
+                switch (tree->OperGet())
                 {
                     case GT_NOT:
                         lval1 = ~lval1;
@@ -14380,7 +14366,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         break;
 
                     case GT_CAST:
-                        assert(genActualType(tree->CastToType()) == tree->gtType);
+                        assert(tree->TypeIs(genActualType(tree->CastToType())));
                         switch (tree->CastToType())
                         {
                             case TYP_BYTE:
@@ -14409,7 +14395,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                     {
                                         goto INT_OVF;
                                     }
-                                    if ((tree->gtFlags & GTF_UNSIGNED) && i1 < 0)
+                                    if (tree->IsUnsigned() && (i1 < 0))
                                     {
                                         goto INT_OVF;
                                     }
@@ -14427,14 +14413,14 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_INT;
 
                             case TYP_ULONG:
-                                if (!(tree->gtFlags & GTF_UNSIGNED) && tree->gtOverflow() && lval1 < 0)
+                                if (!tree->IsUnsigned() && tree->gtOverflow() && (lval1 < 0))
                                 {
                                     goto LNG_OVF;
                                 }
                                 goto CNS_LONG;
 
                             case TYP_LONG:
-                                if ((tree->gtFlags & GTF_UNSIGNED) && tree->gtOverflow() && lval1 < 0)
+                                if (tree->IsUnsigned() && tree->gtOverflow() && (lval1 < 0))
                                 {
                                     goto LNG_OVF;
                                 }
@@ -14442,7 +14428,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                             case TYP_FLOAT:
                             case TYP_DOUBLE:
-                                if ((tree->gtFlags & GTF_UNSIGNED) && lval1 < 0)
+                                if (tree->IsUnsigned() && (lval1 < 0))
                                 {
                                     d1 = FloatingPointUtils::convertUInt64ToDouble((unsigned __int64)lval1);
                                 }
@@ -14471,13 +14457,13 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             case TYP_FLOAT:
             case TYP_DOUBLE:
-                assert(op1->gtOper == GT_CNS_DBL);
+                assert(op1->OperIs(GT_CNS_DBL));
 
-                /* Fold constant DOUBLE unary operator */
+                // Fold constant DOUBLE unary operator.
 
                 d1 = op1->AsDblCon()->gtDconVal;
 
-                switch (tree->gtOper)
+                switch (tree->OperGet())
                 {
                     case GT_NEG:
                         d1 = -d1;
@@ -14490,10 +14476,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                             return tree;
                         }
 
-                        assert(genActualType(tree->CastToType()) == tree->gtType);
+                        assert(tree->TypeIs(genActualType(tree->CastToType())));
 
-                        if ((op1->gtType == TYP_FLOAT && !_finite(forceCastToFloat(d1))) ||
-                            (op1->gtType == TYP_DOUBLE && !_finite(d1)))
+                        if ((op1->TypeIs(TYP_FLOAT) && !_finite(forceCastToFloat(d1))) ||
+                            (op1->TypeIs(TYP_DOUBLE) && !_finite(d1)))
                         {
                             // The floating point constant is not finite.  The ECMA spec says, in
                             // III 3.27, that "...if overflow occurs converting a floating point type
@@ -14561,11 +14547,11 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_DOUBLE;
 
                             case TYP_DOUBLE:
-                                if (op1->gtType == TYP_FLOAT)
+                                if (op1->TypeIs(TYP_FLOAT))
                                 {
-                                    d1 = forceCastToFloat(d1); // truncate precision
+                                    d1 = forceCastToFloat(d1); // Truncate precision.
                                 }
-                                goto CNS_DOUBLE; // redundant cast
+                                goto CNS_DOUBLE; // Redundant cast.
 
                             default:
                                 assert(!"BAD_TYP");
@@ -14579,19 +14565,19 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 goto CNS_DOUBLE;
 
             default:
-                /* not a foldable typ - e.g. RET const */
+                // Not a foldable typ - e.g. RET const.
                 return tree;
         }
     }
 
-    /* We have a binary operator */
+    // We have a binary operator.
 
-    assert(kind & GTK_BINOP);
-    assert(op2);
-    assert(op1->OperKind() & GTK_CONST);
-    assert(op2->OperKind() & GTK_CONST);
+    assert(tree->OperIsBinary());
+    assert(op2 != nullptr);
+    assert(op1->OperIsConst());
+    assert(op2->OperIsConst());
 
-    if (tree->gtOper == GT_COMMA)
+    if (tree->OperIs(GT_COMMA))
     {
         return op2;
     }
@@ -14601,32 +14587,27 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
         return tree;
     }
 
-    switchType = op1->gtType;
+    switchType = op1->TypeGet();
 
     // Normally we will just switch on op1 types, but for the case where
-    //  only op2 is a GC type and op1 is not a GC type, we use the op2 type.
-    //  This makes us handle this as a case of folding for GC type.
-    //
+    // only op2 is a GC type and op1 is not a GC type, we use the op2 type.
+    // This makes us handle this as a case of folding for GC type.
     if (varTypeIsGC(op2->gtType) && !varTypeIsGC(op1->gtType))
     {
-        switchType = op2->gtType;
+        switchType = op2->TypeGet();
     }
 
     switch (switchType)
     {
-
-        /*-------------------------------------------------------------------------
-         * Fold constant REF of BYREF binary operator
-         * These can only be comparisons or null pointers
-         */
+        // Fold constant REF of BYREF binary operator.
+        // These can only be comparisons or null pointers.
 
         case TYP_REF:
 
-            /* String nodes are an RVA at this point */
-
+            // String nodes are an RVA at this point.
             if (op1->OperIs(GT_CNS_STR) || op2->OperIs(GT_CNS_STR))
             {
-                // Fold "ldstr" ==/!= null
+                // Fold "ldstr" ==/!= null.
                 if (op2->IsIntegralConst(0))
                 {
                     if (tree->OperIs(GT_EQ))
@@ -14650,7 +14631,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             i1 = op1->AsIntConCommon()->IconValue();
             i2 = op2->AsIntConCommon()->IconValue();
 
-            switch (tree->gtOper)
+            switch (tree->OperGet())
             {
                 case GT_EQ:
                     i1 = (i1 == i2);
@@ -14661,18 +14642,17 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_ADD:
-                    noway_assert(tree->gtType != TYP_REF);
+                    noway_assert(!tree->TypeIs(TYP_REF));
                     // We only fold a GT_ADD that involves a null reference.
-                    if (((op1->TypeGet() == TYP_REF) && (i1 == 0)) || ((op2->TypeGet() == TYP_REF) && (i2 == 0)))
+                    if ((op1->TypeIs(TYP_REF) && (i1 == 0)) || (op2->TypeIs(TYP_REF) && (i2 == 0)))
                     {
                         JITDUMP("\nFolding operator with constant nodes into a constant:\n");
                         DISPTREE(tree);
 
-                        // Fold into GT_IND of null byref
+                        // Fold into GT_IND of null byref.
                         tree->ChangeOperConst(GT_CNS_INT);
-                        tree->gtType                 = TYP_BYREF;
-                        tree->AsIntCon()->gtIconVal  = 0;
-                        tree->AsIntCon()->gtFieldSeq = FieldSeqStore::NotAField();
+                        tree->ChangeType(TYP_BYREF);
+                        tree->AsIntCon()->SetIconValue(0);
                         if (vnStore != nullptr)
                         {
                             fgValueNumberTreeConst(tree);
@@ -14691,22 +14671,19 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             return tree;
 
-        /*-------------------------------------------------------------------------
-         * Fold constant INT binary operator
-         */
+        // Fold constant INT binary operator.
 
         case TYP_INT:
 
-            if (tree->OperIsCompare() && (tree->gtType == TYP_BYTE))
+            if (tree->OperIsCompare() && tree->TypeIs(TYP_BYTE))
             {
-                tree->gtType = TYP_INT;
+                tree->ChangeType(TYP_INT);
             }
 
-            assert(tree->gtType == TYP_INT || varTypeIsGC(tree->TypeGet()) || tree->gtOper == GT_MKREFANY);
+            assert(tree->TypeIs(TYP_INT) || varTypeIsGC(tree->TypeGet()) || tree->OperIs(GT_MKREFANY));
 
             // No GC pointer types should be folded here...
-            //
-            assert(!varTypeIsGC(op1->gtType) && !varTypeIsGC(op2->gtType));
+            assert(!varTypeIsGC(op1->TypeGet()) && !varTypeIsGC(op2->TypeGet()));
 
             if (!op1->AsIntConCommon()->ImmedValCanBeFolded(this, tree->OperGet()))
             {
@@ -14721,7 +14698,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             i1 = op1->AsIntConCommon()->IconValue();
             i2 = op2->AsIntConCommon()->IconValue();
 
-            switch (tree->gtOper)
+            switch (tree->OperGet())
             {
                 case GT_EQ:
                     i1 = (INT32(i1) == INT32(i2));
@@ -14731,7 +14708,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_LT:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT32(i1) < UINT32(i2));
                     }
@@ -14742,7 +14719,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_LE:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT32(i1) <= UINT32(i2));
                     }
@@ -14753,7 +14730,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_GE:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT32(i1) >= UINT32(i2));
                     }
@@ -14764,7 +14741,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_GT:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT32(i1) > UINT32(i2));
                     }
@@ -14778,7 +14755,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 + i2;
                     if (tree->gtOverflow())
                     {
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             if (INT64(UINT32(itemp)) != INT64(UINT32(i1)) + INT64(UINT32(i2)))
                             {
@@ -14800,7 +14777,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 - i2;
                     if (tree->gtOverflow())
                     {
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             if (INT64(UINT32(itemp)) != ((INT64)((UINT32)i1) - (INT64)((UINT32)i2)))
                             {
@@ -14821,7 +14798,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 * i2;
                     if (tree->gtOverflow())
                     {
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             if (INT64(UINT32(itemp)) != ((INT64)((UINT32)i1) * (INT64)((UINT32)i2)))
                             {
@@ -14881,8 +14858,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     i1 = (i1 << ((32 - i2) & 0x1f)) | (UINT32(i1) >> (i2 & 0x1f));
                     break;
 
-                /* DIV and MOD can generate an INT 0 - if division by 0
-                 * or overflow - when dividing MIN by -1 */
+                // DIV and MOD can throw an exception - if the division is by 0
+                // or there is overflow - when dividing MIN by -1.
 
                 case GT_DIV:
                 case GT_MOD:
@@ -14890,32 +14867,32 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 case GT_UMOD:
                     if (INT32(i2) == 0)
                     {
-                        // Division by zero:
-                        // We have to evaluate this expression and throw an exception
+                        // Division by zero.
+                        // We have to evaluate this expression and throw an exception.
                         return tree;
                     }
                     else if ((INT32(i2) == -1) && (UINT32(i1) == 0x80000000))
                     {
-                        // Overflow Division:
-                        // We have to evaluate this expression and throw an exception
+                        // Overflow Division.
+                        // We have to evaluate this expression and throw an exception.
                         return tree;
                     }
 
-                    if (tree->gtOper == GT_DIV)
+                    if (tree->OperIs(GT_DIV))
                     {
                         i1 = INT32(i1) / INT32(i2);
                     }
-                    else if (tree->gtOper == GT_MOD)
+                    else if (tree->OperIs(GT_MOD))
                     {
                         i1 = INT32(i1) % INT32(i2);
                     }
-                    else if (tree->gtOper == GT_UDIV)
+                    else if (tree->OperIs(GT_UDIV))
                     {
                         i1 = UINT32(i1) / UINT32(i2);
                     }
                     else
                     {
-                        assert(tree->gtOper == GT_UMOD);
+                        assert(tree->OperIs(GT_UMOD));
                         i1 = UINT32(i1) % UINT32(i2);
                     }
                     break;
@@ -14924,8 +14901,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     return tree;
             }
 
-        /* We get here after folding to a GT_CNS_INT type
-         * change the node to the new type / value and make sure the node sizes are OK */
+        // We get here after folding to a GT_CNS_INT type.
+        // change the node to the new type / value and make sure the node sizes are OK.
         CNS_INT:
         FOLD_COND:
 
@@ -14939,12 +14916,12 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             i1 = INT32(i1);
 #endif // TARGET_64BIT
 
-            /* Also all conditional folding jumps here since the node hanging from
-             * GT_JTRUE has to be a GT_CNS_INT - value 0 or 1 */
+            // Also all conditional folding jumps here since the node hanging from
+            // GT_JTRUE has to be a GT_CNS_INT - value 0 or 1.
 
             tree->ChangeOperConst(GT_CNS_INT);
-            tree->gtType                 = TYP_INT;
-            tree->AsIntCon()->gtIconVal  = i1;
+            tree->ChangeType(TYP_INT);
+            tree->AsIntCon()->SetIconValue(i1);
             tree->AsIntCon()->gtFieldSeq = fieldSeq;
             if (vnStore != nullptr)
             {
@@ -14956,16 +14933,16 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             goto DONE;
 
-        /* This operation is going to cause an overflow exception. Morph into
-           an overflow helper. Put a dummy constant value for code generation.
-
-           We could remove all subsequent trees in the current basic block,
-           unless this node is a child of GT_COLON
-
-           NOTE: Since the folded value is not constant we should not change the
-                 "tree" node - otherwise we confuse the logic that checks if the folding
-                 was successful - instead use one of the operands, e.g. op1
-         */
+        // This operation is going to cause an overflow exception. Morph into
+        // an overflow helper. Put a dummy constant value for code generation.
+        //
+        // We could remove all subsequent trees in the current basic block,
+        // unless this node is a child of GT_COLON
+        //
+        // NOTE: Since the folded value is not constant we should not change the
+        //       "tree" node - otherwise we confuse the logic that checks if the folding
+        //       was successful - instead use one of the operands, e.g. op1.
+        //
 
         LNG_OVF:
             // Don't fold overflow operations if not global morph phase.
@@ -15024,20 +15001,19 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             JITDUMP("\nFolding binary operator with constant nodes into a comma throw:\n");
             DISPTREE(tree);
 
-            /* We will change the cast to a GT_COMMA and attach the exception helper as AsOp()->gtOp1.
-             * The constant expression zero becomes op2. */
+            // We will change the cast to a GT_COMMA and attach the exception helper as AsOp()->gtOp1.
+            // The constant expression zero becomes op2.
 
             assert(tree->gtOverflow());
-            assert(tree->gtOper == GT_ADD || tree->gtOper == GT_SUB || tree->gtOper == GT_CAST ||
-                   tree->gtOper == GT_MUL);
-            assert(op1);
+            assert(tree->OperIs(GT_ADD, GT_SUB, GT_CAST, GT_MUL));
+            assert(op1 != nullptr);
 
             op2 = op1;
             op1 = gtNewHelperCallNode(CORINFO_HELP_OVERFLOW, TYP_VOID,
                                       gtNewCallArgs(gtNewIconNode(compCurBB->bbTryIndex)));
 
-            // op1 is a call to the JIT helper that throws an Overflow exception
-            // attach the ExcSet for VNF_OverflowExc(Void) to this call
+            // op1 is a call to the JIT helper that throws an Overflow exception.
+            // Attach the ExcSet for VNF_OverflowExc(Void) to this call.
 
             if (vnStore != nullptr)
             {
@@ -15047,24 +15023,20 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                             vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnStore->VNPForVoid())));
             }
 
-            tree = gtNewOperNode(GT_COMMA, tree->gtType, op1, op2);
+            tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), op1, op2);
 
             return tree;
 
-        /*-------------------------------------------------------------------------
-         * Fold constant LONG binary operator
-         */
+        // Fold constant LONG binary operator.
 
         case TYP_LONG:
 
             // No GC pointer types should be folded here...
-            //
-            assert(!varTypeIsGC(op1->gtType) && !varTypeIsGC(op2->gtType));
+            assert(!varTypeIsGC(op1->TypeGet()) && !varTypeIsGC(op2->TypeGet()));
 
             // op1 is known to be a TYP_LONG, op2 is normally a TYP_LONG, unless we have a shift operator in which case
-            // it is a TYP_INT
-            //
-            assert((op2->gtType == TYP_LONG) || (op2->gtType == TYP_INT));
+            // it is a TYP_INT.
+            assert(op2->TypeIs(TYP_LONG, TYP_INT));
 
             if (!op1->AsIntConCommon()->ImmedValCanBeFolded(this, tree->OperGet()))
             {
@@ -15078,17 +15050,11 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             lval1 = op1->AsIntConCommon()->LngValue();
 
-            // For the shift operators we can have a op2 that is a TYP_INT and thus will be GT_CNS_INT
-            if (op2->OperGet() == GT_CNS_INT)
-            {
-                lval2 = op2->AsIntConCommon()->IconValue();
-            }
-            else
-            {
-                lval2 = op2->AsIntConCommon()->LngValue();
-            }
+            // For the shift operators we can have a op2 that is a TYP_INT.
+            // Thus we cannot just use LngValue(), as it will assert on 32 bit if op2 is not GT_CNS_LNG.
+            lval2 = op2->AsIntConCommon()->IntegralValue();
 
-            switch (tree->gtOper)
+            switch (tree->OperGet())
             {
                 case GT_EQ:
                     i1 = (lval1 == lval2);
@@ -15098,7 +15064,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_LT:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT64(lval1) < UINT64(lval2));
                     }
@@ -15109,7 +15075,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_LE:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT64(lval1) <= UINT64(lval2));
                     }
@@ -15120,7 +15086,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_GE:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT64(lval1) >= UINT64(lval2));
                     }
@@ -15131,7 +15097,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_GT:
-                    if (tree->gtFlags & GTF_UNSIGNED)
+                    if (tree->IsUnsigned())
                     {
                         i1 = (UINT64(lval1) > UINT64(lval2));
                     }
@@ -15145,14 +15111,14 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     ltemp = lval1 + lval2;
 
                 LNG_ADD_CHKOVF:
-                    /* For the SIGNED case - If there is one positive and one negative operand, there can be no overflow
-                     * If both are positive, the result has to be positive, and similary for negatives.
-                     *
-                     * For the UNSIGNED case - If a UINT32 operand is bigger than the result then OVF */
+                    // For the SIGNED case - If there is one positive and one negative operand, there can be no overflow.
+                    // If both are positive, the result has to be positive, and similary for negatives.
+                    //
+                    // For the UNSIGNED case - If a UINT32 operand is bigger than the result then OVF.
 
                     if (tree->gtOverflow())
                     {
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             if ((UINT64(lval1) > UINT64(ltemp)) || (UINT64(lval2) > UINT64(ltemp)))
                             {
@@ -15171,7 +15137,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     ltemp = lval1 - lval2;
                     if (tree->gtOverflow())
                     {
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             if (UINT64(lval2) > UINT64(lval1))
                             {
@@ -15180,8 +15146,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         }
                         else
                         {
-                            /* If both operands are +ve or both are -ve, there can be no
-                               overflow. Else use the logic for : lval1 + (-lval2) */
+                            // If both operands are +ve or both are -ve, there can be no
+                            // overflow. Else use the logic for : lval1 + (-lval2).
 
                             if ((lval1 < 0) != (lval2 < 0))
                             {
@@ -15203,7 +15169,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     if (tree->gtOverflow() && lval2 != 0)
                     {
 
-                        if (tree->gtFlags & GTF_UNSIGNED)
+                        if (tree->IsUnsigned())
                         {
                             UINT64 ultemp = ltemp;
                             UINT64 ulval1 = lval1;
@@ -15217,7 +15183,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         {
                             // This does a multiply and then reverses it.  This test works great except for MIN_INT *
                             //-1.  In that case we mess up the sign on ltmp.  Make sure to double check the sign.
-                            // if either is 0, then no overflow
+                            // if either is 0, then no overflow.
                             if (lval1 != 0) // lval2 checked above.
                             {
                                 if (((lval1 < 0) == (lval2 < 0)) && (ltemp < 0))
@@ -15266,7 +15232,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     lval1 >>= (lval2 & 0x3f);
                     break;
                 case GT_RSZ:
-                    /* logical shift -> make it unsigned to not propagate the sign bit */
+                    // logical shift -> make it unsigned to not propagate the sign bit.
                     lval1 = UINT64(lval1) >> (lval2 & 0x3f);
                     break;
                 case GT_ROL:
@@ -15279,51 +15245,54 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 // Both DIV and IDIV on x86 raise an exception for min_int (and min_long) / -1.  So we preserve
                 // that behavior here.
                 case GT_DIV:
-                    if (!lval2)
+                    if (lval2 == 0)
+                    {
+                        return tree;
+                    }
+                    if ((UINT64(lval1) == UINT64(0x8000000000000000)) && (lval2 == INT64(-1)))
                     {
                         return tree;
                     }
 
-                    if (UINT64(lval1) == UI64(0x8000000000000000) && lval2 == INT64(-1))
-                    {
-                        return tree;
-                    }
                     lval1 /= lval2;
                     break;
 
                 case GT_MOD:
-                    if (!lval2)
+                    if (lval2 == 0)
                     {
                         return tree;
                     }
-                    if (UINT64(lval1) == UI64(0x8000000000000000) && lval2 == INT64(-1))
+                    if ((UINT64(lval1) == UINT64(0x8000000000000000)) && (lval2 == INT64(-1)))
                     {
                         return tree;
                     }
+
                     lval1 %= lval2;
                     break;
 
                 case GT_UDIV:
-                    if (!lval2)
+                    if (lval2 == 0)
                     {
                         return tree;
                     }
-                    if (UINT64(lval1) == UI64(0x8000000000000000) && lval2 == INT64(-1))
+                    if ((UINT64(lval1) == UINT64(0x8000000000000000)) && (lval2 == INT64(-1)))
                     {
                         return tree;
                     }
+
                     lval1 = UINT64(lval1) / UINT64(lval2);
                     break;
 
                 case GT_UMOD:
-                    if (!lval2)
+                    if (lval2 == 0)
                     {
                         return tree;
                     }
-                    if (UINT64(lval1) == UI64(0x8000000000000000) && lval2 == INT64(-1))
+                    if ((UINT64(lval1) == UINT64(0x8000000000000000)) && (lval2 == INT64(-1)))
                     {
                         return tree;
                     }
+
                     lval1 = UINT64(lval1) % UINT64(lval2);
                     break;
                 default:
@@ -15355,9 +15324,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             goto DONE;
 
-        /*-------------------------------------------------------------------------
-         * Fold constant FLOAT or DOUBLE binary operator
-         */
+        // Fold constant FLOAT or DOUBLE binary operator
 
         case TYP_FLOAT:
         case TYP_DOUBLE:
@@ -15367,40 +15334,40 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 return tree;
             }
 
-            assert(op1->gtOper == GT_CNS_DBL);
+            assert(op1->OperIs(GT_CNS_DBL));
             d1 = op1->AsDblCon()->gtDconVal;
 
-            assert(varTypeIsFloating(op2->gtType));
-            assert(op2->gtOper == GT_CNS_DBL);
+            assert(varTypeIsFloating(op2->TypeGet()));
+            assert(op2->OperIs(GT_CNS_DBL));
             d2 = op2->AsDblCon()->gtDconVal;
 
-            /* Special case - check if we have NaN operands.
-             * For comparisons if not an unordered operation always return 0.
-             * For unordered operations (i.e. the GTF_RELOP_NAN_UN flag is set)
-             * the result is always true - return 1. */
+            // Special case - check if we have NaN operands.
+            // For comparisons if not an unordered operation always return 0.
+            // For unordered operations (i.e. the GTF_RELOP_NAN_UN flag is set)
+            // the result is always true - return 1.
 
             if (_isnan(d1) || _isnan(d2))
             {
                 JITDUMP("Double operator(s) is NaN\n");
 
-                if (tree->OperKind() & GTK_RELOP)
+                if (tree->OperIsRelop())
                 {
                     if (tree->gtFlags & GTF_RELOP_NAN_UN)
                     {
-                        /* Unordered comparison with NaN always succeeds */
+                        // Unordered comparison with NaN always succeeds.
                         i1 = 1;
                         goto FOLD_COND;
                     }
                     else
                     {
-                        /* Normal comparison with NaN always fails */
+                        // Normal comparison with NaN always fails.
                         i1 = 0;
                         goto FOLD_COND;
                     }
                 }
             }
 
-            switch (tree->gtOper)
+            switch (tree->OperGet())
             {
                 case GT_EQ:
                     i1 = (d1 == d2);
@@ -15435,7 +15402,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 //                  precision.
                 // flaot c = b/b;   This will produce NaN in single precision and 1 in double precision.
                 case GT_ADD:
-                    if (op1->TypeGet() == TYP_FLOAT)
+                    if (op1->TypeIs(TYP_FLOAT))
                     {
                         f1 = forceCastToFloat(d1);
                         f2 = forceCastToFloat(d2);
@@ -15448,7 +15415,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_SUB:
-                    if (op1->TypeGet() == TYP_FLOAT)
+                    if (op1->TypeIs(TYP_FLOAT))
                     {
                         f1 = forceCastToFloat(d1);
                         f2 = forceCastToFloat(d2);
@@ -15461,7 +15428,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_MUL:
-                    if (op1->TypeGet() == TYP_FLOAT)
+                    if (op1->TypeIs(TYP_FLOAT))
                     {
                         f1 = forceCastToFloat(d1);
                         f2 = forceCastToFloat(d2);
@@ -15474,11 +15441,13 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_DIV:
-                    if (!d2)
+                    // We do not fold division by zero, even for floating point.
+                    // This is because the result will be platform-dependent for an expression like 0d / 0d.
+                    if (d2 == 0)
                     {
                         return tree;
                     }
-                    if (op1->TypeGet() == TYP_FLOAT)
+                    if (op1->TypeIs(TYP_FLOAT))
                     {
                         f1 = forceCastToFloat(d1);
                         f2 = forceCastToFloat(d2);
@@ -15515,15 +15484,13 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             goto DONE;
 
         default:
-            /* not a foldable typ */
+            // Not a foldable type.
             return tree;
     }
 
-//-------------------------------------------------------------------------
-
 DONE:
 
-    /* Make sure no side effect flags are set on this constant node */
+    // Make sure no side effect flags are set on this constant node.
 
     tree->gtFlags &= ~GTF_ALL_EFFECT;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12719,7 +12719,7 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
 GenTree* Compiler::gtFoldExprCall(GenTreeCall* call)
 {
     // Can only fold calls to special intrinsics.
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) == 0)
+    if (!call->IsSpecialIntrinsic())
     {
         return call;
     }
@@ -16196,7 +16196,7 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
                 return TPK_Handle;
             }
         }
-        else if (tree->AsCall()->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
+        else if (tree->AsCall()->IsSpecialIntrinsic())
         {
             if (info.compCompHnd->getIntrinsicID(tree->AsCall()->gtCallMethHnd) == CORINFO_INTRINSIC_Object_GetType)
             {
@@ -17668,7 +17668,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
         case GT_CALL:
         {
             GenTreeCall* call = tree->AsCall();
-            if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
+            if (call->IsSpecialIntrinsic())
             {
                 NamedIntrinsic ni = lookupNamedIntrinsic(call->gtCallMethHnd);
                 if ((ni == NI_System_Array_Clone) || (ni == NI_System_Object_MemberwiseClone))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14220,60 +14220,35 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         break;
 
                     case GT_CAST:
-                        // assert (genActualType(tree->CastToType()) == tree->gtType);
+                        // assert (genActualType(tree->CastToType()) == tree->TypeGet());
+
+                        if (tree->gtOverflow() &&
+                            CheckedOps::CastFromIntOverflows((INT32)i1, tree->CastToType(), tree->IsUnsigned()))
+                        {
+                            goto INTEGRAL_OVF;
+                        }
+
                         switch (tree->CastToType())
                         {
                             case TYP_BYTE:
-                                itemp = INT32(INT8(i1));
-                                goto CHK_OVF;
+                                i1 = INT32(INT8(i1));
+                                goto CNS_INT;
 
                             case TYP_SHORT:
-                                itemp = INT32(INT16(i1));
-                            CHK_OVF:
-                                if (tree->gtOverflow() && ((itemp != i1) || (tree->IsUnsigned() && (i1 < 0))))
-                                {
-                                    goto INT_OVF;
-                                }
-                                i1 = itemp;
+                                i1 = INT32(INT16(i1));
                                 goto CNS_INT;
 
                             case TYP_USHORT:
-                                itemp = INT32(UINT16(i1));
-                                if (tree->gtOverflow())
-                                {
-                                    if (itemp != i1)
-                                    {
-                                        goto INT_OVF;
-                                    }
-                                }
-                                i1 = itemp;
+                                i1 = INT32(UINT16(i1));
                                 goto CNS_INT;
 
                             case TYP_BOOL:
                             case TYP_UBYTE:
-                                itemp = INT32(UINT8(i1));
-                                if (tree->gtOverflow())
-                                {
-                                    if (itemp != i1)
-                                    {
-                                        goto INT_OVF;
-                                    }
-                                }
-                                i1 = itemp;
+                                i1 = INT32(UINT8(i1));
                                 goto CNS_INT;
 
                             case TYP_UINT:
-                                if (!tree->IsUnsigned() && tree->gtOverflow() && (i1 < 0))
-                                {
-                                    goto INT_OVF;
-                                }
-                                goto CNS_INT;
-
                             case TYP_INT:
-                                if (tree->IsUnsigned() && tree->gtOverflow() && (i1 < 0))
-                                {
-                                    goto INT_OVF;
-                                }
                                 goto CNS_INT;
 
                             case TYP_ULONG:
@@ -14283,10 +14258,6 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 }
                                 else
                                 {
-                                    if (tree->gtOverflow() && (i1 < 0))
-                                    {
-                                        goto LNG_OVF;
-                                    }
                                     lval1 = UINT64(INT32(i1));
                                 }
                                 goto CNS_LONG;
@@ -14326,10 +14297,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_DOUBLE;
 
                             default:
-                                assert(!"BAD_TYP");
-                                break;
+                                assert(!"Bad CastToType() in gtFoldExprConst() for a cast from int");
+                                return tree;
                         }
-                        return tree;
 
                     default:
                         return tree;
@@ -14367,63 +14337,41 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                     case GT_CAST:
                         assert(tree->TypeIs(genActualType(tree->CastToType())));
+
+                        if (tree->gtOverflow() &&
+                            CheckedOps::CastFromLongOverflows(lval1, tree->CastToType(), tree->IsUnsigned()))
+                        {
+                            goto INTEGRAL_OVF;
+                        }
+
                         switch (tree->CastToType())
                         {
                             case TYP_BYTE:
                                 i1 = INT32(INT8(lval1));
-                                goto CHECK_INT_OVERFLOW;
+                                goto CNS_INT;
 
                             case TYP_SHORT:
                                 i1 = INT32(INT16(lval1));
-                                goto CHECK_INT_OVERFLOW;
+                                goto CNS_INT;
 
                             case TYP_USHORT:
                                 i1 = INT32(UINT16(lval1));
-                                goto CHECK_UINT_OVERFLOW;
+                                goto CNS_INT;
 
                             case TYP_UBYTE:
                                 i1 = INT32(UINT8(lval1));
-                                goto CHECK_UINT_OVERFLOW;
+                                goto CNS_INT;
 
                             case TYP_INT:
                                 i1 = INT32(lval1);
-
-                            CHECK_INT_OVERFLOW:
-                                if (tree->gtOverflow())
-                                {
-                                    if (i1 != lval1)
-                                    {
-                                        goto INT_OVF;
-                                    }
-                                    if (tree->IsUnsigned() && (i1 < 0))
-                                    {
-                                        goto INT_OVF;
-                                    }
-                                }
                                 goto CNS_INT;
 
                             case TYP_UINT:
                                 i1 = UINT32(lval1);
-
-                            CHECK_UINT_OVERFLOW:
-                                if (tree->gtOverflow() && UINT32(i1) != lval1)
-                                {
-                                    goto INT_OVF;
-                                }
                                 goto CNS_INT;
 
                             case TYP_ULONG:
-                                if (!tree->IsUnsigned() && tree->gtOverflow() && (lval1 < 0))
-                                {
-                                    goto LNG_OVF;
-                                }
-                                goto CNS_LONG;
-
                             case TYP_LONG:
-                                if (tree->IsUnsigned() && tree->gtOverflow() && (lval1 < 0))
-                                {
-                                    goto LNG_OVF;
-                                }
                                 goto CNS_LONG;
 
                             case TYP_FLOAT:
@@ -14444,10 +14392,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 }
                                 goto CNS_DOUBLE;
                             default:
-                                assert(!"BAD_TYP");
-                                break;
+                                assert(!"Bad CastToType() in gtFoldExprConst() for a cast from long");
+                                return tree;
                         }
-                        return tree;
 
                     default:
                         return tree;
@@ -14471,7 +14418,11 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                     case GT_CAST:
 
-                        if (tree->gtOverflowEx())
+                        if (tree->gtOverflow() &&
+                            ((op1->TypeIs(TYP_DOUBLE) &&
+                              CheckedOps::CastFromDoubleOverflows(d1, tree->CastToType())) ||
+                             (op1->TypeIs(TYP_FLOAT) &&
+                              CheckedOps::CastFromDoubleOverflows(forceCastToFloat(d1), tree->CastToType()))))
                         {
                             return tree;
                         }
@@ -14554,7 +14505,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                                 goto CNS_DOUBLE; // Redundant cast.
 
                             default:
-                                assert(!"BAD_TYP");
+                                assert(!"Bad CastToType() in gtFoldExprConst() for a cast from double/float");
                                 break;
                         }
                         return tree;
@@ -14755,7 +14706,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 + i2;
                     if (tree->gtOverflow() && CheckedOps::IntAddOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        goto INT_OVF;
+                        goto INTEGRAL_OVF;
                     }
                     i1       = itemp;
                     fieldSeq = GetFieldSeqStore()->Append(op1->AsIntCon()->gtFieldSeq, op2->AsIntCon()->gtFieldSeq);
@@ -14764,7 +14715,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 - i2;
                     if (tree->gtOverflow() && CheckedOps::IntSubOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        goto INT_OVF;
+                        goto INTEGRAL_OVF;
                     }
                     i1 = itemp;
                     break;
@@ -14772,7 +14723,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     itemp = i1 * i2;
                     if (tree->gtOverflow() && CheckedOps::IntMulOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
-                        goto INT_OVF;
+                        goto INTEGRAL_OVF;
                     }
 
                     // For the very particular case of the "constant array index" pseudo-field, we
@@ -14895,100 +14846,6 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             goto DONE;
 
-        // This operation is going to cause an overflow exception. Morph into
-        // an overflow helper. Put a dummy constant value for code generation.
-        //
-        // We could remove all subsequent trees in the current basic block,
-        // unless this node is a child of GT_COLON
-        //
-        // NOTE: Since the folded value is not constant we should not change the
-        //       "tree" node - otherwise we confuse the logic that checks if the folding
-        //       was successful - instead use one of the operands, e.g. op1.
-        //
-
-        LNG_OVF:
-            // Don't fold overflow operations if not global morph phase.
-            // The reason for this is that this optimization is replacing a gentree node
-            // with another new gentree node. Say a GT_CALL(arglist) has one 'arg'
-            // involving overflow arithmetic.  During assertion prop, it is possible
-            // that the 'arg' could be constant folded and the result could lead to an
-            // overflow.  In such a case 'arg' will get replaced with GT_COMMA node
-            // but fgMorphArgs() - see the logic around "if(lateArgsComputed)" - doesn't
-            // update args table. For this reason this optimization is enabled only
-            // for global morphing phase.
-            //
-            // TODO-CQ: Once fgMorphArgs() is fixed this restriction could be removed.
-
-            if (!fgGlobalMorph)
-            {
-                assert(tree->gtOverflow());
-                return tree;
-            }
-
-            op1 = gtNewLconNode(0);
-            if (vnStore != nullptr)
-            {
-                op1->gtVNPair.SetBoth(vnStore->VNZeroForType(TYP_LONG));
-            }
-            goto OVF;
-
-        INT_OVF:
-            // Don't fold overflow operations if not global morph phase.
-            // The reason for this is that this optimization is replacing a gentree node
-            // with another new gentree node. Say a GT_CALL(arglist) has one 'arg'
-            // involving overflow arithmetic.  During assertion prop, it is possible
-            // that the 'arg' could be constant folded and the result could lead to an
-            // overflow.  In such a case 'arg' will get replaced with GT_COMMA node
-            // but fgMorphArgs() - see the logic around "if(lateArgsComputed)" - doesn't
-            // update args table. For this reason this optimization is enabled only
-            // for global morphing phase.
-            //
-            // TODO-CQ: Once fgMorphArgs() is fixed this restriction could be removed.
-
-            if (!fgGlobalMorph)
-            {
-                assert(tree->gtOverflow());
-                return tree;
-            }
-
-            op1 = gtNewIconNode(0);
-            if (vnStore != nullptr)
-            {
-                op1->gtVNPair.SetBoth(vnStore->VNZeroForType(TYP_INT));
-            }
-            goto OVF;
-
-        OVF:
-
-            JITDUMP("\nFolding binary operator with constant nodes into a comma throw:\n");
-            DISPTREE(tree);
-
-            // We will change the cast to a GT_COMMA and attach the exception helper as AsOp()->gtOp1.
-            // The constant expression zero becomes op2.
-
-            assert(tree->gtOverflow());
-            assert(tree->OperIs(GT_ADD, GT_SUB, GT_CAST, GT_MUL));
-            assert(op1 != nullptr);
-
-            op2 = op1;
-            op1 = gtNewHelperCallNode(CORINFO_HELP_OVERFLOW, TYP_VOID,
-                                      gtNewCallArgs(gtNewIconNode(compCurBB->bbTryIndex)));
-
-            // op1 is a call to the JIT helper that throws an Overflow exception.
-            // Attach the ExcSet for VNF_OverflowExc(Void) to this call.
-
-            if (vnStore != nullptr)
-            {
-                op1->gtVNPair =
-                    vnStore->VNPWithExc(ValueNumPair(ValueNumStore::VNForVoid(), ValueNumStore::VNForVoid()),
-                                        vnStore->VNPExcSetSingleton(
-                                            vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnStore->VNPForVoid())));
-            }
-
-            tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), op1, op2);
-
-            return tree;
-
         // Fold constant LONG binary operator.
 
         case TYP_LONG:
@@ -15073,7 +14930,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     ltemp = lval1 + lval2;
                     if (tree->gtOverflow() && CheckedOps::LongAddOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        goto LNG_OVF;
+                        goto INTEGRAL_OVF;
                     }
                     lval1 = ltemp;
                     break;
@@ -15082,7 +14939,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     ltemp = lval1 - lval2;
                     if (tree->gtOverflow() && CheckedOps::LongSubOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        goto LNG_OVF;
+                        goto INTEGRAL_OVF;
                     }
                     lval1 = ltemp;
                     break;
@@ -15091,7 +14948,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     ltemp = lval1 * lval2;
                     if (tree->gtOverflow() && CheckedOps::LongMulOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
-                        goto LNG_OVF;
+                        goto INTEGRAL_OVF;
                     }
                     lval1 = ltemp;
                     break;
@@ -15374,6 +15231,72 @@ DONE:
     // Make sure no side effect flags are set on this constant node.
 
     tree->gtFlags &= ~GTF_ALL_EFFECT;
+
+    return tree;
+
+INTEGRAL_OVF:
+
+    // This operation is going to cause an overflow exception. Morph into
+    // an overflow helper. Put a dummy constant value for code generation.
+    //
+    // We could remove all subsequent trees in the current basic block,
+    // unless this node is a child of GT_COLON
+    //
+    // NOTE: Since the folded value is not constant we should not change the
+    //       "tree" node - otherwise we confuse the logic that checks if the folding
+    //       was successful - instead use one of the operands, e.g. op1.
+
+    // Don't fold overflow operations if not global morph phase.
+    // The reason for this is that this optimization is replacing a gentree node
+    // with another new gentree node. Say a GT_CALL(arglist) has one 'arg'
+    // involving overflow arithmetic.  During assertion prop, it is possible
+    // that the 'arg' could be constant folded and the result could lead to an
+    // overflow.  In such a case 'arg' will get replaced with GT_COMMA node
+    // but fgMorphArgs() - see the logic around "if(lateArgsComputed)" - doesn't
+    // update args table. For this reason this optimization is enabled only
+    // for global morphing phase.
+    //
+    // TODO-CQ: Once fgMorphArgs() is fixed this restriction could be removed.
+
+    if (!fgGlobalMorph)
+    {
+        assert(tree->gtOverflow());
+        return tree;
+    }
+
+    var_types type = genActualType(tree->TypeGet());
+    op1 = type == TYP_LONG ? gtNewLconNode(0) : gtNewIconNode(0);
+    if (vnStore != nullptr)
+    {
+        op1->gtVNPair.SetBoth(vnStore->VNZeroForType(type));
+    }
+
+    JITDUMP("\nFolding binary operator with constant nodes into a comma throw:\n");
+    DISPTREE(tree);
+
+    // We will change the cast to a GT_COMMA and attach the exception helper as AsOp()->gtOp1.
+    // The constant expression zero becomes op2.
+
+    assert(tree->gtOverflow());
+    assert(tree->OperIs(GT_ADD, GT_SUB, GT_CAST, GT_MUL));
+    assert(op1 != nullptr);
+
+    op2 = op1;
+    op1 = gtNewHelperCallNode(CORINFO_HELP_OVERFLOW, TYP_VOID,
+        gtNewCallArgs(gtNewIconNode(compCurBB->bbTryIndex)));
+
+    // op1 is a call to the JIT helper that throws an Overflow exception.
+    // Attach the ExcSet for VNF_OverflowExc(Void) to this call.
+
+    if (vnStore != nullptr)
+    {
+        op1->gtVNPair =
+            vnStore->VNPWithExc(ValueNumPair(ValueNumStore::VNForVoid(), ValueNumStore::VNForVoid()),
+                vnStore->VNPExcSetSingleton(
+                    vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnStore->VNPForVoid())));
+    }
+
+    tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), op1, op2);
 
     return tree;
 }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4433,6 +4433,7 @@ struct GenTreeCall final : public GenTree
     {
         return false;
     }
+
     bool IsTailCallConvertibleToLoop() const
     {
         return false;
@@ -4443,10 +4444,22 @@ struct GenTreeCall final : public GenTree
     {
         return (gtCallMoreFlags & GTF_CALL_M_NONVIRT_SAME_THIS) != 0;
     }
+
     bool IsDelegateInvoke() const
     {
         return (gtCallMoreFlags & GTF_CALL_M_DELEGATE_INV) != 0;
     }
+
+    bool IsSpecialIntrinsic() const
+    {
+        return (gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) != 0;
+    }
+
+    void SetIsSpecialIntrinsic()
+    {
+        gtCallMoreFlags |= GTF_CALL_M_SPECIAL_INTRINSIC;
+    }
+
     bool IsVirtualStubRelativeIndir() const
     {
         return (gtCallMoreFlags & GTF_CALL_M_VIRTSTUB_REL_INDIRECT) != 0;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1445,6 +1445,16 @@ public:
         return OperIsSimple(gtOper);
     }
 
+    static bool OperIsRelop(genTreeOps gtOper)
+    {
+        return (OperKind(gtOper) & GTK_RELOP) != 0;
+    }
+
+    bool OperIsRelop() const
+    {
+        return OperIsRelop(gtOper);
+    }
+
 #ifdef FEATURE_SIMD
     bool isCommutativeSIMDIntrinsic();
 #else  // !

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4347,7 +4347,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 if (opts.OptimizationEnabled() && impStackTop().val->OperIs(GT_RET_EXPR))
                 {
                     GenTreeCall* call = impStackTop().val->AsRetExpr()->gtInlineCandidate->AsCall();
-                    if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
+                    if (call->IsSpecialIntrinsic())
                     {
                         if (lookupNamedIntrinsic(call->gtCallMethHnd) == NI_System_Threading_Thread_get_CurrentThread)
                         {
@@ -8449,7 +8449,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         // Mark call if it's one of the ones we will maybe treat as an intrinsic
         if (isSpecialIntrinsic)
         {
-            call->AsCall()->gtCallMoreFlags |= GTF_CALL_M_SPECIAL_INTRINSIC;
+            call->AsCall()->SetIsSpecialIntrinsic();
         }
     }
     assert(sig);
@@ -9316,7 +9316,7 @@ DONE_CALL:
                     {
                         spillStack = false;
                     }
-                    else if ((callNode->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) != 0)
+                    else if (callNode->IsSpecialIntrinsic())
                     {
                         spillStack = false;
                     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7369,7 +7369,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 #endif
     };
 
-    if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
+    if (call->IsSpecialIntrinsic())
     {
         failTailCall("Might turn into an intrinsic");
         return nullptr;
@@ -9179,12 +9179,11 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 #endif
     }
 
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) == 0 &&
-        (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR)
+    if (!call->IsSpecialIntrinsic() && (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR)
 #ifdef FEATURE_READYTORUN_COMPILER
-         || call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR)
+                                        || call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR)
 #endif
-             ) &&
+                                            ) &&
         (call == fgMorphStmt->GetRootNode()))
     {
         // This is call to CORINFO_HELP_VIRTUAL_FUNC_PTR with ignored result.
@@ -9244,7 +9243,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     // Morph Type.op_Equality, Type.op_Inequality, and Enum.HasFlag
     //
     // We need to do these before the arguments are morphed
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC))
+    if (call->IsSpecialIntrinsic())
     {
         // See if this is foldable
         GenTree* optTree = gtFoldExprCall(call);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9243,7 +9243,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     // Morph Type.op_Equality, Type.op_Inequality, and Enum.HasFlag
     //
     // We need to do these before the arguments are morphed
-    if (call->IsSpecialIntrinsic())
+    if (call->IsSpecialIntrinsic() || call->IsHelperCall())
     {
         // See if this is foldable
         GenTree* optTree = gtFoldExprCall(call);

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2546,3 +2546,165 @@ int64_t GetSigned64Magic(int64_t d, int* shift /*out*/)
 }
 #endif
 }
+
+namespace CheckedOps
+{
+bool IntAddOverflows(int32_t firstAddend, int32_t secondAddend, bool unsignedAdd)
+{
+    int32_t result = firstAddend + secondAddend;
+
+    if (unsignedAdd)
+    {
+        if ((int64_t)(uint32_t)result != ((int64_t)(uint32_t)firstAddend + (int64_t)(uint32_t)secondAddend))
+        {
+            return true;
+        }
+    }
+    else if ((int64_t)result != ((int64_t)firstAddend + (int64_t)secondAddend))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool IntSubOverflows(int32_t minuend, int32_t subtrahend, bool unsignedSub)
+{
+    int32_t result = minuend - subtrahend;
+
+    if (unsignedSub)
+    {
+        if ((int64_t)(uint32_t)result != ((int64_t)(uint32_t)minuend - (int64_t)(uint32_t)subtrahend))
+        {
+            return true;
+        }
+    }
+    else if ((int64_t)(int32_t)result != ((int64_t)minuend - (int64_t)subtrahend))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool IntMulOverflows(int32_t firstFactor, int32_t secondFactor, bool unsignedMul)
+{
+    int32_t result = firstFactor * secondFactor;
+
+    if (unsignedMul)
+    {
+        if ((int64_t)(uint32_t)result != ((int64_t)(uint32_t)firstFactor * (int64_t)(uint32_t)secondFactor))
+        {
+            return true;
+        }
+    }
+    else if ((int64_t)(int32_t)result != ((int64_t)firstFactor * (int64_t)secondFactor))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool LongAddOverflows(int64_t firstAddend, int64_t secondAddend, bool unsignedAdd)
+{
+    int64_t result = firstAddend + secondAddend;
+
+    // For the SIGNED case - If there is one positive and one negative operand, there can be no overflow.
+    // If both are positive, the result has to be positive, and similary for negatives.
+    // For the UNSIGNED case - If a UINT32 operand is bigger than the result then OVF.
+    if (unsignedAdd)
+    {
+        if (((uint64_t)firstAddend > (uint64_t)result) || ((uint64_t)secondAddend > (uint64_t)result))
+        {
+            return true;
+        }
+    }
+    else if (((firstAddend < 0) == (secondAddend < 0)) && ((firstAddend < 0) != (result < 0)))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool LongSubOverflows(int64_t minuend, int64_t subtrahend, bool unsignedSub)
+{
+    int64_t result = minuend - subtrahend;
+
+    if (unsignedSub)
+    {
+        if ((uint64_t)subtrahend > (uint64_t)minuend)
+        {
+            return true;
+        }
+    }
+    else
+    {
+        // If both operands are positive or negative, there can be no
+        // overflow. Else use the logic for : minuend + (-subtrahend).
+        if ((minuend < 0) != (subtrahend < 0))
+        {
+            if (subtrahend == INT64_MIN)
+            {
+                return true;
+            }
+
+            return LongAddOverflows(minuend, -subtrahend, unsignedSub);
+        }
+    }
+
+    return false;
+}
+
+bool LongMulOverflows(int64_t firstFactor, int64_t secondFactor, bool unsignedMul)
+{
+    int64_t result = firstFactor * secondFactor;
+
+    // No overflow can occur if either of the operands is 0.
+    if (firstFactor == 0 || secondFactor == 0)
+    {
+        return false;
+    }
+
+    if (unsignedMul)
+    {
+        if (((uint64_t)result / (uint64_t)secondFactor) != (uint64_t)firstFactor)
+        {
+            return true;
+        }
+    }
+    else
+    {
+        // This does a multiply and then reverses it.
+        // This test works great except for MIN_INT * -1.
+        // In that case we mess up the sign on the result.  Make sure to double check the sign.
+        // if either is 0, then no overflow.
+
+        if (((firstFactor < 0) == (secondFactor < 0)) && (result < 0))
+        {
+            return true;
+        }
+        if (((firstFactor < 0) != (secondFactor < 0)) && (result > 0))
+        {
+            return true;
+        }
+
+        // TODO-Amd64-Unix: Remove the code that disables optimizations for this method when the
+        // clang
+        // optimizer is fixed and/or the method implementation is refactored in a simpler code.
+        // There is a bug in the clang-3.5 optimizer. The issue is that in release build the
+        // optimizer is mistyping (or just wrongly decides to use 32 bit operation for a corner
+        // case of MIN_LONG) the args of the (result / secondFactor) to int (it does a 32 bit div
+        // operation instead of 64 bit.). For the case of firstFactor and secondFactor equal to MIN_LONG
+        // (0x8000000000000000) this results in raising a SIGFPE.
+        // Optimizations disabled for now. See compiler.h.
+        if ((result / secondFactor) != firstFactor)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+}

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2707,4 +2707,207 @@ bool LongMulOverflows(int64_t firstFactor, int64_t secondFactor, bool unsignedMu
 
     return false;
 }
+
+bool CastFromIntOverflows(int32_t fromValue, var_types toType, bool fromUnsigned)
+{
+    switch (toType)
+    {
+        case TYP_BYTE:
+            return ((int8_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
+        case TYP_BOOL:
+        case TYP_UBYTE:
+            return (uint8_t)fromValue != fromValue;
+        case TYP_SHORT:
+            return ((int16_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
+        case TYP_USHORT:
+            return (uint16_t)fromValue != fromValue;
+        case TYP_INT:
+            return fromUnsigned && (fromValue < 0);
+        case TYP_UINT:
+        case TYP_ULONG:
+            return !fromUnsigned && (fromValue < 0);
+        case TYP_LONG:
+        case TYP_FLOAT:
+        case TYP_DOUBLE:
+            return false;
+        default:
+            unreached();
+    }
+}
+
+bool CastFromLongOverflows(int64_t fromValue, var_types toType, bool fromUnsigned)
+{
+    switch (toType)
+    {
+        case TYP_BYTE:
+            return ((int8_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
+        case TYP_BOOL:
+        case TYP_UBYTE:
+            return (uint8_t)fromValue != fromValue;
+        case TYP_SHORT:
+            return ((int16_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
+        case TYP_USHORT:
+            return (uint16_t)fromValue != fromValue;
+        case TYP_INT:
+            return ((int32_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
+        case TYP_UINT:
+            return (uint32_t)fromValue != fromValue;
+        case TYP_LONG:
+            return fromUnsigned && (fromValue < 0);
+        case TYP_ULONG:
+            return !fromUnsigned && (fromValue < 0);
+        case TYP_FLOAT:
+        case TYP_DOUBLE:
+            return false;
+        default:
+            unreached();
+    }
+}
+
+//  ________________________________________________
+// |                                                |
+// |  Casting from floating point to integer types  |
+// |________________________________________________|
+//
+// The code below uses the following pattern to determine if an overflow would
+// occur when casting from a floating point type to an integer type:
+//
+//     return !(MIN <= fromValue && fromValue <= MAX);
+//
+// This section will provide some background on how MIN and MAX were derived
+// and why they are in fact the values to use in that comparison.
+//
+// First - edge cases:
+// 1) NaNs - they compare "false" to normal numbers, which MIN and MAX are, making
+//    the condition return "false" as well, which is flipped to true via "!", indicating
+//    overflow - exactly what we want.
+// 2) Infinities - they are outside of range of any normal numbers, making one of the comparisons
+//    always return "false", indicating overflow.
+// 3) Subnormal numbers - have no special behavior with respect to comparisons.
+// 4) Minus zero - compares equal to "+0", which is what we want as it can be safely casted to an integer "0".
+//
+// Binary normal floating point numbers are represented in the following format:
+//
+//     number = sign * (1 + mantissa) * 2^exponent
+//
+// Where "exponent" is a biased binary integer.
+// And "mantissa" is a fixed-point binary fraction of the following form:
+//
+//     mantissa = bits[1] * 2^-1 + bits[2] * 2^-2 + ... + bits[n] * 2^-N
+//
+// Where "N" is the number of digits that depends on the width of floating point type
+// in question. Is is equal to "23" for "float"s and to "52" for "double"s.
+//
+// If we did our calculations with real numbers, the condition to check would simply be:
+//
+//     return !((INT_MIN - 1) < fromValue && fromValue < (INT_MAX + 1));
+//
+// This is because casting uses the "round to zero" semantic: "checked((int)((double)int.MaxValue + 0.9))"
+// yields "(double)int.MaxValue" - not an error. Likewise, "checked((int)((double)int.MinValue - 0.9))"
+// results in "(double)int.MinValue". However, "checked((int)((double)int.MaxValue + 1))" will not compile.
+//
+// The problem, of course, is that we are not dealing with real numbers, but rather floating point approximations.
+// At the same time, some real numbers - powers of two - can be represented in the floating point world exactly.
+// It so happens that both "INT_MIN - 1" and "INT_MAX + 1" can satsify that requirement for most cases.
+// For unsigned integers, where M is the width of the type in bits:
+//
+//     INT_MIN - 1 = 0 - 1 = -2^0 - exactly representable.
+//     INT_MAX + 1 = (2^M - 1) + 1 = 2^M - exactly representable.
+//
+// For signed integers:
+//
+//     INT_MIN - 1 = -(2^(M - 1)) - 1 - not always exactly representable.
+//     INT_MAX + 1 = (2^(M - 1) - 1) + 1 = 2^(M - 1) - exactly representable.
+//
+// So, we have simple values for MIN and MAX in all but the signed MIN case.
+// To find out what value should be used then, the following equation needs to be solved:
+//
+//     -(2^(M - 1)) - 1 = -(2^(M - 1)) * (1 + m)
+//     1 + 1 / 2^(M - 1) = 1 + m
+//     m = 2^(1 - M)
+//
+// In this case "m" is the "mantissa". The result obtained means that we can find the exact
+// value in cases when "|1 - M| <= N" <=> "M <= N - 1" - i. e. the precision is high enough for there to be a position
+// in the fixed point mantissa that could represent the "-1". It is the case for the following combinations of types:
+//
+//     float + int8 / int16
+//     double + int8 / int16 / int32
+//
+// For the remaining cases, we could use a value that is the first representable one for the respective type
+// and is less than the infinitely precise MIN: -(1 + 2^-N) * 2^(M - 1).
+// However, a simpler appoach is to just use a different comparison.
+// Instead of "MIN < fromValue", we'll do "MAX_MIN <= fromValue", where
+// "MAX_MIN" is just "-(2^(M - 1))" - the smallest representable value that can be cast safely.
+// The following table shows the final values and operations for MIN:
+//
+//     | Cast            | MIN                     | Comparison |
+//     |-----------------|-------------------------|------------|
+//     | float -> int8   | -129.0f                 | <          |
+//     | float -> int16  | -32769.0f               | <          |
+//     | float -> int32  | -2147483648.0f          | <=         |
+//     | float -> int64  | -9223372036854775808.0f | <=         |
+//     | double -> int8  | -129.0                  | <          |
+//     | double -> int16 | -32769.0                | <          |
+//     | double -> int32 | -2147483649.0           | <          |
+//     | double -> int64 | -9223372036854775808.0  | <=         |
+//
+// Note: casts from floating point to floating point never overflow.
+
+bool CastFromFloatOverflows(float fromValue, var_types toType)
+{
+    switch (toType)
+    {
+        case TYP_BYTE:
+            return !(-129.0f < fromValue && fromValue < 128.0f);
+        case TYP_BOOL:
+        case TYP_UBYTE:
+            return !(-1.0f < fromValue && fromValue < 256.0f);
+        case TYP_SHORT:
+            return !(-32769.0f < fromValue && fromValue < 32768.0f);
+        case TYP_USHORT:
+            return !(-1.0f < fromValue && fromValue < 65536.0f);
+        case TYP_INT:
+            return !(-2147483648.0f <= fromValue && fromValue < 2147483648.0f);
+        case TYP_UINT:
+            return !(-1.0 < fromValue && fromValue < 4294967296.0f);
+        case TYP_LONG:
+            return !(-9223372036854775808.0 <= fromValue && fromValue < 9223372036854775808.0f);
+        case TYP_ULONG:
+            return !(-1.0f < fromValue && fromValue < 18446744073709551616.0f);
+        case TYP_FLOAT:
+        case TYP_DOUBLE:
+            return false;
+        default:
+            unreached();
+    }
+}
+
+bool CastFromDoubleOverflows(double fromValue, var_types toType)
+{
+    switch (toType)
+    {
+        case TYP_BYTE:
+            return !(-129.0 < fromValue && fromValue < 128.0);
+        case TYP_BOOL:
+        case TYP_UBYTE:
+            return !(-1.0 < fromValue && fromValue < 256.0);
+        case TYP_SHORT:
+            return !(-32769.0 < fromValue && fromValue < 32768.0);
+        case TYP_USHORT:
+            return !(-1.0 < fromValue && fromValue < 65536.0);
+        case TYP_INT:
+            return !(-2147483649.0 < fromValue && fromValue < 2147483648.0);
+        case TYP_UINT:
+            return !(-1.0 < fromValue && fromValue < 4294967296.0);
+        case TYP_LONG:
+            return !(-9223372036854775808.0 <= fromValue && fromValue < 9223372036854775808.0);
+        case TYP_ULONG:
+            return !(-1.0 < fromValue && fromValue < 18446744073709551616.0);
+        case TYP_FLOAT:
+        case TYP_DOUBLE:
+            return false;
+        default:
+            unreached();
+    }
+}
 }

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -772,4 +772,18 @@ int64_t GetSigned64Magic(int64_t d, int* shift /*out*/);
 
 double CachedCyclesPerSecond();
 
+namespace CheckedOps
+{
+const bool Unsigned = true;
+const bool Signed = false;
+
+bool IntAddOverflows(int32_t firstAddend, int32_t secondAddend, bool unsignedAdd);
+bool IntSubOverflows(int32_t minuend, int32_t subtrahend, bool unsignedSub);
+bool IntMulOverflows(int32_t firstFactor, int32_t secondFactor, bool unsignedMul);
+
+bool LongAddOverflows(int64_t firstAddend, int64_t secondAddend, bool unsignedAddition);
+bool LongSubOverflows(int64_t minuend, int64_t subtrahend, bool unsignedSubtraction);
+bool LongMulOverflows(int64_t firstFactor, int64_t secondFactor, bool unsignedMultiplication);
+}
+
 #endif // _UTILS_H_

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -18,6 +18,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "iallocator.h"
 #include "hostallocator.h"
 #include "cycletimer.h"
+#include "vartype.h"
 
 // Needed for unreached()
 #include "error.h"
@@ -784,6 +785,11 @@ bool IntMulOverflows(int32_t firstFactor, int32_t secondFactor, bool unsignedMul
 bool LongAddOverflows(int64_t firstAddend, int64_t secondAddend, bool unsignedAddition);
 bool LongSubOverflows(int64_t minuend, int64_t subtrahend, bool unsignedSubtraction);
 bool LongMulOverflows(int64_t firstFactor, int64_t secondFactor, bool unsignedMultiplication);
+
+bool CastFromIntOverflows(int32_t fromValue, var_types toType, bool fromUnsigned);
+bool CastFromLongOverflows(int64_t fromValue, var_types toType, bool fromUnsigned);
+bool CastFromFloatOverflows(float fromValue, var_types toType);
+bool CastFromDoubleOverflows(double fromValue, var_types toType);
 }
 
 #endif // _UTILS_H_

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -776,7 +776,7 @@ double CachedCyclesPerSecond();
 namespace CheckedOps
 {
 const bool Unsigned = true;
-const bool Signed = false;
+const bool Signed   = false;
 
 bool IntAddOverflows(int32_t firstAddend, int32_t secondAddend, bool unsignedAdd);
 bool IntSubOverflows(int32_t minuend, int32_t subtrahend, bool unsignedSub);

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -18,7 +18,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "iallocator.h"
 #include "hostallocator.h"
 #include "cycletimer.h"
-#include "vartype.h"
+#include "vartypesdef.h"
 
 // Needed for unreached()
 #include "error.h"

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3331,7 +3331,7 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
 
 //----------------------------------------------------------------------------------------
 //  EvalUsingMathIdentity
-//                   - Attempts to evaluate 'func' by using mathimatical identities
+//                   - Attempts to evaluate 'func' by using mathematical identities
 //                     that can be applied to 'func'.
 //
 // Arguments:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3346,87 +3346,104 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
 ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueNum arg0VN, ValueNum arg1VN)
 {
     ValueNum resultVN = NoVN; // set default result to unsuccessful
+    ValueNum ZeroVN;
+    ValueNum OneVN;
 
     if (typ == TYP_BYREF) // We don't want/need to optimize a zero byref
     {
         return resultVN; // return the unsuccessful value
     }
 
+    // (0 + x) == x
+    // (x + 0) == x
+    // This identity does not apply for floating point (when x == -0.0).
+    auto identityForAddition = [=]() -> ValueNum
+    {
+        if (!varTypeIsFloating(typ))
+        {
+            ValueNum ZeroVN = VNZeroForType(typ);
+            if (arg0VN == ZeroVN)
+            {
+                return arg1VN;
+            }
+            else if (arg1VN == ZeroVN)
+            {
+                return arg0VN;
+            }
+        }
+
+        return NoVN;
+    };
+
+    // (x - 0) == x
+    // (x - x) == 0
+    // This identity does not apply for floating point (when x == -0.0).
+    auto identityForSubtraction = [=]() -> ValueNum
+    {
+        if (!varTypeIsFloating(typ))
+        {
+            ValueNum ZeroVN = VNZeroForType(typ);
+            if (arg1VN == ZeroVN)
+            {
+                return arg0VN;
+            }
+            else if (arg0VN == arg1VN)
+            {
+                return ZeroVN;
+            }
+        }
+
+        return NoVN;
+    };
+
+    // These identities do not apply for floating point.
+    auto identityForMultiplication = [=]() -> ValueNum
+    {
+        if (!varTypeIsFloating(typ))
+        {
+            // (0 * x) == 0
+            // (x * 0) == 0
+            ValueNum ZeroVN = VNZeroForType(typ);
+            if (arg0VN == ZeroVN)
+            {
+                return ZeroVN;
+            }
+            else if (arg1VN == ZeroVN)
+            {
+                return ZeroVN;
+            }
+
+            // (x * 1) == x
+            // (1 * x) == x
+            ValueNum OneVN = VNOneForType(typ);
+            if (arg0VN == OneVN)
+            {
+                return arg1VN;
+            }
+            else if (arg1VN == OneVN)
+            {
+                return arg0VN;
+            }
+        }
+
+        return NoVN;
+    };
+
     // We have ways of evaluating some binary functions.
     if (func < VNF_Boundary)
     {
         switch (genTreeOps(func))
         {
-            ValueNum ZeroVN;
-            ValueNum OneVN;
-
             case GT_ADD:
-                // (0 + x) == x
-                // (x + 0) == x
-                // This identity does not apply for floating point (when x == -0.0)
-                //
-                if (!varTypeIsFloating(typ))
-                {
-                    ZeroVN = VNZeroForType(typ);
-                    if (arg0VN == ZeroVN)
-                    {
-                        resultVN = arg1VN;
-                    }
-                    else if (arg1VN == ZeroVN)
-                    {
-                        resultVN = arg0VN;
-                    }
-                }
+                resultVN = identityForAddition();
                 break;
 
             case GT_SUB:
-                // (x - 0) == x
-                // (x - x) == 0
-                // This identity does not apply for floating point (when x == -0.0)
-                //
-                if (!varTypeIsFloating(typ))
-                {
-                    ZeroVN = VNZeroForType(typ);
-                    if (arg1VN == ZeroVN)
-                    {
-                        resultVN = arg0VN;
-                    }
-                    else if (arg0VN == arg1VN)
-                    {
-                        resultVN = ZeroVN;
-                    }
-                }
+                resultVN = identityForSubtraction();
                 break;
 
             case GT_MUL:
-                // These identities do not apply for floating point
-                //
-                if (!varTypeIsFloating(typ))
-                {
-                    // (0 * x) == 0
-                    // (x * 0) == 0
-                    ZeroVN = VNZeroForType(typ);
-                    if (arg0VN == ZeroVN)
-                    {
-                        resultVN = ZeroVN;
-                    }
-                    else if (arg1VN == ZeroVN)
-                    {
-                        resultVN = ZeroVN;
-                    }
-
-                    // (x * 1) == x
-                    // (1 * x) == x
-                    OneVN = VNOneForType(typ);
-                    if (arg0VN == OneVN)
-                    {
-                        resultVN = arg1VN;
-                    }
-                    else if (arg1VN == OneVN)
-                    {
-                        resultVN = arg0VN;
-                    }
-                }
+                resultVN = identityForMultiplication();
                 break;
 
             case GT_DIV:
@@ -3551,6 +3568,21 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     {
         switch (func)
         {
+            case VNF_ADD_OVF:
+            case VNF_ADD_UN_OVF:
+                resultVN = identityForAddition();
+                break;
+
+            case VNF_SUB_OVF:
+            case VNF_SUB_UN_OVF:
+                resultVN = identityForSubtraction();
+                break;
+
+            case VNF_MUL_OVF:
+            case VNF_MUL_UN_OVF:
+                resultVN = identityForMultiplication();
+                break;
+
             case VNF_LT_UN:
                 // (x < 0) == false
                 // (x < x) == false

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -363,6 +363,17 @@ VNFunc GetVNFuncForNode(GenTree* node)
     return VNFunc(node->OperGet());
 }
 
+bool ValueNumStore::VNFuncIsOverflowArithmetic(VNFunc vnf)
+{
+    static_assert_no_msg(VNF_ADD_OVF + 1 == VNF_SUB_OVF);
+    static_assert_no_msg(VNF_SUB_OVF + 1 == VNF_MUL_OVF);
+    static_assert_no_msg(VNF_MUL_OVF + 1 == VNF_ADD_UN_OVF);
+    static_assert_no_msg(VNF_ADD_UN_OVF + 1 == VNF_SUB_UN_OVF);
+    static_assert_no_msg(VNF_SUB_UN_OVF + 1 == VNF_MUL_UN_OVF);
+
+    return VNF_ADD_OVF <= vnf && vnf <= VNF_MUL_UN_OVF;
+}
+
 unsigned ValueNumStore::VNFuncArity(VNFunc vnf)
 {
     // Read the bit field out of the table...
@@ -734,6 +745,55 @@ T ValueNumStore::EvalOpSpecialized(VNFunc vnf, T v0, T v1)
 
             default:
                 // For any other value of 'oper', we will assert below
+                break;
+        }
+    }
+    else // must be a VNF_ function
+    {
+        switch (vnf)
+        {
+            // Here we handle those that are the same for all integer types.
+            case VNF_ADD_OVF:
+            case VNF_ADD_UN_OVF:
+                if (sizeof(T) == 8)
+                {
+                    assert(!CheckedOps::LongAddOverflows(v0, v1, vnf == VNF_ADD_UN_OVF));
+                }
+                else
+                {
+                    assert(!CheckedOps::IntAddOverflows(INT32(v0), INT32(v1), vnf == VNF_ADD_UN_OVF));
+                }
+
+                return v0 + v1;
+
+            case VNF_SUB_OVF:
+            case VNF_SUB_UN_OVF:
+                if (sizeof(T) == 8)
+                {
+                    assert(!CheckedOps::LongSubOverflows(v0, v1, vnf == VNF_SUB_UN_OVF));
+                }
+                else
+                {
+                    assert(!CheckedOps::IntSubOverflows(INT32(v0), INT32(v1), vnf == VNF_SUB_UN_OVF));
+                }
+
+                return v0 - v1;
+
+            case VNF_MUL_OVF:
+            case VNF_MUL_UN_OVF:
+                if (sizeof(T) == 8)
+                {
+                    assert(!CheckedOps::LongMulOverflows(v0, v1, vnf == VNF_MUL_UN_OVF));
+                }
+                else
+                {
+                    assert(!CheckedOps::IntMulOverflows(INT32(v0), INT32(v1), vnf == VNF_MUL_UN_OVF));
+                }
+
+                return v0 * v1;
+
+            default:
+                // For any other value of 'vnf', we will assert below
                 break;
         }
     }
@@ -3206,18 +3266,63 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
             return dividend != badDividend;
         }
     }
-    else
+
+    // Is this a checked operation that will always throw an exception?
+    if (VNFuncIsOverflowArithmetic(func))
     {
-        switch (func)
+        if (typ == TYP_INT)
         {
-            // Is this a checked operation that will always throw an exception?
-            case VNF_ADD_OVF:
-            case VNF_SUB_OVF:
-            case VNF_MUL_OVF:
-            case VNF_ADD_UN_OVF:
-            case VNF_SUB_UN_OVF:
-            case VNF_MUL_UN_OVF:
-                return false;
+            int op1 = ConstantValue<int>(arg0VN);
+            int op2 = ConstantValue<int>(arg1VN);
+
+            switch (func)
+            {
+                case VNF_ADD_OVF:
+                    return !CheckedOps::IntAddOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_SUB_OVF:
+                    return !CheckedOps::IntSubOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_MUL_OVF:
+                    return !CheckedOps::IntMulOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_ADD_UN_OVF:
+                    return !CheckedOps::IntAddOverflows(op1, op2, CheckedOps::Unsigned);
+                case VNF_SUB_UN_OVF:
+                    return !CheckedOps::IntSubOverflows(op1, op2, CheckedOps::Unsigned);
+                case VNF_MUL_UN_OVF:
+                    return !CheckedOps::IntMulOverflows(op1, op2, CheckedOps::Unsigned);
+                default:
+                    assert(!"Unexpected checked operation in VNEvalShouldFold");
+                    return false;
+            }
+        }
+        else if (typ == TYP_LONG)
+        {
+            INT64 op1 = ConstantValue<INT64>(arg0VN);
+            INT64 op2 = ConstantValue<INT64>(arg1VN);
+
+            switch (func)
+            {
+                case VNF_ADD_OVF:
+                    return !CheckedOps::LongAddOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_SUB_OVF:
+                    return !CheckedOps::LongSubOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_MUL_OVF:
+                    return !CheckedOps::LongMulOverflows(op1, op2, CheckedOps::Signed);
+                case VNF_ADD_UN_OVF:
+                    return !CheckedOps::LongAddOverflows(op1, op2, CheckedOps::Unsigned);
+                case VNF_SUB_UN_OVF:
+                    return !CheckedOps::LongSubOverflows(op1, op2, CheckedOps::Unsigned);
+                case VNF_MUL_UN_OVF:
+                    return !CheckedOps::LongMulOverflows(op1, op2, CheckedOps::Unsigned);
+                default:
+                    assert(!"Unexpected checked operation in VNEvalShouldFold");
+                    return false;
+            }
+        }
+        else
+        {
+            // TODO-Review: what about TYP_BYREF?
+            assert(!"Unexpected type in VNEvalShouldFold for overflow arithmetic");
+            return false;
         }
     }
 
@@ -7498,9 +7603,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             // Now that we've labeled the assignment as a whole, we don't care about exceptions.
             rhsVNPair = vnStore->VNPNormalPair(rhsVNPair);
 
-            // Record the exeception set for this 'tree' in vnExcSet.
-            // First we'll record the exeception set for the rhs and
-            // later we will union in the exeception set for the lhs
+            // Record the exception set for this 'tree' in vnExcSet.
+            // First we'll record the exception set for the rhs and
+            // later we will union in the exception set for the lhs.
             //
             ValueNum vnExcSet;
 
@@ -10097,7 +10202,7 @@ void Compiler::fgValueNumberAddExceptionSetForDivision(GenTree* tree)
 //
 // Return Value:
 //               - The tree's gtVNPair is updated to include the VNF_OverflowExc
-//                 exception set.
+//                 exception set, except for constant VNs and those produced from identities.
 //
 void Compiler::fgValueNumberAddExceptionSetForOverflow(GenTree* tree)
 {
@@ -10105,31 +10210,53 @@ void Compiler::fgValueNumberAddExceptionSetForOverflow(GenTree* tree)
 
     // We should only be dealing with an Overflow checking ALU operation.
     VNFunc vnf = GetVNFuncForNode(tree);
-    assert((vnf >= VNF_ADD_OVF) && (vnf <= VNF_MUL_UN_OVF));
+    assert(ValueNumStore::VNFuncIsOverflowArithmetic(vnf));
 
-    // Unpack, Norm,Exc for the tree's VN
-    //
-    ValueNumPair vnpTreeNorm;
-    ValueNumPair vnpTreeExc;
+    ValueNumKind vnKinds[2] = { VNK_Liberal, VNK_Conservative };
+    for (ValueNumKind vnKind : vnKinds)
+    {
+        ValueNum vn = tree->GetVN(vnKind);
 
-    vnStore->VNPUnpackExc(tree->gtVNPair, &vnpTreeNorm, &vnpTreeExc);
+        // Unpack Norm, Exc for the current VN.
+        ValueNum vnNorm;
+        ValueNum vnExcSet;
+        vnStore->VNUnpackExc(vn, &vnNorm, &vnExcSet);
+
+        // Don't add exceptions if the normal VN represents a constant.
+        // We only fold to constant VNs for operations that provably cannot overflow.
+        if (vnStore->IsVNConstant(vnNorm))
+        {
+            continue;
+        }
+
+        // Don't add exceptions if the tree's normal VN has been derived from an identity.
+        // This takes care of x + 0 == x, 0 + x == x, x - 0 == x, x * 1 == x, 1 * x == x.
+        // The x - x == 0 and x * 0 == 0, 0 * x == 0 cases are handled by the "IsVNConstant" check above.
+        if ((vnNorm == vnStore->VNNormalValue(tree->gtGetOp1()->GetVN(vnKind))) ||
+            (vnNorm == vnStore->VNNormalValue(tree->gtGetOp2()->GetVN(vnKind))))
+        {
+            // TODO-Review: would it be acceptable to make ValueNumStore::EvalUsingMathIdentity
+            // public just to assert here?
+            continue;
+        }
 
 #ifdef DEBUG
-    // The normal value number function should be the same overflow checking ALU operation as 'vnf'
-    VNFuncApp treeNormFuncApp;
-    assert(vnStore->GetVNFunc(vnpTreeNorm.GetLiberal(), &treeNormFuncApp) && (treeNormFuncApp.m_func == vnf));
+        // The normal value number function should now be the same overflow checking ALU operation as 'vnf'.
+        VNFuncApp normFuncApp;
+        assert(vnStore->GetVNFunc(vnNorm, &normFuncApp) && (normFuncApp.m_func == vnf));
 #endif // DEBUG
 
-    // Overflow-checking operations add an overflow exception
-    // The normal result is used as the input argument for the OverflowExc
-    ValueNumPair overflowExcSet =
-        vnStore->VNPExcSetSingleton(vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnpTreeNorm));
+        // Overflow-checking operations add an overflow exception.
+        // The normal result is used as the input argument for the OverflowExc.
+        ValueNum vnOverflowExc = vnStore->VNExcSetSingleton(vnStore->VNForFunc(TYP_REF, VNF_OverflowExc, vnNorm));
 
-    // Combine the new Overflow exception with the original exception set of tree
-    ValueNumPair newExcSet = vnStore->VNPExcSetUnion(vnpTreeExc, overflowExcSet);
+        // Combine the new Overflow exception with the original exception set.
+        vnExcSet = vnStore->VNExcSetUnion(vnExcSet, vnOverflowExc);
 
-    // Updated VN for tree, it now includes Overflow exception
-    tree->gtVNPair = vnStore->VNPWithExc(vnpTreeNorm, newExcSet);
+        // Update the VN to include the Overflow exception.
+        ValueNum newVN = vnStore->VNWithExc(vnNorm, vnExcSet);
+        tree->SetVN(vnKind, newVN);
+    }
 }
 
 //--------------------------------------------------------------------------------

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3123,6 +3123,14 @@ bool ValueNumStore::CanEvalForConstantArgs(VNFunc vnf)
             case VNF_GE_UN:
             case VNF_LT_UN:
             case VNF_LE_UN:
+
+            case VNF_ADD_OVF:
+            case VNF_SUB_OVF:
+            case VNF_MUL_OVF:
+            case VNF_ADD_UN_OVF:
+            case VNF_SUB_UN_OVF:
+            case VNF_MUL_UN_OVF:
+
             case VNF_Cast:
                 // We can evaluate these.
                 return true;
@@ -3149,8 +3157,6 @@ bool ValueNumStore::CanEvalForConstantArgs(VNFunc vnf)
 //
 bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN, ValueNum arg1VN)
 {
-    bool shouldFold = true;
-
     // We have some arithmetic operations that will always throw
     // an exception given particular constant argument(s).
     // (i.e. integer division by zero)
@@ -3158,75 +3164,64 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
     // We will avoid performing any constant folding on them
     // since they won't actually produce any result.
     // Instead they always will throw an exception.
-    //
-    if (func < VNF_Boundary)
+
+    // Floating point operations do not throw exceptions.
+    if (varTypeIsFloating(typ))
     {
-        genTreeOps oper = genTreeOps(func);
+        return true;
+    }
 
-        // Floating point operations do not throw exceptions
-        //
-        if (!varTypeIsFloating(typ))
+    genTreeOps oper = genTreeOps(func);
+    // Is this an integer divide/modulo that will always throw an exception?
+    if (GenTree::StaticOperIs(oper, GT_DIV, GT_UDIV, GT_MOD, GT_UMOD))
+    {
+        if (!((typ == TYP_INT) || (typ == TYP_LONG)))
         {
-            // Is this an integer divide/modulo that will always throw an exception?
-            //
-            if ((oper == GT_DIV) || (oper == GT_UDIV) || (oper == GT_MOD) || (oper == GT_UMOD))
-            {
-                if ((TypeOfVN(arg0VN) != typ) || (TypeOfVN(arg1VN) != typ))
-                {
-                    // Just in case we have mismatched types
-                    shouldFold = false;
-                }
-                else
-                {
-                    bool isUnsigned = (oper == GT_UDIV) || (oper == GT_UMOD);
-                    if (typ == TYP_LONG)
-                    {
-                        INT64 kArg0 = ConstantValue<INT64>(arg0VN);
-                        INT64 kArg1 = ConstantValue<INT64>(arg1VN);
+            assert(!"Unexpected type in VNEvalShouldFold for integer division/modulus");
+            return false;
+        }
+        // Just in case we have mismatched types.
+        if ((TypeOfVN(arg0VN) != typ) || (TypeOfVN(arg1VN) != typ))
+        {
+            return false;
+        }
 
-                        if (IsIntZero(kArg1))
-                        {
-                            // Don't fold, we have a divide by zero
-                            shouldFold = false;
-                        }
-                        else if (!isUnsigned || IsOverflowIntDiv(kArg0, kArg1))
-                        {
-                            // Don't fold, we have a divide of INT64_MIN/-1
-                            shouldFold = false;
-                        }
-                    }
-                    else if (typ == TYP_INT)
-                    {
-                        int kArg0 = ConstantValue<int>(arg0VN);
-                        int kArg1 = ConstantValue<int>(arg1VN);
+        INT64 divisor = CoercedConstantValue<INT64>(arg1VN);
 
-                        if (IsIntZero(kArg1))
-                        {
-                            // Don't fold, we have a divide by zero
-                            shouldFold = false;
-                        }
-                        else if (!isUnsigned && IsOverflowIntDiv(kArg0, kArg1))
-                        {
-                            // Don't fold, we have a divide of INT32_MIN/-1
-                            shouldFold = false;
-                        }
-                    }
-                    else // strange value for 'typ'
-                    {
-                        assert(!"unexpected 'typ' in VNForFunc constant folding");
-                        shouldFold = false;
-                    }
-                }
-            }
+        if (divisor == 0)
+        {
+            // Don't fold, we have a divide by zero.
+            return false;
+        }
+        else if ((oper == GT_DIV || oper == GT_MOD) && (divisor == -1))
+        {
+            // Don't fold if we have a division of INT32_MIN or INT64_MIN by -1.
+            // Note that while INT_MIN % -1 is mathematically well-defined (and equal to 0),
+            // we still give up on folding it because the "idiv" instruction is used to compute it on x64.
+            // And "idiv" raises an exception on such inputs.
+            INT64 dividend = CoercedConstantValue<INT64>(arg0VN);
+            INT64 badDividend = typ == TYP_INT ? INT32_MIN : INT64_MIN;
+
+            // Only fold if our dividend is good.
+            return dividend != badDividend;
         }
     }
-    else // (func > VNF_Boundary)
+    else
     {
-        // OK to fold,
-        // Add checks in the future if we support folding of VNF_ADD_OVF, etc...
+        switch (func)
+        {
+            // Is this a checked operation that will always throw an exception?
+            case VNF_ADD_OVF:
+            case VNF_SUB_OVF:
+            case VNF_MUL_OVF:
+            case VNF_ADD_UN_OVF:
+            case VNF_SUB_UN_OVF:
+            case VNF_MUL_UN_OVF:
+                return false;
+        }
     }
 
-    return shouldFold;
+    return true;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2884,7 +2884,7 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
     bool      srcIsUnsigned;
     GetCastOperFromVN(arg1VN, &castToType, &srcIsUnsigned);
     var_types castFromType = arg0VNtyp;
-    bool checkedCast       = func == VNF_CastOvf;
+    bool      checkedCast  = func == VNF_CastOvf;
 
     switch (castFromType) // GT_CAST source type
     {
@@ -3275,7 +3275,7 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
             // Note that while INT_MIN % -1 is mathematically well-defined (and equal to 0),
             // we still give up on folding it because the "idiv" instruction is used to compute it on x64.
             // And "idiv" raises an exception on such inputs.
-            INT64 dividend = CoercedConstantValue<INT64>(arg0VN);
+            INT64 dividend    = CoercedConstantValue<INT64>(arg0VN);
             INT64 badDividend = typ == TYP_INT ? INT32_MIN : INT64_MIN;
 
             // Only fold if our dividend is good.
@@ -3396,8 +3396,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     // (0 + x) == x
     // (x + 0) == x
     // This identity does not apply for floating point (when x == -0.0).
-    auto identityForAddition = [=]() -> ValueNum
-    {
+    auto identityForAddition = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
             ValueNum ZeroVN = VNZeroForType(typ);
@@ -3417,8 +3416,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     // (x - 0) == x
     // (x - x) == 0
     // This identity does not apply for floating point (when x == -0.0).
-    auto identityForSubtraction = [=]() -> ValueNum
-    {
+    auto identityForSubtraction = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
             ValueNum ZeroVN = VNZeroForType(typ);
@@ -3436,8 +3434,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     };
 
     // These identities do not apply for floating point.
-    auto identityForMultiplication = [=]() -> ValueNum
-    {
+    auto identityForMultiplication = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
             // (0 * x) == 0
@@ -9317,7 +9314,7 @@ ValueNumPair ValueNumStore::VNPairForCast(ValueNumPair srcVNPair,
     {
         ValueNumPair excSet = ValueNumStore::VNPForEmptyExcSet();
 
-        ValueNumKind vnKinds[2] = { VNK_Liberal, VNK_Conservative };
+        ValueNumKind vnKinds[2] = {VNK_Liberal, VNK_Conservative};
         for (ValueNumKind vnKind : vnKinds)
         {
             // Do not add exceptions for folded casts.
@@ -9327,7 +9324,8 @@ ValueNumPair ValueNumStore::VNPairForCast(ValueNumPair srcVNPair,
                 continue;
             }
 
-            ValueNum ovfChk = VNForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP.Get(vnKind), castTypeVNPair.Get(vnKind));
+            ValueNum ovfChk =
+                VNForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP.Get(vnKind), castTypeVNPair.Get(vnKind));
             excSet.Set(vnKind, VNExcSetSingleton(ovfChk));
         }
 
@@ -9982,10 +9980,11 @@ bool Compiler::fgValueNumberHelperCall(GenTreeCall* call)
                 }
 
                 // CORINFO_HELP_ULNG2DBL is the only helper that casts from an unsigned integer.
-                bool         srcIsUnsigned    = helpFunc == CORINFO_HELP_ULNG2DBL;
-                bool         hasOverflowCheck = vnf == VNF_CastOvf;
+                bool srcIsUnsigned    = helpFunc == CORINFO_HELP_ULNG2DBL;
+                bool hasOverflowCheck = vnf == VNF_CastOvf;
 
-                call->gtVNPair = vnStore->VNPairForCast(srcVNPair, castToType, castFromType, srcIsUnsigned, hasOverflowCheck);
+                call->gtVNPair =
+                    vnStore->VNPairForCast(srcVNPair, castToType, castFromType, srcIsUnsigned, hasOverflowCheck);
 
                 // Casting helpers, checked or not, do not modify the heap.
                 return false;
@@ -10338,7 +10337,7 @@ void Compiler::fgValueNumberAddExceptionSetForOverflow(GenTree* tree)
     VNFunc vnf = GetVNFuncForNode(tree);
     assert(ValueNumStore::VNFuncIsOverflowArithmetic(vnf));
 
-    ValueNumKind vnKinds[2] = { VNK_Liberal, VNK_Conservative };
+    ValueNumKind vnKinds[2] = {VNK_Liberal, VNK_Conservative};
     for (ValueNumKind vnKind : vnKinds)
     {
         ValueNum vn = tree->GetVN(vnKind);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -374,6 +374,11 @@ bool ValueNumStore::VNFuncIsOverflowArithmetic(VNFunc vnf)
     return VNF_ADD_OVF <= vnf && vnf <= VNF_MUL_UN_OVF;
 }
 
+bool ValueNumStore::VNFuncIsNumericCast(VNFunc vnf)
+{
+    return (vnf == VNF_Cast) || (vnf == VNF_CastOvf);
+}
+
 unsigned ValueNumStore::VNFuncArity(VNFunc vnf)
 {
     // Read the bit field out of the table...
@@ -1747,7 +1752,7 @@ ValueNum ValueNumStore::VNForByrefCon(size_t cnsVal)
     return VnForConst(cnsVal, GetByrefCnsMap(), TYP_BYREF);
 }
 
-ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned /*=false*/)
+ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned /*=false*/ DEBUGARG(bool printResult))
 {
     assert(castToType != TYP_STRUCT);
     INT32 cnsVal = INT32(castToType) << INT32(VCA_BitCount);
@@ -1761,7 +1766,7 @@ ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned /
     ValueNum result = VNForIntCon(cnsVal);
 
 #ifdef DEBUG
-    if (m_pComp->verbose)
+    if (printResult && m_pComp->verbose)
     {
         printf("    VNForCastOper(%s%s) is " FMT_VN "\n", varTypeName(castToType), srcIsUnsigned ? ", unsignedSrc" : "",
                result);
@@ -1769,6 +1774,21 @@ ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned /
 #endif
 
     return result;
+}
+
+void ValueNumStore::GetCastOperFromVN(ValueNum vn, var_types* pCastToType, bool* pSrcIsUnsigned)
+{
+    assert(pCastToType != nullptr);
+    assert(pSrcIsUnsigned != nullptr);
+    assert(IsVNInt32Constant(vn));
+
+    int value = GetConstantInt32(vn);
+    assert(value >= 0);
+
+    *pSrcIsUnsigned = (value & INT32(VCA_UnsignedSrc)) != 0;
+    *pCastToType    = var_types(value >> INT32(VCA_BitCount));
+
+    assert(VNForCastOper(*pCastToType, *pSrcIsUnsigned DEBUGARG(false)) == vn);
 }
 
 ValueNum ValueNumStore::VNForHandle(ssize_t cnsVal, unsigned handleFlags)
@@ -1976,26 +1996,23 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
         // Special case for VNF_Cast of constant handles
         // Don't allow an eval/fold of a GT_CAST(non-I_IMPL, Handle)
         //
-        if ((func == VNF_Cast) && (typ != TYP_I_IMPL) && IsVNHandle(arg0VN))
+        if (VNFuncIsNumericCast(func) && (typ != TYP_I_IMPL) && IsVNHandle(arg0VN))
         {
             canFold = false;
         }
 
-        // Currently CanEvalForConstantArgs() returns false for VNF_CastOvf
-        // In the future we could handle this case in folding.
-        assert(func != VNF_CastOvf);
-
         // It is possible for us to have mismatched types (see Bug 750863)
         // We don't try to fold a binary operation when one of the constant operands
-        // is a floating-point constant and the other is not.
-        //
+        // is a floating-point constant and the other is not, except for casts.
+        // For casts, the second operand just carries the information about the source.
+
         var_types arg0VNtyp      = TypeOfVN(arg0VN);
         bool      arg0IsFloating = varTypeIsFloating(arg0VNtyp);
 
         var_types arg1VNtyp      = TypeOfVN(arg1VN);
         bool      arg1IsFloating = varTypeIsFloating(arg1VNtyp);
 
-        if (arg0IsFloating != arg1IsFloating)
+        if (!VNFuncIsNumericCast(func) && (arg0IsFloating != arg1IsFloating))
         {
             canFold = false;
         }
@@ -2634,7 +2651,7 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
     assert(!VNHasExc(arg0VN) && !VNHasExc(arg1VN)); // Otherwise, would not be constant.
 
     // if our func is the VNF_Cast operation we handle it first
-    if (func == VNF_Cast)
+    if (VNFuncIsNumericCast(func))
     {
         return EvalCastForConstantArgs(typ, func, arg0VN, arg1VN);
     }
@@ -2845,7 +2862,7 @@ ValueNum ValueNumStore::EvalFuncForConstantFPArgs(var_types typ, VNFunc func, Va
 //
 ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, ValueNum arg0VN, ValueNum arg1VN)
 {
-    assert(func == VNF_Cast);
+    assert(VNFuncIsNumericCast(func));
     assert(IsVNConstant(arg0VN) && IsVNConstant(arg1VN));
 
     // Stack-normalize the result type.
@@ -2855,12 +2872,6 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
     }
 
     var_types arg0VNtyp = TypeOfVN(arg0VN);
-    var_types arg1VNtyp = TypeOfVN(arg1VN);
-
-    // arg1VN is really the gtCastType that we are casting to
-    assert(arg1VNtyp == TYP_INT);
-    int arg1Val = ConstantValue<int>(arg1VN);
-    assert(arg1Val >= 0);
 
     if (IsVNHandle(arg0VN))
     {
@@ -2868,12 +2879,12 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
         assert(typ == TYP_I_IMPL);
     }
 
-    // We previously encoded the castToType operation using vnForCastOper()
-    //
-    bool      srcIsUnsigned = ((arg1Val & INT32(VCA_UnsignedSrc)) != 0);
-    var_types castToType    = var_types(arg1Val >> INT32(VCA_BitCount));
-
+    // We previously encoded the castToType operation using VNForCastOper().
+    var_types castToType;
+    bool      srcIsUnsigned;
+    GetCastOperFromVN(arg1VN, &castToType, &srcIsUnsigned);
     var_types castFromType = arg0VNtyp;
+    bool checkedCast       = func == VNF_CastOvf;
 
     switch (castFromType) // GT_CAST source type
     {
@@ -2884,6 +2895,7 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
         case TYP_INT:
         {
             int arg0Val = GetConstantInt32(arg0VN);
+            assert(!checkedCast || !CheckedOps::CastFromIntOverflows(arg0Val, castToType, srcIsUnsigned));
 
             switch (castToType)
             {
@@ -2966,6 +2978,7 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
 #endif
                 case TYP_LONG:
                     INT64 arg0Val = GetConstantInt64(arg0VN);
+                    assert(!checkedCast || !CheckedOps::CastFromLongOverflows(arg0Val, castToType, srcIsUnsigned));
 
                     switch (castToType)
                     {
@@ -3022,6 +3035,7 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
         case TYP_FLOAT:
         {
             float arg0Val = GetConstantSingle(arg0VN);
+            assert(!checkedCast || !CheckedOps::CastFromFloatOverflows(arg0Val, castToType));
 
             switch (castToType)
             {
@@ -3063,6 +3077,7 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
         case TYP_DOUBLE:
         {
             double arg0Val = GetConstantDouble(arg0VN);
+            assert(!checkedCast || !CheckedOps::CastFromDoubleOverflows(arg0Val, castToType));
 
             switch (castToType)
             {
@@ -3192,6 +3207,7 @@ bool ValueNumStore::CanEvalForConstantArgs(VNFunc vnf)
             case VNF_MUL_UN_OVF:
 
             case VNF_Cast:
+            case VNF_CastOvf:
                 // We can evaluate these.
                 return true;
 
@@ -3323,6 +3339,29 @@ bool ValueNumStore::VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN
             // TODO-Review: what about TYP_BYREF?
             assert(!"Unexpected type in VNEvalShouldFold for overflow arithmetic");
             return false;
+        }
+    }
+
+    // Is this a checked cast that will always throw an exception?
+    if (func == VNF_CastOvf)
+    {
+        var_types castToType;
+        bool      fromUnsigned;
+        GetCastOperFromVN(arg1VN, &castToType, &fromUnsigned);
+        var_types castFromType = TypeOfVN(arg0VN);
+
+        switch (castFromType)
+        {
+            case TYP_INT:
+                return !CheckedOps::CastFromIntOverflows(GetConstantInt32(arg0VN), castToType, fromUnsigned);
+            case TYP_LONG:
+                return !CheckedOps::CastFromLongOverflows(GetConstantInt64(arg0VN), castToType, fromUnsigned);
+            case TYP_FLOAT:
+                return !CheckedOps::CastFromFloatOverflows(GetConstantSingle(arg0VN), castToType);
+            case TYP_DOUBLE:
+                return !CheckedOps::CastFromDoubleOverflows(GetConstantDouble(arg0VN), castToType);
+            default:
+                return false;
         }
     }
 
@@ -9196,7 +9235,7 @@ void Compiler::fgValueNumberCastTree(GenTree* tree)
     bool         srcIsUnsigned    = ((tree->gtFlags & GTF_UNSIGNED) != 0);
     bool         hasOverflowCheck = tree->gtOverflowEx();
 
-    assert(genActualType(castToType) == genActualType(tree->TypeGet())); // Insure that the resultType is correct
+    assert(genActualType(castToType) == genActualType(tree->TypeGet())); // Ensure that the resultType is correct
 
     tree->gtVNPair = vnStore->VNPairForCast(srcVNPair, castToType, castFromType, srcIsUnsigned, hasOverflowCheck);
 }
@@ -9276,10 +9315,24 @@ ValueNumPair ValueNumStore::VNPairForCast(ValueNumPair srcVNPair,
     // If we have a check for overflow, add the exception information.
     if (hasOverflowCheck)
     {
-        ValueNumPair ovfChk = VNPairForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP, castTypeVNPair);
-        ValueNumPair excSet = VNPExcSetSingleton(ovfChk);
-        excSet              = VNPExcSetUnion(excSet, castArgxVNP);
-        resultVNP           = VNPWithExc(castNormRes, excSet);
+        ValueNumPair excSet = ValueNumStore::VNPForEmptyExcSet();
+
+        ValueNumKind vnKinds[2] = { VNK_Liberal, VNK_Conservative };
+        for (ValueNumKind vnKind : vnKinds)
+        {
+            // Do not add exceptions for folded casts.
+            // We only fold checked casts that do not overflow.
+            if (IsVNConstant(castNormRes.Get(vnKind)))
+            {
+                continue;
+            }
+
+            ValueNum ovfChk = VNForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP.Get(vnKind), castTypeVNPair.Get(vnKind));
+            excSet.Set(vnKind, VNExcSetSingleton(ovfChk));
+        }
+
+        excSet    = VNPExcSetUnion(excSet, castArgxVNP);
+        resultVNP = VNPWithExc(castNormRes, excSet);
     }
 
     return resultVNP;
@@ -9607,34 +9660,18 @@ VNFunc Compiler::fgValueNumberJitHelperMethodVNFunc(CorInfoHelpFunc helpFunc)
             break;
 
         case CORINFO_HELP_LNG2DBL:
-            vnf = VNF_Lng2Dbl;
-            break;
         case CORINFO_HELP_ULNG2DBL:
-            vnf = VNF_ULng2Dbl;
-            break;
         case CORINFO_HELP_DBL2INT:
-            vnf = VNF_Dbl2Int;
+        case CORINFO_HELP_DBL2LNG:
+        case CORINFO_HELP_DBL2UINT:
+        case CORINFO_HELP_DBL2ULNG:
+            vnf = VNF_Cast;
             break;
         case CORINFO_HELP_DBL2INT_OVF:
-            vnf = VNF_Dbl2Int;
-            break;
-        case CORINFO_HELP_DBL2LNG:
-            vnf = VNF_Dbl2Lng;
-            break;
         case CORINFO_HELP_DBL2LNG_OVF:
-            vnf = VNF_Dbl2Lng;
-            break;
-        case CORINFO_HELP_DBL2UINT:
-            vnf = VNF_Dbl2UInt;
-            break;
         case CORINFO_HELP_DBL2UINT_OVF:
-            vnf = VNF_Dbl2UInt;
-            break;
-        case CORINFO_HELP_DBL2ULNG:
-            vnf = VNF_Dbl2ULng;
-            break;
         case CORINFO_HELP_DBL2ULNG_OVF:
-            vnf = VNF_Dbl2ULng;
+            vnf = VNF_CastOvf;
             break;
         case CORINFO_HELP_FLTREM:
             vnf = VNFunc(GT_MOD);
@@ -9859,8 +9896,8 @@ bool Compiler::fgValueNumberHelperCall(GenTreeCall* call)
         //
         switch (helpFunc)
         {
+            // This helper always throws the VNF_OverflowExc exception.
             case CORINFO_HELP_OVERFLOW:
-                // This helper always throws the VNF_OverflowExc exception
                 vnpExc = vnStore->VNPExcSetSingleton(
                     vnStore->VNPairForFunc(TYP_REF, VNF_OverflowExc, vnStore->VNPForVoid()));
                 break;
@@ -9896,6 +9933,63 @@ bool Compiler::fgValueNumberHelperCall(GenTreeCall* call)
         if (!needsFurtherWork && (pure || isAlloc))
         {
             VNFunc vnf = fgValueNumberJitHelperMethodVNFunc(helpFunc);
+
+            // We have a special case: a helper call that represents a cast.
+            // For VN purposes, we do not care that it is actually a call, so
+            // value number it like any normal cast.
+            // TODO-Cleanup: consider moving the expansion to casting helpers
+            // from morph to lower to avoid having to do this special handling
+            // and carbon-copying fgValueNumberCastTree, and having to
+            // handle the actual folding in gtFoldExprCall().
+            if (ValueNumStore::VNFuncIsNumericCast(vnf))
+            {
+                assert(pure && !isAlloc && !modHeap && !mayRunCctor);
+
+                GenTree*     src          = call->gtCallArgs->GetNode();
+                ValueNumPair srcVNPair    = src->gtVNPair;
+                var_types    castFromType = src->TypeGet();
+
+                // The call tree for the helper lost the information about the whether the
+                // destination is signed or not. As such we need to query for the type of helper
+                // we have, again...
+                var_types castToType = TYP_UNDEF;
+                switch (helpFunc)
+                {
+                    case CORINFO_HELP_DBL2INT:
+                    case CORINFO_HELP_DBL2INT_OVF:
+                        castToType = TYP_INT;
+                        break;
+                    case CORINFO_HELP_DBL2UINT:
+                    case CORINFO_HELP_DBL2UINT_OVF:
+                        castToType = TYP_UINT;
+                        break;
+                    case CORINFO_HELP_DBL2LNG_OVF:
+                        castToType = TYP_LONG;
+                        break;
+                    case CORINFO_HELP_DBL2ULNG:
+                    case CORINFO_HELP_DBL2ULNG_OVF:
+                        castToType = TYP_ULONG;
+                        break;
+                    case CORINFO_HELP_LNG2DBL:
+                    case CORINFO_HELP_ULNG2DBL:
+                        castToType = TYP_DOUBLE;
+                        break;
+                    case CORINFO_HELP_DBL2LNG:
+                        castToType = TYP_LONG;
+                        break;
+                    default:
+                        assert(!"Unexpected helper for casts");
+                }
+
+                // CORINFO_HELP_ULNG2DBL is the only helper that casts from an unsigned integer.
+                bool         srcIsUnsigned    = helpFunc == CORINFO_HELP_ULNG2DBL;
+                bool         hasOverflowCheck = vnf == VNF_CastOvf;
+
+                call->gtVNPair = vnStore->VNPairForCast(srcVNPair, castToType, castFromType, srcIsUnsigned, hasOverflowCheck);
+
+                // Casting helpers, checked or not, do not modify the heap.
+                return false;
+            }
 
             if (mayRunCctor)
             {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -597,7 +597,7 @@ public:
     // Returns true iff the VN represents a (non-handle) constant.
     bool IsVNConstant(ValueNum vn);
 
-    // Returns true iff the VN represents an integeral constant.
+    // Returns true iff the VN represents an integer constant.
     bool IsVNInt32Constant(ValueNum vn);
 
     typedef SmallHashTable<ValueNum, bool, 8U> CheckedBoundVNSet;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -334,7 +334,7 @@ public:
     }
 
     // Returns the value number for zero of the given "typ".
-    // It has an unreached() for a "typ" that has no zero value, such as TYP_BYREF.
+    // It has an unreached() for a "typ" that has no zero value, such as TYP_VOID.
     ValueNum VNZeroForType(var_types typ);
 
     // Returns the value number for one of the given "typ".

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -251,6 +251,9 @@ public:
     // VNF_ADD_UN_OVF, VNF_SUB_UN_OVF, VNF_MUL_UN_OVF.
     static bool VNFuncIsOverflowArithmetic(VNFunc vnf);
 
+    // Returns "true" iff "vnf" is VNF_Cast or VNF_CastOvf.
+    static bool VNFuncIsNumericCast(VNFunc vnf);
+
     // Returns the arity of "vnf".
     static unsigned VNFuncArity(VNFunc vnf);
 
@@ -286,7 +289,12 @@ public:
     }
 #endif
 
-    ValueNum VNForCastOper(var_types castToType, bool srcIsUnsigned = false);
+    // Packs information about the cast into an integer constant represented by the returned value number,
+    // to be used as the second operand of VNF_Cast & VNF_CastOvf.
+    ValueNum VNForCastOper(var_types castToType, bool srcIsUnsigned = false DEBUGARG(bool printResult = true));
+
+    // Unpacks the information stored by VNForCastOper in the constant represented by the value number.
+    void GetCastOperFromVN(ValueNum vn, var_types* pCastToType, bool* pSrcIsUnsigned);
 
     // We keep handle values in a separate pool, so we don't confuse a handle with an int constant
     // that happens to be the same...

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -246,6 +246,11 @@ public:
         return unsigned(vnf) > VNF_Boundary || GenTreeOpIsLegalVNFunc(static_cast<genTreeOps>(vnf));
     }
 
+    // Returns "true" iff "vnf" is one of:
+    // VNF_ADD_OVF, VNF_SUB_OVF, VNF_MUL_OVF,
+    // VNF_ADD_UN_OVF, VNF_SUB_UN_OVF, VNF_MUL_UN_OVF.
+    static bool VNFuncIsOverflowArithmetic(VNFunc vnf);
+
     // Returns the arity of "vnf".
     static unsigned VNFuncArity(VNFunc vnf);
 

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -152,8 +152,6 @@ ValueNumFuncDef(LE_UN, 2, false, false, false)
 ValueNumFuncDef(GE_UN, 2, false, false, false)
 ValueNumFuncDef(GT_UN, 2, false, false, false)
 
-// currently we don't constant fold the next six
-
 ValueNumFuncDef(ADD_OVF, 2, true, false, false)     // overflow checking operations
 ValueNumFuncDef(SUB_OVF, 2, false, false, false)
 ValueNumFuncDef(MUL_OVF, 2, true, false, false)

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -29,7 +29,7 @@ ValueNumFuncDef(Cast, 2, false, false, false)           // VNF_Cast: Cast Operat
                                                         //           Args: 0: Source for the cast operation.
                                                         //                 1: Constant integer representing the operation .
                                                         //                    Use VNForCastOper() to construct.
-ValueNumFuncDef(CastOvf, 2, false, false, false)        // Same as a VNF_Cast but also can throw an overflow exception, currently we don't try to constant fold this
+ValueNumFuncDef(CastOvf, 2, false, false, false)        // Same as a VNF_Cast but also can throw an overflow exception.
 
 ValueNumFuncDef(CastClass, 2, false, false, false)          // Args: 0: Handle of class being cast to, 1: object being cast.
 ValueNumFuncDef(IsInstanceOf, 2, false, false, false)       // Args: 0: Handle of class being queried, 1: object being queried.
@@ -68,12 +68,6 @@ ValueNumFuncDef(InvalidCastExc, 2, false, false, false)     // CastClass check, 
 ValueNumFuncDef(NewArrOverflowExc, 1, false, false, false)  // Raises Integer overflow when Arg 0 is negative
 ValueNumFuncDef(HelperMultipleExc, 0, false, false, false)  // Represents one or more different exceptions that could be thrown by a Jit Helper method
 
-ValueNumFuncDef(Lng2Dbl, 1, false, false, false)
-ValueNumFuncDef(ULng2Dbl, 1, false, false, false)
-ValueNumFuncDef(Dbl2Int, 1, false, false, false)
-ValueNumFuncDef(Dbl2UInt, 1, false, false, false)
-ValueNumFuncDef(Dbl2Lng, 1, false, false, false)
-ValueNumFuncDef(Dbl2ULng, 1, false, false, false)
 ValueNumFuncDef(FltRound, 1, false, false, false)
 ValueNumFuncDef(DblRound, 1, false, false, false)
 

--- a/src/coreclr/jit/valuenumtype.h
+++ b/src/coreclr/jit/valuenumtype.h
@@ -77,6 +77,19 @@ public:
         }
     }
 
+    void Set(ValueNumKind vnk, ValueNum vn)
+    {
+        if (vnk == VNK_Liberal)
+        {
+            SetLiberal(vn);
+        }
+        else
+        {
+            assert(vnk == VNK_Conservative);
+            SetConservative(vn);
+        }
+    }
+
     void SetBoth(ValueNum vn)
     {
         m_liberal      = vn;

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -19,13 +19,7 @@ enum var_types_classification
     VTF_S   = 0x0040, // is a struct type
 };
 
-enum var_types : BYTE
-{
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) TYP_##tn,
-#include "typelist.h"
-#undef DEF_TP
-    TYP_COUNT
-};
+#include "vartypesdef.h"
 
 /*****************************************************************************
  * C-style pointers are implemented as TYP_INT or TYP_LONG depending on the

--- a/src/coreclr/jit/vartypesdef.h
+++ b/src/coreclr/jit/vartypesdef.h
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*****************************************************************************/
+#ifndef _VARTYPESDEF_H_
+#define _VARTYPESDEF_H_
+/*****************************************************************************/
+
+enum var_types : BYTE
+{
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) TYP_##tn,
+#include "typelist.h"
+#undef DEF_TP
+    TYP_COUNT
+};
+
+/*****************************************************************************/
+#endif // _VARTYPESDEF_H_
+/*****************************************************************************/

--- a/src/tests/JIT/Directed/ConstantFolding/value_numbering_checked_arithemtic_with_constants_ro.csproj
+++ b/src/tests/JIT/Directed/ConstantFolding/value_numbering_checked_arithemtic_with_constants_ro.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="value_numbering_checked_integer_arithemtic_with_constants.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/ConstantFolding/value_numbering_checked_integer_arithemtic_with_constants.cs
+++ b/src/tests/JIT/Directed/ConstantFolding/value_numbering_checked_integer_arithemtic_with_constants.cs
@@ -1,0 +1,6533 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class ValueNumberingCheckedIntegerArithemticWithConstants
+{
+    private static int _global = 0;
+    private static int _counter = 100;
+
+    public static int Main()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(ValueNumberingCheckedIntegerArithemticWithConstants).TypeHandle);
+        TestInt32();
+        TestUInt32();
+        TestInt64();
+        TestUInt64();
+
+        return _counter;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int IncrementGlobal() => ++_global;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool BreakUpFlow() => false;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void EvalArg<T>(T arg) { }
+
+    private static void TestInt32()
+    {
+        ConfirmAdditionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmAdditionIdentities(int value)
+        {
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value + zero) != value)
+            {
+                Console.WriteLine($"Addition identity for int 'checked(value + zero)' was evaluted to '{checked(value + zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(zero + value) != value)
+            {
+                Console.WriteLine($"Addition identity for int 'checked(zero + value)' was evaluted to '{checked(zero + value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmSubtractionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSubtractionIdentities(int value)
+        {
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value - zero) != value)
+            {
+                Console.WriteLine($"Subtraction identity for int 'checked(value - zero)' was evaluted to '{checked(value - zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(value - value) != 0)
+            {
+                Console.WriteLine($"Subtraction identity for int 'checked(value - value)' was evaluted to '{checked(value - value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMultiplicationIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMultiplicationIdentities(int value)
+        {
+            int zero = 0;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value * zero) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for int 'checked(value * zero)' was evaluted to '{checked(value * zero)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(zero * value) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for int 'checked(zero * value)' was evaluted to '{checked(zero * value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(value * one) != value)
+            {
+                Console.WriteLine($"Multiplication identity for int 'checked(value * one)' was evaluted to '{checked(value * one)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(one * value) != value)
+            {
+                Console.WriteLine($"Multiplication identity for int 'checked(one * value)' was evaluted to '{checked(one * value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinOverflows()
+        {
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + min)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinusHalfOverflows()
+        {
+            int min = int.MinValue;
+            int minusHalf = int.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinusOneOverflows()
+        {
+            int min = int.MinValue;
+            int minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusZeroIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + zero) != int.MinValue + 0)
+            {
+                Console.WriteLine($"'checked(min + zero)' was evaluted to '{checked(min + zero)}'. Expected: '{int.MinValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusOneIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + one) != int.MinValue + 1)
+            {
+                Console.WriteLine($"'checked(min + one)' was evaluted to '{checked(min + one)}'. Expected: '{int.MinValue + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusHalfIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + half) != int.MinValue + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(min + half)' was evaluted to '{checked(min + half)}'. Expected: '{int.MinValue + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMaxIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + max) != int.MinValue + int.MaxValue)
+            {
+                Console.WriteLine($"'checked(min + max)' was evaluted to '{checked(min + max)}'. Expected: '{int.MinValue + int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf + min)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinusHalfIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + minusHalf) != int.MinValue / 2 + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf + minusHalf)' was evaluted to '{checked(minusHalf + minusHalf)}'. Expected: '{int.MinValue / 2 + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinusOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + minusOne) != int.MinValue / 2 + -1)
+            {
+                Console.WriteLine($"'checked(minusHalf + minusOne)' was evaluted to '{checked(minusHalf + minusOne)}'. Expected: '{int.MinValue / 2 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusZeroIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + zero) != int.MinValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(minusHalf + zero)' was evaluted to '{checked(minusHalf + zero)}'. Expected: '{int.MinValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + one) != int.MinValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(minusHalf + one)' was evaluted to '{checked(minusHalf + one)}'. Expected: '{int.MinValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusHalfIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + half) != int.MinValue / 2 + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf + half)' was evaluted to '{checked(minusHalf + half)}'. Expected: '{int.MinValue / 2 + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMaxIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + max) != int.MinValue / 2 + int.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusHalf + max)' was evaluted to '{checked(minusHalf + max)}'. Expected: '{int.MinValue / 2 + int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinOverflows()
+        {
+            int minusOne = -1;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusOne + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusOne + min)' did not throw OverflowException.");
+        }
+        ConfirmMinusOnePlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinusHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + minusHalf) != -1 + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne + minusHalf)' was evaluted to '{checked(minusOne + minusHalf)}'. Expected: '{-1 + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinusOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + minusOne) != -1 + -1)
+            {
+                Console.WriteLine($"'checked(minusOne + minusOne)' was evaluted to '{checked(minusOne + minusOne)}'. Expected: '{-1 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusZeroIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + zero) != -1 + 0)
+            {
+                Console.WriteLine($"'checked(minusOne + zero)' was evaluted to '{checked(minusOne + zero)}'. Expected: '{-1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + one) != -1 + 1)
+            {
+                Console.WriteLine($"'checked(minusOne + one)' was evaluted to '{checked(minusOne + one)}'. Expected: '{-1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + half) != -1 + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne + half)' was evaluted to '{checked(minusOne + half)}'. Expected: '{-1 + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMaxIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + max) != -1 + int.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne + max)' was evaluted to '{checked(minusOne + max)}'. Expected: '{-1 + int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + min) != 0 + int.MinValue)
+            {
+                Console.WriteLine($"'checked(zero + min)' was evaluted to '{checked(zero + min)}'. Expected: '{0 + int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinusHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + minusHalf) != 0 + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + minusHalf)' was evaluted to '{checked(zero + minusHalf)}'. Expected: '{0 + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinusOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + minusOne) != 0 + -1)
+            {
+                Console.WriteLine($"'checked(zero + minusOne)' was evaluted to '{checked(zero + minusOne)}'. Expected: '{0 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusZeroIsFoldedCorrectly()
+        {
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + zero) != 0 + 0)
+            {
+                Console.WriteLine($"'checked(zero + zero)' was evaluted to '{checked(zero + zero)}'. Expected: '{0 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + one) != 0 + 1)
+            {
+                Console.WriteLine($"'checked(zero + one)' was evaluted to '{checked(zero + one)}'. Expected: '{0 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + half) != 0 + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + half)' was evaluted to '{checked(zero + half)}'. Expected: '{0 + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMaxIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + max) != 0 + int.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero + max)' was evaluted to '{checked(zero + max)}'. Expected: '{0 + int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinIsFoldedCorrectly()
+        {
+            int one = 1;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + min) != 1 + int.MinValue)
+            {
+                Console.WriteLine($"'checked(one + min)' was evaluted to '{checked(one + min)}'. Expected: '{1 + int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinusHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + minusHalf) != 1 + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(one + minusHalf)' was evaluted to '{checked(one + minusHalf)}'. Expected: '{1 + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinusOneIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + minusOne) != 1 + -1)
+            {
+                Console.WriteLine($"'checked(one + minusOne)' was evaluted to '{checked(one + minusOne)}'. Expected: '{1 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusZeroIsFoldedCorrectly()
+        {
+            int one = 1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + zero) != 1 + 0)
+            {
+                Console.WriteLine($"'checked(one + zero)' was evaluted to '{checked(one + zero)}'. Expected: '{1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusOneIsFoldedCorrectly()
+        {
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + one) != 1 + 1)
+            {
+                Console.WriteLine($"'checked(one + one)' was evaluted to '{checked(one + one)}'. Expected: '{1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + half) != 1 + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one + half)' was evaluted to '{checked(one + half)}'. Expected: '{1 + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMaxOverflows()
+        {
+            int one = 1;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one + max)' did not throw OverflowException.");
+        }
+        ConfirmHalfPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + min) != int.MaxValue / 2 + int.MinValue)
+            {
+                Console.WriteLine($"'checked(half + min)' was evaluted to '{checked(half + min)}'. Expected: '{int.MaxValue / 2 + int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinusHalfIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + minusHalf) != int.MaxValue / 2 + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(half + minusHalf)' was evaluted to '{checked(half + minusHalf)}'. Expected: '{int.MaxValue / 2 + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinusOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + minusOne) != int.MaxValue / 2 + -1)
+            {
+                Console.WriteLine($"'checked(half + minusOne)' was evaluted to '{checked(half + minusOne)}'. Expected: '{int.MaxValue / 2 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusZeroIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + zero) != int.MaxValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(half + zero)' was evaluted to '{checked(half + zero)}'. Expected: '{int.MaxValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + one) != int.MaxValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(half + one)' was evaluted to '{checked(half + one)}'. Expected: '{int.MaxValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusHalfIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + half) != int.MaxValue / 2 + int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half + half)' was evaluted to '{checked(half + half)}'. Expected: '{int.MaxValue / 2 + int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMaxOverflows()
+        {
+            int half = int.MaxValue / 2;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half + max)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + min) != int.MaxValue + int.MinValue)
+            {
+                Console.WriteLine($"'checked(max + min)' was evaluted to '{checked(max + min)}'. Expected: '{int.MaxValue + int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinusHalfIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + minusHalf) != int.MaxValue + int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(max + minusHalf)' was evaluted to '{checked(max + minusHalf)}'. Expected: '{int.MaxValue + int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinusOneIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + minusOne) != int.MaxValue + -1)
+            {
+                Console.WriteLine($"'checked(max + minusOne)' was evaluted to '{checked(max + minusOne)}'. Expected: '{int.MaxValue + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusZeroIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + zero) != int.MaxValue + 0)
+            {
+                Console.WriteLine($"'checked(max + zero)' was evaluted to '{checked(max + zero)}'. Expected: '{int.MaxValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusOneOverflows()
+        {
+            int max = int.MaxValue;
+            int one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + one)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusHalfOverflows()
+        {
+            int max = int.MaxValue;
+            int half = int.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + half)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMaxOverflows()
+        {
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + max)' did not throw OverflowException.");
+        }
+
+        ConfirmMinMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - min) != int.MinValue - int.MinValue)
+            {
+                Console.WriteLine($"'checked(min - min)' was evaluted to '{checked(min - min)}'. Expected: '{int.MinValue - int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinusHalfIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - minusHalf) != int.MinValue - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(min - minusHalf)' was evaluted to '{checked(min - minusHalf)}'. Expected: '{int.MinValue - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinusOneIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - minusOne) != int.MinValue - -1)
+            {
+                Console.WriteLine($"'checked(min - minusOne)' was evaluted to '{checked(min - minusOne)}'. Expected: '{int.MinValue - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusZeroIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - zero) != int.MinValue - 0)
+            {
+                Console.WriteLine($"'checked(min - zero)' was evaluted to '{checked(min - zero)}'. Expected: '{int.MinValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusOneOverflows()
+        {
+            int min = int.MinValue;
+            int one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - one)' did not throw OverflowException.");
+        }
+        ConfirmMinMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusHalfOverflows()
+        {
+            int min = int.MinValue;
+            int half = int.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - half)' did not throw OverflowException.");
+        }
+        ConfirmMinMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMaxOverflows()
+        {
+            int min = int.MinValue;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - max)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - min) != int.MinValue / 2 - int.MinValue)
+            {
+                Console.WriteLine($"'checked(minusHalf - min)' was evaluted to '{checked(minusHalf - min)}'. Expected: '{int.MinValue / 2 - int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinusHalfIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - minusHalf) != int.MinValue / 2 - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf - minusHalf)' was evaluted to '{checked(minusHalf - minusHalf)}'. Expected: '{int.MinValue / 2 - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinusOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - minusOne) != int.MinValue / 2 - -1)
+            {
+                Console.WriteLine($"'checked(minusHalf - minusOne)' was evaluted to '{checked(minusHalf - minusOne)}'. Expected: '{int.MinValue / 2 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusZeroIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - zero) != int.MinValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(minusHalf - zero)' was evaluted to '{checked(minusHalf - zero)}'. Expected: '{int.MinValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - one) != int.MinValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(minusHalf - one)' was evaluted to '{checked(minusHalf - one)}'. Expected: '{int.MinValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusHalfIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - half) != int.MinValue / 2 - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf - half)' was evaluted to '{checked(minusHalf - half)}'. Expected: '{int.MinValue / 2 - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMaxOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf - max)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - min) != -1 - int.MinValue)
+            {
+                Console.WriteLine($"'checked(minusOne - min)' was evaluted to '{checked(minusOne - min)}'. Expected: '{-1 - int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinusHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - minusHalf) != -1 - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne - minusHalf)' was evaluted to '{checked(minusOne - minusHalf)}'. Expected: '{-1 - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinusOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - minusOne) != -1 - -1)
+            {
+                Console.WriteLine($"'checked(minusOne - minusOne)' was evaluted to '{checked(minusOne - minusOne)}'. Expected: '{-1 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusZeroIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - zero) != -1 - 0)
+            {
+                Console.WriteLine($"'checked(minusOne - zero)' was evaluted to '{checked(minusOne - zero)}'. Expected: '{-1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - one) != -1 - 1)
+            {
+                Console.WriteLine($"'checked(minusOne - one)' was evaluted to '{checked(minusOne - one)}'. Expected: '{-1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - half) != -1 - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne - half)' was evaluted to '{checked(minusOne - half)}'. Expected: '{-1 - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMaxIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - max) != -1 - int.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne - max)' was evaluted to '{checked(minusOne - max)}'. Expected: '{-1 - int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinOverflows()
+        {
+            int zero = 0;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - min)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinusHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - minusHalf) != 0 - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(zero - minusHalf)' was evaluted to '{checked(zero - minusHalf)}'. Expected: '{0 - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinusOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - minusOne) != 0 - -1)
+            {
+                Console.WriteLine($"'checked(zero - minusOne)' was evaluted to '{checked(zero - minusOne)}'. Expected: '{0 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusZeroIsFoldedCorrectly()
+        {
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - zero) != 0 - 0)
+            {
+                Console.WriteLine($"'checked(zero - zero)' was evaluted to '{checked(zero - zero)}'. Expected: '{0 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - one) != 0 - 1)
+            {
+                Console.WriteLine($"'checked(zero - one)' was evaluted to '{checked(zero - one)}'. Expected: '{0 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - half) != 0 - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero - half)' was evaluted to '{checked(zero - half)}'. Expected: '{0 - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMaxIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - max) != 0 - int.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero - max)' was evaluted to '{checked(zero - max)}'. Expected: '{0 - int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinOverflows()
+        {
+            int one = 1;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - min)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinusHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - minusHalf) != 1 - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(one - minusHalf)' was evaluted to '{checked(one - minusHalf)}'. Expected: '{1 - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinusOneIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - minusOne) != 1 - -1)
+            {
+                Console.WriteLine($"'checked(one - minusOne)' was evaluted to '{checked(one - minusOne)}'. Expected: '{1 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusZeroIsFoldedCorrectly()
+        {
+            int one = 1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - zero) != 1 - 0)
+            {
+                Console.WriteLine($"'checked(one - zero)' was evaluted to '{checked(one - zero)}'. Expected: '{1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusOneIsFoldedCorrectly()
+        {
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - one) != 1 - 1)
+            {
+                Console.WriteLine($"'checked(one - one)' was evaluted to '{checked(one - one)}'. Expected: '{1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - half) != 1 - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one - half)' was evaluted to '{checked(one - half)}'. Expected: '{1 - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMaxIsFoldedCorrectly()
+        {
+            int one = 1;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - max) != 1 - int.MaxValue)
+            {
+                Console.WriteLine($"'checked(one - max)' was evaluted to '{checked(one - max)}'. Expected: '{1 - int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinOverflows()
+        {
+            int half = int.MaxValue / 2;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half - min)' did not throw OverflowException.");
+        }
+        ConfirmHalfMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinusHalfIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int minusHalf = int.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - minusHalf) != int.MaxValue / 2 - int.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(half - minusHalf)' was evaluted to '{checked(half - minusHalf)}'. Expected: '{int.MaxValue / 2 - int.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinusOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - minusOne) != int.MaxValue / 2 - -1)
+            {
+                Console.WriteLine($"'checked(half - minusOne)' was evaluted to '{checked(half - minusOne)}'. Expected: '{int.MaxValue / 2 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusZeroIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - zero) != int.MaxValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(half - zero)' was evaluted to '{checked(half - zero)}'. Expected: '{int.MaxValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - one) != int.MaxValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(half - one)' was evaluted to '{checked(half - one)}'. Expected: '{int.MaxValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusHalfIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - half) != int.MaxValue / 2 - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half - half)' was evaluted to '{checked(half - half)}'. Expected: '{int.MaxValue / 2 - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMaxIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - max) != int.MaxValue / 2 - int.MaxValue)
+            {
+                Console.WriteLine($"'checked(half - max)' was evaluted to '{checked(half - max)}'. Expected: '{int.MaxValue / 2 - int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinOverflows()
+        {
+            int max = int.MaxValue;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - min)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinusHalfOverflows()
+        {
+            int max = int.MaxValue;
+            int minusHalf = int.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinusOneOverflows()
+        {
+            int max = int.MaxValue;
+            int minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusZeroIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - zero) != int.MaxValue - 0)
+            {
+                Console.WriteLine($"'checked(max - zero)' was evaluted to '{checked(max - zero)}'. Expected: '{int.MaxValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusOneIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - one) != int.MaxValue - 1)
+            {
+                Console.WriteLine($"'checked(max - one)' was evaluted to '{checked(max - one)}'. Expected: '{int.MaxValue - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusHalfIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int half = int.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - half) != int.MaxValue - int.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(max - half)' was evaluted to '{checked(max - half)}'. Expected: '{int.MaxValue - int.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMaxIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - max) != int.MaxValue - int.MaxValue)
+            {
+                Console.WriteLine($"'checked(max - max)' was evaluted to '{checked(max - max)}'. Expected: '{int.MaxValue - int.MaxValue}'.");
+                _counter++;
+            }
+        }
+
+        ConfirmMinMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinOverflows()
+        {
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * min)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinusHalfOverflows()
+        {
+            int min = int.MinValue;
+            int minusHalf = (int.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(min * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinusOneOverflows()
+        {
+            int min = int.MinValue;
+            int minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByZeroIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min * zero) != int.MinValue * 0)
+            {
+                Console.WriteLine($"'checked(min * zero)' was evaluted to '{checked(min * zero)}'. Expected: '{int.MinValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByOneIsFoldedCorrectly()
+        {
+            int min = int.MinValue;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min * one) != int.MinValue * 1)
+            {
+                Console.WriteLine($"'checked(min * one)' was evaluted to '{checked(min * one)}'. Expected: '{int.MinValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByHalfOverflows()
+        {
+            int min = int.MinValue;
+            int half = (int.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(min * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * half)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMaxOverflows()
+        {
+            int min = int.MinValue;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * max)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * min)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinusHalfOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * minusOne) != int.MinValue / 2 * -1)
+            {
+                Console.WriteLine($"'checked(minusHalf * minusOne)' was evaluted to '{checked(minusHalf * minusOne)}'. Expected: '{int.MinValue / 2 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * zero) != int.MinValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(minusHalf * zero)' was evaluted to '{checked(minusHalf * zero)}'. Expected: '{int.MinValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            int minusHalf = int.MinValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * one) != int.MinValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(minusHalf * one)' was evaluted to '{checked(minusHalf * one)}'. Expected: '{int.MinValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByHalfOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+            int half = (int.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * half)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMaxOverflows()
+        {
+            int minusHalf = int.MinValue / 2;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * max)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinOverflows()
+        {
+            int minusOne = -1;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusOne * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusOne * min)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int minusHalf = (int.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * minusHalf) != -1 * (int.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(minusOne * minusHalf)' was evaluted to '{checked(minusOne * minusHalf)}'. Expected: '{-1 * (int.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * minusOne) != -1 * -1)
+            {
+                Console.WriteLine($"'checked(minusOne * minusOne)' was evaluted to '{checked(minusOne * minusOne)}'. Expected: '{-1 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * zero) != -1 * 0)
+            {
+                Console.WriteLine($"'checked(minusOne * zero)' was evaluted to '{checked(minusOne * zero)}'. Expected: '{-1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByOneIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * one) != -1 * 1)
+            {
+                Console.WriteLine($"'checked(minusOne * one)' was evaluted to '{checked(minusOne * one)}'. Expected: '{-1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int half = (int.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * half) != -1 * (int.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(minusOne * half)' was evaluted to '{checked(minusOne * half)}'. Expected: '{-1 * (int.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            int minusOne = -1;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * max) != -1 * int.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne * max)' was evaluted to '{checked(minusOne * max)}'. Expected: '{-1 * int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * min) != 0 * int.MinValue)
+            {
+                Console.WriteLine($"'checked(zero * min)' was evaluted to '{checked(zero * min)}'. Expected: '{0 * int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusHalf = (int.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * minusHalf) != 0 * (int.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * minusHalf)' was evaluted to '{checked(zero * minusHalf)}'. Expected: '{0 * (int.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * minusOne) != 0 * -1)
+            {
+                Console.WriteLine($"'checked(zero * minusOne)' was evaluted to '{checked(zero * minusOne)}'. Expected: '{0 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByZeroIsFoldedCorrectly()
+        {
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * zero) != 0 * 0)
+            {
+                Console.WriteLine($"'checked(zero * zero)' was evaluted to '{checked(zero * zero)}'. Expected: '{0 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByOneIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * one) != 0 * 1)
+            {
+                Console.WriteLine($"'checked(zero * one)' was evaluted to '{checked(zero * one)}'. Expected: '{0 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByHalfIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int half = (int.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * half) != 0 * (int.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * half)' was evaluted to '{checked(zero * half)}'. Expected: '{0 * (int.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMaxIsFoldedCorrectly()
+        {
+            int zero = 0;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * max) != 0 * int.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero * max)' was evaluted to '{checked(zero * max)}'. Expected: '{0 * int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinIsFoldedCorrectly()
+        {
+            int one = 1;
+            int min = int.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * min) != 1 * int.MinValue)
+            {
+                Console.WriteLine($"'checked(one * min)' was evaluted to '{checked(one * min)}'. Expected: '{1 * int.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusHalf = (int.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * minusHalf) != 1 * (int.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(one * minusHalf)' was evaluted to '{checked(one * minusHalf)}'. Expected: '{1 * (int.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int one = 1;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * minusOne) != 1 * -1)
+            {
+                Console.WriteLine($"'checked(one * minusOne)' was evaluted to '{checked(one * minusOne)}'. Expected: '{1 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            int one = 1;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * zero) != 1 * 0)
+            {
+                Console.WriteLine($"'checked(one * zero)' was evaluted to '{checked(one * zero)}'. Expected: '{1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByOneIsFoldedCorrectly()
+        {
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * one) != 1 * 1)
+            {
+                Console.WriteLine($"'checked(one * one)' was evaluted to '{checked(one * one)}'. Expected: '{1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            int one = 1;
+            int half = (int.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * half) != 1 * (int.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(one * half)' was evaluted to '{checked(one * half)}'. Expected: '{1 * (int.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            int one = 1;
+            int max = int.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * max) != 1 * int.MaxValue)
+            {
+                Console.WriteLine($"'checked(one * max)' was evaluted to '{checked(one * max)}'. Expected: '{1 * int.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinOverflows()
+        {
+            int half = int.MaxValue / 2;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * min)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinusHalfOverflows()
+        {
+            int half = int.MaxValue / 2;
+            int minusHalf = (int.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(half * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * minusOne) != int.MaxValue / 2 * -1)
+            {
+                Console.WriteLine($"'checked(half * minusOne)' was evaluted to '{checked(half * minusOne)}'. Expected: '{int.MaxValue / 2 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * zero) != int.MaxValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(half * zero)' was evaluted to '{checked(half * zero)}'. Expected: '{int.MaxValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            int half = int.MaxValue / 2;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * one) != int.MaxValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(half * one)' was evaluted to '{checked(half * one)}'. Expected: '{int.MaxValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByHalfOverflows()
+        {
+            int half = int.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * half)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMaxOverflows()
+        {
+            int half = int.MaxValue / 2;
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinOverflows()
+        {
+            int max = int.MaxValue;
+            int min = int.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * min)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinusHalfOverflows()
+        {
+            int max = int.MaxValue;
+            int minusHalf = (int.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * minusOne) != int.MaxValue * -1)
+            {
+                Console.WriteLine($"'checked(max * minusOne)' was evaluted to '{checked(max * minusOne)}'. Expected: '{int.MaxValue * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByZeroIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * zero) != int.MaxValue * 0)
+            {
+                Console.WriteLine($"'checked(max * zero)' was evaluted to '{checked(max * zero)}'. Expected: '{int.MaxValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByOneIsFoldedCorrectly()
+        {
+            int max = int.MaxValue;
+            int one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * one) != int.MaxValue * 1)
+            {
+                Console.WriteLine($"'checked(max * one)' was evaluted to '{checked(max * one)}'. Expected: '{int.MaxValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByHalfOverflows()
+        {
+            int max = int.MaxValue;
+            int half = (int.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * half)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMaxOverflows()
+        {
+            int max = int.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * max)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestUInt32()
+    {
+        ConfirmAdditionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmAdditionIdentities(uint value)
+        {
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value + zero) != value)
+            {
+                Console.WriteLine($"Addition identity for uint 'checked(value + zero)' was evaluted to '{checked(value + zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(zero + value) != value)
+            {
+                Console.WriteLine($"Addition identity for uint 'checked(zero + value)' was evaluted to '{checked(zero + value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmSubtractionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSubtractionIdentities(uint value)
+        {
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value - zero) != value)
+            {
+                Console.WriteLine($"Subtraction identity for uint 'checked(value - zero)' was evaluted to '{checked(value - zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(value - value) != 0)
+            {
+                Console.WriteLine($"Subtraction identity for uint 'checked(value - value)' was evaluted to '{checked(value - value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMultiplicationIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMultiplicationIdentities(uint value)
+        {
+            uint zero = 0;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value * zero) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for uint 'checked(value * zero)' was evaluted to '{checked(value * zero)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(zero * value) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for uint 'checked(zero * value)' was evaluted to '{checked(zero * value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(value * one) != value)
+            {
+                Console.WriteLine($"Multiplication identity for uint 'checked(value * one)' was evaluted to '{checked(value * one)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(one * value) != value)
+            {
+                Console.WriteLine($"Multiplication identity for uint 'checked(one * value)' was evaluted to '{checked(one * value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusZeroIsFoldedCorrectly()
+        {
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + zero) != 0 + 0)
+            {
+                Console.WriteLine($"'checked(zero + zero)' was evaluted to '{checked(zero + zero)}'. Expected: '{0 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusOneIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + one) != 0 + 1)
+            {
+                Console.WriteLine($"'checked(zero + one)' was evaluted to '{checked(zero + one)}'. Expected: '{0 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusHalfIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint half = uint.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + half) != 0 + uint.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + half)' was evaluted to '{checked(zero + half)}'. Expected: '{0 + uint.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMaxIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint max = uint.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + max) != 0 + uint.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero + max)' was evaluted to '{checked(zero + max)}'. Expected: '{0 + uint.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusZeroIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + zero) != 1 + 0)
+            {
+                Console.WriteLine($"'checked(one + zero)' was evaluted to '{checked(one + zero)}'. Expected: '{1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusOneIsFoldedCorrectly()
+        {
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + one) != 1 + 1)
+            {
+                Console.WriteLine($"'checked(one + one)' was evaluted to '{checked(one + one)}'. Expected: '{1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusHalfIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint half = uint.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + half) != 1 + uint.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one + half)' was evaluted to '{checked(one + half)}'. Expected: '{1 + uint.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMaxOverflows()
+        {
+            uint one = 1;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one + max)' did not throw OverflowException.");
+        }
+        ConfirmHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusZeroIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + zero) != uint.MaxValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(half + zero)' was evaluted to '{checked(half + zero)}'. Expected: '{uint.MaxValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusOneIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + one) != uint.MaxValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(half + one)' was evaluted to '{checked(half + one)}'. Expected: '{uint.MaxValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusHalfIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + half) != uint.MaxValue / 2 + uint.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half + half)' was evaluted to '{checked(half + half)}'. Expected: '{uint.MaxValue / 2 + uint.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMaxOverflows()
+        {
+            uint half = uint.MaxValue / 2;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half + max)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusZeroIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + zero) != uint.MaxValue + 0)
+            {
+                Console.WriteLine($"'checked(max + zero)' was evaluted to '{checked(max + zero)}'. Expected: '{uint.MaxValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusOneOverflows()
+        {
+            uint max = uint.MaxValue;
+            uint one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + one)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusHalfOverflows()
+        {
+            uint max = uint.MaxValue;
+            uint half = uint.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + half)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMaxOverflows()
+        {
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + max)' did not throw OverflowException.");
+        }
+
+        ConfirmZeroMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusZeroIsFoldedCorrectly()
+        {
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - zero) != 0 - 0)
+            {
+                Console.WriteLine($"'checked(zero - zero)' was evaluted to '{checked(zero - zero)}'. Expected: '{0 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusOneOverflows()
+        {
+            uint zero = 0;
+            uint one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - one)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusHalfOverflows()
+        {
+            uint zero = 0;
+            uint half = uint.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - half)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMaxOverflows()
+        {
+            uint zero = 0;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - max)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusZeroIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - zero) != 1 - 0)
+            {
+                Console.WriteLine($"'checked(one - zero)' was evaluted to '{checked(one - zero)}'. Expected: '{1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusOneIsFoldedCorrectly()
+        {
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - one) != 1 - 1)
+            {
+                Console.WriteLine($"'checked(one - one)' was evaluted to '{checked(one - one)}'. Expected: '{1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusHalfOverflows()
+        {
+            uint one = 1;
+            uint half = uint.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - half)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMaxOverflows()
+        {
+            uint one = 1;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - max)' did not throw OverflowException.");
+        }
+        ConfirmHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusZeroIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - zero) != uint.MaxValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(half - zero)' was evaluted to '{checked(half - zero)}'. Expected: '{uint.MaxValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusOneIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - one) != uint.MaxValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(half - one)' was evaluted to '{checked(half - one)}'. Expected: '{uint.MaxValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusHalfIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - half) != uint.MaxValue / 2 - uint.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half - half)' was evaluted to '{checked(half - half)}'. Expected: '{uint.MaxValue / 2 - uint.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMaxOverflows()
+        {
+            uint half = uint.MaxValue / 2;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half - max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusZeroIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - zero) != uint.MaxValue - 0)
+            {
+                Console.WriteLine($"'checked(max - zero)' was evaluted to '{checked(max - zero)}'. Expected: '{uint.MaxValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusOneIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - one) != uint.MaxValue - 1)
+            {
+                Console.WriteLine($"'checked(max - one)' was evaluted to '{checked(max - one)}'. Expected: '{uint.MaxValue - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusHalfIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint half = uint.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - half) != uint.MaxValue - uint.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(max - half)' was evaluted to '{checked(max - half)}'. Expected: '{uint.MaxValue - uint.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMaxIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - max) != uint.MaxValue - uint.MaxValue)
+            {
+                Console.WriteLine($"'checked(max - max)' was evaluted to '{checked(max - max)}'. Expected: '{uint.MaxValue - uint.MaxValue}'.");
+                _counter++;
+            }
+        }
+
+        ConfirmZeroMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByZeroIsFoldedCorrectly()
+        {
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * zero) != 0 * 0)
+            {
+                Console.WriteLine($"'checked(zero * zero)' was evaluted to '{checked(zero * zero)}'. Expected: '{0 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByOneIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * one) != 0 * 1)
+            {
+                Console.WriteLine($"'checked(zero * one)' was evaluted to '{checked(zero * one)}'. Expected: '{0 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByHalfIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint half = (uint.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * half) != 0 * (uint.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * half)' was evaluted to '{checked(zero * half)}'. Expected: '{0 * (uint.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMaxIsFoldedCorrectly()
+        {
+            uint zero = 0;
+            uint max = uint.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * max) != 0 * uint.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero * max)' was evaluted to '{checked(zero * max)}'. Expected: '{0 * uint.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * zero) != 1 * 0)
+            {
+                Console.WriteLine($"'checked(one * zero)' was evaluted to '{checked(one * zero)}'. Expected: '{1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByOneIsFoldedCorrectly()
+        {
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * one) != 1 * 1)
+            {
+                Console.WriteLine($"'checked(one * one)' was evaluted to '{checked(one * one)}'. Expected: '{1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint half = (uint.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * half) != 1 * (uint.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(one * half)' was evaluted to '{checked(one * half)}'. Expected: '{1 * (uint.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            uint one = 1;
+            uint max = uint.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * max) != 1 * uint.MaxValue)
+            {
+                Console.WriteLine($"'checked(one * max)' was evaluted to '{checked(one * max)}'. Expected: '{1 * uint.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * zero) != uint.MaxValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(half * zero)' was evaluted to '{checked(half * zero)}'. Expected: '{uint.MaxValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            uint half = uint.MaxValue / 2;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * one) != uint.MaxValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(half * one)' was evaluted to '{checked(half * one)}'. Expected: '{uint.MaxValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByHalfOverflows()
+        {
+            uint half = uint.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * half)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMaxOverflows()
+        {
+            uint half = uint.MaxValue / 2;
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByZeroIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * zero) != uint.MaxValue * 0)
+            {
+                Console.WriteLine($"'checked(max * zero)' was evaluted to '{checked(max * zero)}'. Expected: '{uint.MaxValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByOneIsFoldedCorrectly()
+        {
+            uint max = uint.MaxValue;
+            uint one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * one) != uint.MaxValue * 1)
+            {
+                Console.WriteLine($"'checked(max * one)' was evaluted to '{checked(max * one)}'. Expected: '{uint.MaxValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByHalfOverflows()
+        {
+            uint max = uint.MaxValue;
+            uint half = (uint.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * half)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMaxOverflows()
+        {
+            uint max = uint.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * max)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestInt64()
+    {
+        ConfirmAdditionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmAdditionIdentities(long value)
+        {
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value + zero) != value)
+            {
+                Console.WriteLine($"Addition identity for long 'checked(value + zero)' was evaluted to '{checked(value + zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(zero + value) != value)
+            {
+                Console.WriteLine($"Addition identity for long 'checked(zero + value)' was evaluted to '{checked(zero + value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmSubtractionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSubtractionIdentities(long value)
+        {
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value - zero) != value)
+            {
+                Console.WriteLine($"Subtraction identity for long 'checked(value - zero)' was evaluted to '{checked(value - zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(value - value) != 0)
+            {
+                Console.WriteLine($"Subtraction identity for long 'checked(value - value)' was evaluted to '{checked(value - value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMultiplicationIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMultiplicationIdentities(long value)
+        {
+            long zero = 0;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value * zero) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for long 'checked(value * zero)' was evaluted to '{checked(value * zero)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(zero * value) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for long 'checked(zero * value)' was evaluted to '{checked(zero * value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(value * one) != value)
+            {
+                Console.WriteLine($"Multiplication identity for long 'checked(value * one)' was evaluted to '{checked(value * one)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(one * value) != value)
+            {
+                Console.WriteLine($"Multiplication identity for long 'checked(one * value)' was evaluted to '{checked(one * value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinOverflows()
+        {
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + min)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinusHalfOverflows()
+        {
+            long min = long.MinValue;
+            long minusHalf = long.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMinusOneOverflows()
+        {
+            long min = long.MinValue;
+            long minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min + minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min + minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMinPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusZeroIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + zero) != long.MinValue + 0)
+            {
+                Console.WriteLine($"'checked(min + zero)' was evaluted to '{checked(min + zero)}'. Expected: '{long.MinValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusOneIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + one) != long.MinValue + 1)
+            {
+                Console.WriteLine($"'checked(min + one)' was evaluted to '{checked(min + one)}'. Expected: '{long.MinValue + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusHalfIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + half) != long.MinValue + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(min + half)' was evaluted to '{checked(min + half)}'. Expected: '{long.MinValue + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinPlusMaxIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min + max) != long.MinValue + long.MaxValue)
+            {
+                Console.WriteLine($"'checked(min + max)' was evaluted to '{checked(min + max)}'. Expected: '{long.MinValue + long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf + min)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinusHalfIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + minusHalf) != long.MinValue / 2 + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf + minusHalf)' was evaluted to '{checked(minusHalf + minusHalf)}'. Expected: '{long.MinValue / 2 + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMinusOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + minusOne) != long.MinValue / 2 + -1)
+            {
+                Console.WriteLine($"'checked(minusHalf + minusOne)' was evaluted to '{checked(minusHalf + minusOne)}'. Expected: '{long.MinValue / 2 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusZeroIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + zero) != long.MinValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(minusHalf + zero)' was evaluted to '{checked(minusHalf + zero)}'. Expected: '{long.MinValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + one) != long.MinValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(minusHalf + one)' was evaluted to '{checked(minusHalf + one)}'. Expected: '{long.MinValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusHalfIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + half) != long.MinValue / 2 + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf + half)' was evaluted to '{checked(minusHalf + half)}'. Expected: '{long.MinValue / 2 + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfPlusMaxIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf + max) != long.MinValue / 2 + long.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusHalf + max)' was evaluted to '{checked(minusHalf + max)}'. Expected: '{long.MinValue / 2 + long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinOverflows()
+        {
+            long minusOne = -1;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusOne + min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusOne + min)' did not throw OverflowException.");
+        }
+        ConfirmMinusOnePlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinusHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + minusHalf) != -1 + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne + minusHalf)' was evaluted to '{checked(minusOne + minusHalf)}'. Expected: '{-1 + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMinusOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + minusOne) != -1 + -1)
+            {
+                Console.WriteLine($"'checked(minusOne + minusOne)' was evaluted to '{checked(minusOne + minusOne)}'. Expected: '{-1 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusZeroIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + zero) != -1 + 0)
+            {
+                Console.WriteLine($"'checked(minusOne + zero)' was evaluted to '{checked(minusOne + zero)}'. Expected: '{-1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + one) != -1 + 1)
+            {
+                Console.WriteLine($"'checked(minusOne + one)' was evaluted to '{checked(minusOne + one)}'. Expected: '{-1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + half) != -1 + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne + half)' was evaluted to '{checked(minusOne + half)}'. Expected: '{-1 + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOnePlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOnePlusMaxIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne + max) != -1 + long.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne + max)' was evaluted to '{checked(minusOne + max)}'. Expected: '{-1 + long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + min) != 0 + long.MinValue)
+            {
+                Console.WriteLine($"'checked(zero + min)' was evaluted to '{checked(zero + min)}'. Expected: '{0 + long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinusHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + minusHalf) != 0 + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + minusHalf)' was evaluted to '{checked(zero + minusHalf)}'. Expected: '{0 + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMinusOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + minusOne) != 0 + -1)
+            {
+                Console.WriteLine($"'checked(zero + minusOne)' was evaluted to '{checked(zero + minusOne)}'. Expected: '{0 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusZeroIsFoldedCorrectly()
+        {
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + zero) != 0 + 0)
+            {
+                Console.WriteLine($"'checked(zero + zero)' was evaluted to '{checked(zero + zero)}'. Expected: '{0 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + one) != 0 + 1)
+            {
+                Console.WriteLine($"'checked(zero + one)' was evaluted to '{checked(zero + one)}'. Expected: '{0 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + half) != 0 + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + half)' was evaluted to '{checked(zero + half)}'. Expected: '{0 + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMaxIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + max) != 0 + long.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero + max)' was evaluted to '{checked(zero + max)}'. Expected: '{0 + long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinIsFoldedCorrectly()
+        {
+            long one = 1;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + min) != 1 + long.MinValue)
+            {
+                Console.WriteLine($"'checked(one + min)' was evaluted to '{checked(one + min)}'. Expected: '{1 + long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinusHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + minusHalf) != 1 + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(one + minusHalf)' was evaluted to '{checked(one + minusHalf)}'. Expected: '{1 + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMinusOneIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + minusOne) != 1 + -1)
+            {
+                Console.WriteLine($"'checked(one + minusOne)' was evaluted to '{checked(one + minusOne)}'. Expected: '{1 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusZeroIsFoldedCorrectly()
+        {
+            long one = 1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + zero) != 1 + 0)
+            {
+                Console.WriteLine($"'checked(one + zero)' was evaluted to '{checked(one + zero)}'. Expected: '{1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusOneIsFoldedCorrectly()
+        {
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + one) != 1 + 1)
+            {
+                Console.WriteLine($"'checked(one + one)' was evaluted to '{checked(one + one)}'. Expected: '{1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + half) != 1 + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one + half)' was evaluted to '{checked(one + half)}'. Expected: '{1 + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMaxOverflows()
+        {
+            long one = 1;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one + max)' did not throw OverflowException.");
+        }
+        ConfirmHalfPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + min) != long.MaxValue / 2 + long.MinValue)
+            {
+                Console.WriteLine($"'checked(half + min)' was evaluted to '{checked(half + min)}'. Expected: '{long.MaxValue / 2 + long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinusHalfIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + minusHalf) != long.MaxValue / 2 + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(half + minusHalf)' was evaluted to '{checked(half + minusHalf)}'. Expected: '{long.MaxValue / 2 + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMinusOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + minusOne) != long.MaxValue / 2 + -1)
+            {
+                Console.WriteLine($"'checked(half + minusOne)' was evaluted to '{checked(half + minusOne)}'. Expected: '{long.MaxValue / 2 + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusZeroIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + zero) != long.MaxValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(half + zero)' was evaluted to '{checked(half + zero)}'. Expected: '{long.MaxValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + one) != long.MaxValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(half + one)' was evaluted to '{checked(half + one)}'. Expected: '{long.MaxValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusHalfIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + half) != long.MaxValue / 2 + long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half + half)' was evaluted to '{checked(half + half)}'. Expected: '{long.MaxValue / 2 + long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMaxOverflows()
+        {
+            long half = long.MaxValue / 2;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half + max)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + min) != long.MaxValue + long.MinValue)
+            {
+                Console.WriteLine($"'checked(max + min)' was evaluted to '{checked(max + min)}'. Expected: '{long.MaxValue + long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinusHalfIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + minusHalf) != long.MaxValue + long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(max + minusHalf)' was evaluted to '{checked(max + minusHalf)}'. Expected: '{long.MaxValue + long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMinusOneIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + minusOne) != long.MaxValue + -1)
+            {
+                Console.WriteLine($"'checked(max + minusOne)' was evaluted to '{checked(max + minusOne)}'. Expected: '{long.MaxValue + -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusZeroIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + zero) != long.MaxValue + 0)
+            {
+                Console.WriteLine($"'checked(max + zero)' was evaluted to '{checked(max + zero)}'. Expected: '{long.MaxValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusOneOverflows()
+        {
+            long max = long.MaxValue;
+            long one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + one)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusHalfOverflows()
+        {
+            long max = long.MaxValue;
+            long half = long.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + half)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMaxOverflows()
+        {
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + max)' did not throw OverflowException.");
+        }
+
+        ConfirmMinMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - min) != long.MinValue - long.MinValue)
+            {
+                Console.WriteLine($"'checked(min - min)' was evaluted to '{checked(min - min)}'. Expected: '{long.MinValue - long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinusHalfIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - minusHalf) != long.MinValue - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(min - minusHalf)' was evaluted to '{checked(min - minusHalf)}'. Expected: '{long.MinValue - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMinusOneIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - minusOne) != long.MinValue - -1)
+            {
+                Console.WriteLine($"'checked(min - minusOne)' was evaluted to '{checked(min - minusOne)}'. Expected: '{long.MinValue - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusZeroIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min - zero) != long.MinValue - 0)
+            {
+                Console.WriteLine($"'checked(min - zero)' was evaluted to '{checked(min - zero)}'. Expected: '{long.MinValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusOneOverflows()
+        {
+            long min = long.MinValue;
+            long one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - one)' did not throw OverflowException.");
+        }
+        ConfirmMinMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusHalfOverflows()
+        {
+            long min = long.MinValue;
+            long half = long.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - half)' did not throw OverflowException.");
+        }
+        ConfirmMinMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMinusMaxOverflows()
+        {
+            long min = long.MinValue;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min - max)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - min) != long.MinValue / 2 - long.MinValue)
+            {
+                Console.WriteLine($"'checked(minusHalf - min)' was evaluted to '{checked(minusHalf - min)}'. Expected: '{long.MinValue / 2 - long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinusHalfIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - minusHalf) != long.MinValue / 2 - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf - minusHalf)' was evaluted to '{checked(minusHalf - minusHalf)}'. Expected: '{long.MinValue / 2 - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMinusOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - minusOne) != long.MinValue / 2 - -1)
+            {
+                Console.WriteLine($"'checked(minusHalf - minusOne)' was evaluted to '{checked(minusHalf - minusOne)}'. Expected: '{long.MinValue / 2 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusZeroIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - zero) != long.MinValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(minusHalf - zero)' was evaluted to '{checked(minusHalf - zero)}'. Expected: '{long.MinValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - one) != long.MinValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(minusHalf - one)' was evaluted to '{checked(minusHalf - one)}'. Expected: '{long.MinValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusHalfIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf - half) != long.MinValue / 2 - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusHalf - half)' was evaluted to '{checked(minusHalf - half)}'. Expected: '{long.MinValue / 2 - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMinusMaxOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf - max)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMinusMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - min) != -1 - long.MinValue)
+            {
+                Console.WriteLine($"'checked(minusOne - min)' was evaluted to '{checked(minusOne - min)}'. Expected: '{-1 - long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinusHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - minusHalf) != -1 - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne - minusHalf)' was evaluted to '{checked(minusOne - minusHalf)}'. Expected: '{-1 - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMinusOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - minusOne) != -1 - -1)
+            {
+                Console.WriteLine($"'checked(minusOne - minusOne)' was evaluted to '{checked(minusOne - minusOne)}'. Expected: '{-1 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusZeroIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - zero) != -1 - 0)
+            {
+                Console.WriteLine($"'checked(minusOne - zero)' was evaluted to '{checked(minusOne - zero)}'. Expected: '{-1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - one) != -1 - 1)
+            {
+                Console.WriteLine($"'checked(minusOne - one)' was evaluted to '{checked(minusOne - one)}'. Expected: '{-1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - half) != -1 - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(minusOne - half)' was evaluted to '{checked(minusOne - half)}'. Expected: '{-1 - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMinusMaxIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne - max) != -1 - long.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne - max)' was evaluted to '{checked(minusOne - max)}'. Expected: '{-1 - long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinOverflows()
+        {
+            long zero = 0;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - min)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinusHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - minusHalf) != 0 - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(zero - minusHalf)' was evaluted to '{checked(zero - minusHalf)}'. Expected: '{0 - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMinusOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - minusOne) != 0 - -1)
+            {
+                Console.WriteLine($"'checked(zero - minusOne)' was evaluted to '{checked(zero - minusOne)}'. Expected: '{0 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusZeroIsFoldedCorrectly()
+        {
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - zero) != 0 - 0)
+            {
+                Console.WriteLine($"'checked(zero - zero)' was evaluted to '{checked(zero - zero)}'. Expected: '{0 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - one) != 0 - 1)
+            {
+                Console.WriteLine($"'checked(zero - one)' was evaluted to '{checked(zero - one)}'. Expected: '{0 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - half) != 0 - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero - half)' was evaluted to '{checked(zero - half)}'. Expected: '{0 - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMaxIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - max) != 0 - long.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero - max)' was evaluted to '{checked(zero - max)}'. Expected: '{0 - long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinOverflows()
+        {
+            long one = 1;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - min)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinusHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - minusHalf) != 1 - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(one - minusHalf)' was evaluted to '{checked(one - minusHalf)}'. Expected: '{1 - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMinusOneIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - minusOne) != 1 - -1)
+            {
+                Console.WriteLine($"'checked(one - minusOne)' was evaluted to '{checked(one - minusOne)}'. Expected: '{1 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusZeroIsFoldedCorrectly()
+        {
+            long one = 1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - zero) != 1 - 0)
+            {
+                Console.WriteLine($"'checked(one - zero)' was evaluted to '{checked(one - zero)}'. Expected: '{1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusOneIsFoldedCorrectly()
+        {
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - one) != 1 - 1)
+            {
+                Console.WriteLine($"'checked(one - one)' was evaluted to '{checked(one - one)}'. Expected: '{1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - half) != 1 - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one - half)' was evaluted to '{checked(one - half)}'. Expected: '{1 - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMaxIsFoldedCorrectly()
+        {
+            long one = 1;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - max) != 1 - long.MaxValue)
+            {
+                Console.WriteLine($"'checked(one - max)' was evaluted to '{checked(one - max)}'. Expected: '{1 - long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinOverflows()
+        {
+            long half = long.MaxValue / 2;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half - min)' did not throw OverflowException.");
+        }
+        ConfirmHalfMinusMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinusHalfIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long minusHalf = long.MinValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - minusHalf) != long.MaxValue / 2 - long.MinValue / 2)
+            {
+                Console.WriteLine($"'checked(half - minusHalf)' was evaluted to '{checked(half - minusHalf)}'. Expected: '{long.MaxValue / 2 - long.MinValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMinusOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - minusOne) != long.MaxValue / 2 - -1)
+            {
+                Console.WriteLine($"'checked(half - minusOne)' was evaluted to '{checked(half - minusOne)}'. Expected: '{long.MaxValue / 2 - -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusZeroIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - zero) != long.MaxValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(half - zero)' was evaluted to '{checked(half - zero)}'. Expected: '{long.MaxValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - one) != long.MaxValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(half - one)' was evaluted to '{checked(half - one)}'. Expected: '{long.MaxValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusHalfIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - half) != long.MaxValue / 2 - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half - half)' was evaluted to '{checked(half - half)}'. Expected: '{long.MaxValue / 2 - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMaxIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - max) != long.MaxValue / 2 - long.MaxValue)
+            {
+                Console.WriteLine($"'checked(half - max)' was evaluted to '{checked(half - max)}'. Expected: '{long.MaxValue / 2 - long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinOverflows()
+        {
+            long max = long.MaxValue;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - min)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinusHalfOverflows()
+        {
+            long max = long.MaxValue;
+            long minusHalf = long.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMinusOneOverflows()
+        {
+            long max = long.MaxValue;
+            long minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max - minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max - minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusZeroIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - zero) != long.MaxValue - 0)
+            {
+                Console.WriteLine($"'checked(max - zero)' was evaluted to '{checked(max - zero)}'. Expected: '{long.MaxValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusOneIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - one) != long.MaxValue - 1)
+            {
+                Console.WriteLine($"'checked(max - one)' was evaluted to '{checked(max - one)}'. Expected: '{long.MaxValue - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusHalfIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long half = long.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - half) != long.MaxValue - long.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(max - half)' was evaluted to '{checked(max - half)}'. Expected: '{long.MaxValue - long.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMaxIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - max) != long.MaxValue - long.MaxValue)
+            {
+                Console.WriteLine($"'checked(max - max)' was evaluted to '{checked(max - max)}'. Expected: '{long.MaxValue - long.MaxValue}'.");
+                _counter++;
+            }
+        }
+
+        ConfirmMinMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinOverflows()
+        {
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * min)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinusHalfOverflows()
+        {
+            long min = long.MinValue;
+            long minusHalf = (long.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(min * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMinusOneOverflows()
+        {
+            long min = long.MinValue;
+            long minusOne = -1;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * minusOne);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * minusOne)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByZeroIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min * zero) != long.MinValue * 0)
+            {
+                Console.WriteLine($"'checked(min * zero)' was evaluted to '{checked(min * zero)}'. Expected: '{long.MinValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByOneIsFoldedCorrectly()
+        {
+            long min = long.MinValue;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(min * one) != long.MinValue * 1)
+            {
+                Console.WriteLine($"'checked(min * one)' was evaluted to '{checked(min * one)}'. Expected: '{long.MinValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByHalfOverflows()
+        {
+            long min = long.MinValue;
+            long half = (long.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(min * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * half)' did not throw OverflowException.");
+        }
+        ConfirmMinMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinMultipliedByMaxOverflows()
+        {
+            long min = long.MinValue;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(min * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(min * max)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * min)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinusHalfOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * minusOne) != long.MinValue / 2 * -1)
+            {
+                Console.WriteLine($"'checked(minusHalf * minusOne)' was evaluted to '{checked(minusHalf * minusOne)}'. Expected: '{long.MinValue / 2 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * zero) != long.MinValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(minusHalf * zero)' was evaluted to '{checked(minusHalf * zero)}'. Expected: '{long.MinValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            long minusHalf = long.MinValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusHalf * one) != long.MinValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(minusHalf * one)' was evaluted to '{checked(minusHalf * one)}'. Expected: '{long.MinValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByHalfOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+            long half = (long.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * half)' did not throw OverflowException.");
+        }
+        ConfirmMinusHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusHalfMultipliedByMaxOverflows()
+        {
+            long minusHalf = long.MinValue / 2;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusHalf * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusHalf * max)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinOverflows()
+        {
+            long minusOne = -1;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(minusOne * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(minusOne * min)' did not throw OverflowException.");
+        }
+        ConfirmMinusOneMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long minusHalf = (long.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * minusHalf) != -1 * (long.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(minusOne * minusHalf)' was evaluted to '{checked(minusOne * minusHalf)}'. Expected: '{-1 * (long.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * minusOne) != -1 * -1)
+            {
+                Console.WriteLine($"'checked(minusOne * minusOne)' was evaluted to '{checked(minusOne * minusOne)}'. Expected: '{-1 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * zero) != -1 * 0)
+            {
+                Console.WriteLine($"'checked(minusOne * zero)' was evaluted to '{checked(minusOne * zero)}'. Expected: '{-1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByOneIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * one) != -1 * 1)
+            {
+                Console.WriteLine($"'checked(minusOne * one)' was evaluted to '{checked(minusOne * one)}'. Expected: '{-1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long half = (long.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * half) != -1 * (long.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(minusOne * half)' was evaluted to '{checked(minusOne * half)}'. Expected: '{-1 * (long.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmMinusOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMinusOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            long minusOne = -1;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(minusOne * max) != -1 * long.MaxValue)
+            {
+                Console.WriteLine($"'checked(minusOne * max)' was evaluted to '{checked(minusOne * max)}'. Expected: '{-1 * long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * min) != 0 * long.MinValue)
+            {
+                Console.WriteLine($"'checked(zero * min)' was evaluted to '{checked(zero * min)}'. Expected: '{0 * long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusHalf = (long.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * minusHalf) != 0 * (long.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * minusHalf)' was evaluted to '{checked(zero * minusHalf)}'. Expected: '{0 * (long.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * minusOne) != 0 * -1)
+            {
+                Console.WriteLine($"'checked(zero * minusOne)' was evaluted to '{checked(zero * minusOne)}'. Expected: '{0 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByZeroIsFoldedCorrectly()
+        {
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * zero) != 0 * 0)
+            {
+                Console.WriteLine($"'checked(zero * zero)' was evaluted to '{checked(zero * zero)}'. Expected: '{0 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByOneIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * one) != 0 * 1)
+            {
+                Console.WriteLine($"'checked(zero * one)' was evaluted to '{checked(zero * one)}'. Expected: '{0 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByHalfIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long half = (long.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * half) != 0 * (long.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * half)' was evaluted to '{checked(zero * half)}'. Expected: '{0 * (long.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMaxIsFoldedCorrectly()
+        {
+            long zero = 0;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * max) != 0 * long.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero * max)' was evaluted to '{checked(zero * max)}'. Expected: '{0 * long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinIsFoldedCorrectly()
+        {
+            long one = 1;
+            long min = long.MinValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * min) != 1 * long.MinValue)
+            {
+                Console.WriteLine($"'checked(one * min)' was evaluted to '{checked(one * min)}'. Expected: '{1 * long.MinValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinusHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusHalf = (long.MinValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * minusHalf) != 1 * (long.MinValue / 2))
+            {
+                Console.WriteLine($"'checked(one * minusHalf)' was evaluted to '{checked(one * minusHalf)}'. Expected: '{1 * (long.MinValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long one = 1;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * minusOne) != 1 * -1)
+            {
+                Console.WriteLine($"'checked(one * minusOne)' was evaluted to '{checked(one * minusOne)}'. Expected: '{1 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            long one = 1;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * zero) != 1 * 0)
+            {
+                Console.WriteLine($"'checked(one * zero)' was evaluted to '{checked(one * zero)}'. Expected: '{1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByOneIsFoldedCorrectly()
+        {
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * one) != 1 * 1)
+            {
+                Console.WriteLine($"'checked(one * one)' was evaluted to '{checked(one * one)}'. Expected: '{1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            long one = 1;
+            long half = (long.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * half) != 1 * (long.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(one * half)' was evaluted to '{checked(one * half)}'. Expected: '{1 * (long.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            long one = 1;
+            long max = long.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * max) != 1 * long.MaxValue)
+            {
+                Console.WriteLine($"'checked(one * max)' was evaluted to '{checked(one * max)}'. Expected: '{1 * long.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinOverflows()
+        {
+            long half = long.MaxValue / 2;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * min)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinusHalfOverflows()
+        {
+            long half = long.MaxValue / 2;
+            long minusHalf = (long.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(half * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * minusOne) != long.MaxValue / 2 * -1)
+            {
+                Console.WriteLine($"'checked(half * minusOne)' was evaluted to '{checked(half * minusOne)}'. Expected: '{long.MaxValue / 2 * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * zero) != long.MaxValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(half * zero)' was evaluted to '{checked(half * zero)}'. Expected: '{long.MaxValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            long half = long.MaxValue / 2;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * one) != long.MaxValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(half * one)' was evaluted to '{checked(half * one)}'. Expected: '{long.MaxValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByHalfOverflows()
+        {
+            long half = long.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * half)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMaxOverflows()
+        {
+            long half = long.MaxValue / 2;
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinOverflows()
+        {
+            long max = long.MaxValue;
+            long min = long.MinValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * min);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * min)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinusHalfOverflows()
+        {
+            long max = long.MaxValue;
+            long minusHalf = (long.MinValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * minusHalf);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * minusHalf)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMinusOneIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long minusOne = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * minusOne) != long.MaxValue * -1)
+            {
+                Console.WriteLine($"'checked(max * minusOne)' was evaluted to '{checked(max * minusOne)}'. Expected: '{long.MaxValue * -1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByZeroIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * zero) != long.MaxValue * 0)
+            {
+                Console.WriteLine($"'checked(max * zero)' was evaluted to '{checked(max * zero)}'. Expected: '{long.MaxValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByOneIsFoldedCorrectly()
+        {
+            long max = long.MaxValue;
+            long one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * one) != long.MaxValue * 1)
+            {
+                Console.WriteLine($"'checked(max * one)' was evaluted to '{checked(max * one)}'. Expected: '{long.MaxValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByHalfOverflows()
+        {
+            long max = long.MaxValue;
+            long half = (long.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * half)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMaxOverflows()
+        {
+            long max = long.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * max)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestUInt64()
+    {
+        ConfirmAdditionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmAdditionIdentities(ulong value)
+        {
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value + zero) != value)
+            {
+                Console.WriteLine($"Addition identity for ulong 'checked(value + zero)' was evaluted to '{checked(value + zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(zero + value) != value)
+            {
+                Console.WriteLine($"Addition identity for ulong 'checked(zero + value)' was evaluted to '{checked(zero + value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmSubtractionIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSubtractionIdentities(ulong value)
+        {
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value - zero) != value)
+            {
+                Console.WriteLine($"Subtraction identity for ulong 'checked(value - zero)' was evaluted to '{checked(value - zero)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(value - value) != 0)
+            {
+                Console.WriteLine($"Subtraction identity for ulong 'checked(value - value)' was evaluted to '{checked(value - value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMultiplicationIdentities(42);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMultiplicationIdentities(ulong value)
+        {
+            ulong zero = 0;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(value * zero) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for ulong 'checked(value * zero)' was evaluted to '{checked(value * zero)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(zero * value) != 0)
+            {
+                Console.WriteLine($"Multiplication identity for ulong 'checked(zero * value)' was evaluted to '{checked(zero * value)}'. Expected: '{0}'.");
+                _counter++;
+            }
+
+            if (checked(value * one) != value)
+            {
+                Console.WriteLine($"Multiplication identity for ulong 'checked(value * one)' was evaluted to '{checked(value * one)}'. Expected: '{value}'.");
+                _counter++;
+            }
+
+            if (checked(one * value) != value)
+            {
+                Console.WriteLine($"Multiplication identity for ulong 'checked(one * value)' was evaluted to '{checked(one * value)}'. Expected: '{value}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusZeroIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + zero) != 0 + 0)
+            {
+                Console.WriteLine($"'checked(zero + zero)' was evaluted to '{checked(zero + zero)}'. Expected: '{0 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusOneIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + one) != 0 + 1)
+            {
+                Console.WriteLine($"'checked(zero + one)' was evaluted to '{checked(zero + one)}'. Expected: '{0 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusHalfIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong half = ulong.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + half) != 0 + ulong.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(zero + half)' was evaluted to '{checked(zero + half)}'. Expected: '{0 + ulong.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroPlusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroPlusMaxIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong max = ulong.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero + max) != 0 + ulong.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero + max)' was evaluted to '{checked(zero + max)}'. Expected: '{0 + ulong.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusZeroIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + zero) != 1 + 0)
+            {
+                Console.WriteLine($"'checked(one + zero)' was evaluted to '{checked(one + zero)}'. Expected: '{1 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusOneIsFoldedCorrectly()
+        {
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + one) != 1 + 1)
+            {
+                Console.WriteLine($"'checked(one + one)' was evaluted to '{checked(one + one)}'. Expected: '{1 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusHalfIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong half = ulong.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one + half) != 1 + ulong.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(one + half)' was evaluted to '{checked(one + half)}'. Expected: '{1 + ulong.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmOnePlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOnePlusMaxOverflows()
+        {
+            ulong one = 1;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one + max)' did not throw OverflowException.");
+        }
+        ConfirmHalfPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusZeroIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + zero) != ulong.MaxValue / 2 + 0)
+            {
+                Console.WriteLine($"'checked(half + zero)' was evaluted to '{checked(half + zero)}'. Expected: '{ulong.MaxValue / 2 + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusOneIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + one) != ulong.MaxValue / 2 + 1)
+            {
+                Console.WriteLine($"'checked(half + one)' was evaluted to '{checked(half + one)}'. Expected: '{ulong.MaxValue / 2 + 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusHalfIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half + half) != ulong.MaxValue / 2 + ulong.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half + half)' was evaluted to '{checked(half + half)}'. Expected: '{ulong.MaxValue / 2 + ulong.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfPlusMaxOverflows()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half + max)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusZeroIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max + zero) != ulong.MaxValue + 0)
+            {
+                Console.WriteLine($"'checked(max + zero)' was evaluted to '{checked(max + zero)}'. Expected: '{ulong.MaxValue + 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxPlusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusOneOverflows()
+        {
+            ulong max = ulong.MaxValue;
+            ulong one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + one)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusHalfOverflows()
+        {
+            ulong max = ulong.MaxValue;
+            ulong half = ulong.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + half)' did not throw OverflowException.");
+        }
+        ConfirmMaxPlusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxPlusMaxOverflows()
+        {
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max + max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max + max)' did not throw OverflowException.");
+        }
+
+        ConfirmZeroMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusZeroIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero - zero) != 0 - 0)
+            {
+                Console.WriteLine($"'checked(zero - zero)' was evaluted to '{checked(zero - zero)}'. Expected: '{0 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMinusOneOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusOneOverflows()
+        {
+            ulong zero = 0;
+            ulong one = 1;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - one);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - one)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusHalfOverflows()
+        {
+            ulong zero = 0;
+            ulong half = ulong.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - half)' did not throw OverflowException.");
+        }
+        ConfirmZeroMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMinusMaxOverflows()
+        {
+            ulong zero = 0;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(zero - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(zero - max)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusZeroIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - zero) != 1 - 0)
+            {
+                Console.WriteLine($"'checked(one - zero)' was evaluted to '{checked(one - zero)}'. Expected: '{1 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusOneIsFoldedCorrectly()
+        {
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one - one) != 1 - 1)
+            {
+                Console.WriteLine($"'checked(one - one)' was evaluted to '{checked(one - one)}'. Expected: '{1 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMinusHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusHalfOverflows()
+        {
+            ulong one = 1;
+            ulong half = ulong.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - half)' did not throw OverflowException.");
+        }
+        ConfirmOneMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMinusMaxOverflows()
+        {
+            ulong one = 1;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(one - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(one - max)' did not throw OverflowException.");
+        }
+        ConfirmHalfMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusZeroIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - zero) != ulong.MaxValue / 2 - 0)
+            {
+                Console.WriteLine($"'checked(half - zero)' was evaluted to '{checked(half - zero)}'. Expected: '{ulong.MaxValue / 2 - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusOneIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - one) != ulong.MaxValue / 2 - 1)
+            {
+                Console.WriteLine($"'checked(half - one)' was evaluted to '{checked(half - one)}'. Expected: '{ulong.MaxValue / 2 - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusHalfIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half - half) != ulong.MaxValue / 2 - ulong.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(half - half)' was evaluted to '{checked(half - half)}'. Expected: '{ulong.MaxValue / 2 - ulong.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMinusMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMinusMaxOverflows()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half - max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half - max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMinusZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusZeroIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - zero) != ulong.MaxValue - 0)
+            {
+                Console.WriteLine($"'checked(max - zero)' was evaluted to '{checked(max - zero)}'. Expected: '{ulong.MaxValue - 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusOneIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - one) != ulong.MaxValue - 1)
+            {
+                Console.WriteLine($"'checked(max - one)' was evaluted to '{checked(max - one)}'. Expected: '{ulong.MaxValue - 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusHalfIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong half = ulong.MaxValue / 2;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - half) != ulong.MaxValue - ulong.MaxValue / 2)
+            {
+                Console.WriteLine($"'checked(max - half)' was evaluted to '{checked(max - half)}'. Expected: '{ulong.MaxValue - ulong.MaxValue / 2}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMinusMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMinusMaxIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max - max) != ulong.MaxValue - ulong.MaxValue)
+            {
+                Console.WriteLine($"'checked(max - max)' was evaluted to '{checked(max - max)}'. Expected: '{ulong.MaxValue - ulong.MaxValue}'.");
+                _counter++;
+            }
+        }
+
+        ConfirmZeroMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByZeroIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * zero) != 0 * 0)
+            {
+                Console.WriteLine($"'checked(zero * zero)' was evaluted to '{checked(zero * zero)}'. Expected: '{0 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByOneIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * one) != 0 * 1)
+            {
+                Console.WriteLine($"'checked(zero * one)' was evaluted to '{checked(zero * one)}'. Expected: '{0 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByHalfIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong half = (ulong.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * half) != 0 * (ulong.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(zero * half)' was evaluted to '{checked(zero * half)}'. Expected: '{0 * (ulong.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmZeroMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmZeroMultipliedByMaxIsFoldedCorrectly()
+        {
+            ulong zero = 0;
+            ulong max = ulong.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(zero * max) != 0 * ulong.MaxValue)
+            {
+                Console.WriteLine($"'checked(zero * max)' was evaluted to '{checked(zero * max)}'. Expected: '{0 * ulong.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByZeroIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * zero) != 1 * 0)
+            {
+                Console.WriteLine($"'checked(one * zero)' was evaluted to '{checked(one * zero)}'. Expected: '{1 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByOneIsFoldedCorrectly()
+        {
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * one) != 1 * 1)
+            {
+                Console.WriteLine($"'checked(one * one)' was evaluted to '{checked(one * one)}'. Expected: '{1 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByHalfIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByHalfIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong half = (ulong.MaxValue / 2);
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * half) != 1 * (ulong.MaxValue / 2))
+            {
+                Console.WriteLine($"'checked(one * half)' was evaluted to '{checked(one * half)}'. Expected: '{1 * (ulong.MaxValue / 2)}'.");
+                _counter++;
+            }
+        }
+        ConfirmOneMultipliedByMaxIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmOneMultipliedByMaxIsFoldedCorrectly()
+        {
+            ulong one = 1;
+            ulong max = ulong.MaxValue;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(one * max) != 1 * ulong.MaxValue)
+            {
+                Console.WriteLine($"'checked(one * max)' was evaluted to '{checked(one * max)}'. Expected: '{1 * ulong.MaxValue}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByZeroIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * zero) != ulong.MaxValue / 2 * 0)
+            {
+                Console.WriteLine($"'checked(half * zero)' was evaluted to '{checked(half * zero)}'. Expected: '{ulong.MaxValue / 2 * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByOneIsFoldedCorrectly()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(half * one) != ulong.MaxValue / 2 * 1)
+            {
+                Console.WriteLine($"'checked(half * one)' was evaluted to '{checked(half * one)}'. Expected: '{ulong.MaxValue / 2 * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmHalfMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByHalfOverflows()
+        {
+            ulong half = ulong.MaxValue / 2;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * half)' did not throw OverflowException.");
+        }
+        ConfirmHalfMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmHalfMultipliedByMaxOverflows()
+        {
+            ulong half = ulong.MaxValue / 2;
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(half * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(half * max)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByZeroIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByZeroIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong zero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * zero) != ulong.MaxValue * 0)
+            {
+                Console.WriteLine($"'checked(max * zero)' was evaluted to '{checked(max * zero)}'. Expected: '{ulong.MaxValue * 0}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByOneIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByOneIsFoldedCorrectly()
+        {
+            ulong max = ulong.MaxValue;
+            ulong one = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked(max * one) != ulong.MaxValue * 1)
+            {
+                Console.WriteLine($"'checked(max * one)' was evaluted to '{checked(max * one)}'. Expected: '{ulong.MaxValue * 1}'.");
+                _counter++;
+            }
+        }
+        ConfirmMaxMultipliedByHalfOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByHalfOverflows()
+        {
+            ulong max = ulong.MaxValue;
+            ulong half = (ulong.MaxValue / 2);
+
+            _counter++;
+            try
+            {
+                _ = checked(max * half);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * half)' did not throw OverflowException.");
+        }
+        ConfirmMaxMultipliedByMaxOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmMaxMultipliedByMaxOverflows()
+        {
+            ulong max = ulong.MaxValue;
+
+            _counter++;
+            try
+            {
+                _ = checked(max * max);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked(max * max)' did not throw OverflowException.");
+        }
+    }
+}

--- a/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants.cs
+++ b/src/tests/JIT/Directed/ConstantFolding/value_numbering_unordered_comparisons_of_constants.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static int _global = 0;
+    private static int _counter = 100;
+
+    public static int Main()
+    {
+        TestCastingSingleToSByte();
+        TestCastingSingleToByte();
+        TestCastingSingleToInt16();
+        TestCastingSingleToUInt16();
+        TestCastingSingleToInt32();
+        TestCastingSingleToUInt32();
+        TestCastingSingleToInt64();
+        TestCastingSingleToUInt64();
+
+        TestCastingDoubleToSByte();
+        TestCastingDoubleToByte();
+        TestCastingDoubleToInt16();
+        TestCastingDoubleToUInt16();
+        TestCastingDoubleToInt32();
+        TestCastingDoubleToUInt32();
+        TestCastingDoubleToInt64();
+        TestCastingDoubleToUInt64();
+
+        TestCastingSByteToSingle();
+        TestCastingSByteToDouble();
+        TestCastingSByteToSByte();
+        TestCastingSByteToByte();
+        TestCastingSByteToInt16();
+        TestCastingSByteToUInt16();
+        TestCastingSByteToInt32();
+        TestCastingSByteToUInt32();
+        TestCastingSByteToInt64();
+        TestCastingSByteToUInt64();
+        TestCastingByteToSingle();
+        TestCastingByteToDouble();
+        TestCastingByteToSByte();
+        TestCastingByteToByte();
+        TestCastingByteToInt16();
+        TestCastingByteToUInt16();
+        TestCastingByteToInt32();
+        TestCastingByteToUInt32();
+        TestCastingByteToInt64();
+        TestCastingByteToUInt64();
+
+        TestCastingInt16ToSingle();
+        TestCastingInt16ToDouble();
+        TestCastingInt16ToSByte();
+        TestCastingInt16ToByte();
+        TestCastingInt16ToInt16();
+        TestCastingInt16ToUInt16();
+        TestCastingInt16ToInt32();
+        TestCastingInt16ToUInt32();
+        TestCastingInt16ToInt64();
+        TestCastingInt16ToUInt64();
+        TestCastingUInt16ToSingle();
+        TestCastingUInt16ToDouble();
+        TestCastingUInt16ToSByte();
+        TestCastingUInt16ToByte();
+        TestCastingUInt16ToInt16();
+        TestCastingUInt16ToUInt16();
+        TestCastingUInt16ToInt32();
+        TestCastingUInt16ToUInt32();
+        TestCastingUInt16ToInt64();
+        TestCastingUInt16ToUInt64();
+
+        TestCastingInt32ToSingle();
+        TestCastingInt32ToDouble();
+        TestCastingInt32ToSByte();
+        TestCastingInt32ToByte();
+        TestCastingInt32ToInt16();
+        TestCastingInt32ToUInt16();
+        TestCastingInt32ToInt32();
+        TestCastingInt32ToUInt32();
+        TestCastingInt32ToInt64();
+        TestCastingInt32ToUInt64();
+        TestCastingUInt32ToSingle();
+        TestCastingUInt32ToDouble();
+        TestCastingUInt32ToSByte();
+        TestCastingUInt32ToByte();
+        TestCastingUInt32ToInt16();
+        TestCastingUInt32ToUInt16();
+        TestCastingUInt32ToInt32();
+        TestCastingUInt32ToUInt32();
+        TestCastingUInt32ToInt64();
+        TestCastingUInt32ToUInt64();
+
+        TestCastingInt64ToSingle();
+        TestCastingInt64ToDouble();
+        TestCastingInt64ToSByte();
+        TestCastingInt64ToByte();
+        TestCastingInt64ToInt16();
+        TestCastingInt64ToUInt16();
+        TestCastingInt64ToInt32();
+        TestCastingInt64ToUInt32();
+        TestCastingInt64ToInt64();
+        TestCastingInt64ToUInt64();
+        TestCastingUInt64ToSingle();
+        TestCastingUInt64ToDouble();
+        TestCastingUInt64ToSByte();
+        TestCastingUInt64ToByte();
+        TestCastingUInt64ToInt16();
+        TestCastingUInt64ToUInt16();
+        TestCastingUInt64ToInt32();
+        TestCastingUInt64ToUInt32();
+        TestCastingUInt64ToInt64();
+        TestCastingUInt64ToUInt64();
+
+        return _counter;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool BreakUpFlow() => false;
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants.csproj
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="value_numbering_checked_casts_of_constants.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_float.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_double.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_byte.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_short.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_int.cs" />
+    <Compile Include="value_numbering_checked_casts_of_constants_long.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_byte.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_byte.cs
@@ -1,0 +1,2173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingSByteToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMinValue) != -128f)
+            {
+                Console.WriteLine($"'(float)-128' was evaluted to '{(float)sByteMinValue}'. Expected: '-128f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMinValue) != -127f)
+            {
+                Console.WriteLine($"'(float)-127' was evaluted to '{(float)integerOneIncrementAboveSByteMinValue}'. Expected: '-127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMinValue) != -1f)
+            {
+                Console.WriteLine($"'(float)-1' was evaluted to '{(float)integerOneDecrementUnderByteMinValue}'. Expected: '-1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMinValue) != -128d)
+            {
+                Console.WriteLine($"'(double)-128' was evaluted to '{(double)sByteMinValue}'. Expected: '-128d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMinValue) != -127d)
+            {
+                Console.WriteLine($"'(double)-127' was evaluted to '{(double)integerOneIncrementAboveSByteMinValue}'. Expected: '-127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMinValue) != -1d)
+            {
+                Console.WriteLine($"'(double)-1' was evaluted to '{(double)integerOneDecrementUnderByteMinValue}'. Expected: '-1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            sbyte from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            sbyte from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            sbyte from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            sbyte from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            sbyte from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            sbyte from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            sbyte from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            sbyte from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            sbyte from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingSByteToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            sbyte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            sbyte from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            sbyte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            sbyte from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteOneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteOneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            sbyte from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            sbyte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmByteOneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteOneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            byte from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            byte from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmByteOneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteOneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            byte from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingByteToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingByteToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            byte integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            byte integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_double.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_double.cs
@@ -1,0 +1,10023 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingDoubleToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0.0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToSByteIsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)-0d' was evaluted to '{(sbyte)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToSByteIsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0d' was evaluted to '{(sbyte)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToSByteOverflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToSByteOverflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double sByteMinValue = -128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128.0' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127.0' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMinValue = -128.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128.00000000000003d' was evaluted to '{(sbyte)doubleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            double from = -129d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMinValue = -127.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127.99999999999999d' was evaluted to '{(sbyte)doubleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMinValue = -127d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127d' was evaluted to '{(sbyte)doubleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126.99999999999999d' was evaluted to '{(sbyte)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126d' was evaluted to '{(sbyte)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127.00000000000001d' was evaluted to '{(sbyte)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            double from = 128d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            double from = -129.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMinValue = -127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127.0' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126.0' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            double from = 128.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128.0)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            double from = 255.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(sbyte)-5E-324d' was evaluted to '{(sbyte)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMinValue = -1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1d' was evaluted to '{(sbyte)doubleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(sbyte)5E-324d' was evaluted to '{(sbyte)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1d' was evaluted to '{(sbyte)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            double from = 254.99999999999997d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254.99999999999997d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            double from = 254d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            double from = 255.00000000000003d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255.00000000000003d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            double from = 256d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMinValue = -1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1.0' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1.0' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            double from = 254.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            double from = 256.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32768.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32767.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32767d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32766.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32766d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32767.000000000004d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767.000000000004d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32768d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            double from = -32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32766.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65535.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65534.99999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534.99999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65534d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65535.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65536d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65534.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            double from = 65536.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483646.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483646d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483647.0000002d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647.0000002d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483648d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483646.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967295.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967294.9999995d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294.9999995d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967294d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967295.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967294.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToSByteOverflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToSByteOverflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToSByteOverflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSByteOverflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0.0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToByteIsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(byte)-0d' was evaluted to '{(byte)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToByteIsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0d' was evaluted to '{(byte)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToByteOverflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToByteOverflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            double from = -128.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128.0)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127.0' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            double from = -128.00000000000003d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128.00000000000003d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            double from = -129d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            double from = -127.99999999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127.99999999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            double from = -127d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126.99999999999999d' was evaluted to '{(byte)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126d' was evaluted to '{(byte)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127.00000000000001d' was evaluted to '{(byte)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128d' was evaluted to '{(byte)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            double from = -129.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            double from = -127.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126.0' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128.0' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255.0' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(byte)-5E-324d' was evaluted to '{(byte)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            double from = -1d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(byte)5E-324d' was evaluted to '{(byte)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1d' was evaluted to '{(byte)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254.99999999999997d' was evaluted to '{(byte)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254d' was evaluted to '{(byte)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255.00000000000003d' was evaluted to '{(byte)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            double from = 256d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            double from = -1.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1.0' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254.0' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            double from = 256.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToByteOverflows()
+        {
+            double from = -32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            double from = -32768.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            double from = -32767.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            double from = -32767d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32766.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32766d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32767.000000000004d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767.000000000004d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32768d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            double from = -32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32766.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            double from = 32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65535.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65534.99999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534.99999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65534d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65535.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65536d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65534.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            double from = 65536.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483646.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483646d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483647.0000002d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647.0000002d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483648d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483646.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            double from = 2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967295.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967294.9999995d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294.9999995d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967294d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967295.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967294.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToByteOverflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToByteOverflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToByteOverflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToByteOverflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToByteOverflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToByteOverflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0.0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToInt16IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(short)-0d' was evaluted to '{(short)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToInt16IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(short)0d' was evaluted to '{(short)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToInt16Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToInt16Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double sByteMinValue = -128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128.0' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127.0' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMinValue = -128.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128.00000000000003d' was evaluted to '{(short)doubleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMinValue = -129d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129d' was evaluted to '{(short)doubleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMinValue = -127.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127.99999999999999d' was evaluted to '{(short)doubleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMinValue = -127d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127d' was evaluted to '{(short)doubleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126.99999999999999d' was evaluted to '{(short)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126d' was evaluted to '{(short)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127.00000000000001d' was evaluted to '{(short)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128d' was evaluted to '{(short)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMinValue = -129.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129.0' was evaluted to '{(short)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMinValue = -127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127.0' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126.0' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128.0' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255.0' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(short)-5E-324d' was evaluted to '{(short)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMinValue = -1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1d' was evaluted to '{(short)doubleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(short)5E-324d' was evaluted to '{(short)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1d' was evaluted to '{(short)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254.99999999999997d' was evaluted to '{(short)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254d' was evaluted to '{(short)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255.00000000000003d' was evaluted to '{(short)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256d' was evaluted to '{(short)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMinValue = -1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1.0' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1.0' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254.0' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256.0' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            double int16MinValue = -32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768.0' was evaluted to '{(short)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767.0' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MinValue = -32768.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768.00000000001d' was evaluted to '{(short)doubleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MinValue = -32767.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767.999999999996d' was evaluted to '{(short)doubleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MinValue = -32767d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767d' was evaluted to '{(short)doubleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766.999999999996d' was evaluted to '{(short)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766d' was evaluted to '{(short)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767.000000000004d' was evaluted to '{(short)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 32768d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MinValue = -32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767.0' was evaluted to '{(short)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766.0' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65535.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65534.99999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534.99999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65534d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65535.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65536d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65534.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            double from = 65536.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483646.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483646d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483647.0000002d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647.0000002d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483648d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483646.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967295.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967294.9999995d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294.9999995d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967294d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967295.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967294.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt16Overflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt16Overflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt16Overflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt16Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0.0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)-0d' was evaluted to '{(ushort)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0d' was evaluted to '{(ushort)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToUInt16Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToUInt16Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -128.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128.0)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127.0' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -128.00000000000003d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128.00000000000003d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -129d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -127.99999999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127.99999999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -127d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126.99999999999999d' was evaluted to '{(ushort)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126d' was evaluted to '{(ushort)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127.00000000000001d' was evaluted to '{(ushort)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128d' was evaluted to '{(ushort)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -129.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            double from = -127.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126.0' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128.0' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255.0' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ushort)-5E-324d' was evaluted to '{(ushort)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            double from = -1d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ushort)5E-324d' was evaluted to '{(ushort)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1d' was evaluted to '{(ushort)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254.99999999999997d' was evaluted to '{(ushort)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254d' was evaluted to '{(ushort)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255.00000000000003d' was evaluted to '{(ushort)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256d' was evaluted to '{(ushort)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            double from = -1.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1.0' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254.0' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256.0' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767.0' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32768.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32767.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32767d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766.999999999996d' was evaluted to '{(ushort)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766d' was evaluted to '{(ushort)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767.000000000004d' was evaluted to '{(ushort)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MaxValue = 32768d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768d' was evaluted to '{(ushort)doubleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            double from = -32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766.0' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MaxValue = 32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768.0' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double uInt16MaxValue = 65535.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535.0' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt16MaxValue = 65534.99999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534.99999999999d' was evaluted to '{(ushort)doubleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt16MaxValue = 65534d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534d' was evaluted to '{(ushort)doubleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt16MaxValue = 65535.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)doubleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535.00000000001d' was evaluted to '{(ushort)doubleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            double from = 65536d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt16MaxValue = 65534.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534.0' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            double from = 65536.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483646.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483646d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483647.0000002d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647.0000002d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483648d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483646.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967295.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967294.9999995d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294.9999995d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967294d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967295.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967294.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt16Overflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt16Overflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt16Overflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt16Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0.0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToInt32IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(int)-0d' was evaluted to '{(int)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToInt32IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(int)0d' was evaluted to '{(int)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToInt32Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToInt32Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double sByteMinValue = -128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128.0' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127.0' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMinValue = -128.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128.00000000000003d' was evaluted to '{(int)doubleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMinValue = -129d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129d' was evaluted to '{(int)doubleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMinValue = -127.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127.99999999999999d' was evaluted to '{(int)doubleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMinValue = -127d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127d' was evaluted to '{(int)doubleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126.99999999999999d' was evaluted to '{(int)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126d' was evaluted to '{(int)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127.00000000000001d' was evaluted to '{(int)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128d' was evaluted to '{(int)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMinValue = -129.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129.0' was evaluted to '{(int)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMinValue = -127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127.0' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126.0' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128.0' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255.0' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(int)-5E-324d' was evaluted to '{(int)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMinValue = -1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1d' was evaluted to '{(int)doubleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(int)5E-324d' was evaluted to '{(int)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1d' was evaluted to '{(int)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254.99999999999997d' was evaluted to '{(int)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254d' was evaluted to '{(int)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255.00000000000003d' was evaluted to '{(int)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256d' was evaluted to '{(int)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMinValue = -1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1.0' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1.0' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254.0' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256.0' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double int16MinValue = -32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768.0' was evaluted to '{(int)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767.0' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MinValue = -32768.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768.00000000001d' was evaluted to '{(int)doubleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MinValue = -32769d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769d' was evaluted to '{(int)doubleOneFullDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MinValue = -32767.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767.999999999996d' was evaluted to '{(int)doubleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MinValue = -32767d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767d' was evaluted to '{(int)doubleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766.999999999996d' was evaluted to '{(int)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766d' was evaluted to '{(int)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767.000000000004d' was evaluted to '{(int)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MaxValue = 32768d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768d' was evaluted to '{(int)doubleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MinValue = -32769.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769.0' was evaluted to '{(int)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MinValue = -32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767.0' was evaluted to '{(int)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766.0' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MaxValue = 32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768.0' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double uInt16MaxValue = 65535.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535.0' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt16MaxValue = 65534.99999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534.99999999999d' was evaluted to '{(int)doubleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt16MaxValue = 65534d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534d' was evaluted to '{(int)doubleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt16MaxValue = 65535.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535.00000000001d' was evaluted to '{(int)doubleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt16MaxValue = 65536d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536d' was evaluted to '{(int)doubleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt16MaxValue = 65534.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534.0' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt16MaxValue = 65536.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536.0' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double int32MinValue = -2147483648.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483648.0' was evaluted to '{(int)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double int32MaxValue = 2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647.0' was evaluted to '{(int)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MinValue = -2147483648.0000005d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483648.0000005d' was evaluted to '{(int)doubleOneDecrementUnderInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt32Overflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MinValue = -2147483647.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(int)-2147483647.9999998d' was evaluted to '{(int)doubleOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt32MinValue = -2147483647d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(int)-2147483647d' was evaluted to '{(int)doubleOneFullIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MaxValue = 2147483646.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646.9999998d' was evaluted to '{(int)doubleOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt32MaxValue = 2147483646d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneFullDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646d' was evaluted to '{(int)doubleOneFullDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MaxValue = 2147483647.0000002d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)doubleOneIncrementAboveInt32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647.0000002d' was evaluted to '{(int)doubleOneIncrementAboveInt32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 2147483648d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt32Overflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt32MinValue = -2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(int)-2147483647.0' was evaluted to '{(int)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt32MaxValue = 2147483646.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646.0' was evaluted to '{(int)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967295.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967294.9999995d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294.9999995d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967294d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967295.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967294.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt32Overflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt32Overflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt32Overflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt32Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0.0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(uint)-0d' was evaluted to '{(uint)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0d' was evaluted to '{(uint)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToUInt32Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToUInt32Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -128.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128.0)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127.0' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -128.00000000000003d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128.00000000000003d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -129d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -127.99999999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127.99999999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -127d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126.99999999999999d' was evaluted to '{(uint)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126d' was evaluted to '{(uint)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127.00000000000001d' was evaluted to '{(uint)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128d' was evaluted to '{(uint)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -129.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            double from = -127.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126.0' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128.0' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255.0' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(uint)-5E-324d' was evaluted to '{(uint)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            double from = -1d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(uint)5E-324d' was evaluted to '{(uint)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1d' was evaluted to '{(uint)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254.99999999999997d' was evaluted to '{(uint)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254d' was evaluted to '{(uint)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255.00000000000003d' was evaluted to '{(uint)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256d' was evaluted to '{(uint)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            double from = -1.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1.0' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254.0' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256.0' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767.0' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32768.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32767.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32767d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766.999999999996d' was evaluted to '{(uint)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766d' was evaluted to '{(uint)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767.000000000004d' was evaluted to '{(uint)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MaxValue = 32768d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768d' was evaluted to '{(uint)doubleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            double from = -32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766.0' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MaxValue = 32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768.0' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double uInt16MaxValue = 65535.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535.0' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt16MaxValue = 65534.99999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534.99999999999d' was evaluted to '{(uint)doubleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt16MaxValue = 65534d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534d' was evaluted to '{(uint)doubleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt16MaxValue = 65535.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535.00000000001d' was evaluted to '{(uint)doubleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt16MaxValue = 65536d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536d' was evaluted to '{(uint)doubleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt16MaxValue = 65534.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534.0' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt16MaxValue = 65536.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536.0' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double int32MaxValue = 2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647.0' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MaxValue = 2147483646.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646.9999998d' was evaluted to '{(uint)doubleOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt32MaxValue = 2147483646d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646d' was evaluted to '{(uint)doubleOneFullDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MaxValue = 2147483647.0000002d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveInt32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647.0000002d' was evaluted to '{(uint)doubleOneIncrementAboveInt32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt32MaxValue = 2147483648d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648d' was evaluted to '{(uint)doubleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt32MaxValue = 2147483646.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646.0' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt32MaxValue = 2147483648.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648.0' was evaluted to '{(uint)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double uInt32MaxValue = 4294967295.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(uint)4294967295.0' was evaluted to '{(uint)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt32MaxValue = 4294967294.9999995d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294.9999995d' was evaluted to '{(uint)doubleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt32MaxValue = 4294967294d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneFullDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294d' was evaluted to '{(uint)doubleOneFullDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt32MaxValue = 4294967295.0000005d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)doubleOneIncrementAboveUInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(uint)4294967295.0000005d' was evaluted to '{(uint)doubleOneIncrementAboveUInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            double from = 4294967296d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967296d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt32MaxValue = 4294967294.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294.0' was evaluted to '{(uint)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            double from = 4294967296.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967296.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt32Overflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt32Overflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt32Overflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt32Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0.0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToInt64IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(long)-0d' was evaluted to '{(long)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToInt64IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(long)0d' was evaluted to '{(long)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToInt64Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToInt64Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double sByteMinValue = -128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128.0' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127.0' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMinValue = -128.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128.00000000000003d' was evaluted to '{(long)doubleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMinValue = -129d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129d' was evaluted to '{(long)doubleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMinValue = -127.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127.99999999999999d' was evaluted to '{(long)doubleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMinValue = -127d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127d' was evaluted to '{(long)doubleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126.99999999999999d' was evaluted to '{(long)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126d' was evaluted to '{(long)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127.00000000000001d' was evaluted to '{(long)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128d' was evaluted to '{(long)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMinValue = -129.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129.0' was evaluted to '{(long)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMinValue = -127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127.0' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126.0' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128.0' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255.0' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(long)-5E-324d' was evaluted to '{(long)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMinValue = -1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1d' was evaluted to '{(long)doubleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(long)5E-324d' was evaluted to '{(long)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1d' was evaluted to '{(long)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254.99999999999997d' was evaluted to '{(long)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254d' was evaluted to '{(long)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255.00000000000003d' was evaluted to '{(long)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256d' was evaluted to '{(long)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMinValue = -1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1.0' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1.0' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254.0' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256.0' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double int16MinValue = -32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768.0' was evaluted to '{(long)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767.0' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MinValue = -32768.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768.00000000001d' was evaluted to '{(long)doubleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MinValue = -32769d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769d' was evaluted to '{(long)doubleOneFullDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MinValue = -32767.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767.999999999996d' was evaluted to '{(long)doubleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MinValue = -32767d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767d' was evaluted to '{(long)doubleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766.999999999996d' was evaluted to '{(long)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766d' was evaluted to '{(long)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767.000000000004d' was evaluted to '{(long)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MaxValue = 32768d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768d' was evaluted to '{(long)doubleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MinValue = -32769.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769.0' was evaluted to '{(long)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MinValue = -32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767.0' was evaluted to '{(long)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766.0' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MaxValue = 32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768.0' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double uInt16MaxValue = 65535.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535.0' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt16MaxValue = 65534.99999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534.99999999999d' was evaluted to '{(long)doubleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt16MaxValue = 65534d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534d' was evaluted to '{(long)doubleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt16MaxValue = 65535.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535.00000000001d' was evaluted to '{(long)doubleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt16MaxValue = 65536d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536d' was evaluted to '{(long)doubleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt16MaxValue = 65534.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534.0' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt16MaxValue = 65536.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536.0' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double int32MinValue = -2147483648.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483648.0' was evaluted to '{(long)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double int32MaxValue = 2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647.0' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MinValue = -2147483648.0000005d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483648.0000005d' was evaluted to '{(long)doubleOneDecrementUnderInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt32MinValue = -2147483649d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderInt32MinValue) != -2147483649)
+            {
+                Console.WriteLine($"'(long)-2147483649d' was evaluted to '{(long)doubleOneFullDecrementUnderInt32MinValue}'. Expected: '-2147483649'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MinValue = -2147483647.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(long)-2147483647.9999998d' was evaluted to '{(long)doubleOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt32MinValue = -2147483647d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(long)-2147483647d' was evaluted to '{(long)doubleOneFullIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MaxValue = 2147483646.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646.9999998d' was evaluted to '{(long)doubleOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt32MaxValue = 2147483646d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646d' was evaluted to '{(long)doubleOneFullDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MaxValue = 2147483647.0000002d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveInt32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647.0000002d' was evaluted to '{(long)doubleOneIncrementAboveInt32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt32MaxValue = 2147483648d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648d' was evaluted to '{(long)doubleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt32MinValue = -2147483649.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MinValue) != -2147483649)
+            {
+                Console.WriteLine($"'(long)-2147483649.0' was evaluted to '{(long)integerOneDecrementUnderInt32MinValue}'. Expected: '-2147483649'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt32MinValue = -2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(long)-2147483647.0' was evaluted to '{(long)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt32MaxValue = 2147483646.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646.0' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt32MaxValue = 2147483648.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648.0' was evaluted to '{(long)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double uInt32MaxValue = 4294967295.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(long)4294967295.0' was evaluted to '{(long)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt32MaxValue = 4294967294.9999995d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294.9999995d' was evaluted to '{(long)doubleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt32MaxValue = 4294967294d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294d' was evaluted to '{(long)doubleOneFullDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt32MaxValue = 4294967295.0000005d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveUInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(long)4294967295.0000005d' was evaluted to '{(long)doubleOneIncrementAboveUInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt32MaxValue = 4294967296d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneFullIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967296d' was evaluted to '{(long)doubleOneFullIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt32MaxValue = 4294967294.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294.0' was evaluted to '{(long)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt32MaxValue = 4294967296.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967296.0' was evaluted to '{(long)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double int64MinValue = -9223372036854775808.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int64MinValue) != -9223372036854775808)
+            {
+                Console.WriteLine($"'(long)-9223372036854775808.0' was evaluted to '{(long)int64MinValue}'. Expected: '-9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt64MinValue = -9.223372036854775E+18d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneIncrementAboveInt64MinValue) != -9223372036854774784)
+            {
+                Console.WriteLine($"'(long)-9.223372036854775E+18d' was evaluted to '{(long)doubleOneIncrementAboveInt64MinValue}'. Expected: '-9223372036854774784'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt64MaxValue = 9.223372036854775E+18d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)doubleOneDecrementUnderInt64MaxValue) != 9223372036854774784)
+            {
+                Console.WriteLine($"'(long)9.223372036854775E+18d' was evaluted to '{(long)doubleOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854774784'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 9.223372036854778E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9.223372036854778E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 9.223372036854776E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9.223372036854776E+18d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt64MinValue = -9223372036854775807.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt64MinValue) != -9223372036854775808)
+            {
+                Console.WriteLine($"'(long)-9223372036854775807.0' was evaluted to '{(long)integerOneIncrementAboveInt64MinValue}'. Expected: '-9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 9223372036854775806.0;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775806.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 1.844674407370955E+19d;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)1.844674407370955E+19d)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt64Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingDoubleToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            double integerZero = 0.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0.0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinusZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinusZeroCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleMinusZero = -0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleMinusZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)-0d' was evaluted to '{(ulong)doubleMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleZeroCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleZero = 0d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0d' was evaluted to '{(ulong)doubleZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMinValueCastToUInt64Overflows()
+        {
+            double from = -1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleMaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleMaxValueCastToUInt64Overflows()
+        {
+            double from = 1.7976931348623157E+308d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)1.7976931348623157E+308d)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -128.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128.0)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double sByteMaxValue = 127.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127.0' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -128.00000000000003d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128.00000000000003d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -129d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -127.99999999999999d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127.99999999999999d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -127d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderSByteMaxValue = 126.99999999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126.99999999999999d' was evaluted to '{(ulong)doubleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderSByteMaxValue = 126d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126d' was evaluted to '{(ulong)doubleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveSByteMaxValue = 127.00000000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127.00000000000001d' was evaluted to '{(ulong)doubleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveSByteMaxValue = 128d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128d' was evaluted to '{(ulong)doubleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -129.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            double from = -127.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderSByteMaxValue = 126.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126.0' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveSByteMaxValue = 128.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128.0' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double byteMaxValue = 255.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255.0' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMinValue = -5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ulong)-5E-324d' was evaluted to '{(ulong)doubleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            double from = -1d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMinValue = 5E-324d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ulong)5E-324d' was evaluted to '{(ulong)doubleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMinValue = 1d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1d' was evaluted to '{(ulong)doubleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderByteMaxValue = 254.99999999999997d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254.99999999999997d' was evaluted to '{(ulong)doubleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderByteMaxValue = 254d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254d' was evaluted to '{(ulong)doubleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveByteMaxValue = 255.00000000000003d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255.00000000000003d' was evaluted to '{(ulong)doubleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveByteMaxValue = 256d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256d' was evaluted to '{(ulong)doubleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            double from = -1.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMinValue = 1.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1.0' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderByteMaxValue = 254.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254.0' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveByteMaxValue = 256.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256.0' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32768.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768.0)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double int16MaxValue = 32767.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767.0' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32768.00000000001d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768.00000000001d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32769d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32767.999999999996d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767.999999999996d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32767d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt16MaxValue = 32766.999999999996d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766.999999999996d' was evaluted to '{(ulong)doubleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt16MaxValue = 32766d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766d' was evaluted to '{(ulong)doubleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt16MaxValue = 32767.000000000004d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767.000000000004d' was evaluted to '{(ulong)doubleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt16MaxValue = 32768d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768d' was evaluted to '{(ulong)doubleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32769.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            double from = -32767.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt16MaxValue = 32766.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766.0' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt16MaxValue = 32768.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768.0' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double uInt16MaxValue = 65535.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535.0' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt16MaxValue = 65534.99999999999d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534.99999999999d' was evaluted to '{(ulong)doubleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt16MaxValue = 65534d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534d' was evaluted to '{(ulong)doubleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt16MaxValue = 65535.00000000001d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535.00000000001d' was evaluted to '{(ulong)doubleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt16MaxValue = 65536d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536d' was evaluted to '{(ulong)doubleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt16MaxValue = 65534.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534.0' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt16MaxValue = 65536.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536.0' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483648.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483648.0)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double int32MaxValue = 2147483647.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647.0' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483648.0000005d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483648.0000005d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483649d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483649d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483647.9999998d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647.9999998d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483647d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt32MaxValue = 2147483646.9999998d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646.9999998d' was evaluted to '{(ulong)doubleOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderInt32MaxValue = 2147483646d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646d' was evaluted to '{(ulong)doubleOneFullDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt32MaxValue = 2147483647.0000002d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveInt32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647.0000002d' was evaluted to '{(ulong)doubleOneIncrementAboveInt32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt32MaxValue = 2147483648d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648d' was evaluted to '{(ulong)doubleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483649.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483649.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            double from = -2147483647.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt32MaxValue = 2147483646.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646.0' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt32MaxValue = 2147483648.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648.0' was evaluted to '{(ulong)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double uInt32MaxValue = 4294967295.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(ulong)4294967295.0' was evaluted to '{(ulong)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt32MaxValue = 4294967294.9999995d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294.9999995d' was evaluted to '{(ulong)doubleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullDecrementUnderUInt32MaxValue = 4294967294d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294d' was evaluted to '{(ulong)doubleOneFullDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveUInt32MaxValue = 4294967295.0000005d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveUInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(ulong)4294967295.0000005d' was evaluted to '{(ulong)doubleOneIncrementAboveUInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveUInt32MaxValue = 4294967296d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967296d' was evaluted to '{(ulong)doubleOneFullIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderUInt32MaxValue = 4294967294.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294.0' was evaluted to '{(ulong)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveUInt32MaxValue = 4294967296.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967296.0' was evaluted to '{(ulong)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt64Overflows()
+        {
+            double from = -9223372036854775808.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775808.0)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double int64MaxValue = 9223372036854775807.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775807.0' was evaluted to '{(ulong)int64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MinValueCastToUInt64Overflows()
+        {
+            double from = -9.223372036854775E+18d;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9.223372036854775E+18d)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderInt64MaxValue = 9.223372036854775E+18d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderInt64MaxValue) != 9223372036854774784)
+            {
+                Console.WriteLine($"'(ulong)9.223372036854775E+18d' was evaluted to '{(ulong)doubleOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854774784'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneIncrementAboveInt64MaxValue = 9.223372036854778E+18d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneIncrementAboveInt64MaxValue) != 9223372036854777856)
+            {
+                Console.WriteLine($"'(ulong)9.223372036854778E+18d' was evaluted to '{(ulong)doubleOneIncrementAboveInt64MaxValue}'. Expected: '9223372036854777856'.");
+                _counter++;
+            }
+        }
+        ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneFullIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneFullIncrementAboveInt64MaxValue = 9.223372036854776E+18d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneFullIncrementAboveInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9.223372036854776E+18d' was evaluted to '{(ulong)doubleOneFullIncrementAboveInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt64Overflows()
+        {
+            double from = -9223372036854775807.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775807.0)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneDecrementUnderInt64MaxValue = 9223372036854775806.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775806.0' was evaluted to '{(ulong)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double integerOneIncrementAboveInt64MaxValue = 9223372036854775808.0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775808.0' was evaluted to '{(ulong)integerOneIncrementAboveInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64MaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt64Overflows()
+        {
+            double from = 18446744073709551615.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)18446744073709551615.0)' did not throw OverflowException.");
+        }
+        ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmDoubleOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            double doubleOneDecrementUnderUInt64MaxValue = 1.844674407370955E+19d;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)doubleOneDecrementUnderUInt64MaxValue) != 18446744073709549568)
+            {
+                Console.WriteLine($"'(ulong)1.844674407370955E+19d' was evaluted to '{(ulong)doubleOneDecrementUnderUInt64MaxValue}'. Expected: '18446744073709549568'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64Overflows()
+        {
+            double from = 18446744073709551614.0;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)18446744073709551614.0)' did not throw OverflowException.");
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_float.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_float.cs
@@ -1,0 +1,9783 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingSingleToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0.0f' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToSByteIsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)-0f' was evaluted to '{(sbyte)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToSByteIsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)floatZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0f' was evaluted to '{(sbyte)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToSByteOverflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToSByteOverflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToSByteOverflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToSByteOverflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float sByteMinValue = -128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128.0f' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127.0f' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMinValue = -128.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128.00002f' was evaluted to '{(sbyte)singleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            float from = -129f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMinValue = -127.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127.99999f' was evaluted to '{(sbyte)singleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMinValue = -127f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127f' was evaluted to '{(sbyte)singleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126.99999f' was evaluted to '{(sbyte)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126f' was evaluted to '{(sbyte)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127.00001f' was evaluted to '{(sbyte)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            float from = 128f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            float from = -129.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMinValue = -127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127.0f' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126.0f' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            float from = 128.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128.0f)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            float from = 255.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(sbyte)-1E-45f' was evaluted to '{(sbyte)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMinValue = -1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1f' was evaluted to '{(sbyte)singleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(sbyte)1E-45f' was evaluted to '{(sbyte)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1f' was evaluted to '{(sbyte)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            float from = 254.99998f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254.99998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            float from = 254f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            float from = 255.00002f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255.00002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            float from = 256f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMinValue = -1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1.0f' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1.0f' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            float from = 254.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            float from = 256.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32768.004f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32767.998f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32767f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32766.998f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32766f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32767.002f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767.002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32768f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            float from = -32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32766.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65535.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65534.996f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534.996f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65534f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65535.004f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65536f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65534.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            float from = 65536.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSByteOverflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2.1474836E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2.1474836E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2147483646.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4.294967E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4.294967E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToSByteOverflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToSByteOverflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToSByteOverflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSByteOverflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0.0f' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToByteIsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(byte)-0f' was evaluted to '{(byte)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToByteIsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)floatZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0f' was evaluted to '{(byte)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToByteOverflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToByteOverflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToByteOverflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToByteOverflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            float from = -128.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128.0f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127.0f' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            float from = -128.00002f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128.00002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            float from = -129f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            float from = -127.99999f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127.99999f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            float from = -127f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126.99999f' was evaluted to '{(byte)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126f' was evaluted to '{(byte)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127.00001f' was evaluted to '{(byte)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128f' was evaluted to '{(byte)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            float from = -129.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            float from = -127.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126.0f' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128.0f' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255.0f' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(byte)-1E-45f' was evaluted to '{(byte)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            float from = -1f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(byte)1E-45f' was evaluted to '{(byte)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1f' was evaluted to '{(byte)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254.99998f' was evaluted to '{(byte)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254f' was evaluted to '{(byte)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255.00002f' was evaluted to '{(byte)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            float from = 256f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            float from = -1.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1.0f' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254.0f' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            float from = 256.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToByteOverflows()
+        {
+            float from = -32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            float from = -32768.004f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            float from = -32767.998f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            float from = -32767f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32766.998f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32766f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32767.002f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767.002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32768f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            float from = -32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32766.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            float from = 32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65535.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65534.996f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534.996f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65534f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65535.004f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65536f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65534.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            float from = 65536.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToByteOverflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2.1474836E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2.1474836E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2147483646.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            float from = 2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4.294967E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4.294967E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToByteOverflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToByteOverflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToByteOverflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToByteOverflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToByteOverflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToByteOverflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0.0f' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToInt16IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(short)-0f' was evaluted to '{(short)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToInt16IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)floatZero) != 0)
+            {
+                Console.WriteLine($"'(short)0f' was evaluted to '{(short)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToInt16Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToInt16Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToInt16Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToInt16Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float sByteMinValue = -128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128.0f' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127.0f' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMinValue = -128.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128.00002f' was evaluted to '{(short)singleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMinValue = -129f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129f' was evaluted to '{(short)singleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMinValue = -127.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127.99999f' was evaluted to '{(short)singleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMinValue = -127f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127f' was evaluted to '{(short)singleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126.99999f' was evaluted to '{(short)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126f' was evaluted to '{(short)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127.00001f' was evaluted to '{(short)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128f' was evaluted to '{(short)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMinValue = -129.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129.0f' was evaluted to '{(short)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMinValue = -127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127.0f' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126.0f' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128.0f' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255.0f' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(short)-1E-45f' was evaluted to '{(short)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMinValue = -1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1f' was evaluted to '{(short)singleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(short)1E-45f' was evaluted to '{(short)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1f' was evaluted to '{(short)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254.99998f' was evaluted to '{(short)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254f' was evaluted to '{(short)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255.00002f' was evaluted to '{(short)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256f' was evaluted to '{(short)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMinValue = -1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1.0f' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1.0f' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254.0f' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256.0f' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            float int16MinValue = -32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768.0f' was evaluted to '{(short)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767.0f' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MinValue = -32768.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768.004f' was evaluted to '{(short)singleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MinValue = -32767.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767.998f' was evaluted to '{(short)singleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MinValue = -32767f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767f' was evaluted to '{(short)singleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766.998f' was evaluted to '{(short)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766f' was evaluted to '{(short)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767.002f' was evaluted to '{(short)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 32768f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MinValue = -32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767.0f' was evaluted to '{(short)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766.0f' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65535.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65534.996f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534.996f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65534f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65535.004f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65536f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65534.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            float from = 65536.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt16Overflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2.1474836E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2.1474836E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2147483646.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4.294967E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4.294967E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt16Overflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToInt16Overflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt16Overflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt16Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0.0f' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToUInt16IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)-0f' was evaluted to '{(ushort)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToUInt16IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)floatZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0f' was evaluted to '{(ushort)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToUInt16Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToUInt16Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToUInt16Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToUInt16Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -128.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128.0f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127.0f' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -128.00002f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128.00002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -129f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -127.99999f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127.99999f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -127f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126.99999f' was evaluted to '{(ushort)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126f' was evaluted to '{(ushort)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127.00001f' was evaluted to '{(ushort)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128f' was evaluted to '{(ushort)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -129.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            float from = -127.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126.0f' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128.0f' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255.0f' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ushort)-1E-45f' was evaluted to '{(ushort)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            float from = -1f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ushort)1E-45f' was evaluted to '{(ushort)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1f' was evaluted to '{(ushort)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254.99998f' was evaluted to '{(ushort)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254f' was evaluted to '{(ushort)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255.00002f' was evaluted to '{(ushort)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256f' was evaluted to '{(ushort)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            float from = -1.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1.0f' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254.0f' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256.0f' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767.0f' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32768.004f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32767.998f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32767f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766.998f' was evaluted to '{(ushort)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766f' was evaluted to '{(ushort)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767.002f' was evaluted to '{(ushort)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MaxValue = 32768f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768f' was evaluted to '{(ushort)singleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            float from = -32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766.0f' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MaxValue = 32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768.0f' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float uInt16MaxValue = 65535.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535.0f' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt16MaxValue = 65534.996f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534.996f' was evaluted to '{(ushort)singleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderUInt16MaxValue = 65534f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534f' was evaluted to '{(ushort)singleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt16MaxValue = 65535.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)singleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535.004f' was evaluted to '{(ushort)singleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            float from = 65536f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt16MaxValue = 65534.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534.0f' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            float from = 65536.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt16Overflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2.1474836E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2.1474836E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2147483646.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4.294967E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4.294967E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt16Overflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt16Overflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt16Overflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt16Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0.0f' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToInt32IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(int)-0f' was evaluted to '{(int)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToInt32IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)floatZero) != 0)
+            {
+                Console.WriteLine($"'(int)0f' was evaluted to '{(int)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToInt32Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToInt32Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToInt32Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToInt32Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float sByteMinValue = -128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128.0f' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127.0f' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMinValue = -128.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128.00002f' was evaluted to '{(int)singleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMinValue = -129f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129f' was evaluted to '{(int)singleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMinValue = -127.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127.99999f' was evaluted to '{(int)singleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMinValue = -127f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127f' was evaluted to '{(int)singleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126.99999f' was evaluted to '{(int)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126f' was evaluted to '{(int)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127.00001f' was evaluted to '{(int)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128f' was evaluted to '{(int)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMinValue = -129.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129.0f' was evaluted to '{(int)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMinValue = -127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127.0f' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126.0f' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128.0f' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255.0f' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(int)-1E-45f' was evaluted to '{(int)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMinValue = -1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1f' was evaluted to '{(int)singleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(int)1E-45f' was evaluted to '{(int)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1f' was evaluted to '{(int)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254.99998f' was evaluted to '{(int)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254f' was evaluted to '{(int)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255.00002f' was evaluted to '{(int)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256f' was evaluted to '{(int)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMinValue = -1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1.0f' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1.0f' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254.0f' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256.0f' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float int16MinValue = -32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768.0f' was evaluted to '{(int)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767.0f' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MinValue = -32768.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768.004f' was evaluted to '{(int)singleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MinValue = -32769f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769f' was evaluted to '{(int)singleOneFullDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MinValue = -32767.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767.998f' was evaluted to '{(int)singleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MinValue = -32767f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767f' was evaluted to '{(int)singleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766.998f' was evaluted to '{(int)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766f' was evaluted to '{(int)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767.002f' was evaluted to '{(int)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MaxValue = 32768f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768f' was evaluted to '{(int)singleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MinValue = -32769.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769.0f' was evaluted to '{(int)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MinValue = -32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767.0f' was evaluted to '{(int)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766.0f' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MaxValue = 32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768.0f' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float uInt16MaxValue = 65535.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535.0f' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt16MaxValue = 65534.996f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534.996f' was evaluted to '{(int)singleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderUInt16MaxValue = 65534f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534f' was evaluted to '{(int)singleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt16MaxValue = 65535.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535.004f' was evaluted to '{(int)singleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt16MaxValue = 65536f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536f' was evaluted to '{(int)singleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt16MaxValue = 65534.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534.0f' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt16MaxValue = 65536.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536.0f' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float int32MinValue = -2147483648.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483648.0f' was evaluted to '{(int)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToInt32Overflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt32MinValue = -2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneIncrementAboveInt32MinValue) != -2147483520)
+            {
+                Console.WriteLine($"'(int)-2.1474835E+09f' was evaluted to '{(int)singleOneIncrementAboveInt32MinValue}'. Expected: '-2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt32MaxValue = 2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)singleOneDecrementUnderInt32MaxValue) != 2147483520)
+            {
+                Console.WriteLine($"'(int)2.1474835E+09f' was evaluted to '{(int)singleOneDecrementUnderInt32MaxValue}'. Expected: '2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 2.1474836E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2.1474836E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt32MinValue = -2147483649.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483649.0f' was evaluted to '{(int)integerOneDecrementUnderInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt32MinValue = -2147483647.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483647.0f' was evaluted to '{(int)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 2147483646.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483646.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4.294967E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4.294967E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt32Overflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToInt32Overflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt32Overflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt32Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0.0f' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToUInt32IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(uint)-0f' was evaluted to '{(uint)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToUInt32IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)floatZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0f' was evaluted to '{(uint)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToUInt32Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToUInt32Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToUInt32Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToUInt32Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -128.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128.0f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127.0f' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -128.00002f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128.00002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -129f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -127.99999f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127.99999f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -127f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126.99999f' was evaluted to '{(uint)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126f' was evaluted to '{(uint)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127.00001f' was evaluted to '{(uint)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128f' was evaluted to '{(uint)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -129.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            float from = -127.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126.0f' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128.0f' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255.0f' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(uint)-1E-45f' was evaluted to '{(uint)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            float from = -1f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(uint)1E-45f' was evaluted to '{(uint)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1f' was evaluted to '{(uint)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254.99998f' was evaluted to '{(uint)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254f' was evaluted to '{(uint)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255.00002f' was evaluted to '{(uint)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256f' was evaluted to '{(uint)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            float from = -1.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1.0f' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254.0f' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256.0f' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767.0f' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32768.004f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32767.998f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32767f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766.998f' was evaluted to '{(uint)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766f' was evaluted to '{(uint)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767.002f' was evaluted to '{(uint)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MaxValue = 32768f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768f' was evaluted to '{(uint)singleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            float from = -32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766.0f' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MaxValue = 32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768.0f' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float uInt16MaxValue = 65535.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535.0f' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt16MaxValue = 65534.996f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534.996f' was evaluted to '{(uint)singleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderUInt16MaxValue = 65534f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534f' was evaluted to '{(uint)singleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt16MaxValue = 65535.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535.004f' was evaluted to '{(uint)singleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt16MaxValue = 65536f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536f' was evaluted to '{(uint)singleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt16MaxValue = 65534.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534.0f' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt16MaxValue = 65536.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536.0f' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt32Overflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float int32MaxValue = 2147483647.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483647.0f' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt32MaxValue = 2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderInt32MaxValue) != 2147483520)
+            {
+                Console.WriteLine($"'(uint)2.1474835E+09f' was evaluted to '{(uint)singleOneDecrementUnderInt32MaxValue}'. Expected: '2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt32MaxValue = 2.147484E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneIncrementAboveInt32MaxValue) != 2147483904)
+            {
+                Console.WriteLine($"'(uint)2.147484E+09f' was evaluted to '{(uint)singleOneIncrementAboveInt32MaxValue}'. Expected: '2147483904'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt32MaxValue = 2.1474836E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2.1474836E+09f' was evaluted to '{(uint)singleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt32MaxValue = 2147483646.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483646.0f' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt32MaxValue = 2147483648.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648.0f' was evaluted to '{(uint)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt32Overflows()
+        {
+            float from = 4294967295.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967295.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt32MaxValue = 4.294967E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)singleOneDecrementUnderUInt32MaxValue) != 4294967040)
+            {
+                Console.WriteLine($"'(uint)4.294967E+09f' was evaluted to '{(uint)singleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967040'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            float from = 4.294968E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4.294968E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            float from = 4.2949673E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4.2949673E+09f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32Overflows()
+        {
+            float from = 4294967294.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967294.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            float from = 4294967296.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967296.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt32Overflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt32Overflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt32Overflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt32Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0.0f' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToInt64IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(long)-0f' was evaluted to '{(long)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToInt64IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)floatZero) != 0)
+            {
+                Console.WriteLine($"'(long)0f' was evaluted to '{(long)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToInt64Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToInt64Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToInt64Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToInt64Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float sByteMinValue = -128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128.0f' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127.0f' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMinValue = -128.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderSByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128.00002f' was evaluted to '{(long)singleOneDecrementUnderSByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMinValue = -129f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129f' was evaluted to '{(long)singleOneFullDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMinValue = -127.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127.99999f' was evaluted to '{(long)singleOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMinValue = -127f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127f' was evaluted to '{(long)singleOneFullIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126.99999f' was evaluted to '{(long)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126f' was evaluted to '{(long)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127.00001f' was evaluted to '{(long)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128f' was evaluted to '{(long)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMinValue = -129.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129.0f' was evaluted to '{(long)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMinValue = -127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127.0f' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126.0f' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128.0f' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255.0f' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(long)-1E-45f' was evaluted to '{(long)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMinValue = -1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1f' was evaluted to '{(long)singleOneFullDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(long)1E-45f' was evaluted to '{(long)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1f' was evaluted to '{(long)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254.99998f' was evaluted to '{(long)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254f' was evaluted to '{(long)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255.00002f' was evaluted to '{(long)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256f' was evaluted to '{(long)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMinValue = -1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1.0f' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1.0f' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254.0f' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256.0f' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float int16MinValue = -32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768.0f' was evaluted to '{(long)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767.0f' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MinValue = -32768.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderInt16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768.004f' was evaluted to '{(long)singleOneDecrementUnderInt16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MinValue = -32769f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769f' was evaluted to '{(long)singleOneFullDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MinValue = -32767.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767.998f' was evaluted to '{(long)singleOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MinValue = -32767f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767f' was evaluted to '{(long)singleOneFullIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766.998f' was evaluted to '{(long)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766f' was evaluted to '{(long)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767.002f' was evaluted to '{(long)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MaxValue = 32768f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768f' was evaluted to '{(long)singleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MinValue = -32769.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769.0f' was evaluted to '{(long)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MinValue = -32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767.0f' was evaluted to '{(long)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766.0f' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MaxValue = 32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768.0f' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float uInt16MaxValue = 65535.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535.0f' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt16MaxValue = 65534.996f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534.996f' was evaluted to '{(long)singleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderUInt16MaxValue = 65534f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534f' was evaluted to '{(long)singleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt16MaxValue = 65535.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535.004f' was evaluted to '{(long)singleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt16MaxValue = 65536f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536f' was evaluted to '{(long)singleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt16MaxValue = 65534.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534.0f' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt16MaxValue = 65536.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536.0f' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float int32MinValue = -2147483648.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483648.0f' was evaluted to '{(long)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float int32MaxValue = 2147483647.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483647.0f' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt32MinValue = -2.147484E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderInt32MinValue) != -2147483904)
+            {
+                Console.WriteLine($"'(long)-2.147484E+09f' was evaluted to '{(long)singleOneDecrementUnderInt32MinValue}'. Expected: '-2147483904'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt32MinValue = -2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveInt32MinValue) != -2147483520)
+            {
+                Console.WriteLine($"'(long)-2.1474835E+09f' was evaluted to '{(long)singleOneIncrementAboveInt32MinValue}'. Expected: '-2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt32MaxValue = 2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderInt32MaxValue) != 2147483520)
+            {
+                Console.WriteLine($"'(long)2.1474835E+09f' was evaluted to '{(long)singleOneDecrementUnderInt32MaxValue}'. Expected: '2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt32MaxValue = 2.147484E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveInt32MaxValue) != 2147483904)
+            {
+                Console.WriteLine($"'(long)2.147484E+09f' was evaluted to '{(long)singleOneIncrementAboveInt32MaxValue}'. Expected: '2147483904'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt32MaxValue = 2.1474836E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2.1474836E+09f' was evaluted to '{(long)singleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt32MinValue = -2147483649.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483649.0f' was evaluted to '{(long)integerOneDecrementUnderInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt32MinValue = -2147483647.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483647.0f' was evaluted to '{(long)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt32MaxValue = 2147483646.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483646.0f' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt32MaxValue = 2147483648.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648.0f' was evaluted to '{(long)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float uInt32MaxValue = 4294967295.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967295.0f' was evaluted to '{(long)uInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt32MaxValue = 4.294967E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderUInt32MaxValue) != 4294967040)
+            {
+                Console.WriteLine($"'(long)4.294967E+09f' was evaluted to '{(long)singleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967040'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt32MaxValue = 4.294968E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveUInt32MaxValue) != 4294967808)
+            {
+                Console.WriteLine($"'(long)4.294968E+09f' was evaluted to '{(long)singleOneIncrementAboveUInt32MaxValue}'. Expected: '4294967808'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt32MaxValue = 4.2949673E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneFullIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4.2949673E+09f' was evaluted to '{(long)singleOneFullIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt32MaxValue = 4294967294.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967294.0f' was evaluted to '{(long)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt32MaxValue = 4294967296.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967296.0f' was evaluted to '{(long)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float int64MinValue = -9223372036854775808.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int64MinValue) != -9223372036854775808)
+            {
+                Console.WriteLine($"'(long)-9223372036854775808.0f' was evaluted to '{(long)int64MinValue}'. Expected: '-9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt64MinValue = -9.2233715E+18f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneIncrementAboveInt64MinValue) != -9223371487098961920)
+            {
+                Console.WriteLine($"'(long)-9.2233715E+18f' was evaluted to '{(long)singleOneIncrementAboveInt64MinValue}'. Expected: '-9223371487098961920'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt64MaxValue = 9.2233715E+18f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)singleOneDecrementUnderInt64MaxValue) != 9223371487098961920)
+            {
+                Console.WriteLine($"'(long)9.2233715E+18f' was evaluted to '{(long)singleOneDecrementUnderInt64MaxValue}'. Expected: '9223371487098961920'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 9.223373E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9.223373E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 9.223372E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9.223372E+18f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt64MinValue = -9223372036854775807.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt64MinValue) != -9223372036854775808)
+            {
+                Console.WriteLine($"'(long)-9223372036854775807.0f' was evaluted to '{(long)integerOneIncrementAboveInt64MinValue}'. Expected: '-9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 9223372036854775806.0f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775806.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 1.8446743E+19f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)1.8446743E+19f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToInt64Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingSingleToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            float integerZero = 0.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0.0f' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatMinusZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatMinusZeroCastToUInt64IsFoldedCorrectly()
+        {
+            float floatMinusZero = -0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)floatMinusZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)-0f' was evaluted to '{(ulong)floatMinusZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatZeroCastToUInt64IsFoldedCorrectly()
+        {
+            float floatZero = 0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)floatZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0f' was evaluted to '{(ulong)floatZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmFloatHalfOfMaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMaxValueCastToUInt64Overflows()
+        {
+            float from = 1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmFloatHalfOfMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmFloatHalfOfMinValueCastToUInt64Overflows()
+        {
+            float from = -1.7014117E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1.7014117E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMinValueCastToUInt64Overflows()
+        {
+            float from = -3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSingleMaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleMaxValueCastToUInt64Overflows()
+        {
+            float from = 3.4028235E+38f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)3.4028235E+38f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -128.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128.0f)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float sByteMaxValue = 127.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127.0f' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -128.00002f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128.00002f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -129f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -127.99999f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127.99999f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -127f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderSByteMaxValue = 126.99999f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126.99999f' was evaluted to '{(ulong)singleOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderSByteMaxValue = 126f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126f' was evaluted to '{(ulong)singleOneFullDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveSByteMaxValue = 127.00001f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveSByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127.00001f' was evaluted to '{(ulong)singleOneIncrementAboveSByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveSByteMaxValue = 128f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128f' was evaluted to '{(ulong)singleOneFullIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -129.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            float from = -127.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderSByteMaxValue = 126.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126.0f' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveSByteMaxValue = 128.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128.0f' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float byteMaxValue = 255.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255.0f' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMinValue = -1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ulong)-1E-45f' was evaluted to '{(ulong)singleOneDecrementUnderByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            float from = -1f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMinValue = 1E-45f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveByteMinValue) != 0)
+            {
+                Console.WriteLine($"'(ulong)1E-45f' was evaluted to '{(ulong)singleOneIncrementAboveByteMinValue}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMinValue = 1f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1f' was evaluted to '{(ulong)singleOneFullIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderByteMaxValue = 254.99998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254.99998f' was evaluted to '{(ulong)singleOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderByteMaxValue = 254f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254f' was evaluted to '{(ulong)singleOneFullDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveByteMaxValue = 255.00002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveByteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255.00002f' was evaluted to '{(ulong)singleOneIncrementAboveByteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveByteMaxValue = 256f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256f' was evaluted to '{(ulong)singleOneFullIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            float from = -1.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMinValue = 1.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1.0f' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderByteMaxValue = 254.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254.0f' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveByteMaxValue = 256.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256.0f' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32768.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float int16MaxValue = 32767.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767.0f' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32768.004f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768.004f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32769f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32767.998f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767.998f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32767f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt16MaxValue = 32766.998f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766.998f' was evaluted to '{(ulong)singleOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderInt16MaxValue = 32766f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766f' was evaluted to '{(ulong)singleOneFullDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt16MaxValue = 32767.002f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveInt16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767.002f' was evaluted to '{(ulong)singleOneIncrementAboveInt16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt16MaxValue = 32768f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768f' was evaluted to '{(ulong)singleOneFullIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32769.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            float from = -32767.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt16MaxValue = 32766.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766.0f' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt16MaxValue = 32768.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768.0f' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float uInt16MaxValue = 65535.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535.0f' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt16MaxValue = 65534.996f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534.996f' was evaluted to '{(ulong)singleOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullDecrementUnderUInt16MaxValue = 65534f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534f' was evaluted to '{(ulong)singleOneFullDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt16MaxValue = 65535.004f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveUInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535.004f' was evaluted to '{(ulong)singleOneIncrementAboveUInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt16MaxValue = 65536f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536f' was evaluted to '{(ulong)singleOneFullIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt16MaxValue = 65534.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534.0f' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt16MaxValue = 65536.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536.0f' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt64Overflows()
+        {
+            float from = -2147483648.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483648.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float int32MaxValue = 2147483647.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483647.0f' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            float from = -2.147484E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2.147484E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            float from = -2.1474835E+09f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2.1474835E+09f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt32MaxValue = 2.1474835E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderInt32MaxValue) != 2147483520)
+            {
+                Console.WriteLine($"'(ulong)2.1474835E+09f' was evaluted to '{(ulong)singleOneDecrementUnderInt32MaxValue}'. Expected: '2147483520'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt32MaxValue = 2.147484E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveInt32MaxValue) != 2147483904)
+            {
+                Console.WriteLine($"'(ulong)2.147484E+09f' was evaluted to '{(ulong)singleOneIncrementAboveInt32MaxValue}'. Expected: '2147483904'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt32MaxValue = 2.1474836E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2.1474836E+09f' was evaluted to '{(ulong)singleOneFullIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            float from = -2147483649.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483649.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            float from = -2147483647.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt32MaxValue = 2147483646.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483646.0f' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt32MaxValue = 2147483648.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648.0f' was evaluted to '{(ulong)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float uInt32MaxValue = 4294967295.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967295.0f' was evaluted to '{(ulong)uInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt32MaxValue = 4.294967E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderUInt32MaxValue) != 4294967040)
+            {
+                Console.WriteLine($"'(ulong)4.294967E+09f' was evaluted to '{(ulong)singleOneDecrementUnderUInt32MaxValue}'. Expected: '4294967040'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveUInt32MaxValue = 4.294968E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveUInt32MaxValue) != 4294967808)
+            {
+                Console.WriteLine($"'(ulong)4.294968E+09f' was evaluted to '{(ulong)singleOneIncrementAboveUInt32MaxValue}'. Expected: '4294967808'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveUInt32MaxValue = 4.2949673E+09f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4.2949673E+09f' was evaluted to '{(ulong)singleOneFullIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderUInt32MaxValue = 4294967294.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967294.0f' was evaluted to '{(ulong)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveUInt32MaxValue = 4294967296.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967296.0f' was evaluted to '{(ulong)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt64Overflows()
+        {
+            float from = -9223372036854775808.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775808.0f)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float int64MaxValue = 9223372036854775807.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775807.0f' was evaluted to '{(ulong)int64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MinValueCastToUInt64Overflows()
+        {
+            float from = -9.2233715E+18f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9.2233715E+18f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderInt64MaxValue = 9.2233715E+18f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderInt64MaxValue) != 9223371487098961920)
+            {
+                Console.WriteLine($"'(ulong)9.2233715E+18f' was evaluted to '{(ulong)singleOneDecrementUnderInt64MaxValue}'. Expected: '9223371487098961920'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneIncrementAboveInt64MaxValue = 9.223373E+18f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneIncrementAboveInt64MaxValue) != 9223373136366403584)
+            {
+                Console.WriteLine($"'(ulong)9.223373E+18f' was evaluted to '{(ulong)singleOneIncrementAboveInt64MaxValue}'. Expected: '9223373136366403584'.");
+                _counter++;
+            }
+        }
+        ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneFullIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneFullIncrementAboveInt64MaxValue = 9.223372E+18f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneFullIncrementAboveInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9.223372E+18f' was evaluted to '{(ulong)singleOneFullIncrementAboveInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToUInt64Overflows()
+        {
+            float from = -9223372036854775807.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775807.0f)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneDecrementUnderInt64MaxValue = 9223372036854775806.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775806.0f' was evaluted to '{(ulong)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float integerOneIncrementAboveInt64MaxValue = 9223372036854775808.0f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775808.0f' was evaluted to '{(ulong)integerOneIncrementAboveInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64MaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt64Overflows()
+        {
+            float from = 18446744073709551615.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)18446744073709551615.0f)' did not throw OverflowException.");
+        }
+        ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSingleOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            float singleOneDecrementUnderUInt64MaxValue = 1.8446743E+19f;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)singleOneDecrementUnderUInt64MaxValue) != 18446742974197923840)
+            {
+                Console.WriteLine($"'(ulong)1.8446743E+19f' was evaluted to '{(ulong)singleOneDecrementUnderUInt64MaxValue}'. Expected: '18446742974197923840'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64Overflows()
+        {
+            float from = 18446744073709551614.0f;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)18446744073709551614.0f)' did not throw OverflowException.");
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_int.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_int.cs
@@ -1,0 +1,6568 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingInt32ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMinValue) != -128f)
+            {
+                Console.WriteLine($"'(float)-128' was evaluted to '{(float)sByteMinValue}'. Expected: '-128f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMinValue) != -129f)
+            {
+                Console.WriteLine($"'(float)-129' was evaluted to '{(float)integerOneDecrementUnderSByteMinValue}'. Expected: '-129f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMinValue) != -127f)
+            {
+                Console.WriteLine($"'(float)-127' was evaluted to '{(float)integerOneIncrementAboveSByteMinValue}'. Expected: '-127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMinValue) != -1f)
+            {
+                Console.WriteLine($"'(float)-1' was evaluted to '{(float)integerOneDecrementUnderByteMinValue}'. Expected: '-1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            int int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MinValue) != -32768f)
+            {
+                Console.WriteLine($"'(float)-32768' was evaluted to '{(float)int16MinValue}'. Expected: '-32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MinValue) != -32769f)
+            {
+                Console.WriteLine($"'(float)-32769' was evaluted to '{(float)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MinValue) != -32767f)
+            {
+                Console.WriteLine($"'(float)-32767' was evaluted to '{(float)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MaxValue) != 32768f)
+            {
+                Console.WriteLine($"'(float)32768' was evaluted to '{(float)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt16MaxValue) != 65535f)
+            {
+                Console.WriteLine($"'(float)65535' was evaluted to '{(float)uInt16MaxValue}'. Expected: '65535f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt16MaxValue) != 65534f)
+            {
+                Console.WriteLine($"'(float)65534' was evaluted to '{(float)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt16MaxValue) != 65536f)
+            {
+                Console.WriteLine($"'(float)65536' was evaluted to '{(float)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSingleIsFoldedCorrectly()
+        {
+            int int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MinValue) != -2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)-2147483648' was evaluted to '{(float)int32MinValue}'. Expected: '-2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483647' was evaluted to '{(float)int32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt32MinValue) != -2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)-2147483647' was evaluted to '{(float)integerOneIncrementAboveInt32MinValue}'. Expected: '-2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483646' was evaluted to '{(float)integerOneDecrementUnderInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt32ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMinValue) != -128d)
+            {
+                Console.WriteLine($"'(double)-128' was evaluted to '{(double)sByteMinValue}'. Expected: '-128d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMinValue) != -129d)
+            {
+                Console.WriteLine($"'(double)-129' was evaluted to '{(double)integerOneDecrementUnderSByteMinValue}'. Expected: '-129d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMinValue) != -127d)
+            {
+                Console.WriteLine($"'(double)-127' was evaluted to '{(double)integerOneIncrementAboveSByteMinValue}'. Expected: '-127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMinValue) != -1d)
+            {
+                Console.WriteLine($"'(double)-1' was evaluted to '{(double)integerOneDecrementUnderByteMinValue}'. Expected: '-1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MinValue) != -32768d)
+            {
+                Console.WriteLine($"'(double)-32768' was evaluted to '{(double)int16MinValue}'. Expected: '-32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MinValue) != -32769d)
+            {
+                Console.WriteLine($"'(double)-32769' was evaluted to '{(double)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MinValue) != -32767d)
+            {
+                Console.WriteLine($"'(double)-32767' was evaluted to '{(double)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MaxValue) != 32768d)
+            {
+                Console.WriteLine($"'(double)32768' was evaluted to '{(double)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt16MaxValue) != 65535d)
+            {
+                Console.WriteLine($"'(double)65535' was evaluted to '{(double)uInt16MaxValue}'. Expected: '65535d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt16MaxValue) != 65534d)
+            {
+                Console.WriteLine($"'(double)65534' was evaluted to '{(double)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt16MaxValue) != 65536d)
+            {
+                Console.WriteLine($"'(double)65536' was evaluted to '{(double)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MinValue) != -2147483648d)
+            {
+                Console.WriteLine($"'(double)-2147483648' was evaluted to '{(double)int32MinValue}'. Expected: '-2147483648d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MaxValue) != 2147483647d)
+            {
+                Console.WriteLine($"'(double)2147483647' was evaluted to '{(double)int32MaxValue}'. Expected: '2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt32MinValue) != -2147483647d)
+            {
+                Console.WriteLine($"'(double)-2147483647' was evaluted to '{(double)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt32MaxValue) != 2147483646d)
+            {
+                Console.WriteLine($"'(double)2147483646' was evaluted to '{(double)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt32ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            int from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            int from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            int from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            int from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            int from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSByteOverflows()
+        {
+            int from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            int from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            int from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSByteOverflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            int from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            int from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt32ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            int from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            int from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            int from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            int from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            int from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToByteOverflows()
+        {
+            int from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            int from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            int from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            int from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            int from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            int from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            int from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            int from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToByteOverflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            int from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            int from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt32ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129' was evaluted to '{(short)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            int int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768' was evaluted to '{(short)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767' was evaluted to '{(short)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            int from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            int from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            int from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            int from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt16Overflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            int from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            int from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt32ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            int from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            int from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            int from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            int from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt16Overflows()
+        {
+            int from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            int from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            int from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt16Overflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            int from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            int from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt32ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129' was evaluted to '{(int)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            int int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768' was evaluted to '{(int)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769' was evaluted to '{(int)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767' was evaluted to '{(int)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            int int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483648' was evaluted to '{(int)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647' was evaluted to '{(int)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(int)-2147483647' was evaluted to '{(int)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646' was evaluted to '{(int)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt32ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            int from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            int from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            int from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            int from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt32Overflows()
+        {
+            int from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            int from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt32Overflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt32ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            int sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129' was evaluted to '{(long)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            int int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768' was evaluted to '{(long)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769' was evaluted to '{(long)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767' was evaluted to '{(long)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            int int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483648' was evaluted to '{(long)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(long)-2147483647' was evaluted to '{(long)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt32ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            int integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            int from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            int from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            int from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            int from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt64Overflows()
+        {
+            int from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            int from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            int from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt64Overflows()
+        {
+            int from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32OneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            int from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            int integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt32ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MaxValue) != 32768f)
+            {
+                Console.WriteLine($"'(float)32768' was evaluted to '{(float)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt16MaxValue) != 65535f)
+            {
+                Console.WriteLine($"'(float)65535' was evaluted to '{(float)uInt16MaxValue}'. Expected: '65535f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt16MaxValue) != 65534f)
+            {
+                Console.WriteLine($"'(float)65534' was evaluted to '{(float)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt16MaxValue) != 65536f)
+            {
+                Console.WriteLine($"'(float)65536' was evaluted to '{(float)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483647' was evaluted to '{(float)int32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483646' was evaluted to '{(float)integerOneDecrementUnderInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483648' was evaluted to '{(float)integerOneIncrementAboveInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967295' was evaluted to '{(float)uInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967294' was evaluted to '{(float)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt32ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MaxValue) != 32768d)
+            {
+                Console.WriteLine($"'(double)32768' was evaluted to '{(double)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt16MaxValue) != 65535d)
+            {
+                Console.WriteLine($"'(double)65535' was evaluted to '{(double)uInt16MaxValue}'. Expected: '65535d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt16MaxValue) != 65534d)
+            {
+                Console.WriteLine($"'(double)65534' was evaluted to '{(double)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt16MaxValue) != 65536d)
+            {
+                Console.WriteLine($"'(double)65536' was evaluted to '{(double)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MaxValue) != 2147483647d)
+            {
+                Console.WriteLine($"'(double)2147483647' was evaluted to '{(double)int32MaxValue}'. Expected: '2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt32MaxValue) != 2147483646d)
+            {
+                Console.WriteLine($"'(double)2147483646' was evaluted to '{(double)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt32MaxValue) != 2147483648d)
+            {
+                Console.WriteLine($"'(double)2147483648' was evaluted to '{(double)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt32MaxValue) != 4294967295d)
+            {
+                Console.WriteLine($"'(double)4294967295' was evaluted to '{(double)uInt32MaxValue}'. Expected: '4294967295d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt32MaxValue) != 4294967294d)
+            {
+                Console.WriteLine($"'(double)4294967294' was evaluted to '{(double)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt32ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            uint from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            uint from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            uint from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            uint from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            uint from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            uint from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            uint from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            uint from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSByteOverflows()
+        {
+            uint from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            uint from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt32ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            uint from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            uint from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            uint from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            uint from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            uint from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToByteOverflows()
+        {
+            uint from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            uint from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt32ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            uint from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            uint from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            uint from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            uint from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            uint from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            uint from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            uint from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt16Overflows()
+        {
+            uint from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            uint from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt32ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            uint from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            uint from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            uint from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            uint from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt16Overflows()
+        {
+            uint from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            uint from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt32ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647' was evaluted to '{(int)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646' was evaluted to '{(int)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32OneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            uint from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt32Overflows()
+        {
+            uint from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32OneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            uint from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt32ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648' was evaluted to '{(uint)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(uint)4294967295' was evaluted to '{(uint)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294' was evaluted to '{(uint)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt32ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648' was evaluted to '{(long)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(long)4294967295' was evaluted to '{(long)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294' was evaluted to '{(long)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt32ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648' was evaluted to '{(ulong)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(ulong)4294967295' was evaluted to '{(ulong)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            uint integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294' was evaluted to '{(ulong)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_long.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_long.cs
@@ -1,0 +1,8725 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingInt64ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMinValue) != -128f)
+            {
+                Console.WriteLine($"'(float)-128' was evaluted to '{(float)sByteMinValue}'. Expected: '-128f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMinValue) != -129f)
+            {
+                Console.WriteLine($"'(float)-129' was evaluted to '{(float)integerOneDecrementUnderSByteMinValue}'. Expected: '-129f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMinValue) != -127f)
+            {
+                Console.WriteLine($"'(float)-127' was evaluted to '{(float)integerOneIncrementAboveSByteMinValue}'. Expected: '-127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMinValue) != -1f)
+            {
+                Console.WriteLine($"'(float)-1' was evaluted to '{(float)integerOneDecrementUnderByteMinValue}'. Expected: '-1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MinValue) != -32768f)
+            {
+                Console.WriteLine($"'(float)-32768' was evaluted to '{(float)int16MinValue}'. Expected: '-32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MinValue) != -32769f)
+            {
+                Console.WriteLine($"'(float)-32769' was evaluted to '{(float)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MinValue) != -32767f)
+            {
+                Console.WriteLine($"'(float)-32767' was evaluted to '{(float)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MaxValue) != 32768f)
+            {
+                Console.WriteLine($"'(float)32768' was evaluted to '{(float)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt16MaxValue) != 65535f)
+            {
+                Console.WriteLine($"'(float)65535' was evaluted to '{(float)uInt16MaxValue}'. Expected: '65535f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt16MaxValue) != 65534f)
+            {
+                Console.WriteLine($"'(float)65534' was evaluted to '{(float)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt16MaxValue) != 65536f)
+            {
+                Console.WriteLine($"'(float)65536' was evaluted to '{(float)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MinValue) != -2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)-2147483648' was evaluted to '{(float)int32MinValue}'. Expected: '-2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483647' was evaluted to '{(float)int32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MinValue = -2147483649;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt32MinValue) != -2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)-2147483649' was evaluted to '{(float)integerOneDecrementUnderInt32MinValue}'. Expected: '-2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt32MinValue) != -2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)-2147483647' was evaluted to '{(float)integerOneIncrementAboveInt32MinValue}'. Expected: '-2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483646' was evaluted to '{(float)integerOneDecrementUnderInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483648' was evaluted to '{(float)integerOneIncrementAboveInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967295' was evaluted to '{(float)uInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967294' was evaluted to '{(float)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967296' was evaluted to '{(float)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long int64MinValue = -9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int64MinValue) != -9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)-9223372036854775808' was evaluted to '{(float)int64MinValue}'. Expected: '-9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int64MaxValue) != 9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)9223372036854775807' was evaluted to '{(float)int64MaxValue}'. Expected: '9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt64MinValue = -9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt64MinValue) != -9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)-9223372036854775807' was evaluted to '{(float)integerOneIncrementAboveInt64MinValue}'. Expected: '-9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt64MaxValue) != 9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)9223372036854775806' was evaluted to '{(float)integerOneDecrementUnderInt64MaxValue}'. Expected: '9.223372E+18f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt64ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMinValue) != -128d)
+            {
+                Console.WriteLine($"'(double)-128' was evaluted to '{(double)sByteMinValue}'. Expected: '-128d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMinValue) != -129d)
+            {
+                Console.WriteLine($"'(double)-129' was evaluted to '{(double)integerOneDecrementUnderSByteMinValue}'. Expected: '-129d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMinValue) != -127d)
+            {
+                Console.WriteLine($"'(double)-127' was evaluted to '{(double)integerOneIncrementAboveSByteMinValue}'. Expected: '-127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMinValue) != -1d)
+            {
+                Console.WriteLine($"'(double)-1' was evaluted to '{(double)integerOneDecrementUnderByteMinValue}'. Expected: '-1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MinValue) != -32768d)
+            {
+                Console.WriteLine($"'(double)-32768' was evaluted to '{(double)int16MinValue}'. Expected: '-32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MinValue) != -32769d)
+            {
+                Console.WriteLine($"'(double)-32769' was evaluted to '{(double)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MinValue) != -32767d)
+            {
+                Console.WriteLine($"'(double)-32767' was evaluted to '{(double)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MaxValue) != 32768d)
+            {
+                Console.WriteLine($"'(double)32768' was evaluted to '{(double)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt16MaxValue) != 65535d)
+            {
+                Console.WriteLine($"'(double)65535' was evaluted to '{(double)uInt16MaxValue}'. Expected: '65535d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt16MaxValue) != 65534d)
+            {
+                Console.WriteLine($"'(double)65534' was evaluted to '{(double)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt16MaxValue) != 65536d)
+            {
+                Console.WriteLine($"'(double)65536' was evaluted to '{(double)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MinValue) != -2147483648d)
+            {
+                Console.WriteLine($"'(double)-2147483648' was evaluted to '{(double)int32MinValue}'. Expected: '-2147483648d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MaxValue) != 2147483647d)
+            {
+                Console.WriteLine($"'(double)2147483647' was evaluted to '{(double)int32MaxValue}'. Expected: '2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MinValue = -2147483649;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt32MinValue) != -2147483649d)
+            {
+                Console.WriteLine($"'(double)-2147483649' was evaluted to '{(double)integerOneDecrementUnderInt32MinValue}'. Expected: '-2147483649d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt32MinValue) != -2147483647d)
+            {
+                Console.WriteLine($"'(double)-2147483647' was evaluted to '{(double)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt32MaxValue) != 2147483646d)
+            {
+                Console.WriteLine($"'(double)2147483646' was evaluted to '{(double)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt32MaxValue) != 2147483648d)
+            {
+                Console.WriteLine($"'(double)2147483648' was evaluted to '{(double)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt32MaxValue) != 4294967295d)
+            {
+                Console.WriteLine($"'(double)4294967295' was evaluted to '{(double)uInt32MaxValue}'. Expected: '4294967295d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt32MaxValue) != 4294967294d)
+            {
+                Console.WriteLine($"'(double)4294967294' was evaluted to '{(double)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt32MaxValue) != 4294967296d)
+            {
+                Console.WriteLine($"'(double)4294967296' was evaluted to '{(double)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int64MinValue = -9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int64MinValue) != -9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)-9223372036854775808' was evaluted to '{(double)int64MinValue}'. Expected: '-9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int64MaxValue) != 9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)9223372036854775807' was evaluted to '{(double)int64MaxValue}'. Expected: '9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt64MinValue = -9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt64MinValue) != -9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)-9223372036854775807' was evaluted to '{(double)integerOneIncrementAboveInt64MinValue}'. Expected: '-9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt64MaxValue) != 9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)9223372036854775806' was evaluted to '{(double)integerOneDecrementUnderInt64MaxValue}'. Expected: '9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt64ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            long from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            long from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            long from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            long from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            long from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSByteOverflows()
+        {
+            long from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToSByteOverflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            long from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            long from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToSByteOverflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToSByteOverflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToSByteOverflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToSByteOverflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSByteOverflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToSByteOverflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            long from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            long from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            long from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            long from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            long from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToByteOverflows()
+        {
+            long from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            long from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToByteOverflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            long from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            long from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            long from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            long from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            long from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            long from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToByteOverflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            long from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToByteOverflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToByteOverflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            long from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            long from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToByteOverflows()
+        {
+            long from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            long from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToByteOverflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToByteOverflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToByteOverflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129' was evaluted to '{(short)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            long int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768' was evaluted to '{(short)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToInt16Overflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-32769)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767' was evaluted to '{(short)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            long from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            long from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            long from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            long from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt16Overflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToInt16Overflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToInt16Overflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt16Overflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt16Overflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToInt16Overflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            long from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            long from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            long from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            long from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt16Overflows()
+        {
+            long from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt16Overflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            long from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            long from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt16Overflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt16Overflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt16Overflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt16Overflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt16Overflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt16Overflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129' was evaluted to '{(int)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            long int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768' was evaluted to '{(int)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(int)-32769' was evaluted to '{(int)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767' was evaluted to '{(int)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            long int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(int)-2147483648' was evaluted to '{(int)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647' was evaluted to '{(int)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToInt32Overflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(int)-2147483647' was evaluted to '{(int)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646' was evaluted to '{(int)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            long from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt32Overflows()
+        {
+            long from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            long from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt32Overflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt32Overflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToInt32Overflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            long from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            long from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            long from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            long from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt32Overflows()
+        {
+            long from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt32Overflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            long from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt32Overflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt32Overflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt32Overflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648' was evaluted to '{(uint)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(uint)4294967295' was evaluted to '{(uint)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294' was evaluted to '{(uint)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            long from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt32Overflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt32Overflows()
+        {
+            long from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt32Overflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            long from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775806)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt64ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            long sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129' was evaluted to '{(long)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768' was evaluted to '{(long)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MinValue = -32769;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MinValue) != -32769)
+            {
+                Console.WriteLine($"'(long)-32769' was evaluted to '{(long)integerOneDecrementUnderInt16MinValue}'. Expected: '-32769'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767' was evaluted to '{(long)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long int32MinValue = -2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MinValue) != -2147483648)
+            {
+                Console.WriteLine($"'(long)-2147483648' was evaluted to '{(long)int32MinValue}'. Expected: '-2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MinValue = -2147483649;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MinValue) != -2147483649)
+            {
+                Console.WriteLine($"'(long)-2147483649' was evaluted to '{(long)integerOneDecrementUnderInt32MinValue}'. Expected: '-2147483649'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MinValue = -2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MinValue) != -2147483647)
+            {
+                Console.WriteLine($"'(long)-2147483647' was evaluted to '{(long)integerOneIncrementAboveInt32MinValue}'. Expected: '-2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648' was evaluted to '{(long)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(long)4294967295' was evaluted to '{(long)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294' was evaluted to '{(long)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967296' was evaluted to '{(long)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long int64MinValue = -9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int64MinValue) != -9223372036854775808)
+            {
+                Console.WriteLine($"'(long)-9223372036854775808' was evaluted to '{(long)int64MinValue}'. Expected: '-9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int64MaxValue) != 9223372036854775807)
+            {
+                Console.WriteLine($"'(long)9223372036854775807' was evaluted to '{(long)int64MaxValue}'. Expected: '9223372036854775807'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MinValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt64MinValue = -9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt64MinValue) != -9223372036854775807)
+            {
+                Console.WriteLine($"'(long)-9223372036854775807' was evaluted to '{(long)integerOneIncrementAboveInt64MinValue}'. Expected: '-9223372036854775807'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt64MaxValue) != 9223372036854775806)
+            {
+                Console.WriteLine($"'(long)9223372036854775806' was evaluted to '{(long)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775806'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt64ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            long integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            long from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            long from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            long from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            long from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt64Overflows()
+        {
+            long from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt16MinValueCastToUInt64Overflows()
+        {
+            long from = -32769;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32769)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            long from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MinValueCastToUInt64Overflows()
+        {
+            long from = -2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483648)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneDecrementUnderInt32MinValueCastToUInt64Overflows()
+        {
+            long from = -2147483649;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483649)' did not throw OverflowException.");
+        }
+        ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt32MinValueCastToUInt64Overflows()
+        {
+            long from = -2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-2147483647)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648' was evaluted to '{(ulong)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(ulong)4294967295' was evaluted to '{(ulong)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294' was evaluted to '{(ulong)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967296' was evaluted to '{(ulong)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MinValueCastToUInt64Overflows()
+        {
+            long from = -9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int64MaxValue) != 9223372036854775807)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775807' was evaluted to '{(ulong)int64MaxValue}'. Expected: '9223372036854775807'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64OneIncrementAboveInt64MinValueCastToUInt64Overflows()
+        {
+            long from = -9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            long integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt64MaxValue) != 9223372036854775806)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775806' was evaluted to '{(ulong)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775806'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt64ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MaxValue) != 32768f)
+            {
+                Console.WriteLine($"'(float)32768' was evaluted to '{(float)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt16MaxValue) != 65535f)
+            {
+                Console.WriteLine($"'(float)65535' was evaluted to '{(float)uInt16MaxValue}'. Expected: '65535f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt16MaxValue) != 65534f)
+            {
+                Console.WriteLine($"'(float)65534' was evaluted to '{(float)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt16MaxValue) != 65536f)
+            {
+                Console.WriteLine($"'(float)65536' was evaluted to '{(float)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483647' was evaluted to '{(float)int32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483646' was evaluted to '{(float)integerOneDecrementUnderInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt32MaxValue) != 2.1474836E+09f)
+            {
+                Console.WriteLine($"'(float)2147483648' was evaluted to '{(float)integerOneIncrementAboveInt32MaxValue}'. Expected: '2.1474836E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967295' was evaluted to '{(float)uInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967294' was evaluted to '{(float)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveUInt32MaxValue) != 4.2949673E+09f)
+            {
+                Console.WriteLine($"'(float)4294967296' was evaluted to '{(float)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4.2949673E+09f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int64MaxValue) != 9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)9223372036854775807' was evaluted to '{(float)int64MaxValue}'. Expected: '9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt64MaxValue) != 9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)9223372036854775806' was evaluted to '{(float)integerOneDecrementUnderInt64MaxValue}'. Expected: '9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt64MaxValue = 9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt64MaxValue) != 9.223372E+18f)
+            {
+                Console.WriteLine($"'(float)9223372036854775808' was evaluted to '{(float)integerOneIncrementAboveInt64MaxValue}'. Expected: '9.223372E+18f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong uInt64MaxValue = 18446744073709551615;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt64MaxValue) != 1.8446744E+19f)
+            {
+                Console.WriteLine($"'(float)18446744073709551615' was evaluted to '{(float)uInt64MaxValue}'. Expected: '1.8446744E+19f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt64MaxValue = 18446744073709551614;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt64MaxValue) != 1.8446744E+19f)
+            {
+                Console.WriteLine($"'(float)18446744073709551614' was evaluted to '{(float)integerOneDecrementUnderUInt64MaxValue}'. Expected: '1.8446744E+19f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt64ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MaxValue) != 32768d)
+            {
+                Console.WriteLine($"'(double)32768' was evaluted to '{(double)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt16MaxValue) != 65535d)
+            {
+                Console.WriteLine($"'(double)65535' was evaluted to '{(double)uInt16MaxValue}'. Expected: '65535d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt16MaxValue) != 65534d)
+            {
+                Console.WriteLine($"'(double)65534' was evaluted to '{(double)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt16MaxValue) != 65536d)
+            {
+                Console.WriteLine($"'(double)65536' was evaluted to '{(double)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int32MaxValue) != 2147483647d)
+            {
+                Console.WriteLine($"'(double)2147483647' was evaluted to '{(double)int32MaxValue}'. Expected: '2147483647d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt32MaxValue) != 2147483646d)
+            {
+                Console.WriteLine($"'(double)2147483646' was evaluted to '{(double)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt32MaxValue) != 2147483648d)
+            {
+                Console.WriteLine($"'(double)2147483648' was evaluted to '{(double)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt32MaxValue) != 4294967295d)
+            {
+                Console.WriteLine($"'(double)4294967295' was evaluted to '{(double)uInt32MaxValue}'. Expected: '4294967295d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt32MaxValue) != 4294967294d)
+            {
+                Console.WriteLine($"'(double)4294967294' was evaluted to '{(double)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveUInt32MaxValue) != 4294967296d)
+            {
+                Console.WriteLine($"'(double)4294967296' was evaluted to '{(double)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int64MaxValue) != 9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)9223372036854775807' was evaluted to '{(double)int64MaxValue}'. Expected: '9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt64MaxValue) != 9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)9223372036854775806' was evaluted to '{(double)integerOneDecrementUnderInt64MaxValue}'. Expected: '9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt64MaxValue = 9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt64MaxValue) != 9.223372036854776E+18d)
+            {
+                Console.WriteLine($"'(double)9223372036854775808' was evaluted to '{(double)integerOneIncrementAboveInt64MaxValue}'. Expected: '9.223372036854776E+18d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong uInt64MaxValue = 18446744073709551615;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt64MaxValue) != 1.8446744073709552E+19d)
+            {
+                Console.WriteLine($"'(double)18446744073709551615' was evaluted to '{(double)uInt64MaxValue}'. Expected: '1.8446744073709552E+19d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt64MaxValue = 18446744073709551614;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt64MaxValue) != 1.8446744073709552E+19d)
+            {
+                Console.WriteLine($"'(double)18446744073709551614' was evaluted to '{(double)integerOneDecrementUnderUInt64MaxValue}'. Expected: '1.8446744073709552E+19d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt64ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            ulong from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            ulong from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            ulong from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            ulong from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToSByteOverflows()
+        {
+            ulong from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToSByteOverflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToSByteOverflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToSByteOverflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToSByteOverflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToSByteOverflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToSByteOverflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            ulong from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToByteOverflows()
+        {
+            ulong from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToByteOverflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToByteOverflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToByteOverflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToByteOverflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToByteOverflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToByteOverflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            ulong from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            ulong from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            ulong from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToInt16Overflows()
+        {
+            ulong from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToInt16Overflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt16Overflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToInt16Overflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt16Overflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt16Overflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt16Overflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt16MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 65536;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)65536)' did not throw OverflowException.");
+        }
+        ConfirmInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 2147483647;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483647)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 2147483646;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483646)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToUInt16Overflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(int)65536' was evaluted to '{(int)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(int)2147483647' was evaluted to '{(int)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(int)2147483646' was evaluted to '{(int)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt32MaxValueCastToInt32Overflows()
+        {
+            ulong from = 2147483648;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)2147483648)' did not throw OverflowException.");
+        }
+        ConfirmUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt32Overflows()
+        {
+            ulong from = 4294967295;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967295)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt32MaxValueCastToInt32Overflows()
+        {
+            ulong from = 4294967294;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967294)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToInt32Overflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt32Overflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToInt32Overflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt32Overflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt32Overflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt32Overflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((int)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((int)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(uint)65536' was evaluted to '{(uint)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(uint)2147483647' was evaluted to '{(uint)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(uint)2147483646' was evaluted to '{(uint)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(uint)2147483648' was evaluted to '{(uint)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(uint)4294967295' was evaluted to '{(uint)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(uint)4294967294' was evaluted to '{(uint)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveUInt32MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 4294967296;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)4294967296)' did not throw OverflowException.");
+        }
+        ConfirmInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 9223372036854775807;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775807)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderInt64MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 9223372036854775806;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775806)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToUInt32Overflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(long)65536' was evaluted to '{(long)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(long)2147483647' was evaluted to '{(long)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(long)2147483646' was evaluted to '{(long)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(long)2147483648' was evaluted to '{(long)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(long)4294967295' was evaluted to '{(long)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(long)4294967294' was evaluted to '{(long)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(long)4294967296' was evaluted to '{(long)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int64MaxValue) != 9223372036854775807)
+            {
+                Console.WriteLine($"'(long)9223372036854775807' was evaluted to '{(long)int64MaxValue}'. Expected: '9223372036854775807'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt64MaxValue) != 9223372036854775806)
+            {
+                Console.WriteLine($"'(long)9223372036854775806' was evaluted to '{(long)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775806'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneIncrementAboveInt64MaxValueCastToInt64Overflows()
+        {
+            ulong from = 9223372036854775808;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)9223372036854775808)' did not throw OverflowException.");
+        }
+        ConfirmUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToInt64Overflows()
+        {
+            ulong from = 18446744073709551615;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551615)' did not throw OverflowException.");
+        }
+        ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64OneDecrementUnderUInt64MaxValueCastToInt64Overflows()
+        {
+            ulong from = 18446744073709551614;
+            _counter++;
+            try
+            {
+                _ = checked((long)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((long)18446744073709551614)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt64ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt16MaxValue = 65536;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt16MaxValue) != 65536)
+            {
+                Console.WriteLine($"'(ulong)65536' was evaluted to '{(ulong)integerOneIncrementAboveUInt16MaxValue}'. Expected: '65536'.");
+                _counter++;
+            }
+        }
+        ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong int32MaxValue = 2147483647;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int32MaxValue) != 2147483647)
+            {
+                Console.WriteLine($"'(ulong)2147483647' was evaluted to '{(ulong)int32MaxValue}'. Expected: '2147483647'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt32MaxValue = 2147483646;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt32MaxValue) != 2147483646)
+            {
+                Console.WriteLine($"'(ulong)2147483646' was evaluted to '{(ulong)integerOneDecrementUnderInt32MaxValue}'. Expected: '2147483646'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt32MaxValue = 2147483648;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt32MaxValue) != 2147483648)
+            {
+                Console.WriteLine($"'(ulong)2147483648' was evaluted to '{(ulong)integerOneIncrementAboveInt32MaxValue}'. Expected: '2147483648'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong uInt32MaxValue = 4294967295;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt32MaxValue) != 4294967295)
+            {
+                Console.WriteLine($"'(ulong)4294967295' was evaluted to '{(ulong)uInt32MaxValue}'. Expected: '4294967295'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt32MaxValue = 4294967294;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt32MaxValue) != 4294967294)
+            {
+                Console.WriteLine($"'(ulong)4294967294' was evaluted to '{(ulong)integerOneDecrementUnderUInt32MaxValue}'. Expected: '4294967294'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveUInt32MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveUInt32MaxValue = 4294967296;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveUInt32MaxValue) != 4294967296)
+            {
+                Console.WriteLine($"'(ulong)4294967296' was evaluted to '{(ulong)integerOneIncrementAboveUInt32MaxValue}'. Expected: '4294967296'.");
+                _counter++;
+            }
+        }
+        ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong int64MaxValue = 9223372036854775807;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int64MaxValue) != 9223372036854775807)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775807' was evaluted to '{(ulong)int64MaxValue}'. Expected: '9223372036854775807'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderInt64MaxValue = 9223372036854775806;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt64MaxValue) != 9223372036854775806)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775806' was evaluted to '{(ulong)integerOneDecrementUnderInt64MaxValue}'. Expected: '9223372036854775806'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneIncrementAboveInt64MaxValue = 9223372036854775808;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt64MaxValue) != 9223372036854775808)
+            {
+                Console.WriteLine($"'(ulong)9223372036854775808' was evaluted to '{(ulong)integerOneIncrementAboveInt64MaxValue}'. Expected: '9223372036854775808'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong uInt64MaxValue = 18446744073709551615;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt64MaxValue) != 18446744073709551615)
+            {
+                Console.WriteLine($"'(ulong)18446744073709551615' was evaluted to '{(ulong)uInt64MaxValue}'. Expected: '18446744073709551615'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt64MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ulong integerOneDecrementUnderUInt64MaxValue = 18446744073709551614;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt64MaxValue) != 18446744073709551614)
+            {
+                Console.WriteLine($"'(ulong)18446744073709551614' was evaluted to '{(ulong)integerOneDecrementUnderUInt64MaxValue}'. Expected: '18446744073709551614'.");
+                _counter++;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_short.cs
+++ b/src/tests/JIT/Directed/Convert/value_numbering_checked_casts_of_constants_short.cs
@@ -1,0 +1,4384 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public partial class ValueNumberingCheckedCastsOfConstants
+{
+    private static void TestCastingInt16ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMinValue) != -128f)
+            {
+                Console.WriteLine($"'(float)-128' was evaluted to '{(float)sByteMinValue}'. Expected: '-128f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMinValue) != -129f)
+            {
+                Console.WriteLine($"'(float)-129' was evaluted to '{(float)integerOneDecrementUnderSByteMinValue}'. Expected: '-129f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMinValue) != -127f)
+            {
+                Console.WriteLine($"'(float)-127' was evaluted to '{(float)integerOneIncrementAboveSByteMinValue}'. Expected: '-127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMinValue) != -1f)
+            {
+                Console.WriteLine($"'(float)-1' was evaluted to '{(float)integerOneDecrementUnderByteMinValue}'. Expected: '-1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            short int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MinValue) != -32768f)
+            {
+                Console.WriteLine($"'(float)-32768' was evaluted to '{(float)int16MinValue}'. Expected: '-32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MinValue) != -32767f)
+            {
+                Console.WriteLine($"'(float)-32767' was evaluted to '{(float)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMinValue) != -128d)
+            {
+                Console.WriteLine($"'(double)-128' was evaluted to '{(double)sByteMinValue}'. Expected: '-128d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMinValue) != -129d)
+            {
+                Console.WriteLine($"'(double)-129' was evaluted to '{(double)integerOneDecrementUnderSByteMinValue}'. Expected: '-129d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMinValue) != -127d)
+            {
+                Console.WriteLine($"'(double)-127' was evaluted to '{(double)integerOneIncrementAboveSByteMinValue}'. Expected: '-127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMinValue) != -1d)
+            {
+                Console.WriteLine($"'(double)-1' was evaluted to '{(double)integerOneDecrementUnderByteMinValue}'. Expected: '-1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MinValue) != -32768d)
+            {
+                Console.WriteLine($"'(double)-32768' was evaluted to '{(double)int16MinValue}'. Expected: '-32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MinValue) != -32767d)
+            {
+                Console.WriteLine($"'(double)-32767' was evaluted to '{(double)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(sbyte)-128' was evaluted to '{(sbyte)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderSByteMinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderSByteMinValueCastToSByteOverflows()
+        {
+            short from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-129)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(sbyte)-127' was evaluted to '{(sbyte)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            short from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            short from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(sbyte)-1' was evaluted to '{(sbyte)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            short from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            short from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToSByteOverflows()
+        {
+            short from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            short from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveInt16MinValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveInt16MinValueCastToSByteOverflows()
+        {
+            short from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            short from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt16ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToByteOverflows()
+        {
+            short from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderSByteMinValueCastToByteOverflows()
+        {
+            short from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveSByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveSByteMinValueCastToByteOverflows()
+        {
+            short from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderByteMinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderByteMinValueCastToByteOverflows()
+        {
+            short from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            short from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToByteOverflows()
+        {
+            short from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            short from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveInt16MinValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveInt16MinValueCastToByteOverflows()
+        {
+            short from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)-32767)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            short from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingInt16ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(short)-128' was evaluted to '{(short)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(short)-129' was evaluted to '{(short)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(short)-127' was evaluted to '{(short)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(short)-1' was evaluted to '{(short)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            short int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(short)-32768' was evaluted to '{(short)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(short)-32767' was evaluted to '{(short)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt16Overflows()
+        {
+            short from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt16Overflows()
+        {
+            short from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt16Overflows()
+        {
+            short from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderByteMinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderByteMinValueCastToUInt16Overflows()
+        {
+            short from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt16Overflows()
+        {
+            short from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt16Overflows()
+        {
+            short from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ushort)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ushort)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(int)-128' was evaluted to '{(int)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(int)-129' was evaluted to '{(int)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(int)-127' was evaluted to '{(int)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(int)-1' was evaluted to '{(int)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            short int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(int)-32768' was evaluted to '{(int)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(int)-32767' was evaluted to '{(int)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt32Overflows()
+        {
+            short from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt32Overflows()
+        {
+            short from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt32Overflows()
+        {
+            short from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderByteMinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderByteMinValueCastToUInt32Overflows()
+        {
+            short from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt32Overflows()
+        {
+            short from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt32Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt32Overflows()
+        {
+            short from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((uint)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((uint)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            short sByteMinValue = -128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMinValue) != -128)
+            {
+                Console.WriteLine($"'(long)-128' was evaluted to '{(long)sByteMinValue}'. Expected: '-128'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMinValue = -129;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMinValue) != -129)
+            {
+                Console.WriteLine($"'(long)-129' was evaluted to '{(long)integerOneDecrementUnderSByteMinValue}'. Expected: '-129'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMinValue = -127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMinValue) != -127)
+            {
+                Console.WriteLine($"'(long)-127' was evaluted to '{(long)integerOneIncrementAboveSByteMinValue}'. Expected: '-127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMinValue = -1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMinValue) != -1)
+            {
+                Console.WriteLine($"'(long)-1' was evaluted to '{(long)integerOneDecrementUnderByteMinValue}'. Expected: '-1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            short int16MinValue = -32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MinValue) != -32768)
+            {
+                Console.WriteLine($"'(long)-32768' was evaluted to '{(long)int16MinValue}'. Expected: '-32768'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MinValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveInt16MinValue = -32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MinValue) != -32767)
+            {
+                Console.WriteLine($"'(long)-32767' was evaluted to '{(long)integerOneIncrementAboveInt16MinValue}'. Expected: '-32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingInt16ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            short integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMinValueCastToUInt64Overflows()
+        {
+            short from = -128;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-128)' did not throw OverflowException.");
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderSByteMinValueCastToUInt64Overflows()
+        {
+            short from = -129;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-129)' did not throw OverflowException.");
+        }
+        ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveSByteMinValueCastToUInt64Overflows()
+        {
+            short from = -127;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-127)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneDecrementUnderByteMinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneDecrementUnderByteMinValueCastToUInt64Overflows()
+        {
+            short from = -1;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-1)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MinValueCastToUInt64Overflows()
+        {
+            short from = -32768;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32768)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt64Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16OneIncrementAboveInt16MinValueCastToUInt64Overflows()
+        {
+            short from = -32767;
+            _counter++;
+            try
+            {
+                _ = checked((ulong)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((ulong)-32767)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            short integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToSingle()
+    {
+        ConfirmIntegerZeroCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerZero) != 0f)
+            {
+                Console.WriteLine($"'(float)0' was evaluted to '{(float)integerZero}'. Expected: '0f'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)sByteMaxValue) != 127f)
+            {
+                Console.WriteLine($"'(float)127' was evaluted to '{(float)sByteMaxValue}'. Expected: '127f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderSByteMaxValue) != 126f)
+            {
+                Console.WriteLine($"'(float)126' was evaluted to '{(float)integerOneDecrementUnderSByteMaxValue}'. Expected: '126f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveSByteMaxValue) != 128f)
+            {
+                Console.WriteLine($"'(float)128' was evaluted to '{(float)integerOneIncrementAboveSByteMaxValue}'. Expected: '128f'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)byteMaxValue) != 255f)
+            {
+                Console.WriteLine($"'(float)255' was evaluted to '{(float)byteMaxValue}'. Expected: '255f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMinValue) != 1f)
+            {
+                Console.WriteLine($"'(float)1' was evaluted to '{(float)integerOneIncrementAboveByteMinValue}'. Expected: '1f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderByteMaxValue) != 254f)
+            {
+                Console.WriteLine($"'(float)254' was evaluted to '{(float)integerOneDecrementUnderByteMaxValue}'. Expected: '254f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveByteMaxValue) != 256f)
+            {
+                Console.WriteLine($"'(float)256' was evaluted to '{(float)integerOneIncrementAboveByteMaxValue}'. Expected: '256f'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)int16MaxValue) != 32767f)
+            {
+                Console.WriteLine($"'(float)32767' was evaluted to '{(float)int16MaxValue}'. Expected: '32767f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderInt16MaxValue) != 32766f)
+            {
+                Console.WriteLine($"'(float)32766' was evaluted to '{(float)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneIncrementAboveInt16MaxValue) != 32768f)
+            {
+                Console.WriteLine($"'(float)32768' was evaluted to '{(float)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768f'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)uInt16MaxValue) != 65535f)
+            {
+                Console.WriteLine($"'(float)65535' was evaluted to '{(float)uInt16MaxValue}'. Expected: '65535f'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToSingleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((float)integerOneDecrementUnderUInt16MaxValue) != 65534f)
+            {
+                Console.WriteLine($"'(float)65534' was evaluted to '{(float)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534f'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToDouble()
+    {
+        ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerZero) != 0d)
+            {
+                Console.WriteLine($"'(double)0' was evaluted to '{(double)integerZero}'. Expected: '0d'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)sByteMaxValue) != 127d)
+            {
+                Console.WriteLine($"'(double)127' was evaluted to '{(double)sByteMaxValue}'. Expected: '127d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderSByteMaxValue) != 126d)
+            {
+                Console.WriteLine($"'(double)126' was evaluted to '{(double)integerOneDecrementUnderSByteMaxValue}'. Expected: '126d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveSByteMaxValue) != 128d)
+            {
+                Console.WriteLine($"'(double)128' was evaluted to '{(double)integerOneIncrementAboveSByteMaxValue}'. Expected: '128d'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)byteMaxValue) != 255d)
+            {
+                Console.WriteLine($"'(double)255' was evaluted to '{(double)byteMaxValue}'. Expected: '255d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMinValue) != 1d)
+            {
+                Console.WriteLine($"'(double)1' was evaluted to '{(double)integerOneIncrementAboveByteMinValue}'. Expected: '1d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderByteMaxValue) != 254d)
+            {
+                Console.WriteLine($"'(double)254' was evaluted to '{(double)integerOneDecrementUnderByteMaxValue}'. Expected: '254d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveByteMaxValue) != 256d)
+            {
+                Console.WriteLine($"'(double)256' was evaluted to '{(double)integerOneIncrementAboveByteMaxValue}'. Expected: '256d'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)int16MaxValue) != 32767d)
+            {
+                Console.WriteLine($"'(double)32767' was evaluted to '{(double)int16MaxValue}'. Expected: '32767d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderInt16MaxValue) != 32766d)
+            {
+                Console.WriteLine($"'(double)32766' was evaluted to '{(double)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneIncrementAboveInt16MaxValue) != 32768d)
+            {
+                Console.WriteLine($"'(double)32768' was evaluted to '{(double)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768d'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)uInt16MaxValue) != 65535d)
+            {
+                Console.WriteLine($"'(double)65535' was evaluted to '{(double)uInt16MaxValue}'. Expected: '65535d'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToDoubleIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((double)integerOneDecrementUnderUInt16MaxValue) != 65534d)
+            {
+                Console.WriteLine($"'(double)65534' was evaluted to '{(double)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534d'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToSByte()
+    {
+        ConfirmIntegerZeroCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToSByteIsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(sbyte)0' was evaluted to '{(sbyte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(sbyte)127' was evaluted to '{(sbyte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToSByteIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(sbyte)126' was evaluted to '{(sbyte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16OneIncrementAboveSByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveSByteMaxValueCastToSByteOverflows()
+        {
+            ushort from = 128;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)128)' did not throw OverflowException.");
+        }
+        ConfirmByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToSByteOverflows()
+        {
+            ushort from = 255;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)255)' did not throw OverflowException.");
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToSByteIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((sbyte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(sbyte)1' was evaluted to '{(sbyte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16OneDecrementUnderByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderByteMaxValueCastToSByteOverflows()
+        {
+            ushort from = 254;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)254)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneIncrementAboveByteMaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveByteMaxValueCastToSByteOverflows()
+        {
+            ushort from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToSByteOverflows()
+        {
+            ushort from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneDecrementUnderInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderInt16MaxValueCastToSByteOverflows()
+        {
+            ushort from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneIncrementAboveInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveInt16MaxValueCastToSByteOverflows()
+        {
+            ushort from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToSByteOverflows()
+        {
+            ushort from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToSByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToSByteOverflows()
+        {
+            ushort from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((sbyte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((sbyte)65534)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt16ToByte()
+    {
+        ConfirmIntegerZeroCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToByteIsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerZero) != 0)
+            {
+                Console.WriteLine($"'(byte)0' was evaluted to '{(byte)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(byte)127' was evaluted to '{(byte)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(byte)126' was evaluted to '{(byte)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(byte)128' was evaluted to '{(byte)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(byte)255' was evaluted to '{(byte)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToByteIsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(byte)1' was evaluted to '{(byte)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToByteIsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((byte)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(byte)254' was evaluted to '{(byte)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16OneIncrementAboveByteMaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveByteMaxValueCastToByteOverflows()
+        {
+            ushort from = 256;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)256)' did not throw OverflowException.");
+        }
+        ConfirmInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToByteOverflows()
+        {
+            ushort from = 32767;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32767)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneDecrementUnderInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderInt16MaxValueCastToByteOverflows()
+        {
+            ushort from = 32766;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32766)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneIncrementAboveInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveInt16MaxValueCastToByteOverflows()
+        {
+            ushort from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToByteOverflows()
+        {
+            ushort from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToByteOverflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToByteOverflows()
+        {
+            ushort from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((byte)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((byte)65534)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt16ToInt16()
+    {
+        ConfirmIntegerZeroCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerZero) != 0)
+            {
+                Console.WriteLine($"'(short)0' was evaluted to '{(short)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(short)127' was evaluted to '{(short)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(short)126' was evaluted to '{(short)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(short)128' was evaluted to '{(short)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(short)255' was evaluted to '{(short)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(short)1' was evaluted to '{(short)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(short)254' was evaluted to '{(short)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(short)256' was evaluted to '{(short)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(short)32767' was evaluted to '{(short)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((short)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(short)32766' was evaluted to '{(short)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16OneIncrementAboveInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneIncrementAboveInt16MaxValueCastToInt16Overflows()
+        {
+            ushort from = 32768;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)32768)' did not throw OverflowException.");
+        }
+        ConfirmUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt16Overflows()
+        {
+            ushort from = 65535;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65535)' did not throw OverflowException.");
+        }
+        ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToInt16Overflows();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16OneDecrementUnderUInt16MaxValueCastToInt16Overflows()
+        {
+            ushort from = 65534;
+            _counter++;
+            try
+            {
+                _ = checked((short)from);
+            }
+            catch (OverflowException) { _counter--; }
+            if (_counter != 100)
+                Console.WriteLine("'checked((short)65534)' did not throw OverflowException.");
+        }
+    }
+
+    private static void TestCastingUInt16ToUInt16()
+    {
+        ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ushort)0' was evaluted to '{(ushort)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ushort)127' was evaluted to '{(ushort)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ushort)126' was evaluted to '{(ushort)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ushort)128' was evaluted to '{(ushort)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ushort)255' was evaluted to '{(ushort)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ushort)1' was evaluted to '{(ushort)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ushort)254' was evaluted to '{(ushort)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ushort)256' was evaluted to '{(ushort)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ushort)32767' was evaluted to '{(ushort)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ushort)32766' was evaluted to '{(ushort)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ushort)32768' was evaluted to '{(ushort)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ushort)65535' was evaluted to '{(ushort)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt16IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ushort)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ushort)65534' was evaluted to '{(ushort)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToInt32()
+    {
+        ConfirmIntegerZeroCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerZero) != 0)
+            {
+                Console.WriteLine($"'(int)0' was evaluted to '{(int)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(int)127' was evaluted to '{(int)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(int)126' was evaluted to '{(int)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(int)128' was evaluted to '{(int)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(int)255' was evaluted to '{(int)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(int)1' was evaluted to '{(int)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(int)254' was evaluted to '{(int)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(int)256' was evaluted to '{(int)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(int)32767' was evaluted to '{(int)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(int)32766' was evaluted to '{(int)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(int)32768' was evaluted to '{(int)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(int)65535' was evaluted to '{(int)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((int)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(int)65534' was evaluted to '{(int)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToUInt32()
+    {
+        ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerZero) != 0)
+            {
+                Console.WriteLine($"'(uint)0' was evaluted to '{(uint)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(uint)127' was evaluted to '{(uint)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(uint)126' was evaluted to '{(uint)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(uint)128' was evaluted to '{(uint)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(uint)255' was evaluted to '{(uint)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(uint)1' was evaluted to '{(uint)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(uint)254' was evaluted to '{(uint)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(uint)256' was evaluted to '{(uint)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(uint)32767' was evaluted to '{(uint)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(uint)32766' was evaluted to '{(uint)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(uint)32768' was evaluted to '{(uint)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(uint)65535' was evaluted to '{(uint)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt32IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((uint)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(uint)65534' was evaluted to '{(uint)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToInt64()
+    {
+        ConfirmIntegerZeroCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerZero) != 0)
+            {
+                Console.WriteLine($"'(long)0' was evaluted to '{(long)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(long)127' was evaluted to '{(long)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(long)126' was evaluted to '{(long)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(long)128' was evaluted to '{(long)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(long)255' was evaluted to '{(long)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(long)1' was evaluted to '{(long)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(long)254' was evaluted to '{(long)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(long)256' was evaluted to '{(long)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(long)32767' was evaluted to '{(long)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(long)32766' was evaluted to '{(long)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(long)32768' was evaluted to '{(long)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(long)65535' was evaluted to '{(long)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((long)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(long)65534' was evaluted to '{(long)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+    }
+
+    private static void TestCastingUInt16ToUInt64()
+    {
+        ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerZeroCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerZero = 0;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerZero) != 0)
+            {
+                Console.WriteLine($"'(ulong)0' was evaluted to '{(ulong)integerZero}'. Expected: '0'.");
+                _counter++;
+            }
+        }
+        ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort sByteMaxValue = 127;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)sByteMaxValue) != 127)
+            {
+                Console.WriteLine($"'(ulong)127' was evaluted to '{(ulong)sByteMaxValue}'. Expected: '127'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderSByteMaxValue = 126;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderSByteMaxValue) != 126)
+            {
+                Console.WriteLine($"'(ulong)126' was evaluted to '{(ulong)integerOneDecrementUnderSByteMaxValue}'. Expected: '126'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveSByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveSByteMaxValue = 128;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveSByteMaxValue) != 128)
+            {
+                Console.WriteLine($"'(ulong)128' was evaluted to '{(ulong)integerOneIncrementAboveSByteMaxValue}'. Expected: '128'.");
+                _counter++;
+            }
+        }
+        ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort byteMaxValue = 255;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)byteMaxValue) != 255)
+            {
+                Console.WriteLine($"'(ulong)255' was evaluted to '{(ulong)byteMaxValue}'. Expected: '255'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMinValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMinValue = 1;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMinValue) != 1)
+            {
+                Console.WriteLine($"'(ulong)1' was evaluted to '{(ulong)integerOneIncrementAboveByteMinValue}'. Expected: '1'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderByteMaxValue = 254;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderByteMaxValue) != 254)
+            {
+                Console.WriteLine($"'(ulong)254' was evaluted to '{(ulong)integerOneDecrementUnderByteMaxValue}'. Expected: '254'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveByteMaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveByteMaxValue = 256;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveByteMaxValue) != 256)
+            {
+                Console.WriteLine($"'(ulong)256' was evaluted to '{(ulong)integerOneIncrementAboveByteMaxValue}'. Expected: '256'.");
+                _counter++;
+            }
+        }
+        ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort int16MaxValue = 32767;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)int16MaxValue) != 32767)
+            {
+                Console.WriteLine($"'(ulong)32767' was evaluted to '{(ulong)int16MaxValue}'. Expected: '32767'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderInt16MaxValue = 32766;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderInt16MaxValue) != 32766)
+            {
+                Console.WriteLine($"'(ulong)32766' was evaluted to '{(ulong)integerOneDecrementUnderInt16MaxValue}'. Expected: '32766'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneIncrementAboveInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneIncrementAboveInt16MaxValue = 32768;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneIncrementAboveInt16MaxValue) != 32768)
+            {
+                Console.WriteLine($"'(ulong)32768' was evaluted to '{(ulong)integerOneIncrementAboveInt16MaxValue}'. Expected: '32768'.");
+                _counter++;
+            }
+        }
+        ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort uInt16MaxValue = 65535;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)uInt16MaxValue) != 65535)
+            {
+                Console.WriteLine($"'(ulong)65535' was evaluted to '{(ulong)uInt16MaxValue}'. Expected: '65535'.");
+                _counter++;
+            }
+        }
+        ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConfirmIntegerOneDecrementUnderUInt16MaxValueCastToUInt64IsFoldedCorrectly()
+        {
+            ushort integerOneDecrementUnderUInt16MaxValue = 65534;
+
+            if (BreakUpFlow())
+                return;
+
+            if (checked((ulong)integerOneDecrementUnderUInt16MaxValue) != 65534)
+            {
+                Console.WriteLine($"'(ulong)65534' was evaluted to '{(ulong)integerOneDecrementUnderUInt16MaxValue}'. Expected: '65534'.");
+                _counter++;
+            }
+        }
+    }
+}

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1044,6 +1044,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/value_numbering_checked_casts_of_constants/*">
+            <Issue>Test not yet merged, issue will be created if the PR is to be approved</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
             <Issue>Mono does not define out of range fp to int conversions</Issue>
         </ExcludeList>


### PR DESCRIPTION
Contributes to #49535, #1115 and #32776.

Implements the VN part of https://github.com/dotnet/runtime/issues/1115#issuecomment-569377254, also enables value numbering of casts that are done via helpers.

There are three major parts to this PR.

1) Refactoring of `gtFoldExprConst` and the creation of `CheckedOps` namespace so that the overflow checking can live in one place and be shared between the aforementioned `gtFoldExprConst` and VN. I also generally cleaned up the folding function as per the style guide. Notably, the behavior for overflowing **unchecked** casts from floating point types to integer types has been preserved - it will have to wait until #47478 is resolved. As the handling for the `floating point -> integer` overflow checks was a bit simplistic, I had to implement it from scratch, with some commentary on the choice of constants.

2) Unblocking of VN folding the checked operations when the arguments have a known constant VN, including avoiding the addition of exceptions to the exception set for such cases and the addition of relevant asserts - only for the checked cases.

3) Conversion of all VNFuncs that represented casts performed via helpers to plain `VNF_Cast/Ovf`s. This is the part of the change I am least confident in, at the same time, it avoids special-casing the helpers in folding and streamlines the handling in general. There is an associated `TODO` on how this could be avoided if transforming the relevant `GT_CAST`s to the relevant helpers could be done by the backend. I do not know how feasible would that be.

The added tests have been generated via a [script](https://gist.github.com/SingleAccretion/82849e05f0719ec5433786c16d1d3484) (the `#if` controls which part is generated - for arithmetic or for casts).

Draft for now to see what the CI thinks.