### PR TITLE
Fix msquic.dll loading

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -122,7 +122,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         static MsQuicApi()
         {
             // TODO: Consider updating all of these delegates to instead use function pointers.
-            if (NativeLibrary.TryLoad(Interop.Libraries.MsQuic, out IntPtr msQuicHandle))
+            if (NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle))
             {
                 try
                 {


### PR DESCRIPTION
The loading got broken by https://github.com/dotnet/runtime/commit/18ddd57550e72918b88406a182b42d72cb874fc2 by switching form `DllImport` to `NativeLibrary.TryLoad` but not providing correct arguments