### PR TITLE
JIT: fgAddrCouldBeNull should return false for byref "this"

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -981,6 +981,12 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
         {
             return false;
         }
+
+        if (addr->TypeIs(TYP_BYREF) && varDsc->lvVerTypeInfo.IsThisPtr() && !varDsc->lvHasLdAddrOp &&
+            !varDsc->lvAddrExposed)
+        {
+            return false;
+        }
     }
     else if (addr->gtOper == GT_ADDR)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37727

jit-diff (crossgen):
```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 33491276
Total bytes of diff: 33487574
Total bytes of delta: -3702 (-0.01% of base)
    diff is an improvement.


Top file regressions (bytes):
          11 : System.Security.Cryptography.Algorithms.dasm (0.00% of base)
          11 : System.Security.Cryptography.Cng.dasm (0.01% of base)
           2 : ILCompiler.Reflection.ReadyToRun.dasm (0.00% of base)

Top file improvements (bytes):
        -744 : System.Private.Xml.dasm (-0.02% of base)
        -375 : System.Private.CoreLib.dasm (-0.01% of base)
        -313 : System.Reflection.Metadata.dasm (-0.10% of base)
        -285 : System.Net.Http.dasm (-0.05% of base)
        -241 : System.Net.Security.dasm (-0.11% of base)
        -220 : xunit.execution.dotnet.dasm (-0.13% of base)
        -169 : Newtonsoft.Json.dasm (-0.03% of base)
        -143 : System.Collections.Immutable.dasm (-0.06% of base)
         -84 : System.Net.WebSockets.dasm (-0.20% of base)
         -77 : Newtonsoft.Json.Bson.dasm (-0.10% of base)
         -63 : System.Text.Json.dasm (-0.01% of base)
         -58 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -55 : System.Security.Cryptography.Pkcs.dasm (-0.02% of base)
         -54 : System.Net.Quic.dasm (-0.10% of base)
         -49 : System.Net.Http.Json.dasm (-0.51% of base)
         -48 : xunit.assert.dasm (-0.10% of base)
         -48 : System.Private.Xml.Linq.dasm (-0.04% of base)
         -42 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -39 : Microsoft.Extensions.Caching.Abstractions.dasm (-0.58% of base)
         -35 : System.Net.HttpListener.dasm (-0.02% of base)

77 total files with Code Size differences (74 improved, 3 regressed), 194 unchanged.

Top method regressions (bytes):
          40 ( 1.02% of base) : System.Net.HttpListener.dasm - <CloseAsyncCore>d__53:MoveNext():this
          19 ( 0.10% of base) : System.Private.CoreLib.dasm - ValueTuple`8:GetHashCode():int:this (15 methods)
          16 ( 2.01% of base) : System.Private.CoreLib.dasm - ValueTuple`2:GetHashCode():int:this (15 methods)
          15 ( 1.94% of base) : System.Security.Cryptography.Algorithms.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          15 ( 1.94% of base) : System.Security.Cryptography.Cng.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          15 (15.79% of base) : System.Private.CoreLib.dasm - ChunkEnumerator:MoveNext():bool:this
          11 ( 0.88% of base) : xunit.runner.reporters.netcoreapp10.dasm - <SendRequest>d__16:MoveNext():this
           9 ( 1.04% of base) : Newtonsoft.Json.dasm - <EncodeAsync>d__13:MoveNext():this
           9 ( 1.04% of base) : Newtonsoft.Json.Bson.dasm - <EncodeAsync>d__13:MoveNext():this
           9 ( 0.66% of base) : System.Net.Security.dasm - <WriteAsyncChunked>d__176`1:MoveNext():this (3 methods)
           8 ( 0.85% of base) : Microsoft.CodeAnalysis.dasm - <ProcessCompilationEventsCoreAsync>d__59:MoveNext():this
           6 ( 0.27% of base) : System.Security.Cryptography.Primitives.dasm - <WriteAsyncCore>d__52:MoveNext():this
           6 ( 0.39% of base) : System.Private.Xml.Linq.dasm - <WriteElementAsync>d__4:MoveNext():this
           6 ( 1.38% of base) : System.Data.Common.dasm - RBTreeEnumerator:MoveNext():bool:this (2 methods)
           6 ( 0.14% of base) : System.Net.Security.dasm - <WriteAsync>d__110`1:MoveNext():this (3 methods)
           4 ( 1.57% of base) : System.Net.Http.dasm - MultiProxy:ReadNextHelper(byref,byref):bool:this
           4 ( 1.22% of base) : Microsoft.CSharp.dasm - KeyPair`2:GetHashCode():int:this (4 methods)
           4 ( 0.80% of base) : System.Text.Json.dasm - ReadStack:Push():this
           4 ( 0.63% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - PayloadFetch:FromStream(Deserializer):this
           3 ( 0.14% of base) : System.Net.Http.dasm - <SendRequestBodyAsync>d__37:MoveNext():this

Top method improvements (bytes):
         -85 (-4.20% of base) : System.Private.CoreLib.dasm - ArraySegment`1:Slice(int):ArraySegment`1:this (17 methods)
         -85 (-4.06% of base) : System.Private.CoreLib.dasm - ArraySegment`1:Slice(int,int):ArraySegment`1:this (17 methods)
         -54 (-0.48% of base) : System.Net.WebSockets.dasm - <ReceiveAsyncPrivate>d__66`2:MoveNext():this (3 methods)
         -39 (-1.07% of base) : System.Collections.Immutable.dasm - Enumerator:MoveNext():bool:this (15 methods)
         -35 (-4.98% of base) : Microsoft.Extensions.Caching.Abstractions.dasm - <GetOrCreateAsync>d__9`1:MoveNext():this
         -35 (-2.10% of base) : xunit.execution.dotnet.dasm - <<RunAsync>b__47_0>d:MoveNext():this
         -28 (-0.19% of base) : System.Private.CoreLib.dasm - ValueTuple`8:ToString():String:this (15 methods)
         -28 (-0.20% of base) : System.Private.CoreLib.dasm - ValueTuple`8:System.IValueTupleInternal.ToStringEnd():String:this (15 methods)
         -27 (-2.65% of base) : System.Net.HttpListener.dasm - <WriteAsyncCore>d__41:MoveNext():this
         -27 (-0.22% of base) : System.Net.Security.dasm - <ForceAuthenticationAsync>d__171`1:MoveNext():this (3 methods)
         -26 (-1.52% of base) : System.Collections.Immutable.dasm - Enumerator:Reset():this (11 methods)
         -24 (-3.61% of base) : System.Net.Http.dasm - <ReadAsync>d__95:MoveNext():this
         -24 (-3.64% of base) : System.Net.NameResolution.dasm - <<GetAddrInfoWithTelemetryAsync>g__CompleteAsync|34_0>d`1:MoveNext():this
         -22 (-1.23% of base) : System.Collections.Immutable.dasm - Enumerator:Dispose():this (11 methods)
         -22 (-0.30% of base) : System.Net.Security.dasm - <SendBlobAsync>d__122`1:MoveNext():this (3 methods)
         -21 (-1.97% of base) : System.Net.HttpListener.dasm - <ReadAsyncCore>d__30:MoveNext():this
         -21 (-1.14% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__41:MoveNext():this
         -21 (-1.33% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__19:MoveNext():this
         -21 (-1.33% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__37:MoveNext():this
         -21 (-1.39% of base) : xunit.execution.dotnet.dasm - <RunAsync>d__27:MoveNext():this

Top method regressions (percentages):
          15 (15.79% of base) : System.Private.CoreLib.dasm - ChunkEnumerator:MoveNext():bool:this
           3 ( 5.66% of base) : System.Private.CoreLib.dasm - NFloat:Equals(NFloat):bool:this
           2 ( 3.08% of base) : ILCompiler.Reflection.ReadyToRun.dasm - AllEntriesEnumerator:.ctor(NativeHashtable):this
           3 ( 2.21% of base) : System.Private.CoreLib.dasm - NFloat:Equals(Object):bool:this
          16 ( 2.01% of base) : System.Private.CoreLib.dasm - ValueTuple`2:GetHashCode():int:this (15 methods)
          15 ( 1.94% of base) : System.Security.Cryptography.Algorithms.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
          15 ( 1.94% of base) : System.Security.Cryptography.Cng.dasm - SpecifiedECDomain:Encode(AsnWriter,Asn1Tag):this
           2 ( 1.80% of base) : System.Private.CoreLib.dasm - Sha1ForNonSecretPurposes:Append(ReadOnlySpan`1):this
           4 ( 1.57% of base) : System.Net.Http.dasm - MultiProxy:ReadNextHelper(byref,byref):bool:this
           6 ( 1.38% of base) : System.Data.Common.dasm - RBTreeEnumerator:MoveNext():bool:this (2 methods)
           4 ( 1.22% of base) : Microsoft.CSharp.dasm - KeyPair`2:GetHashCode():int:this (4 methods)
           3 ( 1.21% of base) : System.Reflection.Metadata.dasm - CustomAttributeTableReader:.ctor(int,bool,int,int,int,MemoryBlock,int):this
           9 ( 1.04% of base) : Newtonsoft.Json.dasm - <EncodeAsync>d__13:MoveNext():this
           9 ( 1.04% of base) : Newtonsoft.Json.Bson.dasm - <EncodeAsync>d__13:MoveNext():this
          40 ( 1.02% of base) : System.Net.HttpListener.dasm - <CloseAsyncCore>d__53:MoveNext():this
           3 ( 1.00% of base) : System.Text.Json.dasm - WriteStack:Push():this
          11 ( 0.88% of base) : xunit.runner.reporters.netcoreapp10.dasm - <SendRequest>d__16:MoveNext():this
           8 ( 0.85% of base) : Microsoft.CodeAnalysis.dasm - <ProcessCompilationEventsCoreAsync>d__59:MoveNext():this
           1 ( 0.81% of base) : System.Private.CoreLib.dasm - SpanRuneEnumerator:MoveNext():bool:this
           4 ( 0.80% of base) : System.Text.Json.dasm - ReadStack:Push():this

Top method improvements (percentages):
         -12 (-23.53% of base) : System.Reflection.Metadata.dasm - FieldPtrTableReader:GetRowIdForFieldDefRow(int):int:this
         -12 (-23.53% of base) : System.Reflection.Metadata.dasm - MethodPtrTableReader:GetRowIdForMethodDefRow(int):int:this
         -10 (-23.26% of base) : Microsoft.CodeAnalysis.dasm - Enumerator:get_Current():SyntaxNodeOrToken:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - InterfaceImplTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - ConstantTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - CustomAttributeTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - FieldMarshalTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - DeclSecurityTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - ClassLayoutTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - FieldLayoutTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - MethodSemanticsTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - MethodImplTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - ImplMapTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - FieldRVATableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - NestedClassTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - GenericParamTableReader:CheckSorted():bool:this
         -10 (-22.73% of base) : System.Reflection.Metadata.dasm - GenericParamConstraintTableReader:CheckSorted():bool:this
          -2 (-22.22% of base) : System.Private.CoreLib.dasm - BigInteger:GetBlock(int):int:this
         -12 (-21.82% of base) : System.Reflection.Metadata.dasm - ImplMapTableReader:BinarySearchTag(int):int:this
         -12 (-21.82% of base) : System.Reflection.Metadata.dasm - FieldRVATableReader:FindFieldRvaRowId(int):int:this

1273 total methods with Code Size differences (1235 improved, 38 regressed), 200643 unchanged.
```