### PR TITLE
Disable TestDynamicAssembly tests

### DIFF
--- a/src/tests/Loader/ContextualReflection/ContextualReflection.cs
+++ b/src/tests/Loader/ContextualReflection/ContextualReflection.cs
@@ -751,8 +751,10 @@ namespace ContextualReflectionTest
             VerifyContextualReflectionProxy();
             VerifyUsingStatementContextualReflectionUsage();
             VerifyBadContextualReflectionUsage();
-            TestDynamicAssembly(true);
-            TestDynamicAssembly(false);
+
+            // TestDynamicAssembly() disabled due to https://github.com/dotnet/runtime/issues/48579
+            //TestDynamicAssembly(true);
+            //TestDynamicAssembly(false);
 
             RunTests(isolated : false);
             alcProgramInstance.RunTestsIsolated();


### PR DESCRIPTION
These fail under GCStress.

Issue: https://github.com/dotnet/runtime/issues/48579