### PR TITLE
Fix NDirect methods in multicorejit

### DIFF
--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -664,7 +664,21 @@ void MulticoreJitProfilePlayer::JITMethod(Module * pModule, unsigned methodIndex
         else if (pMethod->IsNDirect())
         {
             // NDirect Stub
-            if (GetStubForInteropMethod(pMethod))
+            bool fSuccess = false;
+
+            EX_TRY
+            {
+                if ( !((NDirectMethodDesc *)pMethod)->IsClassConstructorTriggeredAtLinkTime() && GetStubForInteropMethod(pMethod) )
+                {
+                    fSuccess = true;
+                }
+            }
+            EX_CATCH
+            {
+            }
+            EX_END_CATCH(SwallowAllExceptions);
+
+            if (fSuccess)
             {
                 return;
             }


### PR DESCRIPTION
- Exception can be thrown if native library is not found (this is the case if multicorejit is used with crossgen2, where Internal.JitInterface.CorInfoImpl.jitStartup and Internal.JitInterface.CorInfoImpl.getJit have "clrjitilc" native library, which is subtituted with correct library name during execution of crossgen2)
- Assert _ASSERTE(pModule->IsSystem()) can be hit in AssertMulticoreJitAllowedModule if cctor is triggered at P/Invoke link time (IsClassConstructorTriggeredAtLinkTime()), skip such methods

cc @alpencolt 