### PR TITLE
Fix GC overreporting with generics context + GS cookie

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -193,7 +193,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
         // we are generating GS cookie check after a GT_RETURN block.
         // Note: On Amd64 System V RDX is an arg register - REG_ARG_2 - as well
         // as return register for two-register-returned structs.
-        if (compiler->lvaKeepAliveAndReportThis() && compiler->lvaTable[compiler->info.compThisArg].lvRegister &&
+        if (compiler->lvaKeepAliveAndReportThis() && compiler->lvaTable[compiler->info.compThisArg].lvIsInReg() &&
             (compiler->lvaTable[compiler->info.compThisArg].GetRegNum() == REG_ARG_0))
         {
             regGSCheck = REG_ARG_1;


### PR DESCRIPTION
This is a case of a generics context in `this` where we need to keep
`this` alive (but aren't required to by the VM) with a GS cookie check
(due to "JitStress: STRESS_UNSAFE_BUFFER_CHECKS"), and maybe other
JitStress modes, where `genEmitGSCookieCheck` decides to use `rcx`
to load the cookie, even though it is alive. `this` is also mostly
in a register, but it reported live as a stack slot. When the GS
cookie label gets created, the "codegen" gc info hasn't been updated
with the killed register, so the emitter label gets the wrong GC info
and brings rcx back alive just for the `nop`. GC cookie checks kind
of do their own register allocation since they're part of the epilogs.

The GS cookie code checks for keep alive using "lvRegister", but that
isn't set, since the cookie is mostly alive in a stack slock, not
always in a register. Use `lvIsInReg()` instead, so GS cookie check
will use RDX to load the cookie instead.

No SuperPMI asm diffs.

Fixes #50404