### PR TITLE
Remove AssemblyName from SPC descriptor

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -459,8 +459,6 @@
 		<!-- appdomain.c (ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies) -->
 		<type fullname="System.Reflection.Assembly" preserve="fields"/>
 
-		<type fullname="System.Reflection.AssemblyName" preserve="fields" />
-
 		<!-- reflection.c: mono_method_body_get_object -->
 		<type fullname="System.Reflection.RuntimeExceptionHandlingClause" preserve="fields" >
 			<!-- reflection.c mono_object_new_checked in add_exception_handling_clause_to_array -->

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection
 {
-    [StructLayout(LayoutKind.Sequential)]
     public partial class AssemblyName
     {
         public AssemblyName(string assemblyName)


### PR DESCRIPTION
It's not needed as the runtime bridge uses MonoAssemblyName