### PR TITLE
cruntime/*printf*: free temporary string buffers also on failure

### DIFF
--- a/src/coreclr/pal/src/cruntime/printf.cpp
+++ b/src/coreclr/pal/src/cruntime/printf.cpp
@@ -303,7 +303,7 @@ static BOOL Internal_ScanfExtractFormatW(LPCWSTR *Fmt, LPSTR Out, int iOutSize, 
         {
             ERROR("atoi returned a negative value indicative of an overflow.\n");
             SetLastError(ERROR_INTERNAL_ERROR);
-            return Result;
+            goto EXIT;
         }
     }
 
@@ -401,7 +401,7 @@ static BOOL Internal_ScanfExtractFormatW(LPCWSTR *Fmt, LPSTR Out, int iOutSize, 
             {
                 ERROR("strcpy_s failed\n");
                 SetLastError(ERROR_INSUFFICIENT_BUFFER);
-                return FALSE;
+                goto EXIT;
             }
 
             Out += strlen(scanf_longlongfmt);
@@ -532,6 +532,8 @@ static BOOL Internal_ScanfExtractFormatW(LPCWSTR *Fmt, LPSTR Out, int iOutSize, 
     *Out++ = 'n';
 
     *Out = 0;  /* end the string */
+
+EXIT:
     PAL_free(TempStr);
     return Result;
 }

--- a/src/coreclr/pal/src/cruntime/printfcpp.cpp
+++ b/src/coreclr/pal/src/cruntime/printfcpp.cpp
@@ -220,7 +220,7 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
         {
             ERROR("atoi returned a negative value indicative of an overflow.\n");
             pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
-            return Result;
+            goto EXIT;
         }
     }
     else if (**Fmt == '*')
@@ -258,7 +258,7 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
             {
                 ERROR("atoi returned a negative value indicative of an overflow.\n");
                 pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
-                return Result;
+                goto EXIT;
             }
         }
         else if (**Fmt == '*')
@@ -444,6 +444,8 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
     }
 
     *Out = 0;  /* end the string */
+
+EXIT:
     free(TempStr);
     return Result;
 }
@@ -525,7 +527,7 @@ BOOL Internal_ExtractFormatW(CPalThread *pthrCurrent, LPCWSTR *Fmt, LPSTR Out, L
         {
             ERROR("atoi returned a negative value indicative of an overflow.\n");
             pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
-            return Result;
+            goto EXIT;
         }
     }
     else if (**Fmt == '*')
@@ -562,7 +564,7 @@ BOOL Internal_ExtractFormatW(CPalThread *pthrCurrent, LPCWSTR *Fmt, LPSTR Out, L
             {
                 ERROR("atoi returned a negative value indicative of an overflow.\n");
                 pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
-                return Result;
+                goto EXIT;
             }
         }
         else if (**Fmt == '*')
@@ -772,6 +774,8 @@ BOOL Internal_ExtractFormatW(CPalThread *pthrCurrent, LPCWSTR *Fmt, LPSTR Out, L
     }
 
     *Out = 0;  /* end the string */
+
+EXIT:
     free(TempStr);
     return Result;
 }
@@ -899,7 +903,7 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
     LPWSTR OutOriginal;
     INT LengthInStr;
     INT Length;
-    INT Written = 0;
+    INT Written = -1;
 
     LengthInStr = PAL_wcslen(In);
     Length = LengthInStr;
@@ -924,9 +928,8 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         if (wcscpy_s(Out, iLen, In) != SAFECRT_SUCCESS)
         {
             ERROR("wcscpy_s failed!\n");
-            free(OutOriginal);
             pthrCurrent->SetLastError(ERROR_INSUFFICIENT_BUFFER);
-            return -1;
+            goto EXIT;
         }
         Out += LengthInStr;
         iLen -= LengthInStr;
@@ -954,9 +957,8 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         if (wcscpy_s(Out, iLen, In) != SAFECRT_SUCCESS)
         {
             ERROR("wcscpy_s failed!\n");
-            free(OutOriginal);
             pthrCurrent->SetLastError(ERROR_INSUFFICIENT_BUFFER);
-            return -1;
+            goto EXIT;
         }
 
         Out += LengthInStr;
@@ -971,9 +973,14 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         {
             ERROR("fwrite() failed with errno == %d\n", errno);
         }
-        free(OutOriginal);
+    }
+    else
+    {
+        Written = 0;
     }
 
+EXIT:
+    free(OutOriginal);
     return Written;
 }
 

--- a/src/coreclr/pal/src/cruntime/silent_printf.cpp
+++ b/src/coreclr/pal/src/cruntime/silent_printf.cpp
@@ -402,7 +402,7 @@ BOOL Silent_ExtractFormatA(LPCSTR *Fmt, LPSTR Out, LPINT Flags, LPINT Width, LPI
         if (*Width < 0)
         {
             SetLastError(ERROR_INTERNAL_ERROR);
-            return Result;
+            goto EXIT;
         }
     }
     else if (**Fmt == '*')
@@ -439,7 +439,7 @@ BOOL Silent_ExtractFormatA(LPCSTR *Fmt, LPSTR Out, LPINT Flags, LPINT Width, LPI
             if (*Precision < 0)
             {
                 SetLastError(ERROR_INTERNAL_ERROR);
-                return Result;
+                goto EXIT;
             }
         }
         else if (**Fmt == '*')
@@ -595,6 +595,8 @@ BOOL Silent_ExtractFormatA(LPCSTR *Fmt, LPSTR Out, LPINT Flags, LPINT Width, LPI
     }
 
     *Out = 0;  /* end the string */
+
+EXIT:
     PAL_free(TempStr);
     return Result;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50408.

@janvorli ptal