### PR TITLE
Resolve call mdtokens when making tier 1 inline observations

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3844,6 +3844,26 @@ public:
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     */
 
+private:
+    // For prefixFlags
+    enum
+    {
+        PREFIX_TAILCALL_EXPLICIT = 0x00000001, // call has "tail" IL prefix
+        PREFIX_TAILCALL_IMPLICIT =
+            0x00000010, // call is treated as having "tail" prefix even though there is no "tail" IL prefix
+        PREFIX_TAILCALL_STRESS =
+            0x00000100, // call doesn't "tail" IL prefix but is treated as explicit because of tail call stress
+        PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_TAILCALL_IMPLICIT | PREFIX_TAILCALL_STRESS),
+        PREFIX_VOLATILE    = 0x00001000,
+        PREFIX_UNALIGNED   = 0x00010000,
+        PREFIX_CONSTRAINED = 0x00100000,
+        PREFIX_READONLY    = 0x01000000
+    };
+
+    static void impValidateMemoryAccessOpcode(const BYTE* codeAddr, const BYTE* codeEndp, bool volatilePrefix);
+    static OPCODE impGetNonPrefixOpcode(const BYTE* codeAddr, const BYTE* codeEndp);
+    static bool impOpcodeIsCallOpcode(OPCODE opcode);
+
 public:
     void impInit();
     void impImport();

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1525,7 +1525,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
         // Increment the number of observed instructions
         opts.instrCount++;
 
-OBSERVE_OPCODE:
+    OBSERVE_OPCODE:
 
         // Note the opcode we just saw
         if (makeInlineObservations)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -850,7 +850,8 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
     const bool  makeInlineObservations = (compInlineResult != nullptr);
     const bool  isInlining             = compIsForInlining();
     const bool  isTier1                = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1);
-    const bool  resolveTokens          = makeInlineObservations && isTier1;
+    const bool  isPreJit               = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
+    const bool  resolveTokens          = makeInlineObservations && (isTier1 || isPreJit);
     unsigned    retBlocks              = 0;
     unsigned    intrinsicCalls         = 0;
     int         prefixFlags            = 0;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -849,7 +849,12 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
     const bool  isForceInline          = (info.compFlags & CORINFO_FLG_FORCEINLINE) != 0;
     const bool  makeInlineObservations = (compInlineResult != nullptr);
     const bool  isInlining             = compIsForInlining();
+    const bool  isTier1                = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1);
+    const bool  resolveTokens          = makeInlineObservations && isTier1;
     unsigned    retBlocks              = 0;
+    unsigned    intrinsicCalls         = 0;
+    int         prefixFlags            = 0;
+    int         value                  = 0;
 
     if (makeInlineObservations)
     {
@@ -883,12 +888,14 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
         compInlineResult->Note(InlineObservation::CALLEE_BEGIN_OPCODE_SCAN);
     }
 
+    CORINFO_RESOLVED_TOKEN resolvedToken;
+    CORINFO_RESOLVED_TOKEN constrainedResolvedToken;
+    CORINFO_CALL_INFO      callInfo;
+
     while (codeAddr < codeEndp)
     {
         OPCODE opcode = (OPCODE)getU1LittleEndian(codeAddr);
         codeAddr += sizeof(__int8);
-        opts.instrCount++;
-        typeIsNormed = false;
 
     DECODE_OPCODE:
 
@@ -939,18 +946,43 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                 // There has to be code after the call, otherwise the inlinee is unverifiable.
                 if (isInlining)
                 {
-
                     noway_assert(codeAddr < codeEndp - sz);
                 }
 
-                // If the method has a call followed by a ret, assume that
-                // it is a wrapper method.
-                if (makeInlineObservations)
+                if (!makeInlineObservations)
                 {
-                    if ((OPCODE)getU1LittleEndian(codeAddr + sz) == CEE_RET)
-                    {
-                        compInlineResult->Note(InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER);
-                    }
+                    break;
+                }
+
+                CORINFO_METHOD_HANDLE methodHnd   = nullptr;
+                unsigned              methodFlags = 0;
+                bool                  mustExpand  = false;
+                CorInfoIntrinsics     intrinsicID = CORINFO_INTRINSIC_Illegal;
+                NamedIntrinsic        ni          = NI_Illegal;
+
+                if (resolveTokens)
+                {
+                    impResolveToken(codeAddr, &resolvedToken, CORINFO_TOKENKIND_Method);
+                    eeGetCallInfo(&resolvedToken,
+                                  (prefixFlags & PREFIX_CONSTRAINED) ? &constrainedResolvedToken : nullptr,
+                                  combine(CORINFO_CALLINFO_KINDONLY,
+                                          (opcode == CEE_CALLVIRT) ? CORINFO_CALLINFO_CALLVIRT : CORINFO_CALLINFO_NONE),
+                                  &callInfo);
+
+                    methodHnd   = callInfo.hMethod;
+                    methodFlags = callInfo.methodFlags;
+                }
+
+                if ((methodFlags & (CORINFO_FLG_INTRINSIC | CORINFO_FLG_JIT_INTRINSIC)) != 0)
+                {
+                    intrinsicCalls++;
+                }
+
+                if ((OPCODE)getU1LittleEndian(codeAddr + sz) == CEE_RET)
+                {
+                    // If the method has a call followed by a ret, assume that
+                    // it is a wrapper method.
+                    compInlineResult->Note(InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER);
                 }
             }
             break;
@@ -1082,17 +1114,79 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
             break;
 
             case CEE_UNALIGNED:
+            {
+                noway_assert(sz == sizeof(__int8));
+                prefixFlags |= PREFIX_UNALIGNED;
+
+                value = getU1LittleEndian(codeAddr);
+                codeAddr += sizeof(__int8);
+
+                impValidateMemoryAccessOpcode(codeAddr, codeEndp, false);
+                goto OBSERVE_OPCODE;
+            }
+
             case CEE_CONSTRAINED:
+            {
+                noway_assert(sz == sizeof(unsigned));
+                prefixFlags |= PREFIX_CONSTRAINED;
+
+                if (resolveTokens)
+                {
+                    impResolveToken(codeAddr, &constrainedResolvedToken, CORINFO_TOKENKIND_Constrained);
+                }
+                codeAddr += sizeof(unsigned);
+
+                {
+                    OPCODE actualOpcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
+
+                    if (actualOpcode != CEE_CALLVIRT)
+                    {
+                        BADCODE("constrained. has to be followed by callvirt");
+                    }
+                }
+                goto OBSERVE_OPCODE;
+            }
+
             case CEE_READONLY:
+            {
+                noway_assert(sz == 0);
+                prefixFlags |= PREFIX_READONLY;
+
+                {
+                    OPCODE actualOpcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
+
+                    if ((actualOpcode != CEE_LDELEMA) && !impOpcodeIsCallOpcode(actualOpcode))
+                    {
+                        BADCODE("readonly. has to be followed by ldelema or call");
+                    }
+                }
+                goto OBSERVE_OPCODE;
+            }
+
             case CEE_VOLATILE:
+            {
+                noway_assert(sz == 0);
+                prefixFlags |= PREFIX_VOLATILE;
+
+                impValidateMemoryAccessOpcode(codeAddr, codeEndp, true);
+                goto OBSERVE_OPCODE;
+            }
+
             case CEE_TAILCALL:
             {
-                if (codeAddr >= codeEndp)
+                noway_assert(sz == 0);
+                prefixFlags |= PREFIX_TAILCALL_EXPLICIT;
+
                 {
-                    goto TOO_FAR;
+                    OPCODE actualOpcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
+
+                    if (!impOpcodeIsCallOpcode(actualOpcode))
+                    {
+                        BADCODE("tailcall. has to be followed by call, callvirt or calli");
+                    }
                 }
+                goto OBSERVE_OPCODE;
             }
-            break;
 
             case CEE_STARG:
             case CEE_STARG_S:
@@ -1383,6 +1477,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                     fgObserveInlineConstants(opcode, pushedStack, isInlining);
                 }
                 break;
+
             case CEE_RET:
                 retBlocks++;
                 break;
@@ -1394,6 +1489,14 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
         // Skip any remaining operands this opcode may have
         codeAddr += sz;
 
+        // Clear any prefix flags that may have been set
+        prefixFlags = 0;
+
+OBSERVE_OPCODE:
+
+        // Increment the number of observed instructions
+        opts.instrCount++;
+
         // Note the opcode we just saw
         if (makeInlineObservations)
         {
@@ -1401,6 +1504,8 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                 typeIsNormed ? InlineObservation::CALLEE_OPCODE_NORMED : InlineObservation::CALLEE_OPCODE;
             compInlineResult->NoteInt(obs, opcode);
         }
+
+        typeIsNormed = false;
     }
 
     if (codeAddr != codeEndp)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3109,7 +3109,7 @@ unsigned Compiler::impInitBlockLineInfo()
 
 /*****************************************************************************/
 
-static inline bool impOpcodeIsCallOpcode(OPCODE opcode)
+bool Compiler::impOpcodeIsCallOpcode(OPCODE opcode)
 {
     switch (opcode)
     {
@@ -7849,21 +7849,6 @@ bool Compiler::impTailCallRetTypeCompatible(var_types                callerRetTy
     return false;
 }
 
-// For prefixFlags
-enum
-{
-    PREFIX_TAILCALL_EXPLICIT = 0x00000001, // call has "tail" IL prefix
-    PREFIX_TAILCALL_IMPLICIT =
-        0x00000010, // call is treated as having "tail" prefix even though there is no "tail" IL prefix
-    PREFIX_TAILCALL_STRESS =
-        0x00000100, // call doesn't "tail" IL prefix but is treated as explicit because of tail call stress
-    PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_TAILCALL_IMPLICIT | PREFIX_TAILCALL_STRESS),
-    PREFIX_VOLATILE    = 0x00001000,
-    PREFIX_UNALIGNED   = 0x00010000,
-    PREFIX_CONSTRAINED = 0x00100000,
-    PREFIX_READONLY    = 0x01000000
-};
-
 /********************************************************************************
  *
  * Returns true if the current opcode and and the opcodes following it correspond
@@ -10643,7 +10628,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
 // Get the first non-prefix opcode. Used for verification of valid combinations
 // of prefixes and actual opcodes.
 
-static OPCODE impGetNonPrefixOpcode(const BYTE* codeAddr, const BYTE* codeEndp)
+OPCODE Compiler::impGetNonPrefixOpcode(const BYTE* codeAddr, const BYTE* codeEndp)
 {
     while (codeAddr < codeEndp)
     {
@@ -10681,7 +10666,7 @@ static OPCODE impGetNonPrefixOpcode(const BYTE* codeAddr, const BYTE* codeEndp)
 /*****************************************************************************/
 // Checks whether the opcode is a valid opcode for volatile. and unaligned. prefixes
 
-static void impValidateMemoryAccessOpcode(const BYTE* codeAddr, const BYTE* codeEndp, bool volatilePrefix)
+void Compiler::impValidateMemoryAccessOpcode(const BYTE* codeAddr, const BYTE* codeEndp, bool volatilePrefix)
 {
     OPCODE opcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
 


### PR DESCRIPTION
This updates `Compiler::fgFindJumpTargets` to support resolving call tokens when making inline observations for Tier 1.

A test of `csc` compiling a simple `HelloWorld` program (`csc.dll Program.cs /r:System.Runtime.dll /r:System.Console.dll /r:System.Private.Corelib.dll`) with `COMPlus_ReadyToRun=0` and `COMPlus_TieredCompilation=0` resulted in the following impact:
* `Compiler::fgFindJumpTarget` goes from `0.48%` to `0.63%` of instructions retired (`28.5m` to `39.25m`)
* `CEEInfo::resolveToken` goes from `0.32%` to `0.34%` of instructions retired (`19m` to `21m`)
* `CEEInfo::getCallInfo` goes from `0.36%` to `0.32%` of instructions retired (`21.25m` to `19.75m`)

As per the flame graph (see below), the majority of time is still spent in the backend. There was no measured impact for `tier 0` methods.
![image](https://user-images.githubusercontent.com/10487869/113444952-c3488d00-93a9-11eb-895c-3fb2ccd6f9f0.png)

This change will allow us to make potential improvements to inlining for methods that involve many intrinsic calls. Some potential metrics we could use to influence inlining include:
* How many calls are `intrinsic` (Named or Otherwise)
* How many calls are `hwintrinsic` and therefore are not calls at all, but are effectively "simple ops"
* How many calls are CSE or constant folding candidates (such as `Math` calls)
* How many calls are "constants" like `Isa.IsSupported`
* How many calls are potential constants, like `string.Length` or `Type.op_Equality` checks

We can place this behind a `DOTNET_*` (`COMPlus_*`) switch if there are any remaining concerns around impact.