### PR TITLE
Change Configuration.Json to use a regular Dictionary.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Configuration.Json
     {
         private JsonConfigurationFileParser() { }
 
-        private readonly SortedDictionary<string, string> _data = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly Stack<string> _paths = new Stack<string>();
 
         public static IDictionary<string, string> Parse(Stream input)


### PR DESCRIPTION
The other Configuration providers use a regular Dictionary.

This allows for SortedDictionary to be trimmed in a default Blazor WASM app, saving roughly 4 KB .br compressed.