### PR TITLE
Correcting proclib function that did not adhere to filemap wrappers

### DIFF
--- a/src/mono/mono/utils/mono-proclib.h
+++ b/src/mono/mono/utils/mono-proclib.h
@@ -328,7 +328,7 @@ gboolean
 mono_pe_file_time_date_stamp (const gunichar2 *filename, guint32 *out);
 
 gpointer
-mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle);
+mono_pe_file_map (const gunichar2 *filename, guint32 *map_size, void **handle);
 
 void
 mono_pe_file_unmap (gpointer file_map, void *handle);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20989,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>During our upgrade of the mono runtime we ran into a situation where `mono_pe_file_map` was being called as part of opening an image now on android. This function did not currently adhere to the filemap wrapper functions so the difference in data types being used by Unity caused crashes.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
