### PR TITLE
Fix dumping R2R embedded PGO data

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfo.cs
@@ -61,12 +61,20 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             if (_pgoData == null)
             {
-                var compressedIntParser = new PgoProcessor.PgoEncodedCompressedIntParser(Image, Offset);
+                if (Image == null)
+                {
+                    _pgoData = Array.Empty<PgoSchemaElem>();
+                    _size = 0;
+                }
+                else
+                {
+                    var compressedIntParser = new PgoProcessor.PgoEncodedCompressedIntParser(Image, Offset);
 
-                SignatureFormattingOptions formattingOptions = new SignatureFormattingOptions();
+                    SignatureFormattingOptions formattingOptions = new SignatureFormattingOptions();
 
-                _pgoData = PgoProcessor.ParsePgoData<string>(new PgoDataLoader(_r2rReader, formattingOptions), compressedIntParser, true).ToArray();
-                _size = compressedIntParser.Offset - Offset;
+                    _pgoData = PgoProcessor.ParsePgoData<string>(new PgoDataLoader(_r2rReader, formattingOptions), compressedIntParser, true).ToArray();
+                    _size = compressedIntParser.Offset - Offset;
+                }
             }
         }
 
@@ -100,9 +108,12 @@ namespace ILCompiler.Reflection.ReadyToRun
                 }
                 else
                 {
-                    foreach (object o in elem.DataObject)
+                    if (elem.DataObject != null)
                     {
-                        sb.AppendLine(o.ToString());
+                        foreach (object o in elem.DataObject)
+                        {
+                            sb.AppendLine(o.ToString());
+                        }
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -925,7 +925,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             get
             {
                 EnsureMethods();
-                return _pgoInfos.Values;
+
+                if (_pgoInfos != null)
+                    return _pgoInfos.Values;
+                else
+                    return Array.Empty<PgoInfo>();
             }
         }
 

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -150,9 +150,12 @@ namespace R2RDump
 
             if (_options.Pgo)
             {
-                foreach (PgoInfo info in _r2r.AllPgoInfos)
+                if (_r2r != null)
                 {
-                    pgoEntriesNotDumped.Add(info.Key);
+                    foreach (PgoInfo info in _r2r.AllPgoInfos)
+                    {
+                        pgoEntriesNotDumped.Add(info.Key);
+                    }
                 }
             }
             foreach (ReadyToRunMethod method in NormalizedMethods())


### PR DESCRIPTION
- Handle case where assembly has no embedded pgo data
- Handle case where method in file has no embedded pgo data but some other methods do