### PR TITLE
[AndroidCrypto] Remove unused BigNumFromBinary P/Invoke

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Bignum.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Bignum.cs
@@ -10,32 +10,11 @@ internal static partial class Interop
     // TODO: [AndroidCrypto] Rename class to AndroidCrypto once all consumers are split in Android vs. Unix
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_BigNumFromBinary")]
-        private static extern unsafe SafeBignumHandle BigNumFromBinary(byte* s, int len);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_BigNumToBinary")]
         private static extern unsafe int BigNumToBinary(SafeBignumHandle a, byte* to);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_GetBigNumBytes")]
         private static extern int GetBigNumBytes(SafeBignumHandle a);
-
-        internal static SafeBignumHandle CreateBignum(ReadOnlySpan<byte> bigEndianValue)
-        {
-            unsafe
-            {
-                fixed (byte* pBigEndianValue = bigEndianValue)
-                {
-                    SafeBignumHandle ret = BigNumFromBinary(pBigEndianValue, bigEndianValue.Length);
-                    if (ret.IsInvalid)
-                    {
-                        ret.Dispose();
-                        throw new CryptographicException();
-                    }
-
-                    return ret;
-                }
-            }
-        }
 
         internal static unsafe byte[]? ExtractBignum(SafeBignumHandle? bignum, int targetSize)
         {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.c
@@ -3,17 +3,6 @@
 
 #include "pal_bignum.h"
 
-jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len)
-{
-    // return new BigInteger(bytes)
-    JNIEnv* env = GetJNIEnv();
-    jbyteArray buffArray = (*env)->NewByteArray(env, len);
-    (*env)->SetByteArrayRegion(env, buffArray, 0, len, (jbyte*)bytes);
-    jobject bigNum = (*env)->NewObject(env, g_bigNumClass, g_bigNumCtorWithSign, 1, buffArray);
-    (*env)->DeleteLocalRef(env, buffArray);
-    return CheckJNIExceptions(env) ? FAIL : ToGRef(env, bigNum);
-}
-
 int32_t AndroidCryptoNative_BigNumToBinary(jobject bignum, uint8_t* output)
 {
     // bigNum.toByteArray()
@@ -43,6 +32,17 @@ int32_t AndroidCryptoNative_GetBigNumBytes(jobject bignum)
     JNIEnv* env = GetJNIEnv();
     int bytesLen = ((*env)->CallIntMethod(env, bignum, g_bitLengthMethod) + 7) / 8;
     return CheckJNIExceptions(env) ? FAIL : (int32_t)bytesLen;
+}
+
+jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len)
+{
+    // return new BigInteger(bytes)
+    JNIEnv* env = GetJNIEnv();
+    jbyteArray buffArray = (*env)->NewByteArray(env, len);
+    (*env)->SetByteArrayRegion(env, buffArray, 0, len, (jbyte*)bytes);
+    jobject bigNum = (*env)->NewObject(env, g_bigNumClass, g_bigNumCtorWithSign, 1, buffArray);
+    (*env)->DeleteLocalRef(env, buffArray);
+    return CheckJNIExceptions(env) ? FAIL : bigNum;
 }
 
 int32_t AndroidCryptoNative_GetBigNumBytesIncludingPaddingByteForSign(jobject bignum)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.h
@@ -5,8 +5,13 @@
 
 #include "pal_jni.h"
 
-PALEXPORT jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len);
 PALEXPORT int32_t AndroidCryptoNative_BigNumToBinary(jobject bignum, uint8_t* output);
 PALEXPORT int32_t AndroidCryptoNative_GetBigNumBytes(jobject bignum);
 
+/*
+Create a BigInteger from its binary representation.
+
+The returned jobject will be a local reference.
+*/
+jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len);
 int32_t AndroidCryptoNative_GetBigNumBytesIncludingPaddingByteForSign(jobject bignum);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
@@ -313,7 +313,7 @@ int32_t AndroidCryptoNative_DsaKeyCreateByExplicitParameters(
 error:
     returnValue = FAIL;
 cleanup:
-    RELEASE_LOCALS_ENV(bn, ReleaseGRef);
+    RELEASE_LOCALS_ENV(bn, ReleaseLRef);
     RELEASE_LOCALS_ENV(loc, ReleaseLRef);
 
     return returnValue;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -325,7 +325,7 @@ error:
     }
 
 cleanup:
-    RELEASE_LOCALS_ENV(bn, ReleaseGRef);
+    RELEASE_LOCALS_ENV(bn, ReleaseLRef);
     RELEASE_LOCALS_ENV(loc, ReleaseLRef);
     return keyPair;
 }
@@ -546,7 +546,7 @@ EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveTyp
     keyInfo = AndroidCryptoNative_NewEcKey(AddGRef(env, loc[paramSpec]), keyPair);
 
 error:
-    RELEASE_LOCALS_ENV(bn, ReleaseGRef);
+    RELEASE_LOCALS_ENV(bn, ReleaseLRef);
     RELEASE_LOCALS_ENV(loc, ReleaseLRef);
     return keyInfo;
 }


### PR DESCRIPTION
This change also avoids the add/remove of the global references for `BigInteger` objects during key generation.

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs