### PR TITLE
Limit superpmi replay failures using 'failureLimit' command line option

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
@@ -100,6 +100,10 @@ void CommandLine::DumpHelp(const char* program)
     printf("     If 'workerCount' is not specified, the number of workers used is\n");
     printf("     the number of processors on the machine.\n");
     printf("\n");
+    printf(" -failureLimit [limit]\n");
+    printf("     If specified, replay and asm diffs will exit if it sees more than 'limit' failures.\n");
+    printf("     Otherwise, all methods will be compiled.\n");
+    printf("\n");
     printf(" -skipCleanup\n");
     printf("     Skip deletion of temporary files created by child SuperPMI processes with -parallel.\n");
     printf("\n");
@@ -470,6 +474,11 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                         }
                     }
                 }
+            }
+            else if ((_strnicmp(&argv[i][1], "failureLimit", argLen) == 0))
+            {
+                ++i;
+                o->failureLimit = atoi(argv[i]);
             }
             else if ((_stricmp(&argv[i][1], "skipCleanup") == 0))
             {

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
@@ -100,8 +100,8 @@ void CommandLine::DumpHelp(const char* program)
     printf("     If 'workerCount' is not specified, the number of workers used is\n");
     printf("     the number of processors on the machine.\n");
     printf("\n");
-    printf(" -failureLimit [limit]\n");
-    printf("     If specified, replay and asm diffs will exit if it sees more than 'limit' failures.\n");
+    printf(" -failureLimit <limit>\n");
+    printf("     For a positive 'limit' number, replay and asm diffs will exit if it sees more than 'limit' failures.\n");
     printf("     Otherwise, all methods will be compiled.\n");
     printf("\n");
     printf(" -skipCleanup\n");
@@ -477,8 +477,21 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             }
             else if ((_strnicmp(&argv[i][1], "failureLimit", argLen) == 0))
             {
-                ++i;
+                if (++i >= argc)
+                {
+                    DumpHelp(argv[0]);
+                    return false;
+                }
+
                 o->failureLimit = atoi(argv[i]);
+
+                if (o->failureLimit < 1)
+                {
+                    LogError(
+                        "Incorrect limit specified for -failureLimit. Limit must be > 0.");
+                    DumpHelp(argv[0]);
+                    return false;
+                }
             }
             else if ((_stricmp(&argv[i][1], "skipCleanup") == 0))
             {

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
@@ -31,6 +31,7 @@ public:
             , skipCleanup(false)
             , workerCount(-1)
             , indexCount(-1)
+            , failureLimit(-1)
             , indexes(nullptr)
             , hash(nullptr)
             , methodStatsTypes(nullptr)
@@ -60,6 +61,7 @@ public:
         bool  skipCleanup; // In /parallel mode, do we skip cleanup of temporary files? Used for debugging /parallel.
         int   workerCount; // Number of workers to use for /parallel mode. -1 (or 1) means don't use parallel mode.
         int   indexCount;  // If indexCount is -1 and hash points to nullptr it means compile all.
+        int   failureLimit; // Number of failures after which bail out the replay/asmdiffs.
         int*  indexes;
         char* hash;
         char* methodStatsTypes;

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -534,6 +534,11 @@ int __cdecl main(int argc, char* argv[])
                 errorCount++;
                 LogError("main method %d of size %d failed to load and compile correctly.",
                          reader->GetMethodContextIndex(), mc->methodSize);
+                if (errorCount == 100)
+                {
+                    LogError("More than 100 methods failed. Skip compiling remaining methods.");
+                    break;
+                }
                 if ((o.reproName != nullptr) && (o.indexCount == -1))
                 {
                     char buff[500];

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -244,6 +244,7 @@ int __cdecl main(int argc, char* argv[])
     int matchCount        = 0;
     int failToReplayCount = 0;
     int errorCount        = 0;
+    int errorCount2       = 0;
     int missingCount      = 0;
     int index             = 0;
     int excludedCount     = 0;
@@ -384,8 +385,14 @@ int __cdecl main(int argc, char* argv[])
 
             if (res2 == JitInstance::RESULT_ERROR)
             {
+                errorCount2++;
                 LogError("JIT2 main method %d of size %d failed to load and compile correctly.",
                          reader->GetMethodContextIndex(), mc->methodSize);
+                if (errorCount2 == 100)
+                {
+                    LogError("More than 100 JIT2 methods failed. Skip compiling remaining JIT2 methods.");
+                    break;
+                }
             }
 
             // Methods that don't compile due to missing JIT-EE information
@@ -608,7 +615,7 @@ int __cdecl main(int argc, char* argv[])
 
     SpmiResult result = SpmiResult::Success;
 
-    if (errorCount > 0)
+    if ((errorCount > 0) || (errorCount2 > 0))
     {
         result = SpmiResult::Error;
     }

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -388,9 +388,9 @@ int __cdecl main(int argc, char* argv[])
                 errorCount2++;
                 LogError("Method %d of size %d failed to load and compile correctly by JIT2.",
                          reader->GetMethodContextIndex(), mc->methodSize);
-                if (errorCount2 == 100)
+                if (errorCount2 == o.failureLimit)
                 {
-                    LogError("More than 100 methods compilation failed by JIT2. Skip compiling remaining methods.");
+                    LogError("More than %d methods compilation failed by JIT2. Skip compiling remaining methods.", o.failureLimit);
                     break;
                 }
             }
@@ -541,9 +541,9 @@ int __cdecl main(int argc, char* argv[])
                 errorCount++;
                 LogError("main method %d of size %d failed to load and compile correctly.",
                          reader->GetMethodContextIndex(), mc->methodSize);
-                if (errorCount == 100)
+                if (errorCount == o.failureLimit)
                 {
-                    LogError("More than 100 methods failed. Skip compiling remaining methods.");
+                    LogError("More than %d methods failed. Skip compiling remaining methods.", o.failureLimit);
                     break;
                 }
                 if ((o.reproName != nullptr) && (o.indexCount == -1))

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -386,11 +386,11 @@ int __cdecl main(int argc, char* argv[])
             if (res2 == JitInstance::RESULT_ERROR)
             {
                 errorCount2++;
-                LogError("JIT2 main method %d of size %d failed to load and compile correctly.",
+                LogError("Method %d of size %d failed to load and compile correctly by JIT2.",
                          reader->GetMethodContextIndex(), mc->methodSize);
                 if (errorCount2 == 100)
                 {
-                    LogError("More than 100 JIT2 methods failed. Skip compiling remaining JIT2 methods.");
+                    LogError("More than 100 methods compilation failed by JIT2. Skip compiling remaining methods.");
                     break;
                 }
             }


### PR DESCRIPTION
Limit the number of superpmi replay failures ~to 100~ to `failureLimit` command-line option after which we would skip compiling remaining methods.

If there is any obvious bug in the implementation such that every other method fails to compile, we might end up generating 1000s of `.mc` files and they further get copied from `%TEMP%` to spmi-collection folder. Because of this, the completion time of `superpmi replay` command is huge with lot of disk I/O. Instead, cap the failure to ~`100`~ `failureLimit`, in which case it is highly likely that there is a obvious bug that developer should fix before rerunning the replay command again.

Hopefully, it will be useful.
