### PR TITLE
Relax Socket.DualMode exception behavior

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -741,14 +741,11 @@ namespace System.Net.Sockets
             }
             set
             {
-                if (AddressFamily == AddressFamily.InterNetworkV6)
-                {
-                    SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, value ? 0 : 1);
-                }
-                else if (value)
+                if (AddressFamily != AddressFamily.InterNetworkV6)
                 {
                     throw new NotSupportedException(SR.net_invalidversion);
                 }
+                SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, value ? 0 : 1);
             }
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -735,17 +735,20 @@ namespace System.Net.Sockets
             {
                 if (AddressFamily != AddressFamily.InterNetworkV6)
                 {
-                    throw new NotSupportedException(SR.net_invalidversion);
+                    return false;
                 }
                 return ((int)GetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only)! == 0);
             }
             set
             {
-                if (AddressFamily != AddressFamily.InterNetworkV6)
+                if (AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, value ? 0 : 1);
+                }
+                else if (value)
                 {
                     throw new NotSupportedException(SR.net_invalidversion);
                 }
-                SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, value ? 0 : 1);
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -61,12 +61,10 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void IPv4Constructor_DualMode_Setter()
+        public void IPv4Constructor_DualMode_SetterThrows()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.DualMode = false;
-                Assert.False(socket.DualMode);
                 Assert.Throws<NotSupportedException>(() =>
                 {
                     socket.DualMode = true;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -52,15 +52,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void IPv4Constructor_DualModeThrows()
+        public void IPv4Constructor_DualMode_GetterReturnsFalse()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                Assert.Throws<NotSupportedException>(() =>
-                {
-                    Assert.False(socket.DualMode);
-                });
+                Assert.False(socket.DualMode);
+            }
+        }
 
+        [Fact]
+        public void IPv4Constructor_DualMode_Setter()
+        {
+            using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.DualMode = false;
+                Assert.False(socket.DualMode);
                 Assert.Throws<NotSupportedException>(() =>
                 {
                     socket.DualMode = true;


### PR DESCRIPTION
Currently we are throwing `NotSupportedException` from both the getter and setter if the socket is not IPv6. This might be counter-intuitive to users:
https://developercommunity2.visualstudio.com/t/SocketDualMode-documentation-is-missing/1286040

Quoting @geoffkizer from email discussion:

> We try to avoid throwing from property getters. It can make sense in a few cases, but it’s usually in situations where the object is in a state where the property doesn’t have any real meaning, e.g. disposed or not initialized/started or something like that. This doesn’t seem to be any of those.

Proposing to only throw, if the user tries to set the property to `true` for a non-IPv6 socket.

Pro: the proposed behavior is probably more intuitive.
Con: behavioral change between 5 and 6, we need to make sure to update the docs.

@geoffkizer @scalablecory @stephentoub yea or nay?