### PR TITLE
Obsolete message should contain property name.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -793,7 +793,7 @@ namespace System.Runtime.InteropServices
     }
     public static partial class RuntimeEnvironment
     {
-        [System.ObsoleteAttribute("This property is no longer supported.")]
+        [System.ObsoleteAttribute("SystemConfigurationFile is no longer supported.")]
         public static string SystemConfigurationFile { get { throw null; } }
         public static bool FromGlobalAccessCache(System.Reflection.Assembly a) { throw null; }
         public static string GetRuntimeDirectory() { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.InteropServices
 {
     public static class RuntimeEnvironment
     {
-        [Obsolete("This property is no longer supported.")]
+        [Obsolete("SystemConfigurationFile is no longer supported.")]
         public static string SystemConfigurationFile => throw new PlatformNotSupportedException();
 
         public static bool FromGlobalAccessCache(Assembly a) => false;


### PR DESCRIPTION
Missed feedback from original PR. See https://github.com/dotnet/runtime/pull/50666#discussion_r606730767.

/cc @stephentoub 