### PR TITLE
Fix contained LCL_VAR_ADDR in RMW.

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.il
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly extern System.Runtime.CompilerServices.Unsafe
+{
+}
+
+.assembly extern System.Console
+{
+}
+
+.assembly Runtime_40440
+{
+}
+
+.class private auto ansi beforefieldinit Runtime_40440
+       extends [System.Runtime]System.Object
+{
+  .method private hidebysig static float32 
+          PassNullByref(float32 f) cil managed noinlining
+  {
+    // Code size       20 (0x14)
+    .maxstack  8
+    IL_0000:  ldarga.s   f
+    IL_0007:  ldarga.s   f
+    IL_000e:  ldind.i8
+    IL_000f:  ldc.i8 123
+    IL_0010:  add
+    IL_0011:  stind.i8
+    IL_0012:  ldarg.0
+    IL_0013:  ret
+  } // end of method Runtime_40440::PassNullByref
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       27 (0x1b)
+    .maxstack  1
+    .locals init (float32 V_0)
+    IL_0000:  ldc.r4     0.0
+    IL_0005:  call       float32 Runtime_40440::PassNullByref(float32)
+    IL_000a:  stloc.0
+    IL_000b:  ldloca.s   V_0
+    IL_000d:  call       !!1& [System.Runtime.CompilerServices.Unsafe]System.Runtime.CompilerServices.Unsafe::As<float32,int32>(!!0&)
+    IL_0012:  ldind.i4
+    IL_0013:  call       void [System.Console]System.Console::WriteLine(int32)
+    IL_0018:  ldc.i4.s   100
+    IL_001a:  ret
+  } // end of method Runtime_40440::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Runtime_40440::.ctor
+
+} // end of class Runtime_40440

--- a/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.il
@@ -14,11 +14,11 @@
 {
 }
 
-.assembly Runtime_40440
+.assembly Runtime_41073
 {
 }
 
-.class private auto ansi beforefieldinit Runtime_40440
+.class private auto ansi beforefieldinit Runtime_41073
        extends [System.Runtime]System.Object
 {
   .method private hidebysig static float32 
@@ -34,7 +34,7 @@
     IL_0011:  stind.i8
     IL_0012:  ldarg.0
     IL_0013:  ret
-  } // end of method Runtime_40440::PassNullByref
+  } // end of method Runtime_41073::PassNullByref
 
   .method public hidebysig static int32  Main() cil managed
   {
@@ -43,7 +43,7 @@
     .maxstack  1
     .locals init (float32 V_0)
     IL_0000:  ldc.r4     0.0
-    IL_0005:  call       float32 Runtime_40440::PassNullByref(float32)
+    IL_0005:  call       float32 Runtime_41073::PassNullByref(float32)
     IL_000a:  stloc.0
     IL_000b:  ldloca.s   V_0
     IL_000d:  call       !!1& [System.Runtime.CompilerServices.Unsafe]System.Runtime.CompilerServices.Unsafe::As<float32,int32>(!!0&)
@@ -51,7 +51,7 @@
     IL_0013:  call       void [System.Console]System.Console::WriteLine(int32)
     IL_0018:  ldc.i4.s   100
     IL_001a:  ret
-  } // end of method Runtime_40440::Main
+  } // end of method Runtime_41073::Main
 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
@@ -61,6 +61,6 @@
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_0006:  ret
-  } // end of method Runtime_40440::.ctor
+  } // end of method Runtime_41073::.ctor
 
-} // end of class Runtime_40440
+} // end of class Runtime_41073

--- a/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_41073/Runtime_41073.ilproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION

Call `emitIns_S_I` (stack immediate) to generate instruction like:
```
Generating: N008 (  1,  1) [000005] -c----------         t5 =    CNS_INT   long   123 REG NA $200
                                                              /--*  t4     long
                                                              +--*  t5     long
Generating: N010 (  8,  9) [000006] -c--G-------         t6 = *  ADD       long   REG NA <l:$241, c:$240>
Generating: N012 (  3,  4) [000000] Uc-----N----         t0 =    LCL_VAR_ADDR byref  V00 arg0          NA REG NA
                                                              /--*  t0     byref
                                                              +--*  t6     long
Generating: N014 (???,???) [000012] -A--G-------              *  STOREIND  long   REG NA

IN0001: 000009 add      qword ptr [rsp+08H], 123
```

Questions that I had:
1. should not it be fixed in `emitHandleMemOp`?
no, because `emitHandleMemOp` already has an instruction descriptor and it is wrong for this situation because it expects `A` meaning `dereference Address in a register`. We could change the fmt inside like we do for:
https://github.com/dotnet/runtime/blob/5265305d3121d2fce804948b9250b1b3a5f8a22d/src/coreclr/jit/emitxarch.cpp#L2931-L2932
but it would require a copy-paste of `emitIns_S_I` into this function.
Another argument is that we already treat `LCL_VAR_ADDR/LCL_FLD_ADDR` differently, to show such cases I have changed `OperIs(GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR)` to `OperIsLocalAddr()`.

A better long-term solution would be to rewrite `emitHandleMemOp` to create `id` but we don't have time for it now.

2. Do we need to call `genUpdateLife` for the local? 
It appears not to be necessary because the variable liveness does not change there so we can skip it.
However, we can do this, as you see `000000` is marked `VAR_USEASG` so call to `genUpdateLife(storeInd)` will give us the correct result, `UpdateLifeVar` just won't do anything with it. I could still add these calls if I hear an opinion that it will be less confusing.

3. Have I caught all places that need this fix? 
I checked all calls to `emitHandleMemOp` and found 1 more place that was fixed in this PR, others already have it or don't work with contained LCL_VAR_ADDR.


Fixes #41073 and #49880.


No spmi-diffs.