### PR TITLE
[WASM] Use consistent display names for UTC time zone

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.cs
@@ -7,6 +7,7 @@ namespace System
 {
     public sealed partial class TimeZoneInfo
     {
+        private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
         private const string FallbackCultureName = "en-US";
         private const string GmtId = "GMT";
 
@@ -51,6 +52,12 @@ namespace System
                 standardDisplayName = InvariantUtcStandardDisplayName;
 
             return standardDisplayName;
+        }
+
+        // Helper function to get the full display name for the UTC static time zone instance
+        private static string GetUtcFullDisplayName(string timeZoneId, string standardDisplayName)
+        {
+            return $"(UTC) {standardDisplayName}";
         }
 
         // Helper function that retrieves various forms of time zone display names from ICU

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
@@ -12,8 +12,14 @@ namespace System
 
         private static string GetUtcStandardDisplayName()
         {
-            // Just use the invariant display name.
-            return InvariantUtcStandardDisplayName;
+            // For this target, be consistent with other time zone display names that use an abbreviation.
+            return "UTC";
+        }
+
+        private static string GetUtcFullDisplayName(string timeZoneId, string standardDisplayName)
+        {
+            // For this target, be consistent with other time zone display names that use the ID.
+            return $"(UTC) {timeZoneId}";
         }
 
         private static string? GetAlternativeId(string id)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -46,7 +46,7 @@ namespace System
             {
                 _standardDisplayName = GetUtcStandardDisplayName();
                 _daylightDisplayName = _standardDisplayName;
-                _displayName = $"(UTC) {_standardDisplayName}";
+                _displayName = GetUtcFullDisplayName(_id, _standardDisplayName);
                 _baseUtcOffset = TimeSpan.Zero;
                 _adjustmentRules = Array.Empty<AdjustmentRule>();
                 return;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -34,6 +34,7 @@ namespace System
         private const string LastEntryValue = "LastEntry";
 
         private const int MaxKeyLength = 255;
+        private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
         private sealed partial class CachedData
         {
@@ -1037,6 +1038,12 @@ namespace System
                 standardDisplayName = InvariantUtcStandardDisplayName;
 
             return standardDisplayName;
+        }
+
+        // Helper function to get the full display name for the UTC static time zone instance
+        private static string GetUtcFullDisplayName(string timeZoneId, string standardDisplayName)
+        {
+            return $"(UTC) {standardDisplayName}";
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -52,7 +52,6 @@ namespace System
         // constants for TimeZoneInfo.Local and TimeZoneInfo.Utc
         private const string UtcId = "UTC";
         private const string LocalId = "Local";
-        private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
         private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
 
@@ -2020,7 +2019,7 @@ namespace System
         private static TimeZoneInfo CreateUtcTimeZone()
         {
             string standardDisplayName = GetUtcStandardDisplayName();
-            string displayName = $"(UTC) {standardDisplayName}";
+            string displayName = GetUtcFullDisplayName(UtcId, standardDisplayName);
             return CreateCustomTimeZone(UtcId, TimeSpan.Zero, displayName, standardDisplayName);
         }
     }


### PR DESCRIPTION
Resolves #50305

For wasm, the `StandardName` and `DaylightName` properties of the UTC time zone and all aliases of UTC will simply be `"UTC"`.

The `DisplayName` property for UTC and its aliases will follow the same rules as all other display names in wasm in that they use the offset followed by the ID, except that we will also honor the convention from all other targets where the offset string for UTC is `"(UTC)"` rather than `"(UTC+00:00)"`  (This convention is carried over from the established convention in the Windows OS time zone data, as it helps prevent users from picking a different time zone like London that has DST.)

So, with this change, `TimeZoneInfo.Utc.DisplayName` is `"(UTC) UTC"`, which may seem redundant in isolation but aligns well with the format used by other time zones such as `"(UTC-08:00) America/Los_Angeles"` - so works well in a list.

Aliases of UTC will retain their requested IDs, such as `TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC").DisplayName` which will now be `"(UTC) Etc/UTC"`.

This affects the browser target only.  Some minor refactoring was done for consistency of the code, but results in no behavioral changes or visible changes in the output strings of other targets.

@eerhardt @tarekgh @lewing 