### PR TITLE
Remove unnecessary realpath calls from host probing logic 

### DIFF
--- a/src/installer/tests/Assets/TestProjects/StandaloneApp6x/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp6x/Program.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace StandaloneApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp6x/StandaloneApp6x.csproj
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp6x/StandaloneApp6x.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>StandaloneApp</AssemblyName>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
+  </PropertyGroup>
+</Project>

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -242,7 +242,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     $"{Path.Combine(sharedTestState.ComponentWithDependencies.Location, "Newtonsoft.Json.dll")}{Path.PathSeparator}]")
                 .And.HaveStdOutContaining(
                     $"corehost_resolve_component_dependencies native_search_paths:[" +
-                    $"{ExpectedProbingPaths(Path.Combine(sharedTestState.ComponentWithDependencies.Location, "runtimes", "win10-x86", "native"))}]");
+                    $"{Path.Combine(sharedTestState.ComponentWithDependencies.Location, "runtimes", "win10-x86", "native")}" +
+                    $"{Path.DirectorySeparatorChar}{Path.PathSeparator}]");
         }
 
         [Fact]
@@ -369,36 +370,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .Should().Pass()
                 .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
                 .And.HaveStdOutContaining($"corehost_resolve_component_dependencies resource_search_paths:[" +
-                    $"{ExpectedProbingPaths(sharedTestState.ComponentWithResources.Location)}]");
-        }
-
-        private string ExpectedProbingPaths(params string[] paths)
-        {
-            string result = string.Empty;
-            foreach (string path in paths)
-            {
-                string expectedPath = path;
-                if (expectedPath.EndsWith(Path.DirectorySeparatorChar))
-                {
-                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        // On non-windows the paths are normalized to not end with a /
-                        expectedPath = expectedPath.Substring(0, expectedPath.Length - 1);
-                    }
-                }
-                else
-                {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        // On windows all paths are normalized to end with a \
-                        expectedPath += Path.DirectorySeparatorChar;
-                    }
-                }
-
-                result += expectedPath + Path.PathSeparator;
-            }
-
-            return result;
+                    $"{sharedTestState.ComponentWithResources.Location}" +
+                    $"{Path.DirectorySeparatorChar}{Path.PathSeparator}]");
         }
 
         [Fact]
@@ -425,7 +398,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .And.HaveStdOutContaining($"ComponentA: corehost_resolve_component_dependencies assemblies:[{sharedTestState.ComponentWithNoDependencies.AppDll}{Path.PathSeparator}]")
                 .And.HaveStdOutContaining($"ComponentB: corehost_resolve_component_dependencies:Success")
                 .And.HaveStdOutContaining($"ComponentB: corehost_resolve_component_dependencies resource_search_paths:[" +
-                    $"{ExpectedProbingPaths(sharedTestState.ComponentWithResources.Location)}]");
+                    $"{sharedTestState.ComponentWithResources.Location}" +
+                    $"{Path.DirectorySeparatorChar}{Path.PathSeparator}]");
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             // Linux: we fail
             // Windows and Mac, probing succeeds but
             // Windows: probing returns the original name
-            // Mac: probing return the new name including 2 assembly probing with the same new name and the changed deps file
+            // Mac: probing return the new name including 2 assembly probing with the original and new name, and the changed deps file
 
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 sharedTestState.RunComponentResolutionTest(component)
                     .Should().Pass()
                     .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
-                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{changeFile}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
                     .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
                     .And.HaveStdErrContaining($"deps='{changeDepsFile}'")
                     .And.HaveStdErrContaining($"mgd_app='{changeFile}'");
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             // Linux: we fail
             // Windows and Mac, probing succeeds but
             // Windows: probing returns the original name
-            // Mac: probing return the new name including 2 assembly probing with the same new name and the changed deps file
+            // Mac: probing return the new name including 2 assembly probing with the original and new name, and the changed deps file
 
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 sharedTestState.RunComponentResolutionTest(component)
                     .Should().Pass()
                     .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
-                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{changeFile}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
                     .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
                     .And.HaveStdErrContaining($"deps='{changeDepsFile}'")
                     .And.HaveStdErrContaining($"mgd_app='{changeFile}'");

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -252,7 +252,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             var component = sharedTestState.ComponentWithDependencies.Copy();
 
             // Remove a dependency
-            // This will cause the resolution to fail
             File.Delete(Path.Combine(component.Location, "ComponentDependency.dll"));
 
             sharedTestState.RunComponentResolutionTest(component)
@@ -260,6 +259,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
                 .And.HaveStdOutContaining(
                     $"corehost_resolve_component_dependencies assemblies:[" +
+                    $"{Path.Combine(component.Location, "ComponentDependency.dll")}{Path.PathSeparator}" +
                     $"{component.AppDll}{Path.PathSeparator}" +
                     $"{Path.Combine(component.Location, "Newtonsoft.Json.dll")}{Path.PathSeparator}]");
         }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNet.BinPath)
                 .Execute();
 
-            string pathSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Path.DirectorySeparatorChar.ToString() : string.Empty;
+            string pathSuffix = Path.DirectorySeparatorChar.ToString();
             string expectedSearchDirectories =
                 Path.GetDirectoryName(sharedState.AppPath) + pathSuffix + Path.PathSeparator +
                 Path.Combine(sharedState.DotNet.BinPath, "shared", "Microsoft.NETCore.App", SharedTestState.NetCoreAppVersion) + pathSuffix + Path.PathSeparator;

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
@@ -60,7 +60,6 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
                 .EnvironmentVariable(BundleHelper.CoreServicingEnvVariable, serviceBasePath)
                 .Execute()
                 .Should()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
@@ -60,6 +60,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
+                .EnvironmentVariable("COREHOST_TRACE", "1")
                 .EnvironmentVariable(BundleHelper.CoreServicingEnvVariable, serviceBasePath)
                 .Execute()
                 .Should()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.NET.HostModel.Tests
+{
+    public class AppHostUsedWithSymbolicLinks : IClassFixture<AppHostUsedWithSymbolicLinks.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+
+        public AppHostUsedWithSymbolicLinks(AppHostUsedWithSymbolicLinks.SharedTestState fixture)
+        {
+            sharedTestState = fixture;            
+        }
+
+        [Fact]
+        public void Run_apphost_behind_symbolic_link()
+        {
+            while (!System.Diagnostics.Debugger.IsAttached)
+                System.Threading.Thread.Sleep(5000);
+
+            var fixture = sharedTestState.StandaloneAppFixture_Published
+                .Copy();
+            
+            var appExe = fixture.TestProject.AppExe;
+
+            Command.Create(appExe)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture StandaloneAppFixture_Built { get; }
+            public TestProjectFixture StandaloneAppFixture_Published { get; }
+            public RepoDirectoriesProvider RepoDirectories { get; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                var buildFixture = new TestProjectFixture("StandaloneApp6x", RepoDirectories);
+                buildFixture
+                    .EnsureRestoredForRid(buildFixture.CurrentRid)
+                    .BuildProject(runtime: buildFixture.CurrentRid);
+
+                var publishFixture = new TestProjectFixture("StandaloneApp6x", RepoDirectories);
+                publishFixture
+                    .EnsureRestoredForRid(publishFixture.CurrentRid)
+                    .PublishProject(runtime: publishFixture.CurrentRid);
+
+                StandaloneAppFixture_Built = buildFixture;
+                StandaloneAppFixture_Published = publishFixture;
+            }
+
+            public void Dispose()
+            {
+                StandaloneAppFixture_Built.Dispose();
+                StandaloneAppFixture_Published.Dispose();
+            }
+        }
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -101,6 +101,7 @@ namespace Microsoft.NET.HostModel.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
+            var builtDotnet = fixture.BuiltDotnet.BinPath;
             var testDir = Directory.GetParent(appExe).ToString();
             Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(symlinkRelativePath)));
             var symlinkFullPath = Path.Combine(testDir, symlinkRelativePath);
@@ -109,6 +110,8 @@ namespace Microsoft.NET.HostModel.Tests
             Command.Create(symlinkFullPath)
                 .CaptureStdErr()
                 .CaptureStdOut()
+                .EnvironmentVariable("DOTNET_ROOT", builtDotnet)
+                .EnvironmentVariable("DOTNET_ROOT(x86)", builtDotnet)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.HostModel.Tests
 
             var appExe = fixture.TestProject.AppExe;
             var builtDotnet = fixture.BuiltDotnet.BinPath;
-            var testDir = Directory.GetParent(appExe).ToString();
+            var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
             Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(symlinkRelativePath)));
             var symlinkFullPath = Path.Combine(testDir, symlinkRelativePath);
 
@@ -130,7 +130,7 @@ namespace Microsoft.NET.HostModel.Tests
             var appExe = fixture.TestProject.AppExe;
             var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
             var dotnetSymlink = Path.Combine(testDir, "dotnet");
-            var dotnetDir = Directory.GetParent(fixture.BuiltDotnet.DotnetExecutablePath).ToString();
+            var dotnetDir = fixture.BuiltDotnet.BinPath;
 
             CreateSymbolicLink(dotnetSymlink, dotnetDir);
             Command.Create(appExe)

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -88,13 +88,18 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
+        //[Theory]
+        //[InlineData("a/b/SymlinkToFrameworkDependentApp")]
+        //[InlineData("a/SymlinkToFrameworkDependentApp")]
         [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
             "CI failing to use stat on symbolic links on Linux (permission denied).")]
-        public void Run_framework_dependent_app_behind_symlink(string symlinkRelativePath)
+        public void Run_framework_dependent_app_behind_symlink(/* string symlinkRelativePath */)
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return;
+
+            string symlinkRelativePath = string.Empty;
 
             var fixture = sharedTestState.FrameworkDependentAppFixture_Published
                 .Copy();

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -86,6 +86,9 @@ namespace Microsoft.NET.HostModel.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
+
+            Directory.Delete(firstSymbolicLink);
+            Directory.Delete(secondSymbolicLink);
         }
 
         //[Theory]
@@ -193,6 +196,8 @@ namespace Microsoft.NET.HostModel.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
+
+            Directory.Delete(dotnetSymlink);
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -87,8 +87,11 @@ namespace Microsoft.NET.HostModel.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
 
-            Directory.Delete(firstSymbolicLink);
-            Directory.Delete(secondSymbolicLink);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Directory.Delete(firstSymbolicLink);
+                Directory.Delete(secondSymbolicLink);
+            }
         }
 
         //[Theory]
@@ -197,7 +200,10 @@ namespace Microsoft.NET.HostModel.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
 
-            Directory.Delete(dotnetSymlink);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Directory.Delete(dotnetSymlink);
+            }
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.HostModel.Tests
 
         public AppHostUsedWithSymbolicLinks(AppHostUsedWithSymbolicLinks.SharedTestState fixture)
         {
-            sharedTestState = fixture;            
+            sharedTestState = fixture;
         }
 
         [Theory]
@@ -32,6 +32,10 @@ namespace Microsoft.NET.HostModel.Tests
         [InlineData ("a/SymlinkToApphost")]
         public void Run_apphost_behind_symlink(string symlinkRelativePath)
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
 
@@ -56,6 +60,10 @@ namespace Microsoft.NET.HostModel.Tests
         [InlineData ("a/FirstSymlink", "c/SecondSymlink")]
         public void Run_apphost_behind_transitive_symlinks(string firstSymlinkRelativePath, string secondSymlinkRelativePath)
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
             
@@ -83,6 +91,10 @@ namespace Microsoft.NET.HostModel.Tests
         [Fact]
         public void Put_app_directory_behind_symlink()
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
 
@@ -103,6 +115,10 @@ namespace Microsoft.NET.HostModel.Tests
         [Fact]
         public void Put_app_directory_behind_symlink_and_use_dotnet()
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
 
@@ -123,6 +139,10 @@ namespace Microsoft.NET.HostModel.Tests
         [Fact]
         public void Put_app_directory_behind_symlink_and_use_dotnet_run()
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
 
@@ -144,6 +164,10 @@ namespace Microsoft.NET.HostModel.Tests
         [Fact]
         public void Put_satellite_assembly_behind_symlink()
         {
+            // Creating symbolic links requires administrative privilege on Windows, so skip test.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var fixture = sharedTestState.StandaloneAppFixture_Localized
                 .Copy();
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -88,9 +88,8 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        [Theory]
-        [InlineData("a/b/SymlinkToFrameworkDependentApp")]
-        [InlineData("a/SymlinkToFrameworkDependentApp")]
+        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
+            "CI failing to use stat on symbolic links on Linux (permission denied).")]
         public void Run_framework_dependent_app_behind_symlink(string symlinkRelativePath)
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.
@@ -117,7 +116,8 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        [Fact]
+        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
+            "CI failing to use stat on symbolic links on Linux (permission denied).")]
         public void Run_framework_dependent_app_with_runtime_behind_symlink()
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.

--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public static class SymbolicLinking
+    {
+#if WINDOWS
+        [Flags]
+        internal enum SymbolicLinkFlag
+        {
+            IsFile = 0x0,
+            IsDirectory = 0x1,
+            AllowUnprivilegedCreate = 0x2
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)]
+        internal static extern bool CreateSymbolicLink(
+            string symbolicLinkName,
+            string targetFileName,
+            SymbolicLinkFlag flags);
+#else
+        [DllImport("libc", SetLastError = true)]
+        internal static extern int symlink(
+            string symbolicLinkName,
+            string targetFileName);
+
+        [DllImport("libc", CharSet = CharSet.Ansi)]
+        internal static extern IntPtr strerror(int errnum);
+#endif
+
+        public static bool MakeSymbolicLink(string symbolicLinkName, string targetFileName, out string errorMessage)
+        {
+            errorMessage = string.Empty;
+#if WINDOWS
+            if (!CreateSymbolicLink(symbolicLinkName, targetFileName, SymbolicLinkFlag.IsFile))
+            {
+                int errno = Marshal.GetLastWin32Error();
+                return false;
+            }
+#else
+            if (symlink(symbolicLinkName, targetFileName) == -1)
+            {
+                int errno = Marshal.GetLastWin32Error();
+                errorMessage = Marshal.PtrToStringAnsi(strerror(errno));
+                return false; 
+            }
+#endif
+
+            return true;
+        }
+    }
+}

--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -26,8 +26,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
 #else
         [DllImport("libc", SetLastError = true)]
         internal static extern int symlink(
-            string symbolicLinkName,
-            string targetFileName);
+            string targetFileName,
+            string linkPath);
 
         [DllImport("libc", CharSet = CharSet.Ansi)]
         internal static extern IntPtr strerror(int errnum);
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 return false;
             }
 #else
-            if (symlink(symbolicLinkName, targetFileName) == -1)
+            if (symlink(targetFileName, symbolicLinkName) == -1)
             {
                 int errno = Marshal.GetLastWin32Error();
                 errorMessage = Marshal.PtrToStringAnsi(strerror(errno));

--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -18,7 +18,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
         }
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)]
         internal static extern bool CreateSymbolicLink(
             string symbolicLinkName,
             string targetFileName,
@@ -40,6 +39,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             if (!CreateSymbolicLink(symbolicLinkName, targetFileName, SymbolicLinkFlag.IsFile))
             {
                 int errno = Marshal.GetLastWin32Error();
+                errorMessage = $"CreateSymbolicLink failed with error number {errno}";
                 return false;
             }
 #else

--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -36,17 +36,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             internal static extern IntPtr strerror(int errnum);
         }
 
-        static class libSystem
-        {
-            [DllImport("libSystem.dylib", SetLastError = true)]
-            internal static extern int symlink(
-                string targetFileName,
-                string linkPath);
-
-            [DllImport("libSystem.dylib", CharSet = CharSet.Ansi)]
-            internal static extern IntPtr strerror(int errnum);
-        }
-
         public static bool MakeSymbolicLink(string symbolicLinkName, string targetFileName, out string errorMessage)
         {
             errorMessage = string.Empty;
@@ -59,21 +48,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     return false;
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else 
             {
                 if (libc.symlink(targetFileName, symbolicLinkName) == -1)
                 {
                     int errno = Marshal.GetLastWin32Error();
                     errorMessage = Marshal.PtrToStringAnsi(libc.strerror(errno));
-                    return false; 
-                }
-            }
-            else
-            {
-                if (libSystem.symlink(targetFileName, symbolicLinkName) == -1)
-                {
-                    int errno = Marshal.GetLastWin32Error();
-                    errorMessage = Marshal.PtrToStringAnsi(libSystem.strerror(errno));
                     return false; 
                 }
             }

--- a/src/native/corehost/deps_entry.cpp
+++ b/src/native/corehost/deps_entry.cpp
@@ -227,6 +227,6 @@ bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str, u
         append_path(&new_base, library_path.c_str());
     }
 
-    search_options |= deps_entry_t::search_options::look_in_bundle;
+    search_options &= ~deps_entry_t::search_options::look_in_bundle;
     return to_rel_path(new_base, str, search_options);
 }

--- a/src/native/corehost/deps_entry.cpp
+++ b/src/native/corehost/deps_entry.cpp
@@ -98,7 +98,7 @@ void deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
     // before it uses the TPA. So putting the servicing entry into TPA is not enough, since runtime would
     // resolve it from the bundle first anyway. Disabling the file's entry in the bundle
     // ensures that the servicing entry in the TPA gets priority.
-    if (is_servicing && bundle::info_t::is_single_file_bundle())
+    if (is_servicing && bundle::info_t::is_single_file_bundle() && pal::file_exists(candidate.c_str()))
     {
         bundle::runner_t* app = bundle::runner_t::mutable_app();
         assert(!app->has_base(base));

--- a/src/native/corehost/deps_entry.cpp
+++ b/src/native/corehost/deps_entry.cpp
@@ -101,7 +101,7 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
         {
             trace::verbose(_X("    %s path query did not exist %s"), query_type, candidate.c_str());
             candidate.clear();
-            return true;
+            return false;
         }
 
         trace::verbose(_X("    %s path query exists %s"), query_type, candidate.c_str());

--- a/src/native/corehost/deps_entry.cpp
+++ b/src/native/corehost/deps_entry.cpp
@@ -30,17 +30,15 @@ static pal::string_t normalize_dir_separator(const pal::string_t& path)
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
 //    ietf_dir - If this is a resource asset, the IETF intermediate directory
-//    look_in_base - Whether to search as a relative path
-//    look_in_bundle - Whether to look within the single-file bundle
-//    is_servicing - Whether the base directory is the core-servicing directory
 //    str  - (out parameter) If the method returns true, contains the file path for this deps entry
+//    search_options - Flags to instruct where to look for this deps entry
 //    found_in_bundle - (out parameter) True if the candidate is located within the single-file bundle.
 //    
 // Returns:
 //    If the file exists in the path relative to the "base" directory within the 
 //    single-file or on disk.
 
-bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_dir, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool &found_in_bundle, bool check_file_existence) const
+bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_dir, pal::string_t* str, uint32_t search_options, bool &found_in_bundle) const
 {
     pal::string_t& candidate = *str;
 
@@ -58,6 +56,9 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
     // Reserve space for the path below
     candidate.reserve(base.length() + ietf_dir.length() + normalized_path.length() + 3);
 
+    bool look_in_base = search_options & deps_entry_t::search_options::look_in_base;
+    bool look_in_bundle = search_options & deps_entry_t::search_options::look_in_bundle;
+    bool is_servicing = search_options & deps_entry_t::search_options::is_servicing;
     pal::string_t file_path = look_in_base ? get_filename(normalized_path) : normalized_path;
     pal::string_t sub_path = ietf_dir;
     append_path(&sub_path, file_path.c_str());
@@ -95,7 +96,7 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
     append_path(&candidate, sub_path.c_str());
 
     const pal::char_t* query_type = look_in_base ? _X("Local") : _X("Relative");
-    if (check_file_existence)
+    if (search_options & deps_entry_t::search_options::file_existence)
     {
         if (!pal::file_exists(candidate))
         {
@@ -108,7 +109,7 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
     }
     else
     {
-        trace::verbose(_X("    %s path query %s"), query_type, candidate.c_str());
+        trace::verbose(_X("    %s path query %s (skipped file existence check)"), query_type, candidate.c_str());
     }
 
     // If a file is resolved to the servicing directory, mark it as disabled in the bundle.
@@ -137,12 +138,13 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
 //    str  - If the method returns true, contains the file path for this deps entry 
+//    search_options - Flags to instruct where to look for this deps entry
 //    look_in_bundle - Whether to look within the single-file bundle
 //
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
-bool deps_entry_t::to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle, bool check_file_existence) const
+bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const
 {
     pal::string_t ietf_dir;
 
@@ -164,7 +166,10 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, bool look_in_bundle, p
                         base.c_str(), ietf_dir.c_str(), asset.name.c_str());
     }
 
-    return to_path(base, ietf_dir, true, look_in_bundle, false, str, found_in_bundle, check_file_existence);
+
+    search_options |= deps_entry_t::search_options::look_in_base;
+    search_options &= ~deps_entry_t::search_options::is_servicing;
+    return to_path(base, ietf_dir, str, search_options, found_in_bundle);
 }
 
 // -----------------------------------------------------------------------------
@@ -174,16 +179,16 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, bool look_in_bundle, p
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
 //    str  - If the method returns true, contains the file path for this deps entry 
-//    look_in_bundle - Whether to look within the single-file bundle
-//    is_servicing - Whether the base directory is the core-servicing directory
+//    search_options - Flags to instruct where to look for this deps entry
 //
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
-bool deps_entry_t::to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool check_file_existence) const
+bool deps_entry_t::to_rel_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
 {
     bool found_in_bundle;
-    bool result = to_path(base, _X(""), false, look_in_bundle, is_servicing, str, found_in_bundle, check_file_existence);
+    search_options &= ~deps_entry_t::search_options::look_in_base;
+    bool result = to_path(base, _X(""), str, search_options, found_in_bundle);
     assert(!found_in_bundle);
     return result;
 }
@@ -195,12 +200,12 @@ bool deps_entry_t::to_rel_path(const pal::string_t& base, bool look_in_bundle, b
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
 //    str  - If the method returns true, contains the file path for this deps entry 
-//    is_servicing - Whether the base directory is the core-servicing directory
+//    search_options - Flags to instruct where to look for this deps entry
 //
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
-bool deps_entry_t::to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str, bool check_file_existence) const
+bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
 {
     str->clear();
 
@@ -222,5 +227,6 @@ bool deps_entry_t::to_full_path(const pal::string_t& base, bool is_servicing, pa
         append_path(&new_base, library_path.c_str());
     }
 
-    return to_rel_path(new_base, false, is_servicing, str, check_file_existence);
+    search_options |= deps_entry_t::search_options::look_in_bundle;
+    return to_rel_path(new_base, str, search_options);
 }

--- a/src/native/corehost/deps_entry.h
+++ b/src/native/corehost/deps_entry.h
@@ -36,6 +36,15 @@ struct deps_entry_t
         count
     };
 
+    enum search_options : uint32_t
+    {
+        none = 0x0,
+        look_in_base = 0x1,     // Search entry as a relative path
+        look_in_bundle = 0x2,   // Look for entry within the single-file bundle
+        is_servicing = 0x4,     // Whether the base directory is the core-servicing directory
+        file_existence = 0x8,   // Check for entry file existence
+    };
+
     static const std::array<const pal::char_t*, deps_entry_t::asset_types::count> s_known_asset_types;
 
     pal::string_t deps_file;
@@ -52,18 +61,19 @@ struct deps_entry_t
     bool is_rid_specific;
 
     // Given a "base" dir, yield the file path within this directory or single-file bundle.
-    bool to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle, bool check_file_existence) const;
+    bool to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const;
 
     // Given a "base" dir, yield the relative path in the package layout or servicing directory.
-    bool to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool check_file_existence) const;
+    bool to_rel_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
 
     // Given a "base" dir, yield the relative path with package name/version in the package layout or servicing location.
-    bool to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str, bool check_file_existence) const;
+    bool to_full_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
 
 private:
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
+    // flag in "search_options".
     // Returns a path within the single-file bundle, or a file on disk,
-    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool & found_in_bundle, bool check_file_existence) const;
+    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, pal::string_t* str, uint32_t search_options, bool & found_in_bundle) const;
 
 };
 

--- a/src/native/corehost/deps_entry.h
+++ b/src/native/corehost/deps_entry.h
@@ -52,18 +52,18 @@ struct deps_entry_t
     bool is_rid_specific;
 
     // Given a "base" dir, yield the file path within this directory or single-file bundle.
-    void to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle) const;
+    bool to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle, bool check_file_existence) const;
 
     // Given a "base" dir, yield the relative path in the package layout or servicing directory.
-    void to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str) const;
+    bool to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool check_file_existence) const;
 
     // Given a "base" dir, yield the relative path with package name/version in the package layout or servicing location.
-    void to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str) const;
+    bool to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str, bool check_file_existence) const;
 
 private:
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
     // Returns a path within the single-file bundle, or a file on disk,
-    void to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool & found_in_bundle) const;
+    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool & found_in_bundle, bool check_file_existence) const;
 
 };
 

--- a/src/native/corehost/deps_entry.h
+++ b/src/native/corehost/deps_entry.h
@@ -52,18 +52,18 @@ struct deps_entry_t
     bool is_rid_specific;
 
     // Given a "base" dir, yield the file path within this directory or single-file bundle.
-    bool to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle) const;
+    void to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& found_in_bundle) const;
 
     // Given a "base" dir, yield the relative path in the package layout or servicing directory.
-    bool to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str) const;
+    void to_rel_path(const pal::string_t& base, bool look_in_bundle, bool is_servicing, pal::string_t* str) const;
 
     // Given a "base" dir, yield the relative path with package name/version in the package layout or servicing location.
-    bool to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str) const;
+    void to_full_path(const pal::string_t& base, bool is_servicing, pal::string_t* str) const;
 
 private:
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
     // Returns a path within the single-file bundle, or a file on disk,
-    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool & found_in_bundle) const;
+    void to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, bool is_servicing, pal::string_t* str, bool & found_in_bundle) const;
 
 };
 

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -45,7 +45,7 @@ void add_unique_path(
 {
     // Resolve sym links.
     pal::string_t real = path;
-    pal::realpath(&real);
+    // pal::realpath(&real);
 
     if (existing->count(real))
     {
@@ -590,7 +590,7 @@ bool deps_resolver_t::resolve_tpa_list(
     {
         // Workaround for CoreFX not being able to resolve sym links.
         pal::string_t real_asset_path = item.second.resolved_path;
-        pal::realpath(&real_asset_path);
+        //pal::realpath(&real_asset_path);
         output->append(real_asset_path);
         output->push_back(PATH_SEPARATOR);
     }

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -43,29 +43,25 @@ void add_unique_path(
     pal::string_t* non_serviced,
     const pal::string_t& svc_dir)
 {
-    // Resolve sym links.
-    pal::string_t real = path;
-    // pal::realpath(&real);
-
-    if (existing->count(real))
+    if (existing->count(path))
     {
         return;
     }
 
-    trace::verbose(_X("Adding to %s path: %s"), deps_entry_t::s_known_asset_types[asset_type], real.c_str());
+    trace::verbose(_X("Adding to %s path: %s"), deps_entry_t::s_known_asset_types[asset_type], path.c_str());
 
-    if (starts_with(real, svc_dir, false))
+    if (starts_with(path, svc_dir, false))
     {
-        serviced->append(real);
+        serviced->append(path);
         serviced->push_back(PATH_SEPARATOR);
     }
     else
     {
-        non_serviced->append(real);
+        non_serviced->append(path);
         non_serviced->push_back(PATH_SEPARATOR);
     }
 
-    existing->insert(real);
+    existing->insert(path);
 }
 
 // Return the filename from deps path; a deps path always uses a '/' for the separator.
@@ -588,10 +584,7 @@ bool deps_resolver_t::resolve_tpa_list(
     // Convert the paths into a string and return it 
     for (const auto& item : items)
     {
-        // Workaround for CoreFX not being able to resolve sym links.
-        pal::string_t real_asset_path = item.second.resolved_path;
-        //pal::realpath(&real_asset_path);
-        output->append(real_asset_path);
+        output->append(item.second.resolved_path);
         output->push_back(PATH_SEPARATOR);
     }
 

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -304,7 +304,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
         }
         pal::string_t probe_dir = config.probe_dir;
         uint32_t search_options = deps_entry_t::search_options::none;
-        if (m_has_additional_probing_paths)
+        if (m_has_additional_probing_paths || config.only_serviceable_assets)
             search_options |= deps_entry_t::search_options::file_existence;
 
         if (config.is_fx())

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -43,6 +43,9 @@ void add_unique_path(
     pal::string_t* non_serviced,
     const pal::string_t& svc_dir)
 {
+    // To optimize startup time, we avoid calling realpath here.
+    // Because of this, there might be duplicates in the output
+    // whenever path is eiter non-normalized or a symbolic link.
     if (existing->count(path))
     {
         return;
@@ -300,6 +303,12 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             continue;
         }
         pal::string_t probe_dir = config.probe_dir;
+        uint32_t search_options = deps_entry_t::search_options::look_in_bundle;
+        if (m_has_additional_probing_paths)
+            search_options |= deps_entry_t::search_options::file_existence;
+
+        if (config.only_serviceable_assets)
+            search_options |= deps_entry_t::search_options::is_servicing;
 
         if (config.is_fx())
         {
@@ -314,7 +323,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 // If the deps json has the package name and version, then someone has already done rid selection and
                 // put the right asset in the dir. So checking just package name and version would suffice.
                 // No need to check further for the exact asset relative sub path.
-                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, false, candidate, found_in_bundle, m_has_additional_probing_paths))
+                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, candidate, search_options, found_in_bundle))
                 {
                     assert(!found_in_bundle);
                     trace::verbose(_X("    Probed deps json and matched '%s'"), candidate->c_str());
@@ -333,7 +342,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             {
                 if (entry.is_rid_specific)
                 {
-                    if (entry.to_rel_path(deps_dir, true, false, candidate, m_has_additional_probing_paths))
+                    if (entry.to_rel_path(deps_dir, candidate, search_options))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -342,7 +351,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 else
                 {
                     // Non-rid assets, lookup in the published dir.
-                    if (entry.to_dir_path(deps_dir, true, candidate, found_in_bundle, m_has_additional_probing_paths))
+                    if (entry.to_dir_path(deps_dir, candidate, search_options, found_in_bundle))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -352,7 +361,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
             trace::verbose(_X("    Skipping... not found in deps dir '%s'"), deps_dir.c_str());
         }
-        else if (entry.to_full_path(probe_dir, config.only_serviceable_assets, candidate, m_has_additional_probing_paths))
+        else if (entry.to_full_path(probe_dir, candidate, search_options))
         {
             trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
             return true;

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -314,7 +314,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 // If the deps json has the package name and version, then someone has already done rid selection and
                 // put the right asset in the dir. So checking just package name and version would suffice.
                 // No need to check further for the exact asset relative sub path.
-                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, false, candidate, found_in_bundle))
+                entry.to_dir_path(probe_dir, false, candidate, found_in_bundle);
+                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && pal::file_exists(candidate->c_str()))
                 {
                     assert(!found_in_bundle);
                     trace::verbose(_X("    Probed deps json and matched '%s'"), candidate->c_str());
@@ -333,7 +334,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             {
                 if (entry.is_rid_specific)
                 {
-                    if (entry.to_rel_path(deps_dir, true, false, candidate))
+                    entry.to_rel_path(deps_dir, true, false, candidate);
+                    if (pal::file_exists(candidate->c_str()))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -342,7 +344,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 else
                 {
                     // Non-rid assets, lookup in the published dir.
-                    if (entry.to_dir_path(deps_dir, true, candidate, found_in_bundle))
+                    entry.to_dir_path(deps_dir, true, candidate, found_in_bundle);
+                    if (pal::file_exists(candidate->c_str()))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -352,10 +355,14 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
             trace::verbose(_X("    Skipping... not found in deps dir '%s'"), deps_dir.c_str());
         }
-        else if (entry.to_full_path(probe_dir, config.only_serviceable_assets, candidate))
+        else
         {
-            trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
-            return true;
+            entry.to_full_path(probe_dir, config.only_serviceable_assets, candidate);
+            if (pal::file_exists(candidate->c_str()))
+            {
+                trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
+                return true;
+            }
         }
 
         trace::verbose(_X("    Skipping... not found in probe dir '%s'"), probe_dir.c_str());

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -303,12 +303,9 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             continue;
         }
         pal::string_t probe_dir = config.probe_dir;
-        uint32_t search_options = deps_entry_t::search_options::look_in_bundle;
+        uint32_t search_options = deps_entry_t::search_options::none;
         if (m_has_additional_probing_paths)
             search_options |= deps_entry_t::search_options::file_existence;
-
-        if (config.only_serviceable_assets)
-            search_options |= deps_entry_t::search_options::is_servicing;
 
         if (config.is_fx())
         {
@@ -342,7 +339,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             {
                 if (entry.is_rid_specific)
                 {
-                    if (entry.to_rel_path(deps_dir, candidate, search_options))
+                    if (entry.to_rel_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -351,7 +348,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 else
                 {
                     // Non-rid assets, lookup in the published dir.
-                    if (entry.to_dir_path(deps_dir, candidate, search_options, found_in_bundle))
+                    if (entry.to_dir_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle, found_in_bundle))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -361,7 +358,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
             trace::verbose(_X("    Skipping... not found in deps dir '%s'"), deps_dir.c_str());
         }
-        else if (entry.to_full_path(probe_dir, candidate, search_options))
+        else if (entry.to_full_path(probe_dir, candidate, search_options | (config.only_serviceable_assets ? deps_entry_t::search_options::is_servicing : 0)))
         {
             trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
             return true;

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -52,6 +52,7 @@ public:
         , m_managed_app(args.managed_application)
         , m_core_servicing(args.core_servicing)
         , m_is_framework_dependent(is_framework_dependent)
+        , m_has_additional_probing_paths(false)
     {
         int lowest_framework = static_cast<int>(m_fx_definitions.size()) - 1;
         int root_framework = -1;
@@ -90,6 +91,8 @@ public:
 
         setup_additional_probes(args.probe_paths);
         setup_probe_config(args);
+
+        m_has_additional_probing_paths = m_additional_probes.size() > 0;
     }
 
     bool valid(pal::string_t* errors)
@@ -170,6 +173,11 @@ public:
     bool is_framework_dependent() const
     {
         return m_is_framework_dependent;
+    }
+
+    bool has_additional_probe_paths() const
+    {
+        return m_has_additional_probing_paths;
     }
 
     void get_app_dir(pal::string_t *app_dir) const
@@ -272,6 +280,9 @@ private:
 
     // Is the deps file for an app using shared frameworks?
     const bool m_is_framework_dependent;
+
+    // There are additional probing paths
+    bool m_has_additional_probing_paths;
 };
 
 #endif // DEPS_RESOLVER_H

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -52,7 +52,7 @@ public:
         , m_managed_app(args.managed_application)
         , m_core_servicing(args.core_servicing)
         , m_is_framework_dependent(is_framework_dependent)
-        , m_has_additional_probing_paths(false)
+        , m_needs_file_existence_checks(false)
     {
         int lowest_framework = static_cast<int>(m_fx_definitions.size()) - 1;
         int root_framework = -1;
@@ -92,7 +92,10 @@ public:
         setup_additional_probes(args.probe_paths);
         setup_probe_config(args);
 
-        m_has_additional_probing_paths = m_additional_probes.size() > 0 || m_additional_deps.size() > 0;
+        if (m_additional_deps.size() > 0)
+        {
+            m_needs_file_existence_checks = true;
+        }
     }
 
     bool valid(pal::string_t* errors)
@@ -175,9 +178,9 @@ public:
         return m_is_framework_dependent;
     }
 
-    bool has_additional_probe_paths() const
+    bool needs_file_existence_checks() const
     {
-        return m_has_additional_probing_paths;
+        return m_needs_file_existence_checks;
     }
 
     void get_app_dir(pal::string_t *app_dir) const
@@ -281,8 +284,8 @@ private:
     // Is the deps file for an app using shared frameworks?
     const bool m_is_framework_dependent;
 
-    // There are additional probing paths
-    bool m_has_additional_probing_paths;
+    // File existence checks must be performed for probed paths.This will cause symlinks to be resolved.
+    bool m_needs_file_existence_checks;
 };
 
 #endif // DEPS_RESOLVER_H

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -92,7 +92,7 @@ public:
         setup_additional_probes(args.probe_paths);
         setup_probe_config(args);
 
-        m_has_additional_probing_paths = m_additional_probes.size() > 0;
+        m_has_additional_probing_paths = m_additional_probes.size() > 0 || m_additional_deps.size() > 0;
     }
 
     bool valid(pal::string_t* errors)


### PR DESCRIPTION
In an effort to improve startup time, this PR gets rid of three different file-accessing calls inside the host:

https://github.com/dotnet/runtime/blob/5265305d3121d2fce804948b9250b1b3a5f8a22d/src/native/corehost/hostpolicy/deps_resolver.cpp#L654

Which performs a file existence check on each of the assets inside a deps.json.

And:

https://github.com/dotnet/runtime/blob/8ad1d7d665c9867621193d4f8362cdb983602cae/src/native/corehost/hostpolicy/deps_resolver.cpp#L593

https://github.com/dotnet/runtime/blob/8ad1d7d665c9867621193d4f8362cdb983602cae/src/native/corehost/hostpolicy/deps_resolver.cpp#L48

Which purpose is to unroll the symbolic link of a given path and, in the later case, to later normalize the path.