### PR TITLE
Remove must-init requirement for GS Cookies

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4181,7 +4181,7 @@ inline void Compiler::CLR_API_Leave(API_ICorJitInfo_Names ename)
 bool Compiler::fgVarIsNeverZeroInitializedInProlog(unsigned varNum)
 {
     LclVarDsc* varDsc = lvaGetDesc(varNum);
-    bool result = varDsc->lvIsParam || lvaIsOSRLocal(varNum) || (opts.IsOSR() && (varNum == lvaGSSecurityCookie)) ||
+    bool       result = varDsc->lvIsParam || lvaIsOSRLocal(varNum) || (varNum == lvaGSSecurityCookie) ||
                   (varNum == lvaInlinedPInvokeFrameVar) || (varNum == lvaStubArgumentVar) || (varNum == lvaRetAddrVar);
 
 #if FEATURE_FIXED_OUT_ARGS


### PR DESCRIPTION
The cookie is always initialized in the prolog, where no user code is allowed.
Likewise, there should be no GC concerns with it as the prolog is not interruptible.

This change should be validated with some GCStess'ed runs.

The diffs look generally positive as expected, the regressions are because of the differences in the zero-initting strategies (e. g. [here](https://www.diffchecker.com/o7hRWCOp) it looks like a switch from a longer loop to a shorter loop + two explicit stores).

```
libraries.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 67824
Total bytes of diff: 67374
Total bytes of delta: -450 (-0.66% of base)
    diff is an improvement.

Top file regressions (bytes):
          16 : 212958.dasm (0.65% of base)
           2 : 175944.dasm (0.96% of base)
           2 : 175948.dasm (0.95% of base)
           2 : 175945.dasm (0.95% of base)
           2 : 175947.dasm (0.95% of base)
           2 : 175946.dasm (0.95% of base)
           1 : 203366.dasm (0.57% of base)
           1 : 203361.dasm (0.56% of base)
           1 : 203363.dasm (0.57% of base)
           1 : 203364.dasm (0.53% of base)
           1 : 212535.dasm (0.17% of base)
           1 : 203362.dasm (0.56% of base)
           1 : 83342.dasm (0.17% of base)

Top file improvements (bytes):
         -20 : 212527.dasm (-2.77% of base)
         -19 : 212937.dasm (-2.78% of base)
         -13 : 175648.dasm (-0.98% of base)
         -10 : 203370.dasm (-1.12% of base)
         -10 : 232447.dasm (-2.39% of base)
         -10 : 83292.dasm (-1.22% of base)
         -10 : 232445.dasm (-2.92% of base)
          -9 : 232446.dasm (-2.43% of base)
          -9 : 232448.dasm (-1.94% of base)
          -9 : 203369.dasm (-1.01% of base)
          -8 : 176098.dasm (-1.66% of base)
          -8 : 176067.dasm (-1.65% of base)
          -8 : 212524.dasm (-0.28% of base)
          -8 : 145624.dasm (-1.15% of base)
          -8 : 145625.dasm (-1.15% of base)
          -7 : 212516.dasm (-0.60% of base)
          -7 : 213015.dasm (-0.56% of base)
          -7 : 178539.dasm (-3.52% of base)
          -7 : 213080.dasm (-0.37% of base)
          -6 : 83285.dasm (-2.17% of base)
```

cc @AndyAyersMS