### PR TITLE
improve connection scavenge logic by doing zero-byte read

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1594,7 +1594,7 @@ namespace System.Net.Http
 
             if (LifetimeExpired(nowTicks, connectionLifetime))
             {
-                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP2 Connection no longer usable. Lifetime {TimeSpan.FromMilliseconds(nowTicks - CreationTickCount)} > {connectionLifetime}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/2 connection no longer usable. Lifetime {TimeSpan.FromMilliseconds(nowTicks - CreationTickCount)} > {connectionLifetime}.");
 
                 return true;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1587,12 +1587,19 @@ namespace System.Net.Http
                 (_httpStreams.Count == 0) &&
                 ((nowTicks - _idleSinceTickCount) > connectionIdleTimeout.TotalMilliseconds))
             {
-                if (NetEventSource.Log.IsEnabled()) Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP2 Connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
 
                 return true;
             }
 
-            return LifetimeExpired(nowTicks, connectionLifetime);
+            if (LifetimeExpired(nowTicks, connectionLifetime))
+            {
+                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP2 Connection no longer usable. Lifetime {TimeSpan.FromMilliseconds(nowTicks - CreationTickCount)} > {connectionLifetime}.");
+
+                return true;
+            }
+
+            return false;
         }
 
         private void AbortStreams(Exception abortException)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1587,7 +1587,7 @@ namespace System.Net.Http
                 (_httpStreams.Count == 0) &&
                 ((nowTicks - _idleSinceTickCount) > connectionIdleTimeout.TotalMilliseconds))
             {
-                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP2 Connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/2 connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
 
                 return true;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -202,7 +202,7 @@ namespace System.Net.Http
             async ValueTask<int> ReadAheadWithZeroByteReadAsync()
             {
                 Debug.Assert(_readAheadTask is null);
-                Debug.Assert(_readLength == 0);
+                Debug.Assert(RemainingBuffer.Length == 0);
 
                 // Issue a zero-byte read.
                 // If the underlying stream supports it, this will not complete until the stream has data available,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -135,54 +135,84 @@ namespace System.Net.Http
             }
         }
 
-        /// <summary>Do a non-blocking poll to see whether the connection has data available or has been closed.</summary>
-        /// <remarks>If we don't have direct access to the underlying socket, we instead use a read-ahead task.</remarks>
-        public bool PollRead()
+        /// <summary>Prepare an idle connection to be used for a new request.</summary>
+        /// <param name="async">Indicates whether the coming request will be sync or async.</param>
+        /// <returns>True if connection can be used, false if it is invalid due to receiving EOF or unexpected data.</returns>
+        public bool PrepareForReuse(bool async)
         {
-            if (_socket != null) // may be null if we don't have direct access to the socket
+            // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
+            // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
+            if (_readAheadTask is not null)
             {
+                return !_readAheadTask.Value.IsCompleted;
+            }
+
+            // Check to see if we've received anything on the connection; if we have, that's
+            // either erroneous data (we shouldn't have received anything yet) or the connection
+            // has been closed; either way, we can't use it.
+            if (!async && _socket is not null)
+            {
+                // Directly poll the socket rather than doing an async read, so that we can
+                // issue an appropriate sync read when we actually need it.
                 try
                 {
-                    return _socket.Poll(0, SelectMode.SelectRead);
+                    return !_socket.Poll(0, SelectMode.SelectRead);
                 }
                 catch (Exception e) when (e is SocketException || e is ObjectDisposedException)
                 {
                     // Poll can throw when used on a closed socket.
-                    return true;
+                    return false;
                 }
             }
             else
             {
-                return EnsureReadAheadAndPollRead();
-            }
-        }
-
-        /// <summary>
-        /// Issues a read-ahead on the connection, which will serve both as the first read on the
-        /// response as well as a polling indication of whether the connection is usable.
-        /// </summary>
-        /// <returns>true if there's data available on the connection or it's been closed; otherwise, false.</returns>
-        public bool EnsureReadAheadAndPollRead()
-        {
-            try
-            {
-                Debug.Assert(_readAheadTask == null || _socket == null, "Should only already have a read-ahead task if we don't have a socket to poll");
-                if (_readAheadTask == null)
+                // Perform an async read on the stream, since we're going to need to read from it
+                // anyway, and in doing so we can avoid the extra syscall.
+                try
                 {
 #pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
                     _readAheadTask = _stream.ReadAsync(new Memory<byte>(_readBuffer));
 #pragma warning restore CA2012
+                    return !_readAheadTask.Value.IsCompleted;
+                }
+                catch (Exception error)
+                {
+                    // If reading throws, eat the error and don't reuse the connection.
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Error performing read ahead: {error}");
+                    return false;
                 }
             }
-            catch (Exception error)
+        }
+
+        /// <summary>Check whether a currently idle connection is still usable, or should be scavenged.</summary>
+        /// <returns>True if connection can be used, false if it is invalid due to receiving EOF or unexpected data.</returns>
+        public bool CheckUsabilityOnScavenge()
+        {
+            // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
+            if (_readAheadTask is null)
             {
-                // If reading throws, eat the error and don't pool the connection.
-                if (NetEventSource.Log.IsEnabled()) Trace($"Error performing read ahead: {error}");
-                Dispose();
-                _readAheadTask = new ValueTask<int>(0);
+#pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
+                _readAheadTask = ReadAheadWithZeroByteReadAsync();
+#pragma warning restore CA2012
             }
 
-            return _readAheadTask.Value.IsCompleted; // equivalent to polling
+            // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
+            return !_readAheadTask.Value.IsCompleted;
+
+            async ValueTask<int> ReadAheadWithZeroByteReadAsync()
+            {
+                Debug.Assert(_readAheadTask is null);
+                Debug.Assert(_readLength == 0);
+
+                // Issue a zero-byte read.
+                // If the underlying stream supports it, this will not complete until the stream has data available,
+                // which will avoid pinning the connection's read buffer (and possibly allow us to release it to the buffer pool in the future, if desired).
+                // If not, it will complete immediately.
+                await _stream.ReadAsync(Memory<byte>.Empty).ConfigureAwait(false);
+
+                // We don't know for sure that the stream actually has data available, so we need to issue a real read now.
+                return await _stream.ReadAsync(new Memory<byte>(_readBuffer)).ConfigureAwait(false);
+            }
         }
 
         private ValueTask<int>? ConsumeReadAheadTask()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -60,17 +60,13 @@ namespace System.Net.Http
             }
         }
 
-        private long CreationTickCount { get; } = Environment.TickCount64;
+        public long CreationTickCount { get; } = Environment.TickCount64;
 
         // Check if lifetime expired on connection.
         public bool LifetimeExpired(long nowTicks, TimeSpan lifetime)
         {
-            bool expired =
-                lifetime != Timeout.InfiniteTimeSpan &&
+            return lifetime != Timeout.InfiniteTimeSpan &&
                 (lifetime == TimeSpan.Zero || (nowTicks - CreationTickCount) > lifetime.TotalMilliseconds);
-
-            if (expired && NetEventSource.Log.IsEnabled()) Trace($"Connection no longer usable. Alive {TimeSpan.FromMilliseconds((nowTicks - CreationTickCount))} > {lifetime}.");
-            return expired;
         }
 
         internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1489,11 +1489,9 @@ namespace System.Net.Http
 
             Debug.Assert(_maxConnections != int.MaxValue, "_waiters queue is allocated but no connection limit is set??");
 
-            while (_waiters.Count > 0)
+            while (_waiters.TryDequeue(out TaskCompletionSourceWithCancellation<HttpConnection?>? waiter))
             {
                 Debug.Assert(_idleConnections.Count == 0, $"With {_idleConnections.Count} idle connections, we shouldn't have a waiter.");
-
-                TaskCompletionSource<HttpConnection?> waiter = _waiters.Dequeue();
 
                 // Try to complete the task. If it's been cancelled already, this will fail.
                 if (waiter.TrySetResult(connection))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -396,27 +396,6 @@ namespace System.Net.Http
             return GetHttpConnectionAsync(request, async, cancellationToken);
         }
 
-        private static bool IsUsableHttp11Connection(HttpConnection connection, long nowTicks, TimeSpan lifetime, bool async)
-        {
-            if (connection.LifetimeExpired(nowTicks, lifetime))
-            {
-                return false;
-            }
-
-            // Check to see if we've received anything on the connection; if we have, that's
-            // either erroneous data (we shouldn't have received anything yet) or the connection
-            // has been closed; either way, we can't use it.  If this is an async request, we
-            // perform an async read on the stream, since we're going to need to read from it
-            // anyway, and in doing so we can avoid the extra syscall.  For sync requests, we
-            // try to directly poll the socket rather than doing an async read, so that we can
-            // issue an appropriate sync read when we actually need it.  We don't have the
-            // underlying socket in all cases, though, so PollRead may fall back to an async
-            // read in some cases.
-            return async ?
-                !connection.EnsureReadAheadAndPollRead() :
-                !connection.PollRead();
-        }
-
         private ValueTask<HttpConnection?> GetOrReserveHttp11ConnectionAsync(bool async, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -474,16 +453,22 @@ namespace System.Net.Http
                     }
                 }
 
-                if (IsUsableHttp11Connection(connection, nowTicks, _poolManager.Settings._pooledConnectionLifetime, async))
+                if (connection.LifetimeExpired(nowTicks, _poolManager.Settings._pooledConnectionLifetime))
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found usable connection in pool.");
-                    return new ValueTask<HttpConnection?>(connection);
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found expired connection in pool.");
+                    connection.Dispose();
+                    continue;
                 }
-                else
+
+                if (!connection.PrepareForReuse(async))
                 {
                     if (NetEventSource.Log.IsEnabled()) connection.Trace("Found invalid connection in pool.");
                     connection.Dispose();
+                    continue;
                 }
+
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Found usable connection in pool.");
+                return new ValueTask<HttpConnection?>(connection);
             }
 
             // We are at the connection limit. Wait for an available connection or connection count.
@@ -716,6 +701,7 @@ namespace System.Net.Http
                 if (http2Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime))
                 {
                     // Connection expired.
+                    if (NetEventSource.Log.IsEnabled()) http2Connection.Trace("Found expired HTTP2 connection.");
                     http2Connection.Dispose();
                     InvalidateHttp2Connection(http2Connection);
                 }
@@ -760,6 +746,7 @@ namespace System.Net.Http
                 if (http3Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime) || http3Connection.Authority != authority)
                 {
                     // Connection expired.
+                    if (NetEventSource.Log.IsEnabled()) http3Connection.Trace("Found expired HTTP3 connection.");
                     http3Connection.Dispose();
                     InvalidateHttp3Connection(http3Connection);
                 }
@@ -1470,24 +1457,6 @@ namespace System.Net.Http
             return waiter;
         }
 
-        private bool HasWaiter()
-        {
-            Debug.Assert(Monitor.IsEntered(SyncObj));
-
-            return (_waiters != null && _waiters.Count > 0);
-        }
-
-        /// <summary>Dequeues a waiter from the waiters list.  The list must not be empty.</summary>
-        /// <returns>The dequeued waiter.</returns>
-        private TaskCompletionSourceWithCancellation<HttpConnection?> DequeueWaiter()
-        {
-            Debug.Assert(Monitor.IsEntered(SyncObj));
-            Debug.Assert(Settings._maxConnectionsPerServer != int.MaxValue);
-            Debug.Assert(_idleConnections.Count == 0, $"With {_idleConnections.Count} idle connections, we shouldn't have a waiter.");
-
-            return _waiters!.Dequeue();
-        }
-
         private void IncrementConnectionCountNoLock()
         {
             Debug.Assert(Monitor.IsEntered(SyncObj), $"Expected to be holding {nameof(SyncObj)}");
@@ -1513,9 +1482,18 @@ namespace System.Net.Http
         {
             Debug.Assert(Monitor.IsEntered(SyncObj));
 
-            while (HasWaiter())
+            if (_waiters == null)
             {
-                TaskCompletionSource<HttpConnection?> waiter = DequeueWaiter();
+                return false;
+            }
+
+            Debug.Assert(_maxConnections != int.MaxValue, "_waiters queue is allocated but no connection limit is set??");
+
+            while (_waiters.Count > 0)
+            {
+                Debug.Assert(_idleConnections.Count == 0, $"With {_idleConnections.Count} idle connections, we shouldn't have a waiter.");
+
+                TaskCompletionSource<HttpConnection?> waiter = _waiters.Dequeue();
 
                 // Try to complete the task. If it's been cancelled already, this will fail.
                 if (waiter.TrySetResult(connection))
@@ -1562,61 +1540,51 @@ namespace System.Net.Http
         /// <param name="connection">The connection to return.</param>
         public void ReturnConnection(HttpConnection connection)
         {
-            bool lifetimeExpired = connection.LifetimeExpired(Environment.TickCount64, _poolManager.Settings._pooledConnectionLifetime);
-
-            if (!lifetimeExpired)
+            if (connection.LifetimeExpired(Environment.TickCount64, _poolManager.Settings._pooledConnectionLifetime))
             {
-                List<CachedConnection> list = _idleConnections;
-                lock (SyncObj)
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection return to pool. Connection lifetime expired.");
+                connection.Dispose();
+                return;
+            }
+
+            List<CachedConnection> list = _idleConnections;
+            lock (SyncObj)
+            {
+                Debug.Assert(list.Count <= _maxConnections, $"Expected {list.Count} <= {_maxConnections}");
+
+                // Mark the pool as still being active.
+                _usedSinceLastCleanup = true;
+
+                // If there's someone waiting for a connection and this one's still valid, simply transfer this one to them rather than pooling it.
+                // Note that while we checked connection lifetime above, we don't check idle timeout, as even if idle timeout
+                // is zero, we consider a connection that's just handed from one use to another to never actually be idle.
+                if (TransferConnection(connection))
                 {
-                    Debug.Assert(list.Count <= _maxConnections, $"Expected {list.Count} <= {_maxConnections}");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Transferred connection to waiter.");
+                    return;
+                }
 
-                    // Mark the pool as still being active.
-                    _usedSinceLastCleanup = true;
-
-                    // If there's someone waiting for a connection and this one's still valid, simply transfer this one to them rather than pooling it.
-                    // Note that while we checked connection lifetime above, we don't check idle timeout, as even if idle timeout
-                    // is zero, we consider a connection that's just handed from one use to another to never actually be idle.
-                    bool receivedUnexpectedData = false;
-                    if (HasWaiter())
-                    {
-                        receivedUnexpectedData = connection.EnsureReadAheadAndPollRead();
-                        if (!receivedUnexpectedData && TransferConnection(connection))
-                        {
-                            if (NetEventSource.Log.IsEnabled()) connection.Trace("Transferred connection to waiter.");
-                            return;
-                        }
-                    }
-
-                    // If the connection is still valid, add it to the list.
+                if (_poolManager.Settings._pooledConnectionIdleTimeout == TimeSpan.Zero)
+                {
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection returned to pool. Zero idle timeout.");
+                }
+                else if (_disposed)
+                {
                     // If the pool has been disposed of, dispose the connection being returned,
                     // as the pool is being deactivated. We do this after the above in order to
                     // use pooled connections to satisfy any requests that pended before the
-                    // the pool was disposed of.  We also dispose of connections if connection
-                    // timeouts are such that the connection would immediately expire, anyway, as
-                    // well as for connections that have unexpectedly received extraneous data / EOF.
-                    if (!receivedUnexpectedData &&
-                        !_disposed &&
-                        _poolManager.Settings._pooledConnectionIdleTimeout != TimeSpan.Zero)
-                    {
-                        // Pool the connection by adding it to the list.
-                        list.Add(new CachedConnection(connection));
-                        if (NetEventSource.Log.IsEnabled()) connection.Trace("Stored connection in pool.");
-                        return;
-                    }
+                    // the pool was disposed of.
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection returned to pool. Pool was disposed.");
+                }
+                else
+                {
+                    // Pool the connection by adding it to the list.
+                    list.Add(new CachedConnection(connection));
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Stored connection in pool.");
+                    return;
                 }
             }
 
-            // The connection could be not be reused.  Dispose of it.
-            // Disposing it will alert any waiters that a connection slot has become available.
-            if (NetEventSource.Log.IsEnabled())
-            {
-                connection.Trace(
-                    lifetimeExpired ? "Disposing connection return to pool. Connection lifetime expired." :
-                    _poolManager.Settings._pooledConnectionIdleTimeout == TimeSpan.Zero ? "Disposing connection returned to pool. Zero idle timeout." :
-                    _disposed ? "Disposing connection returned to pool. Pool was disposed." :
-                    "Disposing connection returned to pool. Read-ahead unexpectedly completed.");
-            }
             connection.Dispose();
         }
 
@@ -1941,11 +1909,24 @@ namespace System.Net.Http
                 if ((pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan) &&
                     ((nowTicks - _returnedTickCount) > pooledConnectionIdleTimeout.TotalMilliseconds))
                 {
-                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds((nowTicks - _returnedTickCount))} > {pooledConnectionIdleTimeout}.");
+                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Idle {TimeSpan.FromMilliseconds((nowTicks - _returnedTickCount))} > {pooledConnectionIdleTimeout}.");
                     return false;
                 }
 
-                return IsUsableHttp11Connection(_connection, nowTicks, pooledConnectionLifetime, false);
+                // Validate that the connection lifetime has not been exceeded.
+                if (_connection.LifetimeExpired(nowTicks, pooledConnectionLifetime))
+                {
+                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Lifetime {TimeSpan.FromMilliseconds((nowTicks - _connection.CreationTickCount))} > {pooledConnectionLifetime}.");
+                    return false;
+                }
+
+                if (!_connection.CheckUsabilityOnScavenge())
+                {
+                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Unexpected data or EOF received.");
+                    return false;
+                }
+
+                return true;
             }
 
             public bool Equals(CachedConnection other) => ReferenceEquals(other._connection, _connection);


### PR DESCRIPTION
Currently, during our periodic scavenge of idle connections, we check whether the connection is still valid (i.e. has not received EOF or invalid data) by either (a) doing a socket poll, if we have access to the underlying socket; or (b) issuing a read-ahead, when we don't have access to the underlying socket.

Approach (b) is problematic because it pins our read buffer for potentially a long period of time (on Windows), and prevents us from freeing this buffer back to the pool in the future. The negative impact of this approach can be seen here: https://github.com/dotnet/runtime/issues/49431

Unfortunately, there are common cases where we don't have access to the underlying socket, and thus today have to fall back to approach (b). Most importantly, if a user supplies a ConnectCallback, then we never have access to the underlying socket, even if the ConnectCallback does trivial things like logging.

This PR addresses the problem as follows: Instead of doing a poll or a read-ahead in these cases, just do a zero-byte read. For Streams that implement proper zero-byte read support (that is, the read does not complete until data is available), this will avoid unnecessary buffer pinning. It's also probably cheaper than polling, since we only need to pend one zero-byte read in this case vs potentially multiple calls to poll.

Since we cannot depend on the Stream properly supporting zero-byte read semantics, we must issue an actual read-ahead when the zero-byte read completes. For non-compliant Streams, this results in the same behavior as previously: we will immediately pin the read buffer. For compliant Streams, the completion will only happen when either the connection is invalid (as occurs today) or when there is actual valid response data on the connection, in which case we would have issued a read-ahead when the connection is about to be reused anyway.

Note that we also issue a read-ahead when we retrieve an idle connection from the pool for reuse. This logic is essentially unchanged, but refactored a bit, and no longer shared with the scavenge logic since we want different behavior in these two cases.

Also, this PR changes the behavior in ReturnConnection (called when a connection is about to be returned to the pool) to not check for EOF or invalid data in the case where we are about to transfer the connection to a waiting request. Any invalid data would likely have been detected as part of response processing. And since we are about to reuse the connection anyway, the likelihood of detecting an invalid connection during the transfer is very small and highly timing-dependent. Note this only affects cases where a connection limit is set, since this is the only case in which we have waiting requests currently.

Related to #49431

@scalablecory @stephentoub @wfurt @dotnet/ncl 