### PR TITLE
Fix default nothrow behavior for MethodIL.GetObject

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ResolutionFailure.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ResolutionFailure.cs
@@ -84,7 +84,7 @@ namespace Internal.TypeSystem
 
         public void Throw()
         {
-            switch(_failureType)
+            switch (_failureType)
             {
                 case FailureType.TypeLoadException1:
                     ThrowHelper.ThrowTypeLoadException(_name, _module);

--- a/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
@@ -86,7 +86,7 @@ namespace Internal.IL
         /// (typically a <see cref="MethodDesc"/>, <see cref="FieldDesc"/>, <see cref="TypeDesc"/>,
         /// or <see cref="MethodSignature"/>).
         /// </summary>
-        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.ReturnNull);
+        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw);
 
         /// <summary>
         /// Gets a list of exception regions this method body defines.


### PR DESCRIPTION
Discovered by failing tests in NativeAOT FI (https://github.com/dotnet/runtimelab/pull/898)