### PR TITLE
JIT: Fix weights in fgOptimizeUncondBranchToSimpleCond

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1311,6 +1311,8 @@ public:
                                  bool*                wbUsedSlop);
     void setEdgeWeights(BasicBlock::weight_t newMinWeight, BasicBlock::weight_t newMaxWeight, BasicBlock* bDst);
 
+    void scaleEdgeWeights(BasicBlock::weight_t scale, BasicBlock* bDst);
+
     flowList(BasicBlock* block, flowList* rest)
         : flNext(rest), m_block(block), flEdgeWeightMin(0), flEdgeWeightMax(0), flDupCount(0)
     {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3207,6 +3207,12 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
     // `fgUpdateFlowGraph` has been called with `doTailDuplication` set to true, and the
     // backend always calls `fgUpdateFlowGraph` with `doTailDuplication` set to false.
     assert(!block->IsLIR());
+    
+    // The optimization doesn't make sense in this case
+    if (target->bbWeight == 0.0)
+    {
+        return false;
+    }
 
     // See https://github.com/dotnet/runtime/pull/50490#pullrequestreview-625700642
     //

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2750,6 +2750,22 @@ void flowList::setEdgeWeights(BasicBlock::weight_t theMinWeight, BasicBlock::wei
     flEdgeWeightMax = theMaxWeight;
 }
 
+//------------------------------------------------------------------------
+// scaleEdgeWeights: Scale both min and max weights by some factor 
+//
+// Arguments:
+//    scale - scale to apply
+//    bDst  - the destination block for the edge
+//
+void flowList::scaleEdgeWeights(BasicBlock::weight_t scale, BasicBlock* bDst)
+{
+    JITDUMP("Scalling edge weights for " FMT_BB " -> " FMT_BB " by " FMT_WT "\n", getBlock()->bbNum, bDst->bbNum,
+            scale);
+
+    flEdgeWeightMin *= scale;
+    flEdgeWeightMax *= scale;
+}
+
 //-------------------------------------------------------------
 // fgComputeBlockAndEdgeWeights: determine weights for blocks
 //   and optionally for edges


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50419

Repro (`COMPlus_TieredPGO=1`):
```csharp
using System.Runtime.CompilerServices;
using System.Threading;

class Program
{
    static void Main()
    {
        // Collect some profile, wait for tier0->tier1 promotion.
        for (int i = 0; i < 100; i++)
        {
            Test(new object());
            Thread.Sleep(16);
        }
    }

    static object someObj;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static void Test(object o)
    {
        if (o != someObj)
            o = null;

        if (o != null)
            Test1();
    }

    [MethodImpl(MethodImplOptions.NoInlining)] static void Test1() { }
}
```
Codegen diff between main and this PR: https://www.diffchecker.com/iqSxlzMG (note "edge weights are invalid" on the left)

![image](https://user-images.githubusercontent.com/523221/113172057-bd8b6400-9250-11eb-9110-524786a53457.png)

The edges' weights aren't even rendered on the left (same phase).