### PR TITLE
Reenable readytorun/coreroot_determinism since referenced issues are closed.

### DIFF
--- a/src/tests/baseservices/threading/regressions/beta2/437017.csproj
+++ b/src/tests/baseservices/threading/regressions/beta2/437017.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/37237 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This test leaves random number of WaitOrTimerCallbacks registered at the exit, which prevents unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/baseservices/threading/threadpool/unregister/regression_749068.csproj
+++ b/src/tests/baseservices/threading/threadpool/unregister/regression_749068.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/37237 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="regression_749068.cs" />

--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -4,11 +4,6 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
-    <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- It is currently failing with JitStress https://github.com/dotnet/runtime/issues/45326-->
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- This is an explicit crossgen test -->
     <CrossGenTest>false</CrossGenTest>
     <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>


### PR DESCRIPTION
Both referenced issues in the project file have been closed. The following issues do not repro locally and given the recorded reason for the test being disabled is no longer valid, we will reenable the test.

Fixes https://github.com/dotnet/runtime/issues/45092
Fixes https://github.com/dotnet/runtime/issues/45326

/cc @BruceForstall 