### PR TITLE
Fix setting or getting pointer fields with reflection

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2796,7 +2796,7 @@ mono_field_static_set_value_internal (MonoVTable *vt, MonoClassField *field, voi
 	} else {
 		dest = (char*)mono_vtable_get_static_field_data (vt) + field->offset;
 	}
-	mono_copy_value (field->type, dest, value, FALSE);
+	mono_copy_value (field->type, dest, value, value && field->type->type == MONO_TYPE_PTR);
 }
 
 gpointer


### PR DESCRIPTION
Manual sync of https://github.com/mono/mono/pull/20891 to dotnet/runtime.  Thanks @spaarmann for the PR.

---- 

Setting a pointer via reflection incorrectly added an extra layer of
indirection, and getting a pointer via reflection incorrectly
dereferenced the value once.

As a result, setting and then getting only via reflection worked
correctly, but doing either step by directly accessing the field and the
other via reflection was broken.

Also adjusts `FieldInfoTest` to test this, for both static and instance
fields (the set path especially is different for those.)

Fixes https://github.com/mono/mono/issues/20872

This change is released under the MIT license.