### PR TITLE
Improve performance of System.Random.LegacyImpl.NextBytes(Span<T>)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.LegacyImpl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.LegacyImpl.cs
@@ -163,10 +163,9 @@ namespace System
 
             public override void NextBytes(Span<byte> buffer)
             {
-                for (int i = 0; i < buffer.Length; i++)
-                {
-                    buffer[i] = (byte)_parent.Next();
-                }
+                byte[] tmpBuf = new byte[buffer.Length];
+                NextBytes(tmpBuf);
+                MemoryExtensions.CopyTo<byte>(tmpBuf, buffer);
             }
 
             private int InternalSample()


### PR DESCRIPTION
Reworked `System.Random.LegacyImpl.NextBytes(Span<byte>)` to reuse the method `System.Random.LegacyImpl.NextBytes(byte[])` instead, resulting in a performance increase of ~20% in the [System.Tests.Perf_Random.NextBytes_span](https://github.com/dotnet/performance/blob/71bc939f17660302f4455ee8dec2957eda332559/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs#L56) microbenchmark. Allocates a temporary array to store the bytes in, then copies the bytes to the Span instead of directly writing them to the Span.

<details>

<summary>BenchmarkDotNet Results</summary>

### Before (built from 93b8e18029e784fa8e96e7a01381137125ca632d)

```
$ py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter *Perf_Random* --corerun C:\Users\acovingt\source\repos\runtime-master\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\net6.0-before

 // * Summary *

BenchmarkDotNet=v0.12.1.1521-nightly, OS=Windows 10.0.19042.867 (20H2/October2020Update)
AMD Ryzen 7 5800, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100-preview.4.21180.9
   [Host]     : .NET 6.0.0 (6.0.21.17806), X64 RyuJIT
   Job-OOHBWY : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  Toolchain=CoreRun
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15
WarmupCount=1

|                  Method |         Mean |      Error |    StdDev |       Median |          Min |          Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |-------------:|-----------:|----------:|-------------:|-------------:|-------------:|-------:|------:|------:|----------:|
|             ctor_seeded |   348.610 ns |  1.0968 ns | 0.9723 ns |   348.598 ns |   347.197 ns |   350.525 ns | 0.0183 |     - |     - |     312 B |
|                    ctor |    90.831 ns |  0.1929 ns | 0.1506 ns |    90.837 ns |    90.543 ns |    91.057 ns | 0.0041 |     - |     - |      72 B |
|                    Next |     8.448 ns |  0.0096 ns | 0.0080 ns |     8.447 ns |     8.436 ns |     8.462 ns |      - |     - |     - |         - |
|           Next_unseeded |     2.266 ns |  0.0146 ns | 0.0137 ns |     2.266 ns |     2.245 ns |     2.293 ns |      - |     - |     - |         - |
|                Next_int |    12.146 ns |  0.0081 ns | 0.0076 ns |    12.147 ns |    12.133 ns |    12.159 ns |      - |     - |     - |         - |
|       Next_int_unseeded |     7.748 ns |  0.0219 ns | 0.0205 ns |     7.746 ns |     7.719 ns |     7.791 ns |      - |     - |     - |         - |
|            Next_int_int |    12.300 ns |  0.0077 ns | 0.0060 ns |    12.302 ns |    12.290 ns |    12.307 ns |      - |     - |     - |         - |
|   Next_int_int_unseeded |     8.508 ns |  0.0098 ns | 0.0092 ns |     8.507 ns |     8.493 ns |     8.521 ns |      - |     - |     - |         - |
|               NextBytes | 7,504.988 ns |  6.5221 ns | 5.7817 ns | 7,503.710 ns | 7,495.979 ns | 7,515.494 ns |      - |     - |     - |         - |
|      NextBytes_unseeded |   125.463 ns |  0.2649 ns | 0.2478 ns |   125.459 ns |   125.112 ns |   125.903 ns |      - |     - |     - |         - |
|              NextDouble |    11.247 ns |  0.0134 ns | 0.0125 ns |    11.247 ns |    11.228 ns |    11.264 ns |      - |     - |     - |         - |
|     NextDouble_unseeded |     2.226 ns |  0.0166 ns | 0.0147 ns |     2.230 ns |     2.203 ns |     2.248 ns |      - |     - |     - |         - |
|          NextBytes_span | 8,686.233 ns | 10.2703 ns | 9.6068 ns | 8,685.596 ns | 8,667.526 ns | 8,701.568 ns |      - |     - |     - |         - |
| NextBytes_span_unseeded |   126.738 ns |  0.1502 ns | 0.1405 ns |   126.786 ns |   126.459 ns |   126.950 ns |      - |     - |     - |         - |
|               Next_long |   112.478 ns |  0.9127 ns | 0.8537 ns |   112.059 ns |   111.753 ns |   114.542 ns |      - |     - |     - |         - |
|      Next_long_unseeded |     4.817 ns |  0.0361 ns | 0.0320 ns |     4.804 ns |     4.780 ns |     4.897 ns |      - |     - |     - |         - |
|          Next_long_long |   128.473 ns |  0.1494 ns | 0.1398 ns |   128.446 ns |   128.257 ns |   128.755 ns |      - |     - |     - |         - |
| Next_long_long_unseeded |     8.274 ns |  0.0078 ns | 0.0073 ns |     8.275 ns |     8.259 ns |     8.285 ns |      - |     - |     - |         - |
|              NextSingle |    11.662 ns |  0.0255 ns | 0.0226 ns |    11.664 ns |    11.626 ns |    11.698 ns |      - |     - |     - |         - |
|     NextSingle_unseeded |     2.578 ns |  0.0123 ns | 0.0115 ns |     2.580 ns |     2.555 ns |     2.602 ns |      - |     - |     - |         - |


```

### After

```
$  py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter *Perf_Random* --corerun C:\Users\acovingt\source\repos\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\net6.0-after

// * Summary *

BenchmarkDotNet=v0.12.1.1521-nightly, OS=Windows 10.0.19042.867 (20H2/October2020Update)
AMD Ryzen 7 5800, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100-preview.4.21180.9
   [Host]     : .NET 6.0.0 (6.0.21.17806), X64 RyuJIT
   Job-YDMWPV : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  Toolchain=CoreRun
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15
WarmupCount=1

|                  Method |         Mean |     Error |    StdDev |       Median |          Min |          Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |-------------:|----------:|----------:|-------------:|-------------:|-------------:|-------:|------:|------:|----------:|
|             ctor_seeded |   349.385 ns | 0.9390 ns | 0.8783 ns |   349.484 ns |   347.969 ns |   350.727 ns | 0.0184 |     - |     - |     312 B |
|                    ctor |    91.735 ns | 0.3246 ns | 0.2710 ns |    91.746 ns |    91.279 ns |    92.274 ns | 0.0042 |     - |     - |      72 B |
|                    Next |     8.443 ns | 0.0142 ns | 0.0126 ns |     8.443 ns |     8.410 ns |     8.465 ns |      - |     - |     - |         - |
|           Next_unseeded |     1.903 ns | 0.0146 ns | 0.0130 ns |     1.902 ns |     1.883 ns |     1.926 ns |      - |     - |     - |         - |
|                Next_int |    11.986 ns | 0.0106 ns | 0.0094 ns |    11.986 ns |    11.971 ns |    12.005 ns |      - |     - |     - |         - |
|       Next_int_unseeded |     7.762 ns | 0.0225 ns | 0.0211 ns |     7.767 ns |     7.725 ns |     7.807 ns |      - |     - |     - |         - |
|            Next_int_int |    12.251 ns | 0.0098 ns | 0.0087 ns |    12.250 ns |    12.231 ns |    12.265 ns |      - |     - |     - |         - |
|   Next_int_int_unseeded |     8.506 ns | 0.0125 ns | 0.0097 ns |     8.500 ns |     8.497 ns |     8.528 ns |      - |     - |     - |         - |
|               NextBytes | 7,502.390 ns | 4.5286 ns | 4.0145 ns | 7,502.783 ns | 7,494.968 ns | 7,508.820 ns |      - |     - |     - |         - |
|      NextBytes_unseeded |   125.360 ns | 0.3051 ns | 0.2704 ns |   125.328 ns |   124.935 ns |   125.763 ns |      - |     - |     - |         - |
|              NextDouble |    11.274 ns | 0.0156 ns | 0.0146 ns |    11.277 ns |    11.251 ns |    11.294 ns |      - |     - |     - |         - |
|     NextDouble_unseeded |     2.216 ns | 0.0262 ns | 0.0245 ns |     2.216 ns |     2.171 ns |     2.252 ns |      - |     - |     - |         - |
|          NextBytes_span | 7,153.914 ns | 5.2299 ns | 4.3672 ns | 7,153.929 ns | 7,147.859 ns | 7,161.468 ns | 0.0573 |     - |     - |   1,024 B |
| NextBytes_span_unseeded |   126.568 ns | 0.1058 ns | 0.0883 ns |   126.566 ns |   126.441 ns |   126.735 ns |      - |     - |     - |         - |
|               Next_long |   113.034 ns | 0.3859 ns | 0.3421 ns |   112.997 ns |   112.394 ns |   113.608 ns | 0.0028 |     - |     - |      47 B |
|      Next_long_unseeded |     5.730 ns | 0.0138 ns | 0.0122 ns |     5.731 ns |     5.707 ns |     5.753 ns |      - |     - |     - |         - |
|          Next_long_long |   129.941 ns | 1.2275 ns | 1.1482 ns |   129.889 ns |   127.210 ns |   131.883 ns | 0.0031 |     - |     - |      53 B |
| Next_long_long_unseeded |     8.505 ns | 0.0159 ns | 0.0148 ns |     8.505 ns |     8.485 ns |     8.539 ns |      - |     - |     - |         - |
|              NextSingle |    11.670 ns | 0.0262 ns | 0.0218 ns |    11.673 ns |    11.638 ns |    11.716 ns |      - |     - |     - |         - |
|     NextSingle_unseeded |     2.268 ns | 0.0340 ns | 0.0318 ns |     2.264 ns |     2.213 ns |     2.323 ns |      - |     - |     - |         - |
```

### Results Comparer

```
$ dotnet run -- --base C:\Users\acovingt\Documents\net6.0-before\ --diff C:\Users\acovingt\Documents\net6.0-after\ --threshold 1% --noise 5ns
summary:
better: 1, geomean: 1.213
total diff: 1

No Slower results for the provided threshold = 1% and noise filter = 5ns.

| Faster                                  | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_Random.NextBytes_span |      1.21 |          8674.77 |          7149.92 |         |
```
</details>

Please let me know if I can clarify or expand on any of the above. Thanks!