### PR TITLE
Use GC.AllocateUninitializedArray in MemoryStream.ToArray

### DIFF
--- a/src/libraries/System.IO/tests/MemoryStream/MemoryStream.ToArrayTests.cs
+++ b/src/libraries/System.IO/tests/MemoryStream/MemoryStream.ToArrayTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+namespace System.IO.Tests
+{
+    public class MemoryStream_ToArrayTests
+    {
+        [Theory]
+        [MemberData(nameof(GetArraysVariedBySize))]
+        public static void ToArray_ZeroOffset(byte[] array)
+        {
+            var stream = new MemoryStream();
+            stream.Write(array);
+            var newArray = stream.ToArray();
+
+            Assert.Equal(array.Length, newArray.Length);
+            Assert.Equal(array, newArray);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetArraysVariedBySize))]
+        public static void ToArray_Offset(byte[] array)
+        {
+            int index = 0;
+            int count = array.Length;
+
+            if (count > 3)
+            {
+                // Trim some off each end
+                index = 1;
+                count -= 3;
+            }
+
+            var stream = new MemoryStream(array, index, count);
+            var newArray = stream.ToArray();
+
+            Assert.Equal(count, newArray.Length);
+            Assert.True(array.AsSpan(index, count).SequenceEqual(newArray));
+        }
+
+        public static IEnumerable<object[]> GetArraysVariedBySize()
+        {
+            yield return new object[] { FillWithData(new byte[0]) };
+            yield return new object[] { FillWithData(new byte[1]) };
+            yield return new object[] { FillWithData(new byte[2]) };
+            yield return new object[] { FillWithData(new byte[256]) };
+            yield return new object[] { FillWithData(new byte[512]) };
+            yield return new object[] { FillWithData(new byte[1024]) };
+            yield return new object[] { FillWithData(new byte[2047]) };
+            yield return new object[] { FillWithData(new byte[2048]) };
+            yield return new object[] { FillWithData(new byte[2049]) };
+            yield return new object[] { FillWithData(new byte[2100]) };
+        }
+
+        private static byte[] FillWithData(byte[] buffer)
+        {
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = unchecked((byte)i);
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/libraries/System.IO/tests/MemoryStream/MemoryStream.ToArrayTests.cs
+++ b/src/libraries/System.IO/tests/MemoryStream/MemoryStream.ToArrayTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 namespace System.IO.Tests
 {
@@ -45,26 +46,16 @@ namespace System.IO.Tests
 
         public static IEnumerable<object[]> GetArraysVariedBySize()
         {
-            yield return new object[] { FillWithData(new byte[0]) };
-            yield return new object[] { FillWithData(new byte[1]) };
-            yield return new object[] { FillWithData(new byte[2]) };
-            yield return new object[] { FillWithData(new byte[256]) };
-            yield return new object[] { FillWithData(new byte[512]) };
-            yield return new object[] { FillWithData(new byte[1024]) };
-            yield return new object[] { FillWithData(new byte[2047]) };
-            yield return new object[] { FillWithData(new byte[2048]) };
-            yield return new object[] { FillWithData(new byte[2049]) };
-            yield return new object[] { FillWithData(new byte[2100]) };
-        }
-
-        private static byte[] FillWithData(byte[] buffer)
-        {
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                buffer[i] = unchecked((byte)i);
-            }
-
-            return buffer;
+            yield return new object[] { RandomNumberGenerator.GetBytes(0) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(1) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(2) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(256) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(512) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(1024) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(2047) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(2048) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(2049) };
+            yield return new object[] { RandomNumberGenerator.GetBytes(2100) };
         }
     }
 }

--- a/src/libraries/System.IO/tests/System.IO.Tests.csproj
+++ b/src/libraries/System.IO/tests/System.IO.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="IndentedTextWriter.cs" />
     <Compile Include="BinaryReader\BinaryReaderTests.cs" />
+    <Compile Include="MemoryStream\MemoryStream.ToArrayTests.cs" />
     <Compile Include="MemoryStream\MemoryStream.GetBufferTests.cs" />
     <Compile Include="StreamReader\StreamReader.cs" />
     <Compile Include="StreamReader\StreamReader.StringCtorTests.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -602,8 +602,8 @@ namespace System.IO
             int count = _length - _origin;
             if (count == 0)
                 return Array.Empty<byte>();
-            byte[] copy = new byte[count];
-            Buffer.BlockCopy(_buffer, _origin, copy, 0, count);
+            byte[] copy = GC.AllocateUninitializedArray<byte>(count);
+            _buffer.AsSpan(_origin, count).CopyTo(copy);
             return copy;
         }
 


### PR DESCRIPTION
Array is fully overwritten because destination is of length `count` and if source is not at least count the span creation fails.
`AllocateUninitializedArray` has a little extra overhead so earn that back by using the span overloads which have 4 less branches for a byte array and mostly inlines before the copying starts.

Before:
|  Method |    N |        Mean |     Error |    StdDev |
|-------- |----- |------------:|----------:|----------:|
| ToArray |    0 |   0.4153 ns | 0.0278 ns | 0.0260 ns |
| ToArray |   10 |  11.4839 ns | 0.0824 ns | 0.0731 ns |
| ToArray |  100 |  21.8340 ns | 0.1151 ns | 0.0961 ns |
| ToArray | 1000 | 119.6432 ns | 0.9287 ns | 0.7755 ns |
| ToArray | 2048 | 241.4621 ns | 1.9803 ns | 1.7555 ns |
| ToArray | 4000 | 443.5040 ns | 2.6265 ns | 2.1932 ns |
| ToArray | 8000 | 950.8504 ns | 4.8754 ns | 4.0711 ns |


After:
|  Method |    N |        Mean |     Error |    StdDev |
|-------- |----- |------------:|----------:|----------:|
| ToArray |    0 |   0.4083 ns | 0.0106 ns | 0.0094 ns |
| ToArray |   10 |   8.9956 ns | 0.0401 ns | 0.0313 ns |
| ToArray |  100 |  18.4092 ns | 0.0852 ns | 0.0755 ns |
| ToArray | 1000 | 115.5323 ns | 0.8911 ns | 0.7900 ns |
| ToArray | 2048 | 232.6255 ns | 2.2498 ns | 1.7565 ns |
| ToArray | 4000 | 382.9079 ns | 1.4441 ns | 1.2059 ns |
| ToArray | 8000 | 689.5457 ns | 5.6236 ns | 4.6960 ns |

Once we get up to sizes representing an in-memory file (pdf's, etc) the difference becomes more apparent.

Before:
|  Method |       N |     Mean |    Error |   StdDev |
|-------- |-------- |---------:|---------:|---------:|
| ToArray | 2000000 | 880.7 us | 41.40 us | 115.4 us |

After:
|  Method |       N |     Mean |   Error |   StdDev |
|-------- |-------- |---------:|--------:|---------:|
| ToArray | 2000000 | 460.9 us | 9.19 us | 25.76 us |