### PR TITLE
Simplify mibc usage in the build

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -18,7 +18,7 @@
 
   <!-- Upfront restore hooks -->
   <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
-  <Import Project="$(RepositoryEngineeringDir)restore\optimizationData.targets" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(EnableNgenOptimization)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)restore\optimizationData.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
   <Target Name="BuildLocalTasks"
           BeforeTargets="Build">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -200,7 +200,7 @@
 
   <!--Feature switches -->
   <PropertyGroup>
-    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release'">true</EnableNgenOptimization>
+    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'Checked')">true</EnableNgenOptimization>
     <!-- Enable NuGet static graph evaluation to optimize incremental restore -->
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
     <!-- Turn off end of life target framework checks as we intentionally build older .NETCoreApp configurations. -->

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -45,6 +45,10 @@
       <CrossGen2DllFiles Condition="'$(CrossDir)' != ''" Include="$(BinDir)/$(CrossDir)/crossgen2/*" />
     </ItemGroup>
 
+    <ItemGroup>
+      <OptimizationMibcFiles Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" />
+    </ItemGroup>
+
     <PropertyGroup>
       <CoreLibAssemblyName>System.Private.CoreLib</CoreLibAssemblyName>
       <CoreLibInputPath>$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '$(CoreLibAssemblyName).dll'))</CoreLibInputPath>
@@ -53,12 +57,28 @@
       <CoreLibPerfMapPath></CoreLibPerfMapPath>
       <CoreLibNiPdbPath Condition="$(BuildPdb)">$([MSBuild]::NormalizePath('$(BinDir)', 'PDB', '$(CoreLibAssemblyName).ni.pdb'))</CoreLibNiPdbPath>
       <CoreLibPerfMapPath Condition="$(BuildPerfMap)">$([MSBuild]::NormalizePath('$(BinDir)', '$(CoreLibAssemblyName).perf.map'))</CoreLibPerfMapPath>
+      <MergedMibcPath>$([MSBuild]::NormalizePath('$(BinDir)', 'StandardOptimizationData.mibc'))</MergedMibcPath>
     </PropertyGroup>
   </Target>
 
-  <Target Name="InvokeCrossgen"
+  <Target Name="CreateMergedMibcFile"
           DependsOnTargets="PrepareForCrossgen"
-          Inputs="$(CoreLibInputPath);@(CrossGen2DllFiles)"
+          Inputs="@(OptimizationMibcFiles)"
+          Outputs="$(MergedMibcPath)">
+
+    <PropertyGroup>
+      <DotNetPgoCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', 'dotnet-pgo', 'dotnet-pgo.dll')) merge</DotNetPgoCmd>
+      <DotNetPgoCmd>$(DotNetPgoCmd) -o:$(MergedMibcPath)</DotNetPgoCmd>
+      <DotNetPgoCmd>$(DotNetPgoCmd) @(OptimizationMibcFiles->'-i:%(Identity)', ' ')</DotNetPgoCmd>
+    </PropertyGroup>
+
+    <Message Condition="'$(DotNetBuildFromSource)' != 'true'" Importance="High" Text="$(DotNetPgoCmd)"/>
+    <Exec Condition="'$(DotNetBuildFromSource)' != 'true'" Command="$(DotNetPgoCmd)" />
+  </Target>
+
+  <Target Name="InvokeCrossgen"
+          DependsOnTargets="PrepareForCrossgen;CreateMergedMibcFile"
+          Inputs="$(CoreLibInputPath);@(CrossGen2DllFiles);$(MergedMibcPath)"
           Outputs="$(CoreLibOutputPath);$(CoreLibNiPdbPath);$(CoreLibPerfMapPath)"
           AfterTargets="Build">
 
@@ -75,17 +95,12 @@
     <Message Importance="High"
       Text="Generating native image of System.Private.CoreLib for $(OSPlatformConfig). Logging to $(CrossGenCoreLibLog)" />
 
-    <ItemGroup>
-      <OptimizationMibcFiles Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" />
-    </ItemGroup>
-
     <PropertyGroup>
       <CrossGenDllCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', '$(CrossDir)', 'crossgen2', 'crossgen2.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
-      <MibcArgs>@(OptimizationMibcFiles->'-m:%(Identity)', ' ')</MibcArgs>
-      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'">$(CrossGenDllCmd) $(MibcArgs) --embed-pgo-data</CrossGenDllCmd>
+      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) -m:$(MergedMibcPath) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
     </PropertyGroup>

--- a/src/coreclr/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/tools/r2rtest/BuildOptions.cs
@@ -49,6 +49,7 @@ namespace R2RTest
         public string InputFileSearchString { get; set; }
         public string ConfigurationSuffix => (Release ? "-ret.out" : "-chk.out");
         public string GCStress { get; set; }
+        public FileInfo[] MibcPath { get; set; }
         public string DotNetCli
         {
             get

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -70,6 +70,7 @@ namespace R2RTest
                         R2RDumpPath(),
                         MeasurePerf(),
                         InputFileSearchString(),
+                        MibcPath(),
                     },
                     CompileDirectoryCommand.CompileDirectory);
 
@@ -107,6 +108,7 @@ namespace R2RTest
                         ExecutionTimeoutMinutes(),
                         R2RDumpPath(),
                         GCStress(),
+                        MibcPath(),
                     },
                     CompileSubtreeCommand.CompileSubtree);
 
@@ -137,6 +139,7 @@ namespace R2RTest
                         MeasurePerf(),
                         InputFileSearchString(),
                         OutputDirectory(),
+                        MibcPath(),
                     },
                     CompileFrameworkCommand.CompileFramework);
 
@@ -155,6 +158,7 @@ namespace R2RTest
                         DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
+                        MibcPath(),
                     },
                     CompileNugetCommand.CompileNuget);
 
@@ -170,6 +174,7 @@ namespace R2RTest
                         Pdb(),
                         CompilationTimeoutMinutes(),
                         Crossgen2Path(),
+                        MibcPath(),
                     },
                     options =>
                     {
@@ -194,6 +199,10 @@ namespace R2RTest
             Option ReferencePath() =>
                 new Option<DirectoryInfo[]>(new[] { "--reference-path", "-r" }, "Folder containing assemblies to reference during compilation")
                 { Argument = new Argument<DirectoryInfo[]>() { Arity = ArgumentArity.ZeroOrMore }.ExistingOnly() };
+
+            Option MibcPath() =>
+                new Option<FileInfo[]>(new[] { "--mibc-path", "-m" }, "Mibc files to use in compilation")
+                { Argument = new Argument<FileInfo[]>() { Arity = ArgumentArity.ZeroOrMore }.ExistingOnly() };
 
             Option Crossgen() =>
                 new Option<bool>(new[] { "--crossgen" }, "Compile the apps using Crossgen in the CORE_ROOT folder");

--- a/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
@@ -122,6 +122,15 @@ namespace R2RTest
                 yield return "--composite";
             }
 
+            if (_options.MibcPath != null && _options.MibcPath.Length > 0)
+            {
+                yield return "--embed-pgo-data";
+                foreach (FileInfo mibc in _options.MibcPath)
+                {
+                    yield return $"-m:{mibc.FullName}";
+                }
+            }
+
             if (!string.IsNullOrEmpty(Crossgen2RunnerOptions.CompositeRoot))
             {
                 yield return $"--compositerootpath={Crossgen2RunnerOptions.CompositeRoot}";

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -1,15 +1,15 @@
 <Project>
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup>
-      <OptimizationMibcFiles Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" />
+      <OptimizationMibcFiles Include="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>
       <PublishReadyToRunCrossgen2ExtraArgsList Include="--targetarch:$(TargetArchitecture)"/>
 
       <!-- Only use mibc files if UsingToolIbcOptimization is false. Allows enabling/disabling using ibc instead of mibc data -->
-      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'" Include="@(OptimizationMibcFiles->'-m:%(Identity)')"/>
-      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(Configuration)' == 'Release'" Include="--embed-pgo-data"/>
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'" Include="@(OptimizationMibcFiles->'-m:%(Identity)')"/>
+      <PublishReadyToRunCrossgen2ExtraArgsList Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'" Include="--embed-pgo-data"/>
     </ItemGroup>
 
     <!-- The following property group can be simplified once runtime repo switches over to SDK 6.0 drop -->

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -578,7 +578,7 @@ exit /b 1
 
 set "__CrossgenOutputDir=%__TestIntermediatesDir%\crossgen.out"
 
-set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%__CrossgenOutputDir%" --release --nocleanup --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
+set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%__CrossgenOutputDir%" --release --nocleanup --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS% -m "%CORE_ROOT%\StandardOptimizationData.mibc"
 
 if defined __CreatePdb (
     set __CrossgenCmd=!__CrossgenCmd! --pdb

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -158,7 +158,7 @@ precompile_coreroot_fx()
     fi
 
     local outputDir="$__TestIntermediatesDir/crossgen.out"
-    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$outputDir\" --release --nocleanup --target-arch $__BuildArch -dop $__NumProc"
+    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$outputDir\" --release --nocleanup --target-arch $__BuildArch -dop $__NumProc  -m \"$CORE_ROOT/StandardOptimizationData.mibc\""
 
     if [[ "$__CompositeBuildMode" != 0 ]]; then
         crossgenCmd="$crossgenCmd --composite"


### PR DESCRIPTION
- Produce a merged mibc with all scenarios squished together
- Properly attach the mibc data to the incremental build for System.Private.CoreLib
  - This can't be done for the framework here. It will require mibc integration in the SDK
- Enable pgo optimization in checked builds
- Enable pgo optimization in framework compile for outerloop runs