### PR TITLE
Pool the underlying list and dictionary in scopes.

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopePool.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopePool.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    internal class ScopePool
+    {
+        // Modest number to re-use. We only really care about reuse for short lived scopes
+        private static readonly int s_maxQueueSize = Environment.ProcessorCount * 2;
+
+        private int _count;
+        private readonly ConcurrentQueue<State> _queue = new();
+
+        public State Rent()
+        {
+            if (_queue.TryDequeue(out State state))
+            {
+                Interlocked.Decrement(ref _count);
+                return state;
+            }
+            return new State(this);
+        }
+
+        public bool Return(State state)
+        {
+            if (Interlocked.Increment(ref _count) > s_maxQueueSize)
+            {
+                Interlocked.Decrement(ref _count);
+                return false;
+            }
+
+            state.Clear();
+            _queue.Enqueue(state);
+            return true;
+        }
+
+        public class State
+        {
+            private readonly ScopePool _pool;
+
+            public IDictionary<ServiceCacheKey, object> ResolvedServices { get; }
+            public List<object> Disposables { get; set; }
+
+            public State(ScopePool pool = null)
+            {
+                _pool = pool;
+                ResolvedServices = pool == null ? new ConcurrentDictionary<ServiceCacheKey, object>() : new Dictionary<ServiceCacheKey, object>();
+            }
+
+            internal void Clear()
+            {
+                // REVIEW: Should we trim excess here as well?
+                ResolvedServices.Clear();
+                Disposables?.Clear();
+            }
+
+            public bool Return()
+            {
+                return _pool?.Return(this) ?? false;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopePool.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopePool.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
     internal class ScopePool
     {
         // Modest number to re-use. We only really care about reuse for short lived scopes
-        private static readonly int s_maxQueueSize = Environment.ProcessorCount * 2;
+        private const int s_maxQueueSize = 128;
 
         private int _count;
         private readonly ConcurrentQueue<State> _queue = new();
@@ -50,6 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
             public State(ScopePool pool = null)
             {
                 _pool = pool;
+                // When pool is null, we're in the global scope which doesn't need pooling.
+                // To reduce lock contention for singletons upon resolve we use a concurrent dictionary.
                 ResolvedServices = pool == null ? new ConcurrentDictionary<ServiceCacheKey, object>() : new Dictionary<ServiceCacheKey, object>();
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // For scoped: takes a dictionary as both a resolution lock and a dictionary access lock.
             Debug.Assert(
                 (lockType == RuntimeResolverLock.Root && resolvedServices is ConcurrentDictionary<ServiceCacheKey, object>) ||
-                (lockType == RuntimeResolverLock.Scope && Monitor.IsEntered(resolvedServices)));
+                (lockType == RuntimeResolverLock.Scope && Monitor.IsEntered(serviceProviderEngine.Sync)));
 
             if (resolvedServices.TryGetValue(callSite.Cache.Key, out object resolved))
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private object VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
         {
             bool lockTaken = false;
-            IDictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
+            object sync = serviceProviderEngine.Sync;
 
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // releasing the lock
             if ((context.AcquiredLocks & lockType) == 0)
             {
-                Monitor.Enter(resolvedServices, ref lockTaken);
+                Monitor.Enter(sync, ref lockTaken);
             }
 
             try
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 if (lockTaken)
                 {
-                    Monitor.Exit(resolvedServices);
+                    Monitor.Exit(sync);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -26,11 +26,18 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private static readonly ParameterExpression ScopeParameter = Expression.Parameter(typeof(ServiceProviderEngineScope));
 
         private static readonly ParameterExpression ResolvedServices = Expression.Variable(typeof(IDictionary<ServiceCacheKey, object>), ScopeParameter.Name + "resolvedServices");
+        private static readonly ParameterExpression Sync = Expression.Variable(typeof(object), ScopeParameter.Name + "sync");
         private static readonly BinaryExpression ResolvedServicesVariableAssignment =
             Expression.Assign(ResolvedServices,
                 Expression.Property(
                     ScopeParameter,
                     typeof(ServiceProviderEngineScope).GetProperty(nameof(ServiceProviderEngineScope.ResolvedServices), BindingFlags.Instance | BindingFlags.NonPublic)));
+
+        private static readonly BinaryExpression SyncVariableAssignment =
+            Expression.Assign(Sync,
+                Expression.Property(
+                    ScopeParameter,
+                    typeof(ServiceProviderEngineScope).GetProperty(nameof(ServiceProviderEngineScope.Sync), BindingFlags.Instance | BindingFlags.NonPublic)));
 
         private static readonly ParameterExpression CaptureDisposableParameter = Expression.Parameter(typeof(object));
         private static readonly LambdaExpression CaptureDisposable = Expression.Lambda(
@@ -96,8 +103,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 return Expression.Lambda<Func<ServiceProviderEngineScope, object>>(
                     Expression.Block(
-                        new[] { ResolvedServices },
+                        new[] { ResolvedServices, Sync },
                         ResolvedServicesVariableAssignment,
+                        SyncVariableAssignment,
                         BuildScopedExpression(callSite)),
                     ScopeParameter);
             }
@@ -213,7 +221,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Move off the main stack
         private Expression BuildScopedExpression(ServiceCallSite callSite)
         {
-
             ConstantExpression keyExpression = Expression.Constant(
                 callSite.Cache.Key,
                 typeof(ServiceCacheKey));
@@ -257,9 +264,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // The C# compiler would copy the lock object to guard against mutation.
             // We don't, since we know the lock object is readonly.
             ParameterExpression lockWasTaken = Expression.Variable(typeof(bool), "lockWasTaken");
+            ParameterExpression sync = Sync;
 
-            MethodCallExpression monitorEnter = Expression.Call(MonitorEnterMethodInfo, resolvedServices, lockWasTaken);
-            MethodCallExpression monitorExit = Expression.Call(MonitorExitMethodInfo, resolvedServices);
+            MethodCallExpression monitorEnter = Expression.Call(MonitorEnterMethodInfo, sync, lockWasTaken);
+            MethodCallExpression monitorExit = Expression.Call(MonitorExitMethodInfo, sync);
 
             BlockExpression tryBody = Expression.Block(monitorEnter, blockExpression);
             ConditionalExpression finallyBody = Expression.IfThen(lockWasTaken, monitorExit);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 Ldloc(context.Generator, lockTakenLocal.LocalIndex);
                 // return if not
                 context.Generator.Emit(OpCodes.Brfalse, returnLabel);
-                // Load resolvedServices
+                // Load syncLocal
                 Ldloc(context.Generator, syncLocal.LocalIndex);
                 // Monitor.Exit
                 context.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.MonitorExitMethodInfo);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private static readonly MethodInfo ResolvedServicesGetter = typeof(ServiceProviderEngineScope).GetProperty(
             nameof(ServiceProviderEngineScope.ResolvedServices), BindingFlags.Instance | BindingFlags.NonPublic).GetMethod;
 
+        private static readonly MethodInfo ScopeLockGetter = typeof(ServiceProviderEngineScope).GetProperty(
+            nameof(ServiceProviderEngineScope.Sync), BindingFlags.Instance | BindingFlags.NonPublic).GetMethod;
+
         private static readonly FieldInfo FactoriesField = typeof(ILEmitResolverBuilderRuntimeContext).GetField(nameof(ILEmitResolverBuilderRuntimeContext.Factories));
         private static readonly FieldInfo ConstantsField = typeof(ILEmitResolverBuilderRuntimeContext).GetField(nameof(ILEmitResolverBuilderRuntimeContext.Constants));
         private static readonly MethodInfo GetTypeFromHandleMethod = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle));
@@ -319,6 +322,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 LocalBuilder cacheKeyLocal = context.Generator.DeclareLocal(typeof(ServiceCacheKey));
                 LocalBuilder resolvedServicesLocal = context.Generator.DeclareLocal(typeof(IDictionary<ServiceCacheKey, object>));
+                LocalBuilder syncLocal = context.Generator.DeclareLocal(typeof(object));
                 LocalBuilder lockTakenLocal = context.Generator.DeclareLocal(typeof(bool));
                 LocalBuilder resultLocal = context.Generator.DeclareLocal(typeof(object));
 
@@ -339,8 +343,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // Store resolved services
                 Stloc(context.Generator, resolvedServicesLocal.LocalIndex);
 
-                // Load resolvedServices
-                Ldloc(context.Generator, resolvedServicesLocal.LocalIndex);
+                // scope
+                context.Generator.Emit(OpCodes.Ldarg_1);
+                // .Sync
+                context.Generator.Emit(OpCodes.Callvirt, ScopeLockGetter);
+                // Store syncLocal
+                Stloc(context.Generator, syncLocal.LocalIndex);
+
+                // Load syncLocal
+                Ldloc(context.Generator, syncLocal.LocalIndex);
                 // Load address of lockTaken
                 context.Generator.Emit(OpCodes.Ldloca_S, lockTakenLocal.LocalIndex);
                 // Monitor.Enter
@@ -389,7 +400,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // return if not
                 context.Generator.Emit(OpCodes.Brfalse, returnLabel);
                 // Load resolvedServices
-                Ldloc(context.Generator, resolvedServicesLocal.LocalIndex);
+                Ldloc(context.Generator, syncLocal.LocalIndex);
                 // Monitor.Exit
                 context.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.MonitorExitMethodInfo);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             CallSiteFactory.Add(typeof(IServiceProvider), new ServiceProviderCallSite());
             CallSiteFactory.Add(typeof(IServiceScopeFactory), new ServiceScopeFactoryCallSite());
             RealizedServices = new ConcurrentDictionary<Type, Func<ServiceProviderEngineScope, object>>();
+            ScopePool = new ScopePool();
         }
+
+        internal ScopePool ScopePool { get; }
 
         internal ConcurrentDictionary<Type, Func<ServiceProviderEngineScope, object>> RealizedServices { get; }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -20,13 +20,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private readonly object _disposeLock = new object();
 
         // This protects resolved services, this is only used if isRoot is false
-        private readonly object _scopeLock;
+        private readonly object _scopeLock = new object();
 
         public ServiceProviderEngineScope(ServiceProviderEngine engine, bool isRoot = false)
         {
             Engine = engine;
             _state = isRoot ? new ScopePool.State() : engine.ScopePool.Rent();
-            _scopeLock = isRoot ? null : new object();
         }
 
         internal IDictionary<ServiceCacheKey, object> ResolvedServices => _state?.ResolvedServices ?? ScopeDisposed();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
 
@@ -9,13 +11,28 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     public class ServiceProviderEngineScopeTests
     {
         [Fact]
-        public void Dispose_DoesntClearResolvedServices()
+        public void ResolvedServicesAfterDispose_ThrowsObjectDispose()
         {
-            var serviceProviderEngineScope = new ServiceProviderEngineScope(null);
+            var engine = new FakeEngine();
+            var serviceProviderEngineScope = new ServiceProviderEngineScope(engine);
             serviceProviderEngineScope.ResolvedServices.Add(new ServiceCacheKey(typeof(IFakeService), 0), null);
             serviceProviderEngineScope.Dispose();
 
-            Assert.Single(serviceProviderEngineScope.ResolvedServices);
+            Assert.Throws<ObjectDisposedException>(() => serviceProviderEngineScope.ResolvedServices);
+        }
+
+        private class FakeEngine : ServiceProviderEngine
+        {
+            public FakeEngine() :
+                base(Array.Empty<ServiceDescriptor>())
+            {
+            }
+
+            protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
+            {
+                return scope => null;
+            }
+
         }
     }
 }


### PR DESCRIPTION
- Today DI scopes allocate a dictionary and an optional list of disposables per request. That dictionary starts off with the default capacity and resizes as scoped services are resolved.  Depending on how many scoped services are resolved, this can end up with many resizes per request which result in new array allocations. This change pools those 2 lists assuming that short lived scopes look mostly the same (same number of services resolved and disposed per scope instance).
- This change pools a set of scopes assuming they are short lived.
- One breaking change is that after disposal, pooled scopes will throw if services are accessed afterwards on the scope.
- We *could* make this an opt in flag but, I'm not sure if it it makes sense. Accessing a scope after it's disposed is broken anyways.

~PS: Needs testing, getting early feedback.~
~TODO: Performance tests~

cc @sebastienros 

Fixes https://github.com/dotnet/runtime/issues/47607

Update: @sebastienros confirmed it fixes the issue.