### PR TITLE
Make sure separated_poh_p and use_large_pages_p works together

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -4964,6 +4964,25 @@ BOOL gc_heap::reserve_initial_memory (size_t normal_size, size_t large_size, siz
         }
     }
 
+    if (reserve_success && separated_poh_p)
+    {
+        for (int heap_no = 0; reserve_success && heap_no < num_heaps; heap_no++)
+        {
+            if (!GCToOSInterface::VirtualCommit(memory_details.initial_pinned_heap[heap_no].memory_base, pinned_size))
+            {
+                reserve_success = FALSE;
+            }
+        }
+        if (!reserve_success)
+        {
+            for (int heap_no = 0; reserve_success && heap_no < num_heaps; heap_no++)
+            {
+                virtual_free(memory_details.initial_normal_heap[heap_no].memory_base, normal_size);
+                virtual_free(memory_details.initial_large_heap[heap_no].memory_base, large_size);
+                virtual_free(memory_details.initial_pinned_heap[heap_no].memory_base, pinned_size);
+            }
+        }
+    }
 
     return reserve_success;
 }
@@ -6581,7 +6600,6 @@ bool gc_heap::virtual_decommit (void* address, size_t size, gc_oh_num oh, int h_
 
 void gc_heap::virtual_free (void* add, size_t allocated_size, heap_segment* sg)
 {
-    assert(!heap_hard_limit);
     bool release_succeeded_p = GCToOSInterface::VirtualRelease (add, allocated_size);
     if (release_succeeded_p)
     {
@@ -11732,13 +11750,17 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         return E_FAIL;
     }
 #else //USE_REGIONS
-    bool separated_poh_p = use_large_pages_p && 
-                           heap_hard_limit_oh[soh] && 
-                           (GCConfig::GetGCHeapHardLimitPOH() == 0) && 
-                           (GCConfig::GetGCHeapHardLimitPOHPercent() == 0);
+    bool empty_poh_p = heap_hard_limit_oh[soh] && 
+                       (GCConfig::GetGCHeapHardLimitPOH() == 0) && 
+                       (GCConfig::GetGCHeapHardLimitPOHPercent() == 0);
     if (!reserve_initial_memory (soh_segment_size, loh_segment_size, poh_segment_size, number_of_heaps, 
-                                 use_large_pages_p, separated_poh_p, heap_no_to_numa_node))
+                                 use_large_pages_p, empty_poh_p && use_large_pages_p, heap_no_to_numa_node))
         return E_OUTOFMEMORY;
+    if (empty_poh_p)
+    {
+        heap_hard_limit_oh[poh] = min_segment_size_hard_limit * number_of_heaps;
+        heap_hard_limit += heap_hard_limit_oh[poh];
+    }
 #endif //USE_REGIONS
 
 #ifdef CARD_BUNDLE

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -4966,20 +4966,11 @@ BOOL gc_heap::reserve_initial_memory (size_t normal_size, size_t large_size, siz
 
     if (reserve_success && separated_poh_p)
     {
-        for (int heap_no = 0; reserve_success && heap_no < num_heaps; heap_no++)
+        for (int heap_no = 0; (reserve_success && (heap_no < num_heaps)); heap_no++)
         {
             if (!GCToOSInterface::VirtualCommit(memory_details.initial_pinned_heap[heap_no].memory_base, pinned_size))
             {
                 reserve_success = FALSE;
-            }
-        }
-        if (!reserve_success)
-        {
-            for (int heap_no = 0; reserve_success && heap_no < num_heaps; heap_no++)
-            {
-                virtual_free(memory_details.initial_normal_heap[heap_no].memory_base, normal_size);
-                virtual_free(memory_details.initial_large_heap[heap_no].memory_base, large_size);
-                virtual_free(memory_details.initial_pinned_heap[heap_no].memory_base, pinned_size);
             }
         }
     }
@@ -11750,13 +11741,14 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         return E_FAIL;
     }
 #else //USE_REGIONS
-    bool empty_poh_p = heap_hard_limit_oh[soh] && 
-                       (GCConfig::GetGCHeapHardLimitPOH() == 0) && 
-                       (GCConfig::GetGCHeapHardLimitPOHPercent() == 0);
+    bool separated_poh_p = use_large_pages_p && 
+                           heap_hard_limit_oh[soh] && 
+                           (GCConfig::GetGCHeapHardLimitPOH() == 0) && 
+                           (GCConfig::GetGCHeapHardLimitPOHPercent() == 0);
     if (!reserve_initial_memory (soh_segment_size, loh_segment_size, poh_segment_size, number_of_heaps, 
-                                 use_large_pages_p, empty_poh_p && use_large_pages_p, heap_no_to_numa_node))
+                                 use_large_pages_p, separated_poh_p, heap_no_to_numa_node))
         return E_OUTOFMEMORY;
-    if (empty_poh_p)
+    if (separated_poh_p)
     {
         heap_hard_limit_oh[poh] = min_segment_size_hard_limit * number_of_heaps;
         heap_hard_limit += heap_hard_limit_oh[poh];
@@ -40144,6 +40136,10 @@ HRESULT GCHeap::Initialize()
             return E_INVALIDARG;
         }
         if (!gc_heap::heap_hard_limit_oh[loh])
+        {
+            return E_INVALIDARG;
+        }
+        if (!gc_heap::heap_hard_limit_oh[poh] && !GCConfig::GetGCLargePages())
         {
             return E_INVALIDARG;
         }


### PR DESCRIPTION
This fixes 3 issues in the area:

1. If we decided to give some memory to POH even when it is set to 0, we should adjust the corresponding `heap_hard_limit` and `heap_hard_limit_oh` to avoid failing the `virtual_commit` call. The `virtual_commit` call consumes the `heap_hard_limit` regardless of whether or not the memory is actually committed.

2. In the large page case, if we decided to allocate the POH part of the memory using normal pages, then we need to commit them as well because the rest of the system assumes all the memory of large page cases is committed upfront.

3. `virtual_free` could be called by `reserve_initial_memory` if the memory operations fail, therefore it could be called in the `heap_hard_limit` case as well, removing the erroneous assert in that case. 

