### PR TITLE
Moving Suppress message to assembly level and adding Scope in order to get right suppressing behavior

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
@@ -5,9 +5,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 [assembly: UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-        Target = "M:System.Security.Cryptography.CryptoConfigForwarder.#cctor",
-        Scope = "member",
-        Justification = "The cctor caches the RequiresUnreferencedCode call in a delegate, and usage of that delegate is marked with RequiresUnreferencedCode.")]
+    Target = "M:System.Security.Cryptography.CryptoConfigForwarder.#cctor",
+    Scope = "member",
+    Justification = "The cctor caches the RequiresUnreferencedCode call in a delegate, and usage of that delegate is marked with RequiresUnreferencedCode.")]
 
 namespace System.Security.Cryptography
 {

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
@@ -4,11 +4,13 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
+[assembly: UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+        Target = "M:System.Security.Cryptography.CryptoConfigForwarder.#cctor",
+        Scope = "member",
+        Justification = "The cctor caches the RequiresUnreferencedCode call in a delegate, and usage of that delegate is marked with RequiresUnreferencedCode.")]
+
 namespace System.Security.Cryptography
 {
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-        Target = "M:System.Security.Cryptography.CryptoConfigForwarder.#cctor",
-        Justification = "The cctor caches the RequiresUnreferencedCode call in a delegate, and usage of that delegate is marked with RequiresUnreferencedCode.")]
     internal static class CryptoConfigForwarder
     {
         internal const string CreateFromNameUnreferencedCodeMessage = "The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.";


### PR DESCRIPTION
cc: @eerhardt @sbomer @tlakollo 

While doing the System.Private.Xml linker warning changes, I discovered that whenever you try to suppress a message using Target parameter, you must a) make sure the attribute is set to either module or assembly level and b) you also specify Scope to be "type" or "member". If you don't do this, and instead have the attribute in the class, you will have the unintentional side effect that all warnings from that class will be suppressed and the Target won't be applied. I'll log a bug on the linker to investigate what we can do to catch this unintentional suppressions and provide feedback to the consumer.