### PR TITLE
Enforce 64KB event payload size limit on EventPipe 

### DIFF
--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -889,7 +889,7 @@ ep_buffer_manager_write_event (
 	EventPipeBuffer *buffer = NULL;
 	EventPipeThreadSessionState *session_state = NULL;
 	EventPipeStackContents stack_contents;
-	EventPipeStackContents *current_stack_contents = nullptr;
+	EventPipeStackContents *current_stack_contents = NULL;
 
 	EP_ASSERT (buffer_manager != NULL);
 	EP_ASSERT (ep_event != NULL);

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -888,6 +888,8 @@ ep_buffer_manager_write_event (
 	bool alloc_new_buffer = false;
 	EventPipeBuffer *buffer = NULL;
 	EventPipeThreadSessionState *session_state = NULL;
+	EventPipeStackContents stack_contents;
+	EventPipeStackContents *current_stack_contents = nullptr;
 
 	EP_ASSERT (buffer_manager != NULL);
 	EP_ASSERT (ep_event != NULL);
@@ -915,8 +917,6 @@ ep_buffer_manager_write_event (
 	if (event_thread == NULL)
 		event_thread = thread;
 
-	EventPipeStackContents stack_contents;
-	EventPipeStackContents *current_stack_contents;
 	current_stack_contents = ep_stack_contents_init (&stack_contents);
 	if (stack == NULL && ep_event_get_need_stack (ep_event) && !ep_session_get_rundown_enabled (session)) {
 		ep_walk_managed_stack_for_current_thread (current_stack_contents);

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -897,6 +897,9 @@ ep_buffer_manager_write_event (
 	// Before we pick a buffer, make sure the event is enabled.
 	ep_return_false_if_nok (ep_event_is_enabled (ep_event));
 
+	// Check that the payload size is less than 64 KB (max size for ETW events)
+	ep_return_false_if_nok (ep_event_payload_get_size (payload) <= 64 * 1024);
+
 	// Check to see an event thread was specified. If not, then use the current thread.
 	if (event_thread == NULL)
 		event_thread = thread;

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -125,6 +125,9 @@ struct _EventPipeBufferManager_Internal {
 	// The total amount of allocations we can do after one sequence
 	// point before triggering the next one
 	size_t sequence_point_alloc_budget;
+	// number of times an event was dropped due to it being too
+	// large to fit in the 64KB size limit
+	volatile int64_t num_oversized_events_dropped;
 
 #ifdef EP_CHECKED_BUILD
 	volatile int64_t num_events_stored;

--- a/src/native/eventpipe/ep-file.c
+++ b/src/native/eventpipe/ep-file.c
@@ -317,7 +317,7 @@ ep_file_alloc (
 	instance->stream_writer = stream_writer;
 	instance->format = format;
 
-	instance->event_block = ep_event_block_alloc (100 * 1024, format);
+	instance->event_block = ep_event_block_alloc (1024 * 1024, format);
 	ep_raise_error_if_nok (instance->event_block != NULL);
 
 	instance->metadata_block = ep_metadata_block_alloc (100 * 1024);

--- a/src/native/eventpipe/ep-file.c
+++ b/src/native/eventpipe/ep-file.c
@@ -317,7 +317,7 @@ ep_file_alloc (
 	instance->stream_writer = stream_writer;
 	instance->format = format;
 
-	instance->event_block = ep_event_block_alloc (1024 * 1024, format);
+	instance->event_block = ep_event_block_alloc (100 * 1024, format);
 	ep_raise_error_if_nok (instance->event_block != NULL);
 
 	instance->metadata_block = ep_metadata_block_alloc (100 * 1024);

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.cs
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+
+namespace Tracing.Tests.BigEventsValidation
+{
+
+    public sealed class BigEventSource : EventSource
+    {
+        private static string bigString = new String('a', 100 * 1024);
+        private static string smallString = new String('a', 10);
+
+        private BigEventSource()
+        {
+        }
+
+        public static BigEventSource Log = new BigEventSource();
+        
+        public void BigEvent()
+        {
+            WriteEvent(1, bigString);        
+        }
+
+        public void SmallEvent()
+        {
+            WriteEvent(2, smallString);
+        }
+    }
+
+    
+    public class BigEventsValidation
+    {
+        public static int Main(string[] args)
+        {
+            // This test tries to send a big event (>100KB) and checks that the app does not crash
+            // See https://github.com/dotnet/runtime/issues/50515 for the regression issue
+            var providers = new List<Provider>()
+            {
+                new Provider("BigEventSource")
+            };
+
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _Verify);
+        }
+
+        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        {
+            { "BigEventSource", -1 }
+        };
+
+        private static Action _eventGeneratingAction = () => 
+        {
+            // Write 10 big events
+            for (int i = 0; i < 10; i++)
+            {
+                BigEventSource.Log.BigEvent();
+            }
+            // Write 10 small events
+            for (int i = 0; i < 10; i++)
+            {
+                BigEventSource.Log.SmallEvent();
+            }
+        };
+
+        private static Func<EventPipeEventSource, Func<int>> _Verify = (source) =>
+        {
+            bool hasSmallEvent = false;
+            source.Dynamic.All += (TraceEvent data) =>
+            {
+                if (data.EventName == "SmallEvent")
+                {
+                    hasSmallEvent = true;
+                }
+            };
+            return () => hasSmallEvent ? 100 : -1;
+        };
+    }
+}

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
ETW has a maximum of 64KB event payload size limit that is not enforced on EventPipe. This causes issues like https://github.com/dotnet/runtime/issues/50515 to occur where an event that's greater than 100KB can cause the flushing thread's event block to be too small to fit a single event payload, which crashes the application. 

