### PR TITLE
Fix for NullRef during CG2 compilation of the crossgen2smoke test

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
@@ -86,7 +86,7 @@ namespace Internal.IL
         /// (typically a <see cref="MethodDesc"/>, <see cref="FieldDesc"/>, <see cref="TypeDesc"/>,
         /// or <see cref="MethodSignature"/>).
         /// </summary>
-        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.ReturnNull);
+        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw);
 
         /// <summary>
         /// Gets a list of exception regions this method body defines.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/50520

/cc @dotnet/crossgen-contrib 