### PR TITLE
`AVInRuntimeImplOkayHolder`  should use `GetThreadNULLOk()`

### DIFF
--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4170,7 +4170,7 @@ public:
         Thread * const m_pThread;
     public:
         AVInRuntimeImplOkayHolder() :
-            m_pThread(GetThread())
+            m_pThread(GetThreadNULLOk())
         {
             LIMITED_METHOD_CONTRACT;
             AVInRuntimeImplOkayAcquire(m_pThread);


### PR DESCRIPTION
Found this while investigating unrelated issues.

`AVInRuntimeImplOkayHolder`  should use `GetThreadNULLOk()`. 
The thread can be NULL there when debugging.

The consequence of this is that JIT-attaching VS debugger to something asserting on Checked runtime, causes another native assert (about `nThread`) and that crashes the debug session.

