### PR TITLE
Remove code that references resolved issues

### DIFF
--- a/src/coreclr/debug/ee/dactable.cpp
+++ b/src/coreclr/debug/ee/dactable.cpp
@@ -20,10 +20,6 @@
 #include "../../vm/common.h"
 #include "../../vm/gcenv.h"
 #include "../../vm/ecall.h"
-// This header include will need to be rmeoved as part of GitHub#12170.
-// The only reason it's here now is that this file references the GC-private
-// variable g_HandleTableMap.
-#include "../../gc/objecthandle.h"
 
 #ifdef DEBUGGING_SUPPORTED
 

--- a/src/coreclr/inc/winwrap.h
+++ b/src/coreclr/inc/winwrap.h
@@ -329,17 +329,6 @@ InterlockedCompareExchangePointer (
 
 #endif // HOST_X86 && _MSC_VER
 
-#if defined(HOST_ARM) & !defined(HOST_UNIX)
-//
-// InterlockedCompareExchangeAcquire/InterlockedCompareExchangeRelease is not mapped in SDK to the correct intrinsics. Remove once
-// the SDK definition is fixed (OS Bug #516255)
-//
-#undef InterlockedCompareExchangeAcquire
-#define InterlockedCompareExchangeAcquire _InterlockedCompareExchange_acq
-#undef InterlockedCompareExchangeRelease
-#define InterlockedCompareExchangeRelease _InterlockedCompareExchange_rel
-#endif
-
 #if defined(HOST_X86) & !defined(InterlockedIncrement64)
 
 // Interlockedxxx64 that do not have intrinsics are only supported on Windows Server 2003

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -595,9 +595,7 @@ void DispatchHolder::InitializeStatic()
 
     static_assert_no_msg(((sizeof(DispatchStub) + sizeof(DispatchStubShort)) % sizeof(void*)) == 0);
     static_assert_no_msg(((sizeof(DispatchStub) + sizeof(DispatchStubLong)) % sizeof(void*)) == 0);
-    // TODO: This should be a static_assert_no_msg(), but there were reports of build failure with VS 2019 due to the expression
-    // not being a compile-time constant, see https://github.com/dotnet/runtime/issues/11858
-    _ASSERTE((DispatchStubLong_offsetof_failLabel - DispatchStubLong_offsetof_failDisplBase) < INT8_MAX);
+    static_assert_no_msg((DispatchStubLong_offsetof_failLabel - DispatchStubLong_offsetof_failDisplBase) < INT8_MAX);
 
     // Common dispatch stub initialization
     dispatchInit._entryPoint [0]      = 0x48;

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -307,16 +307,6 @@ public:
         return fProbeForStackOverflow;
     }
 
-#ifdef _DEBUG
-    inline bool AppDomainLeaks() const
-    {
-        // Workaround for CoreCLR bug #12075, until this configuration option is removed
-        // (CoreCLR Bug #12094)
-        LIMITED_METHOD_DAC_CONTRACT;
-        return false;
-    }
-#endif
-
 #ifdef TEST_DATA_CONSISTENCY
     // get the value of fTestDataConsistency, which controls whether we test that we can correctly detect
     // held locks in DAC builds. This is determined by an environment variable.


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/8291 (aka 12094)
See https://github.com/dotnet/runtime/issues/11858
See https://github.com/dotnet/runtime/issues/8322 (aka 12170)
OS Bug #516255 was filed by @jkotas in 2011 and fixed a few months later :-)