### PR TITLE
[mono] Add back mono_register_config_for_assembly

### DIFF
--- a/src/mono/mono/metadata/assembly.h
+++ b/src/mono/mono/metadata/assembly.h
@@ -124,7 +124,7 @@ typedef struct {
 } MonoBundledAssembly;
 
 MONO_API void          mono_register_bundled_assemblies (const MonoBundledAssembly **assemblies);
-MONO_API void          mono_register_config_for_assembly (const char* assembly_name, const char* config_xml);
+MONO_API MONO_RT_EXTERNAL_ONLY void          mono_register_config_for_assembly (const char* assembly_name, const char* config_xml);
 MONO_API void          mono_register_symfile_for_assembly (const char* assembly_name, const mono_byte *raw_contents, int size);
 MONO_API void	      mono_register_machine_config (const char *config_xml);
 

--- a/src/mono/mono/metadata/external-only.c
+++ b/src/mono/mono/metadata/external-only.c
@@ -17,6 +17,7 @@
 #include "mono-config-internals.h"
 #include "object-internals.h"
 #include "class-init.h"
+#include "assembly.h"
 #include "marshal.h"
 #include "object.h"
 #include "assembly-internals.h"
@@ -370,4 +371,9 @@ void
 mono_thread_manage (void)
 {
 	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_thread_manage_internal ());
+}
+
+void
+mono_register_config_for_assembly (const char* assembly_name, const char* config_xml)
+{
 }


### PR DESCRIPTION
Can't drop API symbols.