### PR TITLE
[AppleAppBuilder] Entitlements to run tests on catalyst using the JIT

### DIFF
--- a/src/mono/sample/iOS/Makefile
+++ b/src/mono/sample/iOS/Makefile
@@ -18,5 +18,21 @@ run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
 	/p:UseLLVM=$(USE_LLVM) /p:ForceAOT=$(AOT)
 
+run-sim: clean appbuilder
+	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetOS=iOSSimulator /p:TargetArchitecture=$(MONO_ARCH) \
+	/p:UseLLVM=$(USE_LLVM) /p:ForceAOT=$(AOT)
+
+run-catalyst:
+	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetOS=MacCatalyst /p:TargetArchitecture=$(MONO_ARCH) \
+	/p:UseLLVM=False /p:ForceAOT=False
+
+run-sim-interp: clean appbuilder
+	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetOS=iOSSimulator /p:TargetArchitecture=$(MONO_ARCH) \
+	/p:UseLLVM=$(USE_LLVM) /p:ForceAOT=$(AOT) /p:MonoForceInterpreter=true
+
+run-catalyst-interp:
+	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetOS=MacCatalyst /p:TargetArchitecture=$(MONO_ARCH) \
+	/p:UseLLVM=False /p:ForceAOT=False /p:MonoForceInterpreter=true
+
 clean:
 	rm -rf bin

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -12,13 +12,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- FIXME: for some reason trimming is throwing errors errors. -->
+    <!-- FIXME: for some reason trimming is throwing errors about something in System.Diagnostics. -->
     <!-- <PublishTrimmed>true</PublishTrimmed> -->
     <!-- <TrimMode>Link</TrimMode> -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'MacCatalyst'">
-    <!-- MonoForceInterpreter>true</MonoForceInterpreter> -->
     <DevTeamProvisioning Condition="'$(TargetOS)' == 'MacCatalyst' and '$(DevTeamProvisioning)' == ''">-</DevTeamProvisioning>
   </PropertyGroup>
 

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -8,9 +8,18 @@
     <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.$(TargetOS.ToLower())-$(TargetArchitecture)\$(Configuration)\runtimes\$(TargetOS.ToLower())-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <RuntimeIdentifier>$(TargetOS.ToLower())-$(TargetArchitecture)</RuntimeIdentifier>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>Link</TrimMode>
     <DefineConstants Condition="'$(ArchiveTests)' == 'true'">$(DefineConstants);CI_TEST</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- FIXME: for some reason trimming is throwing errors errors. -->
+    <!-- <PublishTrimmed>true</PublishTrimmed> -->
+    <!-- <TrimMode>Link</TrimMode> -->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'MacCatalyst'">
+    <!-- MonoForceInterpreter>true</MonoForceInterpreter> -->
+    <DevTeamProvisioning Condition="'$(TargetOS)' == 'MacCatalyst' and '$(DevTeamProvisioning)' == ''">-</DevTeamProvisioning>
   </PropertyGroup>
 
   <!-- Redirect 'dotnet publish' to in-tree runtime pack -->
@@ -35,7 +44,7 @@
       <AppDir>$(MSBuildThisFileDirectory)$(PublishDir)\app</AppDir>
       <IosSimulator Condition="'$(TargetsiOSSimulator)' == 'true'">iPhone 11</IosSimulator>
       <Optimized Condition="'$(Configuration)' == 'Release'">True</Optimized>
-      <RunAOTCompilation Condition="'$(IosSimulator)' == '' or '$(ForceAOT)' == 'true'">true</RunAOTCompilation>
+      <RunAOTCompilation Condition="('$(TargetsMacCatalyst)' == 'false' and '$(IosSimulator)' == '') or '$(ForceAOT)' == 'true'">true</RunAOTCompilation>
     </PropertyGroup>
 
     <RemoveDir Directories="$(AppDir)" />
@@ -83,11 +92,16 @@
     <Message Importance="High" Text="Xcode: $(XcodeProjectPath)"/>
     <Message Importance="High" Text="App:   $(AppBundlePath)"/>
 
+    <!-- install and run on ios simulator -->
     <Exec Condition="'$(IosSimulator)' != '' and '$(ArchiveTests)' != 'true'" Command="xcrun simctl shutdown &quot;$(IosSimulator)&quot;" ContinueOnError="WarnAndContinue" />
     <Exec Condition="'$(IosSimulator)' != '' and '$(ArchiveTests)' != 'true'" Command="xcrun simctl boot &quot;$(IosSimulator)&quot;" />
     <Exec Condition="'$(IosSimulator)' != '' and '$(ArchiveTests)' != 'true'" Command="open -a Simulator" />
     <Exec Condition="'$(IosSimulator)' != '' and '$(ArchiveTests)' != 'true'" Command="xcrun simctl install &quot;$(IosSimulator)&quot; $(AppBundlePath)" />
     <Exec Condition="'$(IosSimulator)' != '' and '$(ArchiveTests)' != 'true'" Command="xcrun simctl launch --console booted net.dot.HelloiOS" />
+
+    <!-- run on MacCatalyst -->
+    <Exec Condition="'$(TargetOS)' == 'MacCatalyst'" Command="dotnet xharness apple run --app=$(AppBundlePath) --targets=maccatalyst --output-directory=/tmp/out" />
+
   </Target>
 
   <Target Name="CopySampleAppToHelixTestDir" 

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -31,6 +31,21 @@ set_target_properties(%ProjectName% PROPERTIES
     RESOURCE "${APP_RESOURCES}"
 )
 
+set(HARDENED_RUNTIME
+%HardenedRuntime%
+)
+
+set(HARDENED_RUNTIME_USE_JIT
+%HardenedRuntimeUseJit%
+)
+
+if("${HARDENED_RUNTIME}")
+  set_target_properties(%ProjectName% PROPERTIES XCODE_ATTRIBUTE_HARDENED_RUNTIME "YES")
+  if("${HARDENED_RUNTIME_USE_JIT}")
+    set_target_properties(%ProjectName% PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "app.entitlements")
+  endif()
+endif()
+
 # FIXME: `XCODE_ATTRIBUTE_DEAD_CODE_STRIPPING` should not be NO
 
 target_link_libraries(

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -35,13 +35,13 @@ set(HARDENED_RUNTIME
 %HardenedRuntime%
 )
 
-set(HARDENED_RUNTIME_USE_JIT
-%HardenedRuntimeUseJit%
+set(HARDENED_RUNTIME_USE_ENTITLEMENTS_FILE
+%HardenedRuntimeUseEntitlementsFile%
 )
 
 if("${HARDENED_RUNTIME}")
   set_target_properties(%ProjectName% PROPERTIES XCODE_ATTRIBUTE_HARDENED_RUNTIME "YES")
-  if("${HARDENED_RUNTIME_USE_JIT}")
+  if("${HARDENED_RUNTIME_USE_ENTITLEMENTS_FILE}")
     set_target_properties(%ProjectName% PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "app.entitlements")
   endif()
 endif()

--- a/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
+++ b/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
@@ -4,5 +4,7 @@
 <dict>
         <key>com.apple.security.cs.allow-jit</key>
         <true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
+++ b/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
@@ -2,9 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-        <key>com.apple.security.cs.allow-jit</key>
-        <true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
+%Entitlements%
 </dict>
 </plist>

--- a/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
+++ b/src/tasks/AppleAppBuilder/Templates/app.entitlements.template
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+</dict>
+</plist>

--- a/src/tasks/AppleAppBuilder/Templates/runtime.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime.m
@@ -246,14 +246,14 @@ mono_ios_runtime_init (void)
     const char *appctx_keys [] = {
         "RUNTIME_IDENTIFIER", 
         "APP_CONTEXT_BASE_DIRECTORY",
-#ifndef INVARIANT_GLOBALIZATION
+#if !defined(INVARIANT_GLOBALIZATION) && !TARGET_OS_MACCATALYST
         "ICU_DAT_FILE_PATH"
 #endif
     };
     const char *appctx_values [] = {
         APPLE_RUNTIME_IDENTIFIER,
         bundle,
-#ifndef INVARIANT_GLOBALIZATION
+#if !defined(INVARIANT_GLOBALIZATION) && !TARGET_OS_MACCATALYST
         icu_dat_path
 #endif
     };


### PR DESCRIPTION
It still doesn't pass tests, but now it doesn't crash on startup


1. Don't set the `ICU_DAT_FILE_PATH` since we're not bundling a static ICU.  Fixes interpreter runs.
2. If using the JIT, enable the hardened runtime and add two entitlements:
   a. the JITing entitlement - without it, we can't mmap `MAP_JIT` pages in catalyst apps
   b. the "disable library validation" entitlement - without it, we can't load the system libicu, or the in-bundle (but unsigned) libSystem.Native.dylib
3. Update the iOS sample to run on Catalyst, too - using `make run-catalyst`

