### PR TITLE
Support DOTNET_ prefix

### DIFF
--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -107,6 +107,7 @@ nativeStringResourceTable_mscorrc
 #FlushFileBuffers
 #FlushInstructionCache
 #FormatMessageW
+#FreeEnvironmentStringsW
 #FreeLibrary
 #FileTimeToSystemTime
 #GetACP
@@ -114,6 +115,7 @@ nativeStringResourceTable_mscorrc
 #GetCurrentProcess
 #GetCurrentProcessId
 #GetCurrentThreadId
+#GetEnvironmentStringsW
 #GetEnvironmentVariableA
 #GetEnvironmentVariableW
 #GetFileAttributesExW

--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -102,8 +102,17 @@ elseif(CLR_CMAKE_HOST_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
         palrt
-        coreclrpal
-        # share the PAL in the dac module
+    )
+
+    # Due to the pal_redefines_file adding redirects
+    # on Linux, the coreclrpal must be used only on OSX.
+    if(CLR_CMAKE_HOST_OSX)
+        list(APPEND COREDBI_LIBRARIES
+            coreclrpal
+        )
+    endif(CLR_CMAKE_HOST_OSX)
+
+    list(APPEND COREDBI_LIBRARIES
         mscordaccore
     )
 

--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -102,6 +102,7 @@ elseif(CLR_CMAKE_HOST_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
         palrt
+        coreclrpal
         # share the PAL in the dac module
         mscordaccore
     )

--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -102,17 +102,7 @@ elseif(CLR_CMAKE_HOST_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
         palrt
-    )
-
-    # Due to the pal_redefines_file adding redirects
-    # on Linux, the coreclrpal must be used only on OSX.
-    if(CLR_CMAKE_HOST_OSX)
-        list(APPEND COREDBI_LIBRARIES
-            coreclrpal
-        )
-    endif(CLR_CMAKE_HOST_OSX)
-
-    list(APPEND COREDBI_LIBRARIES
+        # share the PAL in the dac module
         mscordaccore
     )
 

--- a/src/coreclr/inc/clrconfig.h
+++ b/src/coreclr/inc/clrconfig.h
@@ -26,12 +26,12 @@ public:
         // Default options.
         Default = 0,
 
-        // If set, do not prepend "COMPlus_" when doing environment variable lookup.
-        DontPrependCOMPlus_ = 0x1,
+        // If set, do not prepend prefix when doing environment variable lookup.
+        DontPrependPrefix = 0x1,
 
         // Remove any whitespace at beginning and end of value.  (Only applicable for
         // *string* configuration values.)
-        TrimWhiteSpaceFromStringValue = 0x2,
+        TrimWhiteSpaceFromStringValue = 0x2
     };
 
     // Struct used to store information about where/how to find a Config DWORD.
@@ -132,8 +132,8 @@ public:
     // Free a string returned by GetConfigValue
     static void FreeConfigString(__in __in_z LPWSTR name);
 
-    // Populate the caches with current state to improve lookup times.
-    static void InitCache();
+    // Initialize the configuration.
+    static void Initialize();
 };
 
 inline CLRConfig::LookupOptions operator|(CLRConfig::LookupOptions lhs, CLRConfig::LookupOptions rhs)

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -56,7 +56,7 @@
 // of options and their descriptions, see code:CLRConfig.LookupOptions
 //
 // Example: CONFIG_DWORD_INFO_EX(INTERNAL_EnableInternetHREFexes, W("EnableInternetHREFexes"), 0, "",
-// (CLRConfig::LookupOptions) (CLRConfig::LookupOptions::DontPrependCOMPlus_))
+// (CLRConfig::LookupOptions) (CLRConfig::LookupOptions::DontPrependPrefix))
 //
 // #Strings:
 // --------------------------------------------------------------------------
@@ -108,6 +108,11 @@
 // * W("INTERNAL_Security_FullAccessChecks")
 // * W("UNSUPPORTED_Security_DisableTransparency")
 // * W("Security_LegacyHMACMode") <---------------------- (No EXTERNAL prefix)
+
+///
+/// Configuration
+///
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableDOTNETPrefix, W("EnableDOTNETPrefix"), TRUE, "Set if the runtime should check for the DOTNET_ prefix or only use COMPlus_.")
 
 ///
 /// AppDomain
@@ -402,10 +407,6 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_InterpreterHWIntrinsicsIsSupportedFalse, W("In
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_InterpreterFallback, W("InterpreterFallback"), 0, "Fallback to the interpreter when the JIT compiler fails")
 
 ///
-/// Loader
-///
-
-///
 /// Loader heap
 ///
 CONFIG_DWORD_INFO(INTERNAL_LoaderHeapCallTracing, W("LoaderHeapCallTracing"), 0, "Loader heap troubleshooting")
@@ -442,7 +443,7 @@ CONFIG_DWORD_INFO(INTERNAL_MD_MiniMDBreak, W("MD_MiniMDBreak"), 0, "ASSERT when 
 CONFIG_DWORD_INFO(INTERNAL_MD_PreSaveBreak, W("MD_PreSaveBreak"), 0, "ASSERT when calling CMiniMdRw::PreSave")
 CONFIG_DWORD_INFO(INTERNAL_MD_RegMetaBreak, W("MD_RegMetaBreak"), 0, "ASSERT when creating RegMeta class")
 CONFIG_DWORD_INFO(INTERNAL_MD_RegMetaDump, W("MD_RegMetaDump"), 0, "Dump MD in 4 functions (?)")
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_MODIFIABLE_ASSEMBLIES, W("DOTNET_MODIFIABLE_ASSEMBLIES"), "Enables hot reload on debug built assemblies with the 'debug' keyword", CLRConfig::LookupOptions::DontPrependCOMPlus_ | CLRConfig::LookupOptions::TrimWhiteSpaceFromStringValue);
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_MODIFIABLE_ASSEMBLIES, W("DOTNET_MODIFIABLE_ASSEMBLIES"), "Enables hot reload on debug built assemblies with the 'debug' keyword", CLRConfig::LookupOptions::DontPrependPrefix | CLRConfig::LookupOptions::TrimWhiteSpaceFromStringValue);
 
 // Metadata - mscordbi only - this flag is only intended to mitigate potential issues in bug fix 458597.
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_MD_PreserveDebuggerMetadataMemory, W("MD_PreserveDebuggerMetadataMemory"), 0, "Save all versions of metadata memory in the debugger when debuggee metadata is updated")
@@ -495,18 +496,18 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_CrossGenAssumeInputSigned, W("CrossGenAssumeIn
 ///
 /// Profiling API / ETW
 ///
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_COR_ENABLE_PROFILING, W("COR_ENABLE_PROFILING"), 0, "Flag to indicate whether profiling should be enabled for the currently running process.", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER, W("COR_PROFILER"), "Specifies GUID of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH, W("COR_PROFILER_PATH"), "Specifies the path to the DLL of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH_32, W("COR_PROFILER_PATH_32"), "Specifies the path to the DLL of profiler to load into currently running 32 bits process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH_64, W("COR_PROFILER_PATH_64"), "Specifies the path to the DLL of profiler to load into currently running 64 bits process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_CORECLR_ENABLE_PROFILING, W("CORECLR_ENABLE_PROFILING"), 0, "CoreCLR only: Flag to indicate whether profiling should be enabled for the currently running process.", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER, W("CORECLR_PROFILER"), "CoreCLR only: Specifies GUID of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH, W("CORECLR_PROFILER_PATH"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_32, W("CORECLR_PROFILER_PATH_32"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running 32 process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_64, W("CORECLR_PROFILER_PATH_64"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running 64 process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_ARM32, W("CORECLR_PROFILER_PATH_ARM32"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running ARM32 process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_ARM64, W("CORECLR_PROFILER_PATH_ARM64"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running ARM64 process", CLRConfig::LookupOptions::DontPrependCOMPlus_)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_COR_ENABLE_PROFILING, W("COR_ENABLE_PROFILING"), 0, "Flag to indicate whether profiling should be enabled for the currently running process.", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER, W("COR_PROFILER"), "Specifies GUID of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH, W("COR_PROFILER_PATH"), "Specifies the path to the DLL of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH_32, W("COR_PROFILER_PATH_32"), "Specifies the path to the DLL of profiler to load into currently running 32 bits process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_COR_PROFILER_PATH_64, W("COR_PROFILER_PATH_64"), "Specifies the path to the DLL of profiler to load into currently running 64 bits process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_CORECLR_ENABLE_PROFILING, W("CORECLR_ENABLE_PROFILING"), 0, "CoreCLR only: Flag to indicate whether profiling should be enabled for the currently running process.", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER, W("CORECLR_PROFILER"), "CoreCLR only: Specifies GUID of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH, W("CORECLR_PROFILER_PATH"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_32, W("CORECLR_PROFILER_PATH_32"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running 32 process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_64, W("CORECLR_PROFILER_PATH_64"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running 64 process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_ARM32, W("CORECLR_PROFILER_PATH_ARM32"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running ARM32 process", CLRConfig::LookupOptions::DontPrependPrefix)
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_CORECLR_PROFILER_PATH_ARM64, W("CORECLR_PROFILER_PATH_ARM64"), "CoreCLR only: Specifies the path to the DLL of profiler to load into currently running ARM64 process", CLRConfig::LookupOptions::DontPrependPrefix)
 RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_ProfAPI_ProfilerCompatibilitySetting, W("ProfAPI_ProfilerCompatibilitySetting"), "Specifies the profiler loading policy (the default is not to load a V2 profiler in V4)", CLRConfig::LookupOptions::TrimWhiteSpaceFromStringValue)
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_DetachMinSleepMs, W("ProfAPI_DetachMinSleepMs"), 0, "The minimum time, in milliseconds, the CLR will wait before checking whether a profiler that is in the process of detaching is ready to be unloaded.")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_DetachMaxSleepMs, W("ProfAPI_DetachMaxSleepMs"), 0, "The maximum time, in milliseconds, the CLR will wait before checking whether a profiler that is in the process of detaching is ready to be unloaded.")
@@ -722,8 +723,8 @@ RETAIL_CONFIG_STRING_INFO(INTERNAL_GCGenAnalysisCmd, W("GCGenAnalysisCmd"), "An 
 //
 // Diagnostics Ports
 //
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend, W("DOTNET_DefaultDiagnosticPortSuspend"), 0, "This sets the deafult diagnostic port to suspend causing the runtime to pause during startup before major subsystems are started.  Resume using the Diagnostics IPC ResumeStartup command on the default diagnostic port.", CLRConfig::LookupOptions::DontPrependCOMPlus_);
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_DiagnosticPorts, W("DOTNET_DiagnosticPorts"), "A semicolon delimited list of additional Diagnostic Ports, where a Diagnostic Port is a NamedPipe path without '\\\\.\\pipe\\' on Windows or the full path of Unix Domain Socket on Linux/Unix followed by optional tags, e.g., '<path>,connect,nosuspend;<path>'", CLRConfig::LookupOptions::DontPrependCOMPlus_);
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend, W("DOTNET_DefaultDiagnosticPortSuspend"), 0, "This sets the deafult diagnostic port to suspend causing the runtime to pause during startup before major subsystems are started.  Resume using the Diagnostics IPC ResumeStartup command on the default diagnostic port.", CLRConfig::LookupOptions::DontPrependPrefix);
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_DiagnosticPorts, W("DOTNET_DiagnosticPorts"), "A semicolon delimited list of additional Diagnostic Ports, where a Diagnostic Port is a NamedPipe path without '\\\\.\\pipe\\' on Windows or the full path of Unix Domain Socket on Linux/Unix followed by optional tags, e.g., '<path>,connect,nosuspend;<path>'", CLRConfig::LookupOptions::DontPrependPrefix);
 
 //
 // LTTng

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -438,7 +438,7 @@ CONFIG_DWORD_INFO(INTERNAL_MD_MiniMDBreak, W("MD_MiniMDBreak"), 0, "ASSERT when 
 CONFIG_DWORD_INFO(INTERNAL_MD_PreSaveBreak, W("MD_PreSaveBreak"), 0, "ASSERT when calling CMiniMdRw::PreSave")
 CONFIG_DWORD_INFO(INTERNAL_MD_RegMetaBreak, W("MD_RegMetaBreak"), 0, "ASSERT when creating RegMeta class")
 CONFIG_DWORD_INFO(INTERNAL_MD_RegMetaDump, W("MD_RegMetaDump"), 0, "Dump MD in 4 functions (?)")
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_MODIFIABLE_ASSEMBLIES, W("DOTNET_MODIFIABLE_ASSEMBLIES"), "Enables hot reload on debug built assemblies with the 'debug' keyword", CLRConfig::LookupOptions::DontPrependPrefix | CLRConfig::LookupOptions::TrimWhiteSpaceFromStringValue);
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_MODIFIABLE_ASSEMBLIES, W("MODIFIABLE_ASSEMBLIES"), "Enables hot reload on debug built assemblies with the 'debug' keyword", CLRConfig::LookupOptions::TrimWhiteSpaceFromStringValue);
 
 // Metadata - mscordbi only - this flag is only intended to mitigate potential issues in bug fix 458597.
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_MD_PreserveDebuggerMetadataMemory, W("MD_PreserveDebuggerMetadataMemory"), 0, "Save all versions of metadata memory in the debugger when debuggee metadata is updated")
@@ -718,8 +718,8 @@ RETAIL_CONFIG_STRING_INFO(INTERNAL_GCGenAnalysisCmd, W("GCGenAnalysisCmd"), "An 
 //
 // Diagnostics Ports
 //
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend, W("DOTNET_DefaultDiagnosticPortSuspend"), 0, "This sets the deafult diagnostic port to suspend causing the runtime to pause during startup before major subsystems are started.  Resume using the Diagnostics IPC ResumeStartup command on the default diagnostic port.", CLRConfig::LookupOptions::DontPrependPrefix);
-RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_DiagnosticPorts, W("DOTNET_DiagnosticPorts"), "A semicolon delimited list of additional Diagnostic Ports, where a Diagnostic Port is a NamedPipe path without '\\\\.\\pipe\\' on Windows or the full path of Unix Domain Socket on Linux/Unix followed by optional tags, e.g., '<path>,connect,nosuspend;<path>'", CLRConfig::LookupOptions::DontPrependPrefix);
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend, W("DefaultDiagnosticPortSuspend"), 0, "This sets the deafult diagnostic port to suspend causing the runtime to pause during startup before major subsystems are started.  Resume using the Diagnostics IPC ResumeStartup command on the default diagnostic port.");
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_DOTNET_DiagnosticPorts, W("DiagnosticPorts"), "A semicolon delimited list of additional Diagnostic Ports, where a Diagnostic Port is a NamedPipe path without '\\\\.\\pipe\\' on Windows or the full path of Unix Domain Socket on Linux/Unix followed by optional tags, e.g., '<path>,connect,nosuspend;<path>'");
 
 //
 // LTTng

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -110,11 +110,6 @@
 // * W("Security_LegacyHMACMode") <---------------------- (No EXTERNAL prefix)
 
 ///
-/// Configuration
-///
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableDOTNETPrefix, W("EnableDOTNETPrefix"), TRUE, "Set if the runtime should check for the DOTNET_ prefix or only use COMPlus_.")
-
-///
 /// AppDomain
 ///
 CONFIG_DWORD_INFO(INTERNAL_EnableFullDebug, W("EnableFullDebug"), 0, "Heavy-weight checking for AD boundary violations (AD leaks)")

--- a/src/coreclr/inc/winwrap.h
+++ b/src/coreclr/inc/winwrap.h
@@ -134,8 +134,6 @@
 //
 
 // winbase.h
-#define WszGetEnvironmentStrings   GetEnvironmentStringsW
-#define WszFreeEnvironmentStrings   FreeEnvironmentStringsW
 #define WszFormatMessage   FormatMessageW
 #define Wszlstrcmp   lstrcmpW
 #define Wszlstrcmpi   lstrcmpiW

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -625,12 +625,11 @@ void CLRConfig::Initialize()
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DisableConfigCache) != 0)
         return;
 
-#ifdef TARGET_WINDOWS
     const WCHAR prefixC = towlower(COMPLUS_PREFIX[0]);
     const WCHAR prefixD = towlower(DOTNET_PREFIX[0]);
 
     // Create a cache of environment variables
-    WCHAR* wszStrings = WszGetEnvironmentStrings();
+    WCHAR* wszStrings = GetEnvironmentStringsW();
     if (wszStrings != NULL)
     {
         // GetEnvironmentStrings returns pointer to a null terminated block containing
@@ -674,8 +673,7 @@ void CLRConfig::Initialize()
                 wszCurr++;
         }
 
-        WszFreeEnvironmentStrings(wszStrings);
+        FreeEnvironmentStringsW(wszStrings);
         s_fUseEnvCache = true;
     }
-#endif // TARGET_WINDOWS
 }

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -11,7 +11,10 @@
 
 // Config prefixes
 #define COMPLUS_PREFIX W("COMPlus_")
-#define LEN_OF_COMPLUS_PREFIX 8
+#define LEN_OF_COMPLUS_PREFIX StrLen(COMPLUS_PREFIX)
+
+#define DOTNET_PREFIX W("DOTNET_")
+#define LEN_OF_DOTNET_PREFIX StrLen(DOTNET_PREFIX)
 
 using ConfigDWORDInfo = CLRConfig::ConfigDWORDInfo;
 using ConfigStringInfo = CLRConfig::ConfigStringInfo;
@@ -68,7 +71,7 @@ namespace
         // Return TRUE if a name *may have* been added to the set;
         // return FALSE if the name *definitely* was NOT ever added to the set.
         //
-        BOOL MayContain(LPCWSTR name) const
+        bool MayContain(LPCWSTR name) const
         {
             WRAPPER_NO_CONTRACT;
 
@@ -98,10 +101,11 @@ namespace
         }
     };
 
-    BOOL s_fUseEnvCache = FALSE;
+    bool s_enableDotnetPrefix = true;
+    bool s_fUseEnvCache = false;
     ProbabilisticNameSet s_EnvNames; // set of environment value names seen
 
-    BOOL EnvCacheValueNameSeenPerhaps(LPCWSTR name)
+    bool EnvCacheValueNameSeenPerhaps(LPCWSTR name)
     {
         WRAPPER_NO_CONTRACT;
 
@@ -109,10 +113,30 @@ namespace
             || s_EnvNames.MayContain(name);
     }
 
+    bool CheckLookupOption(const ConfigDWORDInfo & info, LookupOptions option)
+    {
+        LIMITED_METHOD_CONTRACT;
+        return ((info.options & option) == option);
+    }
+
+    bool CheckLookupOption(const ConfigStringInfo & info, LookupOptions option)
+    {
+        LIMITED_METHOD_CONTRACT;
+        return ((info.options & option) == option);
+    }
+
+    bool CheckLookupOption(LookupOptions infoOptions, LookupOptions optionToCheck)
+    {
+        LIMITED_METHOD_CONTRACT;
+        return ((infoOptions & optionToCheck) == optionToCheck);
+    }
+
     //*****************************************************************************
     // Reads from the environment setting
     //*****************************************************************************
-    LPWSTR EnvGetString(LPCWSTR name, bool fPrependCOMPLUS)
+    LPWSTR EnvGetString(
+        LPCWSTR name,
+        LookupOptions options)
     {
         CONTRACTL
         {
@@ -124,22 +148,46 @@ namespace
         CONTRACTL_END;
 
         WCHAR buff[64];
+        const WCHAR* fallbackPrefix = NULL;
+        const size_t namelen = wcslen(name);
 
-        if(wcslen(name) > (size_t)(64 - 1 - (fPrependCOMPLUS ? LEN_OF_COMPLUS_PREFIX : 0)))
+        bool noPrefix = CheckLookupOption(options, LookupOptions::DontPrependPrefix);
+        if (noPrefix)
         {
-            return NULL;
-        }
-
-        if (fPrependCOMPLUS)
-        {
-            if (!EnvCacheValueNameSeenPerhaps(name))
+            if (namelen >= _countof(buff))
+            {
+                _ASSERTE(!"Environment variable name too long.");
                 return NULL;
+            }
 
-            wcscpy_s(buff, _countof(buff), COMPLUS_PREFIX);
+            *buff = W('\0');
         }
         else
         {
-            *buff = 0;
+            bool dotnetValid = namelen < (size_t)(_countof(buff) - 1 - LEN_OF_DOTNET_PREFIX);
+            bool complusValid = namelen < (size_t)(_countof(buff) - 1 - LEN_OF_COMPLUS_PREFIX);
+            if(!dotnetValid || !complusValid)
+            {
+                _ASSERTE(!"Environment variable name too long.");
+                return NULL;
+            }
+
+            // Check if the name has been cached.
+            if (!EnvCacheValueNameSeenPerhaps(name))
+                return NULL;
+
+            // Priority order is DOTNET_ and then COMPlus_. Users can request
+            // skipping of DOTNET_ if desired.
+            if (s_enableDotnetPrefix)
+            {
+                wcscpy_s(buff, _countof(buff), DOTNET_PREFIX);
+                fallbackPrefix = COMPLUS_PREFIX;
+            }
+            else
+            {
+                wcscpy_s(buff, _countof(buff), COMPLUS_PREFIX);
+                fallbackPrefix = NULL;
+            }
         }
 
         wcscat_s(buff, _countof(buff), name);
@@ -148,17 +196,20 @@ namespace
 
         NewArrayHolder<WCHAR> ret = NULL;
         HRESULT hr = S_OK;
-        DWORD Len;
         EX_TRY
         {
             PathString temp;
 
-            Len = WszGetEnvironmentVariable(buff, temp);
-            if (Len != 0)
+            DWORD len = WszGetEnvironmentVariable(buff, temp);
+            if (len == 0 && fallbackPrefix != NULL)
             {
-                ret = temp.GetCopyOfUnicodeString();
+                wcscpy_s(buff, _countof(buff), fallbackPrefix);
+                wcscat_s(buff, _countof(buff), name);
+                len = WszGetEnvironmentVariable(buff, temp);
             }
 
+            if (len != 0)
+                ret = temp.GetCopyOfUnicodeString();
         }
         EX_CATCH_HRESULT(hr);
 
@@ -177,7 +228,7 @@ namespace
         LPCWSTR name,
         DWORD defValue,
         __out DWORD *result,
-        bool fPrependCOMPLUS)
+        LookupOptions options)
     {
         CONTRACTL
         {
@@ -192,7 +243,7 @@ namespace
 
         FAULT_NOT_FATAL(); // We don't report OOM errors here, we return a default value.
 
-        NewArrayHolder<WCHAR> val = EnvGetString(name, fPrependCOMPLUS);
+        NewArrayHolder<WCHAR> val = EnvGetString(name, options);
         if (val != NULL)
         {
             errno = 0;
@@ -212,7 +263,7 @@ namespace
 
     LPWSTR GetConfigString(
         LPCWSTR name,
-        bool fPrependCOMPLUS)
+        LookupOptions options)
     {
         CONTRACTL
         {
@@ -226,7 +277,7 @@ namespace
 
         FAULT_NOT_FATAL(); // We don't report OOM errors here, we return a default value.
 
-        ret = EnvGetString(name, fPrependCOMPLUS);
+        ret = EnvGetString(name, options);
         if (ret != NULL)
         {
             if (*ret != W('\0'))
@@ -238,24 +289,6 @@ namespace
         }
 
         return NULL;
-    }
-
-    bool CheckLookupOption(const ConfigDWORDInfo & info, LookupOptions option)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return ((info.options & option) == option);
-    }
-
-    bool CheckLookupOption(const ConfigStringInfo & info, LookupOptions option)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return ((info.options & option) == option);
-    }
-
-    bool CheckLookupOption(LookupOptions infoOptions, LookupOptions optionToCheck)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return ((infoOptions & optionToCheck) == optionToCheck);
     }
 
     //---------------------------------------------------------------------------------------
@@ -402,9 +435,8 @@ DWORD CLRConfig::GetConfigValue(const ConfigDWORDInfo & info, /* [Out] */ bool *
 
     _ASSERTE (isDefault != nullptr);
 
-    bool prependCOMPlus = !CheckLookupOption(info, LookupOptions::DontPrependCOMPlus_);
     DWORD resultMaybe;
-    HRESULT hr = GetConfigDWORD(info.name, info.defaultValue, &resultMaybe, prependCOMPlus);
+    HRESULT hr = GetConfigDWORD(info.name, info.defaultValue, &resultMaybe, info.options);
 
     // Ignore the default value even if it's set explicitly.
     if (resultMaybe != info.defaultValue)
@@ -504,9 +536,7 @@ HRESULT CLRConfig::GetConfigValue(const ConfigStringInfo & info, __deref_out_z L
 
     LPWSTR result = NULL;
 
-    bool prependCOMPlus = !CheckLookupOption(info, LookupOptions::DontPrependCOMPlus_);
-    result = GetConfigString(info.name, prependCOMPlus);
-
+    result = GetConfigString(info.name, info.options);
     if ((result != NULL) && CheckLookupOption(info, LookupOptions::TrimWhiteSpaceFromStringValue))
     {
         // If this fails, result remains untouched, so we'll just return the untrimmed
@@ -545,14 +575,14 @@ BOOL CLRConfig::IsConfigOptionSpecified(LPCWSTR name)
     {
         LPWSTR result = NULL;
 
-        result = GetConfigString(name, true /* fPrependCOMPLUS */);
+        result = GetConfigString(name, LookupOptions::Default);
         if (result != NULL)
         {
             FreeConfigString(result);
             return TRUE;
         }
 
-        result = GetConfigString(name, false /* fPrependCOMPLUS */);
+        result = GetConfigString(name, LookupOptions::DontPrependPrefix);
         if (result != NULL)
         {
             FreeConfigString(result);
@@ -576,10 +606,10 @@ void CLRConfig::FreeConfigString(__in_z LPWSTR str)
 }
 
 //
-// Initialize the internal cache faster lookup.
+// Initialize the internal cache for faster lookup.
 //
 // static
-void CLRConfig::InitCache()
+void CLRConfig::Initialize()
 {
     CONTRACTL
     {
@@ -588,11 +618,17 @@ void CLRConfig::InitCache()
     }
     CONTRACTL_END;
 
+    // Check if the environment has been configured to disable lookup using the DOTNET_ prefix.
+    s_enableDotnetPrefix = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDOTNETPrefix) != 0;
+
     // Check if caching is disabled.
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DisableConfigCache) != 0)
         return;
 
 #ifdef TARGET_WINDOWS
+    const WCHAR prefixC = towlower(COMPLUS_PREFIX[0]);
+    const WCHAR prefixD = towlower(DOTNET_PREFIX[0]);
+
     // Create a cache of environment variables
     WCHAR* wszStrings = WszGetEnvironmentStrings();
     if (wszStrings != NULL)
@@ -603,8 +639,10 @@ void CLRConfig::InitCache()
         {
             WCHAR wch = towlower(*wszCurr);
 
-            // Lets only cache env variables with the COMPlus prefix only
-            if (wch == W('c'))
+            // Lets only cache env variables with targeted prefixes
+            bool matchC = wch == prefixC;
+            bool matchD = wch == prefixD;
+            if (matchC || matchD)
             {
                 WCHAR *wszName = wszCurr;
 
@@ -615,22 +653,29 @@ void CLRConfig::InitCache()
                 if (*wszCurr == W('='))
                 {
                     // Check the prefix
-                    if(!SString::_wcsnicmp(wszName, COMPLUS_PREFIX, LEN_OF_COMPLUS_PREFIX))
+                    if(matchC
+                        && SString::_wcsnicmp(wszName, COMPLUS_PREFIX, LEN_OF_COMPLUS_PREFIX) == 0)
                     {
                         wszName += LEN_OF_COMPLUS_PREFIX;
                         s_EnvNames.Add(wszName, (DWORD) (wszCurr - wszName));
                     }
+                    else if (s_enableDotnetPrefix
+                        && matchD
+                        && SString::_wcsnicmp(wszName, DOTNET_PREFIX, LEN_OF_DOTNET_PREFIX) == 0)
+                    {
+                        wszName += LEN_OF_DOTNET_PREFIX;
+                        s_EnvNames.Add(wszName, (DWORD) (wszCurr - wszName));
+                    }
                 }
-
             }
+
             // Look for current string termination
             while (*wszCurr)
                 wszCurr++;
-
         }
 
         WszFreeEnvironmentStrings(wszStrings);
-        s_fUseEnvCache = TRUE;
+        s_fUseEnvCache = true;
     }
 #endif // TARGET_WINDOWS
 }

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -101,7 +101,6 @@ namespace
         }
     };
 
-    bool s_enableDotnetPrefix = true;
     bool s_fUseEnvCache = false;
     ProbabilisticNameSet s_EnvNames; // set of environment value names seen
 
@@ -176,18 +175,9 @@ namespace
             if (!EnvCacheValueNameSeenPerhaps(name))
                 return NULL;
 
-            // Priority order is DOTNET_ and then COMPlus_. Users can request
-            // skipping of DOTNET_ if desired.
-            if (s_enableDotnetPrefix)
-            {
-                wcscpy_s(buff, _countof(buff), DOTNET_PREFIX);
-                fallbackPrefix = COMPLUS_PREFIX;
-            }
-            else
-            {
-                wcscpy_s(buff, _countof(buff), COMPLUS_PREFIX);
-                fallbackPrefix = NULL;
-            }
+            // Priority order is DOTNET_ and then COMPlus_.
+            wcscpy_s(buff, _countof(buff), DOTNET_PREFIX);
+            fallbackPrefix = COMPLUS_PREFIX;
         }
 
         wcscat_s(buff, _countof(buff), name);
@@ -618,9 +608,6 @@ void CLRConfig::Initialize()
     }
     CONTRACTL_END;
 
-    // Check if the environment has been configured to disable lookup using the DOTNET_ prefix.
-    s_enableDotnetPrefix = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDOTNETPrefix) != 0;
-
     // Check if caching is disabled.
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DisableConfigCache) != 0)
         return;
@@ -658,8 +645,7 @@ void CLRConfig::Initialize()
                         wszName += LEN_OF_COMPLUS_PREFIX;
                         s_EnvNames.Add(wszName, (DWORD) (wszCurr - wszName));
                     }
-                    else if (s_enableDotnetPrefix
-                        && matchD
+                    else if (matchD
                         && SString::_wcsnicmp(wszName, DOTNET_PREFIX, LEN_OF_DOTNET_PREFIX) == 0)
                     {
                         wszName += LEN_OF_DOTNET_PREFIX;

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -305,8 +305,8 @@ HRESULT EnsureEEStarted()
     {
         BEGIN_ENTRYPOINT_NOTHROW;
 
-        // Initialize our configuration cache to avoid unuseful probing.
-        CLRConfig::InitCache();
+        // Initialize our configuration.
+        CLRConfig::Initialize();
 
         BOOL bStarted=FALSE;
 

--- a/src/coreclr/vm/debughelp.cpp
+++ b/src/coreclr/vm/debughelp.cpp
@@ -194,7 +194,7 @@ void *DumpEnvironmentBlock(void)
     CONTRACTL_END;
 
     LPTSTR lpszVariable;
-    lpszVariable = (LPTSTR)WszGetEnvironmentStrings();
+    lpszVariable = (LPTSTR)GetEnvironmentStringsW();
 
     while (*lpszVariable)
     {
@@ -203,7 +203,7 @@ void *DumpEnvironmentBlock(void)
 
     fprintf(stderr, "\n");
 
-    return WszGetEnvironmentStrings();
+    return GetEnvironmentStringsW();
 }
 
 #if defined(TARGET_X86) && !defined(TARGET_UNIX)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/47283

This enables support for using the `DOTNET_` prefix and is now the preferred first choice. The `COMPlus_` is still supported but is the fallback.

~~A new flag was created to ignore the `DOTNET_` prefix in case external users have created a conflicting variable name.~~
 - ~~`DOTNET_EnableDOTNETPrefix=0`~~
 - ~~`COMPlus_EnableDOTNETPrefix=0`~~