### PR TITLE
Fix the docs on building Mono runtime packages

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -66,11 +66,11 @@ See the instructions for [Testing iOS](../../testing/libraries/testing-apple.md)
 To generate nuget packages:
 
 ```bash
-./build.sh mono -pack (with optional release configuration)
+./build.sh packs -runtimeFlavor mono (with optional release configuration)
 ```
 or on Windows,
 ```cmd
-build.cmd mono -pack (with optional release configuration)
+build.cmd packs -runtimeFlavor mono (with optional release configuration)
 ```
 
 The following packages will be created under `artifacts\packages\<configuration>\Shipping`:


### PR DESCRIPTION
Note: it took me quite some time to get to the correct combination of arguments...

It is not obvious that neither `./build mono.packages` nor even the plain `./build.sh` build the runtime packs, which are required if you want if you want to `make run` the sample AFAICT.