### PR TITLE
Improve RGB Min Max evaluation performance by using 2 or 3 comparison…

### DIFF
--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -490,27 +490,34 @@ namespace System.Drawing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void MinMaxRgb(out int min, out int max, int r, int g, int b)
         {
-            if (b < g) {
-                if (b < r) {
+            if (b < g)
+            {
+                if (b < r)
+                {
                     min = b;
-                    if (r < g) {
+                    if (r < g)
                         max = g;
-                    } else {
+                    else
                         max = r;
-                    }
-                } else {
+                }
+                else
+                {
                     min = r;
                     max = g;
                 }
-            } else {
-                if (r < b) {
+            }
+            else
+            {
+                if (r < b)
+                {
                     max = b;
-                    if (g < r) {
+                    if (g < r)
                         min = g;
-                    } else {
+                    else
                         min = r;
-                    }
-                } else {
+                }
+                else
+                {
                     max = r;
                     min = g;
                 }

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -495,10 +495,7 @@ namespace System.Drawing
                 if (b < r)
                 {
                     min = b;
-                    if (r < g)
-                        max = g;
-                    else
-                        max = r;
+                    max = r < g ? g : r;
                 }
                 else
                 {
@@ -511,10 +508,7 @@ namespace System.Drawing
                 if (r < b)
                 {
                     max = b;
-                    if (g < r)
-                        min = g;
-                    else
-                        min = r;
+                    min = g < r ? g : r;
                 }
                 else
                 {
@@ -528,8 +522,7 @@ namespace System.Drawing
         {
             GetRgbValues(out int r, out int g, out int b);
 
-            int min, max;
-            MinMaxRgb(out min, out max, r, g, b);
+            MinMaxRgb(out int min, out int max, r, g, b);
 
             return (max + min) / (byte.MaxValue * 2f);
         }
@@ -541,8 +534,7 @@ namespace System.Drawing
             if (r == g && g == b)
                 return 0f;
 
-            int min, max;
-            MinMaxRgb(out min, out max, r, g, b);
+            MinMaxRgb(out int min, out int max, r, g, b);
 
             float delta = max - min;
             float hue;
@@ -568,8 +560,7 @@ namespace System.Drawing
             if (r == g && g == b)
                 return 0f;
 
-            int min, max;
-            MinMaxRgb(out min, out max, r, g, b);
+            MinMaxRgb(out int min, out int max, r, g, b);
 
             int div = max + min;
             if (div > byte.MaxValue)

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -487,12 +487,42 @@ namespace System.Drawing
             b = (int)(value & ARGBBlueMask) >> ARGBBlueShift;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void MinMaxRgb(out int min, out int max, int r, int g, int b)
+        {
+            if (b < g) {
+                if (b < r) {
+                    min = b;
+                    if (r < g) {
+                        max = g;
+                    } else {
+                        max = r;
+                    }
+                } else {
+                    min = r;
+                    max = g;
+                }
+            } else {
+                if (r < b) {
+                    max = b;
+                    if (g < r) {
+                        min = g;
+                    } else {
+                        min = r;
+                    }
+                } else {
+                    max = r;
+                    min = g;
+                }
+            }
+        }
+
         public float GetBrightness()
         {
             GetRgbValues(out int r, out int g, out int b);
 
-            int min = Math.Min(Math.Min(r, g), b);
-            int max = Math.Max(Math.Max(r, g), b);
+            int min, max;
+            MinMaxRgb(out min, out max, r, g, b);
 
             return (max + min) / (byte.MaxValue * 2f);
         }
@@ -504,8 +534,8 @@ namespace System.Drawing
             if (r == g && g == b)
                 return 0f;
 
-            int min = Math.Min(Math.Min(r, g), b);
-            int max = Math.Max(Math.Max(r, g), b);
+            int min, max;
+            MinMaxRgb(out min, out max, r, g, b);
 
             float delta = max - min;
             float hue;
@@ -531,8 +561,8 @@ namespace System.Drawing
             if (r == g && g == b)
                 return 0f;
 
-            int min = Math.Min(Math.Min(r, g), b);
-            int max = Math.Max(Math.Max(r, g), b);
+            int min, max;
+            MinMaxRgb(out min, out max, r, g, b);
 
             int div = max + min;
             if (div > byte.MaxValue)

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -488,33 +488,25 @@ namespace System.Drawing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void MinMaxRgb(out int min, out int max, int r, int g, int b)
+        private static void MinMaxRgb(out int min, out int max, int r, int g, int b)
         {
-            if (b < g)
+            if (r > g)
             {
-                if (b < r)
-                {
-                    min = b;
-                    max = r < g ? g : r;
-                }
-                else
-                {
-                    min = r;
-                    max = g;
-                }
+                max = r;
+                min = g;
             }
             else
             {
-                if (r < b)
-                {
-                    max = b;
-                    min = g < r ? g : r;
-                }
-                else
-                {
-                    max = r;
-                    min = g;
-                }
+                max = g;
+                min = r;
+            }
+            if (b > max)
+            {
+                max = b;
+            }
+            else if (b < min)
+            {
+                min = b;
             }
         }
 

--- a/src/libraries/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/libraries/System.Drawing.Primitives/tests/ColorTests.cs
@@ -390,6 +390,12 @@ namespace System.Drawing.Primitives.Tests
         [InlineData(51, 255, 51, 0.6f)]
         [InlineData(51, 51, 255, 0.6f)]
         [InlineData(51, 51, 51, 0.2f)]
+        [InlineData(0, 51, 255, 0.5f)]
+        [InlineData(51, 255, 0, 0.5f)]
+        [InlineData(0, 255, 51, 0.5f)]
+        [InlineData(255, 0, 51, 0.5f)]
+        [InlineData(51, 0, 255, 0.5f)]
+        [InlineData(255, 51, 0, 0.5f)]
         public void GetBrightness(int r, int g, int b, float expected)
         {
             Assert.Equal(expected, Color.FromArgb(r, g, b).GetBrightness());


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/46153

…s instead of 4

* Replaces 2 calls each to Math.Min and Math.Max (a total of 4 required
  comparisons) with a single call to MinMaxRgb (at least 2 required
  comparisons and at worst 3).