### PR TITLE
Big-endian fix: Accessing OBJECTHEADER in ImageConverter

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -120,7 +120,7 @@ namespace System.Drawing
                     return null;
                 }
 
-                // The data is in the form of OBJECTHEADER. It's an encoded format that Access uses to push imagesinto the DB.
+                // The data is in the form of OBJECTHEADER. It's an encoded format that Access uses to push images into the DB.
                 //
                 // The layout of OBJECTHEADER is as follows - we only need the signature
                 // and headersize fields, which need to be read as little-endian data:

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Imaging;
@@ -112,7 +113,7 @@ namespace System.Drawing
         {
             try
             {
-                short signature = MemoryMarshal.Read<short>(rawData);
+                short signature = BinaryPrimitives.ReadInt16LittleEndian(rawData);
 
                 if (signature != 0x1c15)
                 {
@@ -120,12 +121,30 @@ namespace System.Drawing
                 }
 
                 // The data is in the form of OBJECTHEADER. It's an encoded format that Access uses to push imagesinto the DB.
-                OBJECTHEADER pHeader = MemoryMarshal.Read<OBJECTHEADER>(rawData);
+                //
+                // The layout of OBJECTHEADER is as follows - we only need the signature
+                // and headersize fields, which need to be read as little-endian data:
+                //
+                //   [StructLayout(LayoutKind.Sequential)]
+                //   private struct OBJECTHEADER
+                //   {
+                //       public short signature; // it's always 0x1c15
+                //       public short headersize;
+                //       public short objectType;
+                //       public short nameLen;
+                //       public short classLen;
+                //       public short nameOffset;
+                //       public short classOffset;
+                //       public short width;
+                //       public short height;
+                //       public IntPtr pInfo;
+                //   }
+                short headersize = BinaryPrimitives.ReadInt16LittleEndian(rawData.Slice(2, 2));
 
                 // pHeader.signature will always be 0x1c15.
                 // "PBrush" should be the 6 chars after position 12 as well.
-                if (rawData.Length <= pHeader.headersize + 18 ||
-                    !rawData.Slice(pHeader.headersize + 12, 6).SequenceEqual(PBrush))
+                if (rawData.Length <= headersize + 18 ||
+                    !rawData.Slice(headersize + 12, 6).SequenceEqual(PBrush))
                 {
                     return null;
                 }
@@ -142,21 +161,6 @@ namespace System.Drawing
             }
 
             return null;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct OBJECTHEADER
-        {
-            public short signature; // it's always 0x1c15
-            public short headersize;
-            public short objectType;
-            public short nameLen;
-            public short classLen;
-            public short nameOffset;
-            public short classOffset;
-            public short width;
-            public short height;
-            public IntPtr pInfo;
         }
     }
 }


### PR DESCRIPTION
The GetBitmapStream routine in ImageConverter is supposed to
skip an embedded OBJECTHEADER structure.  However, this
structure needs to be read in little-endian mode, not in
native byte order.

Fixes the ImageConverterTest.ImageWithOleHeader test on
big-endian systems.