### PR TITLE
Disable Comparer_get_Default under GCStress

### DIFF
--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.csproj
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
+    <!-- Too slow under GCStress=3: https://github.com/dotnet/runtime/issues/50594 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Comparer_get_Default.cs" />


### PR DESCRIPTION
It fails with timeout under GCStress=3.

Tracking: https://github.com/dotnet/runtime/issues/50594