### PR TITLE
Fix formatting string for assembly MVID mismatch

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -86,7 +86,7 @@ Crst ArgBasedStubCache
 End
 
 Crst AssemblyLoader
-    AcquiredBefore DeadlockDetection UniqueStack
+    AcquiredBefore DeadlockDetection UniqueStack DebuggerMutex
 End
 
 Crst AvailableClass

--- a/src/coreclr/inc/crsttypes.h
+++ b/src/coreclr/inc/crsttypes.h
@@ -149,7 +149,7 @@ int g_rgCrstLevelMap[] =
     14,         // CrstAppDomainHandleTable
     0,          // CrstArgBasedStubCache
     0,          // CrstAssemblyList
-    7,          // CrstAssemblyLoader
+    12,         // CrstAssemblyLoader
     3,          // CrstAvailableClass
     4,          // CrstAvailableParamTypes
     7,          // CrstBaseDomain

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -285,7 +285,7 @@ void NativeImage::CheckAssemblyMvid(Assembly *assembly) const
     StringFromGUID2(*componentMvid, componentMvidText, MVID_TEXT_LENGTH);
 
     SString message;
-    message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
+    message.Printf(W("MVID mismatch between loaded assembly '%S' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
         assembly->GetSimpleName(),
         assemblyMvidText,
         SString(SString::Utf8, GetFileName()).GetUnicode(),

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -285,8 +285,8 @@ void NativeImage::CheckAssemblyMvid(Assembly *assembly) const
     StringFromGUID2(*componentMvid, componentMvidText, MVID_TEXT_LENGTH);
 
     SString message;
-    message.Printf(W("MVID mismatch between loaded assembly '%S' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
-        assembly->GetSimpleName(),
+    message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
+        SString(SString::Utf8, assembly->GetSimpleName()).GetUnicode(),
         assemblyMvidText,
         SString(SString::Utf8, GetFileName()).GetUnicode(),
         componentMvidText);


### PR DESCRIPTION
During development of the MVID check change I at some point ended
up with mismatched printf specifiers and arguments - the string
is Unicode so that we need %S to print the 8-bit string
returned from GetSimpleName.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 