### PR TITLE
Disable test VerifyInMemoryDirectoryInfo_IsNotEmpty

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -844,6 +844,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         }
 
         [Fact] // https://github.com/dotnet/runtime/issues/36415
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50648")]
         public void VerifyInMemoryDirectoryInfo_IsNotEmpty()
         {
             IEnumerable<string> files = new[] { @"pagefile.sys" };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50648

This is to unblock people seeing the CI failure.

The actual bug is here, and will need a deeper investigation: https://github.com/dotnet/runtime/issues/50648#issuecomment-812695029