### PR TITLE
Disable crossroot_determinism for GCStress runs

### DIFF
--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -4,6 +4,9 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <!-- See https://github.com/dotnet/runtime/issues/50704 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This is an explicit crossgen test -->
     <CrossGenTest>false</CrossGenTest>
     <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>


### PR DESCRIPTION
Disabling based on https://github.com/dotnet/runtime/pull/50676#issuecomment-813115472

Tracked with https://github.com/dotnet/runtime/issues/50704