### PR TITLE
basic certificate handling for quic

### DIFF
--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -67,6 +67,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Include="libmsquic.dylib" Condition="Exists('libmsquic.dylib')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Include="libmsquic.so" Condition="Exists('libmsquic.so')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Net.Sockets" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.X509Certificates" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Channels" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
@@ -19,6 +19,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         CONTEXT,
         FILE,
         FILE_PROTECTED,
+        PKCS12,
         STUB_NULL = 0xF0000000, // Pass as server cert to stubtls implementation.
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
@@ -20,7 +20,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         FILE,
         FILE_PROTECTED,
         PKCS12,
-        STUB_NULL = 0xF0000000, // Pass as server cert to stubtls implementation.
     }
 
     [Flags]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -215,30 +215,33 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal struct CredentialConfigCertificateUnion
         {
             [FieldOffset(0)]
-            internal CredentialConfigCertificateCertificateHash CertificateHash;
+            internal CredentialConfigCertificateHash CertificateHash;
 
             [FieldOffset(0)]
-            internal CredentialConfigCertificateCertificateHashStore CertificateHashStore;
+            internal CredentialConfigCertificateHashStore CertificateHashStore;
 
             [FieldOffset(0)]
             internal IntPtr CertificateContext;
 
             [FieldOffset(0)]
-            internal CredentialConfigCertificateCertificateFile CertificateFile;
+            internal CredentialConfigCertificateFile CertificateFile;
 
             [FieldOffset(0)]
-            internal CredentialConfigCertificateCertificateFileProtected CertificateFileProtected;
+            internal CredentialConfigCertificateFileProtected CertificateFileProtected;
+
+            [FieldOffset(0)]
+            internal CredentialConfigCertificatePkcs12 CertificatePkcs12;
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct CredentialConfigCertificateCertificateHash
+        internal struct CredentialConfigCertificateHash
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
             internal byte[] ShaHash;
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        internal struct CredentialConfigCertificateCertificateHashStore
+        internal struct CredentialConfigCertificateHashStore
         {
             internal QUIC_CERTIFICATE_HASH_STORE_FLAGS Flags;
 
@@ -250,7 +253,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct CredentialConfigCertificateCertificateFile
+        internal struct CredentialConfigCertificateFile
         {
             [MarshalAs(UnmanagedType.LPUTF8Str)]
             internal string PrivateKeyFile;
@@ -260,7 +263,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct CredentialConfigCertificateCertificateFileProtected
+        internal struct CredentialConfigCertificateFileProtected
         {
             [MarshalAs(UnmanagedType.LPUTF8Str)]
             internal string PrivateKeyFile;
@@ -270,6 +273,17 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             [MarshalAs(UnmanagedType.LPUTF8Str)]
             internal string PrivateKeyPassword;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct CredentialConfigCertificatePkcs12
+        {
+            internal IntPtr Asn1Blob;
+
+            internal int Asn1BlobLength;
+
+            //[MarshalAs(UnmanagedType.LPUTF8Str)]
+            internal IntPtr PrivateKeyPassword;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -280,9 +280,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         {
             internal IntPtr Asn1Blob;
 
-            internal int Asn1BlobLength;
+            internal uint Asn1BlobLength;
 
-            //[MarshalAs(UnmanagedType.LPUTF8Str)]
             internal IntPtr PrivateKeyPassword;
         }
 
@@ -426,7 +425,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         {
             internal IntPtr PlatformCertificateHandle;
             internal uint DeferredErrorFlags;
-            internal int DeferredStatus;
+            internal uint DeferredStatus;
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -457,9 +457,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal ConnectionEventDataStreamsAvailable StreamsAvailable;
 
             [FieldOffset(0)]
-            internal ConnectionEventPeerCertificateReceived PeerCertificate;
+            internal ConnectionEventPeerCertificateReceived PeerCertificateReceived;
 
-            // TODO: missing IDEAL_PROCESSOR_CHANGED, ...,  (7 total)
+            // TODO: missing IDEAL_PROCESSOR_CHANGED, ...,  (6 total)
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -407,6 +407,14 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal ushort UniDirectionalCount;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ConnectionEventPeerCertificateReceived
+        {
+            internal IntPtr PlatformCertificateHandle;
+            internal uint DeferredErrorFlags;
+            internal int DeferredStatus;
+        }
+
         [StructLayout(LayoutKind.Explicit)]
         internal struct ConnectionEventDataUnion
         {
@@ -434,7 +442,10 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             [FieldOffset(0)]
             internal ConnectionEventDataStreamsAvailable StreamsAvailable;
 
-            // TODO: missing IDEAL_PROCESSOR_CHANGED, ..., PEER_CERTIFICATE_RECEIVED (7 total)
+            [FieldOffset(0)]
+            internal ConnectionEventPeerCertificateReceived PeerCertificate;
+
+            // TODO: missing IDEAL_PROCESSOR_CHANGED, ...,  (7 total)
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
@@ -5,14 +5,14 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal static class MsQuicStatusCodes
     {
-        internal static uint Success => OperatingSystem.IsWindows() ? Windows.Success : Linux.Success;
-        internal static uint Pending => OperatingSystem.IsWindows() ? Windows.Pending : Linux.Pending;
-        internal static uint InternalError => OperatingSystem.IsWindows() ? Windows.InternalError : Linux.InternalError;
-        internal static uint InvalidState => OperatingSystem.IsWindows() ? Windows.InvalidState : Linux.InvalidState;
-        internal static uint HandshakeFailure => OperatingSystem.IsWindows() ? Windows.HandshakeFailure : Linux.HandshakeFailure;
+        internal static uint Success => OperatingSystem.IsWindows() ? Windows.Success : Posix.Success;
+        internal static uint Pending => OperatingSystem.IsWindows() ? Windows.Pending : Posix.Pending;
+        internal static uint InternalError => OperatingSystem.IsWindows() ? Windows.InternalError : Posix.InternalError;
+        internal static uint InvalidState => OperatingSystem.IsWindows() ? Windows.InvalidState : Posix.InvalidState;
+        internal static uint HandshakeFailure => OperatingSystem.IsWindows() ? Windows.HandshakeFailure : Posix.HandshakeFailure;
 
         // TODO return better error messages here.
-        public static string GetError(uint status) => OperatingSystem.IsWindows() ? Windows.GetError(status) : Linux.GetError(status);
+        public static string GetError(uint status) => OperatingSystem.IsWindows() ? Windows.GetError(status) : Posix.GetError(status);
 
         private static class Windows
         {
@@ -71,7 +71,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             }
         }
 
-        private static class Linux
+        private static class Posix
         {
             internal const uint Success = 0;
             internal const uint Pending = unchecked((uint)-2);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
@@ -8,6 +8,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal static uint Success => OperatingSystem.IsWindows() ? Windows.Success : Linux.Success;
         internal static uint Pending => OperatingSystem.IsWindows() ? Windows.Pending : Linux.Pending;
         internal static uint InternalError => OperatingSystem.IsWindows() ? Windows.InternalError : Linux.InternalError;
+        internal static uint InvalidState => OperatingSystem.IsWindows() ? Windows.InvalidState : Linux.InvalidState;
+        internal static uint HandshakeFailure => OperatingSystem.IsWindows() ? Windows.HandshakeFailure : Linux.HandshakeFailure;
 
         // TODO return better error messages here.
         public static string GetError(uint status) => OperatingSystem.IsWindows() ? Windows.GetError(status) : Linux.GetError(status);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusHelper.cs
@@ -12,7 +12,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 return status < 0x80000000;
             }
 
-            if (OperatingSystem.IsLinux())
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
                 return (int)status <= 0;
             }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -130,7 +130,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                         fixed (void* ptr = asn1)
                         {
                             pkcs12Config.Asn1Blob = (IntPtr)ptr;
-                            pkcs12Config.Asn1BlobLength = asn1.Length;
+                            pkcs12Config.Asn1BlobLength = (uint)asn1.Length;
                             pkcs12Config.PrivateKeyPassword = IntPtr.Zero;
 
                             config.Type = QUIC_CREDENTIAL_TYPE.PKCS12;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -251,7 +251,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 {
                     bool success = connection._remoteCertificateValidationCallback(connection, certificate, chain, sslPolicyErrors);
                     if (!success && NetEventSource.Log.IsEnabled())
-                        NetEventSource.Error(state.Connection, $"Remote certificate rejected by verification callback");
+                        NetEventSource.Error(state.Connection, "Remote certificate rejected by verification callback");
                     return success ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;
                 }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -207,7 +207,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (!OperatingSystem.IsWindows())
             {
-                // TBD fix validation with OpenSSL
+                // TODO fix validation with OpenSSL
                 return MsQuicStatusCodes.Success;
             }
 
@@ -217,9 +217,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                 return MsQuicStatusCodes.InvalidState;
             }
 
-            if (connectionEvent.Data.PeerCertificate.PlatformCertificateHandle != IntPtr.Zero)
+            if (connectionEvent.Data.PeerCertificateReceived.PlatformCertificateHandle != IntPtr.Zero)
             {
-                certificate = new X509Certificate2(connectionEvent.Data.PeerCertificate.PlatformCertificateHandle);
+                certificate = new X509Certificate2(connectionEvent.Data.PeerCertificateReceived.PlatformCertificateHandle);
             }
 
             try
@@ -236,7 +236,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                     chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
                     chain.ChainPolicy.ApplicationPolicy.Add(connection._isServer ? s_clientAuthOid : s_serverAuthOid);
 
-                    if (!chain.Build(certificate)) {
+                    if (!chain.Build(certificate))
+                    {
                         sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
                     }
                 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -7,6 +7,8 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -16,6 +18,9 @@ namespace System.Net.Quic.Implementations.MsQuic
 {
     internal sealed class MsQuicConnection : QuicConnectionProvider
     {
+        private static readonly Oid s_clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
+        private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
+
         // Delegate that wraps the static function that will be called when receiving an event.
         private static readonly ConnectionCallbackDelegate s_connectionDelegate = new ConnectionCallbackDelegate(NativeCallbackHandler);
 
@@ -30,6 +35,10 @@ namespace System.Net.Quic.Implementations.MsQuic
         private IPEndPoint? _localEndPoint;
         private readonly EndPoint _remoteEndPoint;
         private SslApplicationProtocol _negotiatedAlpnProtocol;
+        private bool _isServer;
+        private bool _remoteCertificateRequired;
+        private X509RevocationMode _revocationMode = X509RevocationMode.Offline;
+        private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
 
         private sealed class State
         {
@@ -61,6 +70,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             _state.Connected = true;
             _localEndPoint = localEndPoint;
             _remoteEndPoint = remoteEndPoint;
+            _remoteCertificateRequired = false;
+            _isServer = true;
 
             _stateHandle = GCHandle.Alloc(_state);
 
@@ -83,6 +94,13 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             _remoteEndPoint = options.RemoteEndPoint!;
             _configuration = SafeMsQuicConfigurationHandle.Create(options);
+            _isServer = false;
+            _remoteCertificateRequired = true;
+            if (options.ClientAuthenticationOptions != null)
+            {
+                _revocationMode = options.ClientAuthenticationOptions.CertificateRevocationCheckMode;
+                _remoteCertificateValidationCallback = options.ClientAuthenticationOptions.RemoteCertificateValidationCallback;
+            }
 
             _stateHandle = GCHandle.Alloc(_state);
             try
@@ -179,6 +197,74 @@ namespace System.Net.Quic.Implementations.MsQuic
         private static uint HandleEventStreamsAvailable(State state, ref ConnectionEvent connectionEvent)
         {
             return MsQuicStatusCodes.Success;
+        }
+
+        private static uint HandleEventPeerCertificateReceived(State state, ref ConnectionEvent connectionEvent)
+        {
+            SslPolicyErrors sslPolicyErrors  = SslPolicyErrors.None;
+            X509Chain? chain = null;
+            X509Certificate2? certificate = null;
+
+            if (!OperatingSystem.IsWindows())
+            {
+                // TBD fix validation with OpenSSL
+                return MsQuicStatusCodes.Success;
+            }
+
+            MsQuicConnection? connection = state.Connection;
+            if (connection == null)
+            {
+                return MsQuicStatusCodes.InvalidState;
+            }
+
+            if (connectionEvent.Data.PeerCertificate.PlatformCertificateHandle != IntPtr.Zero)
+            {
+                certificate = new X509Certificate2(connectionEvent.Data.PeerCertificate.PlatformCertificateHandle);
+            }
+
+            try
+            {
+                if (certificate == null)
+                {
+                    if (NetEventSource.Log.IsEnabled() && connection._remoteCertificateRequired) NetEventSource.Error(state.Connection, $"Remote certificate required, but no remote certificate received");
+                    sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
+                }
+                else
+                {
+                    chain = new X509Chain();
+                    chain.ChainPolicy.RevocationMode = connection._revocationMode;
+                    chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+                    chain.ChainPolicy.ApplicationPolicy.Add(connection._isServer ? s_clientAuthOid : s_serverAuthOid);
+
+                    if (!chain.Build(certificate)) {
+                        sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
+                    }
+                }
+
+                if (!connection._remoteCertificateRequired)
+                {
+                    sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateNotAvailable;
+                }
+
+                if (connection._remoteCertificateValidationCallback != null)
+                {
+                    bool success = connection._remoteCertificateValidationCallback(connection, certificate, chain, sslPolicyErrors);
+                    if (!success && NetEventSource.Log.IsEnabled())
+                        NetEventSource.Error(state.Connection, $"Remote certificate rejected by verification callback");
+                    return success ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;
+                }
+
+                if (NetEventSource.Log.IsEnabled())
+                    NetEventSource.Info(state.Connection, $"Certificate validation for '${certificate?.Subject}' finished with ${sslPolicyErrors}");
+
+                return (sslPolicyErrors == SslPolicyErrors.None) ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;
+            }
+            catch (Exception ex)
+            {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state.Connection, $"Certificate validation failed ${ex.Message}");
+            }
+
+            return MsQuicStatusCodes.InternalError;
         }
 
         internal override async ValueTask<QuicStreamProvider> AcceptStreamAsync(CancellationToken cancellationToken = default)
@@ -312,10 +398,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             ref ConnectionEvent connectionEvent)
         {
             var state = (State)GCHandle.FromIntPtr(context).Target!;
-
             try
             {
-                switch ((QUIC_CONNECTION_EVENT_TYPE)connectionEvent.Type)
+                switch (connectionEvent.Type)
                 {
                     case QUIC_CONNECTION_EVENT_TYPE.CONNECTED:
                         return HandleEventConnected(state, ref connectionEvent);
@@ -329,6 +414,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                         return HandleEventNewStream(state, ref connectionEvent);
                     case QUIC_CONNECTION_EVENT_TYPE.STREAMS_AVAILABLE:
                         return HandleEventStreamsAvailable(state, ref connectionEvent);
+                    case QUIC_CONNECTION_EVENT_TYPE.PEER_CERTIFICATE_RECEIVED:
+                        return HandleEventPeerCertificateReceived(state, ref connectionEvent);
                     default:
                         return MsQuicStatusCodes.Success;
                 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTestBase.cs
@@ -24,7 +24,8 @@ namespace System.Net.Quic.Tests
         {
             return new SslClientAuthenticationOptions()
             {
-                ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("quictest") }
+                ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("quictest") },
+                RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => { return true; }
             };
         }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -31,7 +31,8 @@ namespace System.Net.Quic.Tests
         {
             return new SslClientAuthenticationOptions()
             {
-                ApplicationProtocols = new List<SslApplicationProtocol>() { ApplicationProtocol }
+                ApplicationProtocols = new List<SslApplicationProtocol>() { ApplicationProtocol },
+                RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => { return true; }
             };
         }
 


### PR DESCRIPTION
With https://github.com/microsoft/msquic/pull/1411 support for STUB Tls was removed and we only have real option left. 

This change adds server support for normal X509Certificate and plus usual verification callback so the fate of the handshake can be decided from .NET. 

Right now, this is supported only ion Windows, Linux & macOS coming (hopefully) soon.

This is also missing support for custom certificate chains, SslStreamCertificateContext, and client certificates. 

cc: @nibanks 