### PR TITLE
Disable stackoverflowtester under gcstress

### DIFF
--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
@@ -4,6 +4,8 @@
     <Optimize>false</Optimize>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- Fails in many GCStress jobs. https://github.com/dotnet/runtime/issues/46279 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="stackoverflowtester.cs" />


### PR DESCRIPTION
This test currently fails under many gcstress legs.

Tracking issue: https://github.com/dotnet/runtime/issues/46279