### PR TITLE
Add loop alignment stats to JitLogCsv

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -8338,7 +8338,7 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
 #ifdef DEBUG
     fprintf(s_csvFile, "%u,", comp->loopAlignCandidates);
     fprintf(s_csvFile, "%u,", comp->loopsAligned);
-#endif  // DEBUG
+#endif // DEBUG
 #endif // FEATURE_LOOP_ALIGN
     unsigned __int64 totCycles = 0;
     for (int i = 0; i < PHASE_NUMBER_OF; i++)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -8255,7 +8255,10 @@ void JitTimer::PrintCsvHeader()
             fprintf(s_csvFile, "\"Min Opts\",");
             fprintf(s_csvFile, "\"Loops\",");
             fprintf(s_csvFile, "\"Loops Cloned\",");
-
+#if FEATURE_LOOP_ALIGN
+            fprintf(s_csvFile, "\"Alignment Candidates\",");
+            fprintf(s_csvFile, "\"Loops Aligned\",");
+#endif // FEATURE_LOOP_ALIGN
             for (int i = 0; i < PHASE_NUMBER_OF; i++)
             {
                 fprintf(s_csvFile, "\"%s\",", PhaseNames[i]);
@@ -8329,6 +8332,10 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
     fprintf(s_csvFile, "%u,", comp->opts.MinOpts());
     fprintf(s_csvFile, "%u,", comp->optLoopCount);
     fprintf(s_csvFile, "%u,", comp->optLoopsCloned);
+#if FEATURE_LOOP_ALIGN
+    fprintf(s_csvFile, "%u,", comp->loopAlignCandidates);
+    fprintf(s_csvFile, "%u,", comp->loopsAligned);
+#endif // FEATURE_LOOP_ALIGN
     unsigned __int64 totCycles = 0;
     for (int i = 0; i < PHASE_NUMBER_OF; i++)
     {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -8256,8 +8256,10 @@ void JitTimer::PrintCsvHeader()
             fprintf(s_csvFile, "\"Loops\",");
             fprintf(s_csvFile, "\"Loops Cloned\",");
 #if FEATURE_LOOP_ALIGN
+#ifdef DEBUG
             fprintf(s_csvFile, "\"Alignment Candidates\",");
             fprintf(s_csvFile, "\"Loops Aligned\",");
+#endif // DEBUG
 #endif // FEATURE_LOOP_ALIGN
             for (int i = 0; i < PHASE_NUMBER_OF; i++)
             {
@@ -8333,8 +8335,10 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
     fprintf(s_csvFile, "%u,", comp->optLoopCount);
     fprintf(s_csvFile, "%u,", comp->optLoopsCloned);
 #if FEATURE_LOOP_ALIGN
+#ifdef DEBUG
     fprintf(s_csvFile, "%u,", comp->loopAlignCandidates);
     fprintf(s_csvFile, "%u,", comp->loopsAligned);
+#endif  // DEBUG
 #endif // FEATURE_LOOP_ALIGN
     unsigned __int64 totCycles = 0;
     for (int i = 0; i < PHASE_NUMBER_OF; i++)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6435,6 +6435,11 @@ public:
     LoopDsc*      optLoopTable; // loop descriptor table
     unsigned char optLoopCount; // number of tracked loops
 
+#ifdef DEBUG
+    unsigned char loopAlignCandidates; // number of loops identified for alignment
+    unsigned char loopsAligned;        // number of loops actually aligned
+#endif                                 // DEBUG
+
     bool optRecordLoop(BasicBlock*   head,
                        BasicBlock*   first,
                        BasicBlock*   top,

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4650,6 +4650,10 @@ void emitter::emitLoopAlignment()
 
     JITDUMP("Adding 'align' instruction of %d bytes in G_M%03u_IG%02u.\n", paddingBytes, emitComp->compMethodID,
             emitCurIG->igNum);
+
+#ifdef DEBUG
+    emitComp->loopAlignCandidates++;
+#endif // DEBUG
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9434,6 +9434,8 @@ BYTE* emitter::emitOutputAlign(insGroup* ig, instrDesc* id, BYTE* dst)
     {
         assert(paddingToAdd == paddingNeeded);
     }
+
+    emitComp->loopsAligned++;
 #endif
 
     return emitOutputNOP(dst, paddingToAdd);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -27,6 +27,11 @@ void Compiler::optInit()
     optLoopCount = 0;
     optLoopTable = nullptr;
 
+#ifdef DEBUG
+    loopAlignCandidates = 0;
+    loopsAligned        = 0;
+#endif
+
     /* Keep track of the number of calls and indirect calls made by this method */
     optCallCount         = 0;
     optIndirectCallCount = 0;


### PR DESCRIPTION
Add `LoopAlignCandidates` and `LoopsAligned` to JitLogCsv output so we can tune the heuristics in future.