### PR TITLE
BinaryFormatter deprecation for System.Configuration.ConfigurationManager

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
@@ -1213,6 +1213,7 @@ namespace System.Configuration
     {
         String = 0,
         Xml = 1,
+        [System.ObsoleteAttribute(System.Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.", false)]
         Binary = 2,
         ProviderSpecific = 3,
     }

--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Configuration.ConfigurationManager.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Security.Permissions\ref\System.Security.Permissions.csproj" />

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -248,6 +248,7 @@
     <Compile Include="System\UriIdnScope.cs" />
     <Compile Include="$(CommonPath)System\IO\TempFileCollection.cs"
              Link="Common\System\IO\TempFileCollection.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Cryptography.ProtectedData\src\System.Security.Cryptography.ProtectedData.csproj" />

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/LocalFileSettingsProvider.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/LocalFileSettingsProvider.cs
@@ -462,7 +462,9 @@ namespace System.Configuration
 
             string serializedValue = value.SerializedValue as string;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (serializedValue == null && setting.SerializeAs == SettingsSerializeAs.Binary)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 // SettingsPropertyValue returns a byte[] in the binary serialization case. We need to
                 // encode this - we use base64 since SettingsPropertyValue understands it and we won't have

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsProperty.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsProperty.cs
@@ -5,6 +5,8 @@ namespace System.Configuration
 {
     public class SettingsProperty
     {
+        internal static bool EnableUnsafeBinaryFormatterInPropertyValueSerialization { get; } = AppContext.TryGetSwitch("System.Configuration.ConfigurationManager.EnableUnsafeBinaryFormatterInPropertyValueSerialization", out bool isEnabled) ? isEnabled : false;
+
         public virtual string Name { get; set; }
         public virtual bool IsReadOnly { get; set; }
         public virtual object DefaultValue { get; set; }
@@ -37,7 +39,19 @@ namespace System.Configuration
             Provider = provider;
             IsReadOnly = isReadOnly;
             DefaultValue = defaultValue;
-            SerializeAs = serializeAs;
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (serializeAs == SettingsSerializeAs.Binary)
+#pragma warning restore CS0618 // Type or member is obsolete
+            {
+                if (EnableUnsafeBinaryFormatterInPropertyValueSerialization)
+                {
+                    SerializeAs = serializeAs;
+                }
+                else
+                {
+                    throw new NotSupportedException(Obsoletions.BinaryFormatterMessage);
+                }
+            }
             Attributes = attributes;
             ThrowOnErrorDeserializing = throwOnErrorDeserializing;
             ThrowOnErrorSerializing = throwOnErrorSerializing;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
@@ -97,7 +97,6 @@ namespace System.Configuration
                     }
                     else
                     {
-                        // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                         if (SettingsProperty.EnableUnsafeBinaryFormatterInPropertyValueSerialization)
                         {
                             using (MemoryStream ms = new MemoryStream((byte[])SerializedValue))
@@ -213,7 +212,6 @@ namespace System.Configuration
                         byte[] buffer = Convert.FromBase64String(serializedValue);
                         using (MemoryStream ms = new MemoryStream(buffer))
                         {
-                            // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                             return (new BinaryFormatter()).Deserialize(ms);
                         }
                     }
@@ -252,7 +250,6 @@ namespace System.Configuration
                 using (MemoryStream ms = new MemoryStream())
                 {
                     BinaryFormatter bf = new BinaryFormatter();
-                    // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                     bf.Serialize(ms, _value);
                     return ms.ToArray();
                 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
@@ -88,6 +88,7 @@ namespace System.Configuration
             // Attempt 1: Try creating from SerializedValue
             if (SerializedValue != null)
             {
+                bool throwBinaryFormatterDeprecationException = false;
                 try
                 {
                     if (SerializedValue is string)
@@ -96,10 +97,17 @@ namespace System.Configuration
                     }
                     else
                     {
-                        using (MemoryStream ms = new MemoryStream((byte[])SerializedValue))
+                        // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
+                        if (SettingsProperty.EnableUnsafeBinaryFormatterInPropertyValueSerialization)
                         {
-                            // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
-                            value = (new BinaryFormatter()).Deserialize(ms);
+                            using (MemoryStream ms = new MemoryStream((byte[])SerializedValue))
+                            {
+                                value = (new BinaryFormatter()).Deserialize(ms);
+                            }
+                        }
+                        else
+                        {
+                            throwBinaryFormatterDeprecationException = true;
                         }
                     }
                 }
@@ -122,6 +130,11 @@ namespace System.Configuration
                     catch
                     {
                     }
+                }
+
+                if (throwBinaryFormatterDeprecationException)
+                {
+                    throw new NotSupportedException(Obsoletions.BinaryFormatterMessage);
                 }
 
                 if (value != null && !Property.PropertyType.IsAssignableFrom(value.GetType())) // is it the correct type
@@ -192,12 +205,21 @@ namespace System.Configuration
             // Convert based on the serialized type
             switch (serializeAs)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 case SettingsSerializeAs.Binary:
-                    byte[] buffer = Convert.FromBase64String(serializedValue);
-                    using (MemoryStream ms = new MemoryStream(buffer))
+#pragma warning restore CS0618 // Type or member is obsolete
+                    if (SettingsProperty.EnableUnsafeBinaryFormatterInPropertyValueSerialization)
                     {
-                        // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
-                        return (new BinaryFormatter()).Deserialize(ms);
+                        byte[] buffer = Convert.FromBase64String(serializedValue);
+                        using (MemoryStream ms = new MemoryStream(buffer))
+                        {
+                            // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
+                            return (new BinaryFormatter()).Deserialize(ms);
+                        }
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(Obsoletions.BinaryFormatterMessage);
                     }
                 case SettingsSerializeAs.Xml:
                     StringReader sr = new StringReader(serializedValue);
@@ -218,15 +240,26 @@ namespace System.Configuration
             if (_value == null)
                 return null;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (Property.SerializeAs != SettingsSerializeAs.Binary)
-                return ConvertObjectToString(_value, Property.PropertyType, Property.SerializeAs, Property.ThrowOnErrorSerializing);
-
-            using (MemoryStream ms = new MemoryStream())
+#pragma warning restore CS0618 // Type or member is obsolete
             {
-                // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
-                BinaryFormatter bf = new BinaryFormatter();
-                bf.Serialize(ms, _value);
-                return ms.ToArray();
+                return ConvertObjectToString(_value, Property.PropertyType, Property.SerializeAs, Property.ThrowOnErrorSerializing);
+            }
+
+            if (SettingsProperty.EnableUnsafeBinaryFormatterInPropertyValueSerialization)
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    BinaryFormatter bf = new BinaryFormatter();
+                    // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
+                    bf.Serialize(ms, _value);
+                    return ms.ToArray();
+                }
+            }
+            else
+            {
+                throw new NotSupportedException(Obsoletions.BinaryFormatterMessage);
             }
         }
 
@@ -255,7 +288,9 @@ namespace System.Configuration
 
                         xs.Serialize(sw, propertyValue);
                         return sw.ToString();
+#pragma warning disable CS0618 // Type or member is obsolete
                     case SettingsSerializeAs.Binary:
+#pragma warning restore CS0618 // Type or member is obsolete
                         Debug.Fail("Should not have gotten here with Binary formatting");
                         break;
                 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsSerializeAs.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsSerializeAs.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace System.Configuration
 {
     public enum SettingsSerializeAs
     {
         String = 0,
         Xml = 1,
+        [Obsolete(Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.", false)]
         Binary = 2,
         ProviderSpecific = 3
     }

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="System\Configuration\ApplicationSettingsBaseTests.cs" />
     <Compile Include="System\Configuration\AppSettingsReaderTests.cs" />
     <Compile Include="System\Configuration\AppSettingsTests.cs" />
+    <Compile Include="System\Configuration\BinaryFormatterDeprecationTests.cs" />
     <Compile Include="System\Configuration\CallBackValidatorAttributeTests.cs" />
     <Compile Include="System\Configuration\ConfigPathUtilityTests.cs" />
     <Compile Include="System\Configuration\ConfigurationElementCollectionTests.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -213,7 +213,9 @@ namespace System.ConfigurationTests
         [ReadOnly(false)]
         [SettingsGroupName("TestGroup")]
         [SettingsProvider(typeof(TestProvider))]
+#pragma warning disable CS0618 // Type or member is obsolete
         [SettingsSerializeAs(SettingsSerializeAs.Binary)]
+#pragma warning restore CS0618 // Type or member is obsolete
         private class SettingsWithAttributes : ApplicationSettingsBase
         {
             [ApplicationScopedSetting]
@@ -243,7 +245,9 @@ namespace System.ConfigurationTests
             Assert.Equal(1, settings.Properties.Count);
             SettingsProperty property = settings.Properties["StringProperty"];
             Assert.Equal(typeof(TestProvider), property.Provider.GetType());
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal(SettingsSerializeAs.Binary, property.SerializeAs);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/BinaryFormatterDeprecationTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/BinaryFormatterDeprecationTests.cs
@@ -21,6 +21,7 @@ namespace System.ConfigurationTests
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "SettingsSerializeAs.Binary is deprecated only on Core")]
         [ConditionalFact(nameof(AreBinaryFormatterAndRemoteExecutorSupportedOnThisPlatform))]
         public void SerializeAndDeserializeWithSettingsSerializeAsBinary()
         {

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/BinaryFormatterDeprecationTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/BinaryFormatterDeprecationTests.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Configuration;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class BinaryFormatterDeprecationTests
+    {
+        private static bool AreBinaryFormatterAndRemoteExecutorSupportedOnThisPlatform => PlatformDetection.IsBinaryFormatterSupported && RemoteExecutor.IsSupported;
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "SettingsSerializeAs.Binary is deprecated only on Core")]
+        [Fact]
+        public void ThrowOnSettingsPropertyConstructorWithSettingsSerializeAsBinary()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.Throws<NotSupportedException>(() => new SettingsProperty("Binary", typeof(byte[]), null, false,"AString", SettingsSerializeAs.Binary, new SettingsAttributeDictionary(), true, true));
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [ConditionalFact(nameof(AreBinaryFormatterAndRemoteExecutorSupportedOnThisPlatform))]
+        public void SerializeAndDeserializeWithSettingsSerializeAsBinary()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.RuntimeConfigurationOptions.Add("System.Configuration.ConfigurationManager.EnableUnsafeBinaryFormatterInPropertyValueSerialization", bool.TrueString);
+            RemoteExecutor.Invoke(() =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                SettingsProperty property = new SettingsProperty("Binary", typeof(string), null, false, "AString", SettingsSerializeAs.Binary, new SettingsAttributeDictionary(), true, true);
+#pragma warning restore CS0618 // Type or member is obsolete
+                SettingsPropertyValue value = new SettingsPropertyValue(property);
+                value.PropertyValue = "AString"; // To force _changedSinceLastSerialized to true to allow for serialization in the next call
+                object serializedValue = value.SerializedValue;
+                Assert.NotNull(serializedValue);
+                value.Deserialized = false;
+                object deserializedValue = value.PropertyValue;
+                Assert.Equal("AString", deserializedValue);
+            }, options).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This is a draft PR to turn off the BinaryFormatter code paths by default in System.Configuration.ConfigurationManager. Essentially all I'm doing here is deprecating `SettingsSerializeAs.Binary` and hiding the `BinaryFormatter` related code paths behind an AppContext switch.

@buyaa-n @joperezr @krwq @safern @steveharter @maryamariyan (these are the current/past area-owners). I'm not super familiar with this area so I'd like feedback about the approach here from the area owners. Specifically, if you can think of the following, that would be super appreciated:
1. Scenarios that this PR breaks (I can't think of any since no code is being deleted and current behavior is enabled by the AppContext switch)
2. Test cases I haven't added
3. Anything else that I've missed

This is NOT the most minimal change. We might be able to get away with just marking `SettingsSerializeAs.Binary` as `Obsolete`. I, however, chose to be more conservative and hid all the BinaryFormatter code paths behind an AppContext switch since this way we actually deprecate the BinaryFormatter code paths.

Fixes https://github.com/dotnet/runtime/issues/39295

cc @GrabYourPitchforks 
