### PR TITLE
Use integer division trick to get exact base64 length 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2527,16 +2527,16 @@ namespace System
 
         private static int ToBase64_CalculateAndValidateOutputLength(int inputLength, bool insertLineBreaks)
         {
-            long outlen = ((long)inputLength) / 3 * 4;          // the base length - we want integer division here.
-            outlen += ((inputLength % 3) != 0) ? 4 : 0;         // at most 4 more chars for the remainder
+            // the base length - we want integer division here, at most 4 more chars for the remainder
+            long outlen = ((long)inputLength + 2) / 3 * 4;
 
             if (outlen == 0)
                 return 0;
 
             if (insertLineBreaks)
             {
-                long newLines = outlen / base64LineBreakPosition;
-                if ((outlen % base64LineBreakPosition) == 0)
+                long newLines = Math.DivRem(outlen, base64LineBreakPosition, out long remainder);
+                if (remainder == 0)
                 {
                     --newLines;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2535,7 +2535,7 @@ namespace System
 
             if (insertLineBreaks)
             {
-                long newLines = Math.DivRem(outlen, base64LineBreakPosition, out long remainder);
+                (long newLines, long remainder) = Math.DivRem(outlen, base64LineBreakPosition);
                 if (remainder == 0)
                 {
                     --newLines;


### PR DESCRIPTION
...and avoid (explicit) modulo operation.

Produces [less machine code](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIGYACMhgYQYG8aHuGAHKAJYA3bBhgNIAO1wYGAybOB4YqADLyYAIVjYA1gAUIuARgERJDALwMA7EgDcXHk+79ho8cXJI5ChgBUITWVUAH0WbAAbMABXSI8AQUkAEwA1KIFkjwB5GIxePNUYSQBzDAALAAp5WXkCjCLSirQGYAgISN9cGCgGjW0YPVwAShcOMZ4GSPMShgg8yOKrBkrK6dLhusLisvLhhgB6BkYAKgYUe0mrw6OK8SVuqZ2KhjgGAHdxd+w/GpgSnoMZLCATGcwMco9GAAOgmPHmGEWFgA1NZVlsGs9ygwAKTHfYAQmsAAZ9gB+c4MEAMYmXa7cA5HUQMfBGWQoFnQcRgcrYKC4BgAM2gDDuDFg+Gw8mSPRocO4AkFKwRSKsJNG1HpV2INhpjmo8rkSuq0h6fUkWh0uhGhs4mq1PHWswt73UFoF1hVSyODxUKDdlsGBiMJjMkn1Dp4ipWlS9FjxvrU/SthmMpnM+0s6sNkztkeucDgLoDuAj+YAvjn4QslqiGMWNAKzqQ6fmbqLIfWYvhgICIErIhpWlaJLz+R8YABySKdbDJZItABEAB0oMvJIvDZWDfbroyGABJJWfOZCHqC6bvBg/XyyO4WE9gH6SCCyKLTJ9iBjFeYlcqG/d8BgVkoAAT1FCA5jyeoO3EERIhicRcEgiooAgd5DWjWMawsAA+W9oQAWWwBB0gQmANTbVD0PrGAr1yDBskFQjgOgUCAFEEDAGBeHTSRKmGfVDR1FYamGOMy24bdJjGNwRC/LwfBqAIghCFBwiiWJ4jEJI0gyLIxAY+pGl2cgTVqSRjKxFo2g6LozQDAYhko+k83zfcxV9J4mmxN4T2+X4FH+QFgSEUEwwhKEWmZVkZEpEDuTHAVhSgWDxWAqUUllXcHSdKDESWNE1hmYZKhiMSMRMl5kQYUh9iOU5ziEnKtSwuM1RpFy224ETaTlFr6Sw+Rul6RyrRtAbrjc7qphmWjXUbZZiIqaEABFhAAJWA7CCskGy1LGoNU1DcwWgRWbSnSyVpR6QSq2uLCJUymVUqzTr7quaaZp4QsG3dSTuuk772rrP6YCbWrW3c25O0kbte1S/spiHYARx5PkBU+adZ3nJdV3XTdJqubcPv3I8J1Pc9L2vCxlPvCmn0kF83xnCBP3EH8Yj/UmjiAkDwIwSCERgsV4MQhhkI7NCMKJyY2pwhh8JqIiSLIxCuu66irxdBgGKYlj+c47jeLDATmrbETzPEnCAcmbdyyAA===).