### PR TITLE
Do not confuse fgDispBasicBlocks in fgMorphBlocks

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10610,7 +10610,6 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, __in __in_z _
                     {
                         // Promoted implicit by-refs can have this state during
                         // global morph while they are being rewritten
-                        assert(fgGlobalMorph);
                         printf("(P?!)"); // Promoted struct
                     }
                 }
@@ -11310,7 +11309,6 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                 {
                     // Promoted implicit byrefs can get in this state while they are being rewritten
                     // in global morph.
-                    assert(fgGlobalMorph);
                 }
                 else
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17226,6 +17226,10 @@ void Compiler::fgMorphBlocks()
         block = block->bbNext;
     } while (block != nullptr);
 
+    // We are done with the global morphing phase
+    fgGlobalMorph = false;
+    compCurBB     = nullptr;
+
     // Under OSR, we no longer need to specially protect the original method entry
     //
     if (opts.IsOSR() && (fgEntryBB != nullptr) && (fgEntryBB->bbFlags & BBF_IMPORTED))
@@ -17243,10 +17247,6 @@ void Compiler::fgMorphBlocks()
         fgDispBasicBlocks(true);
     }
 #endif
-
-    // We are done with the global morphing phase
-    fgGlobalMorph = false;
-    compCurBB     = nullptr;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17226,10 +17226,6 @@ void Compiler::fgMorphBlocks()
         block = block->bbNext;
     } while (block != nullptr);
 
-    // We are done with the global morphing phase
-    fgGlobalMorph = false;
-    compCurBB     = nullptr;
-
     // Under OSR, we no longer need to specially protect the original method entry
     //
     if (opts.IsOSR() && (fgEntryBB != nullptr) && (fgEntryBB->bbFlags & BBF_IMPORTED))
@@ -17247,6 +17243,10 @@ void Compiler::fgMorphBlocks()
         fgDispBasicBlocks(true);
     }
 #endif
+
+    // We are done with the global morphing phase
+    fgGlobalMorph = false;
+    compCurBB     = nullptr;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
The logic in "fgDispBasicBlocks" has a check for promoted implicit by-refs
that only allows them during global morph via an 'assert(fgGlobalMorph)'.
However, "fgMorphBlocks" was calling "fgDispBasicBlocks" after having set "fgGlobalMorph" to "false",
leading it to falsely believe it was not actually being called during global morph
and asserting with a message like "assertion failed 'fgGlobalMorph' - during 'Morph - Global'".
Fix this by setting "fgGlobalMorph" to "false" at the very end of "fgMorphBlocks".