### PR TITLE
Stop skipping entire System.Net.Http functional test suite on Android

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System;
 using Xunit;
 
 [assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", RuntimeConfiguration.Checked)]
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/131", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsNotBrowser))] // System.Net.Tests are flaky and/or long running
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/131", ~(TestPlatforms.Android | TestPlatforms.Browser), TargetFrameworkMonikers.Any, TestRuntimes.Mono)] // System.Net.Tests are flaky and/or long running
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -56,6 +56,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Ping\tests\FunctionalTests\System.Net.Ping.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />


### PR DESCRIPTION
It is skipped based on flakiness/slowness on a Checked/Debug runtime, which we are not currently using for Android tests. Put the test suite under Android test ProjectExclusions instead.

cc @steveisok @jkoritzinsky @AaronRobinsonMSFT @wfurt 