### PR TITLE
Disable test b426654 for GCStress

### DIFF
--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- This test is too slow under GCStress=3. Issue: https://github.com/dotnet/runtime/issues/50615 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
It has been failing with timeouts on GCStress=3.

Tracking issue: https://github.com/dotnet/runtime/issues/50615