### PR TITLE
Disable EventSource generator in design-time builds

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -300,7 +300,11 @@
   <!-- Include additional sources shared files in the compilation -->
   <Import Project="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems" Label="Shared" />
 
-  <ItemGroup>
+  <!--
+  TODO https://github.com/dotnet/roslyn/pull/51964: EventSource generator is currently disabled for design time builds as it is
+  causing impactful slowdowns while typing in the Corelib project.
+  -->
+  <ItemGroup Condition="'$(DesignTimeBuild)'!='true'">
     <ProjectReference Include="$(LibrariesProjectRoot)\System.Private.CoreLib\generators\System.Private.CoreLib.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
cc: @sharwell, @chsienki, @benaadams 

I think we can get away with this for the EventSource generator, as the values it generates shouldn't be needed while working in the project.  But I expect we won't be as lucky with the [DllImportGenerator](https://github.com/dotnet/runtimelab/tree/feature/DllImportGenerator) cc: @jkoritzinsky, @AaronRobinsonMSFT.  @chsienki, is there a recommendation for how to avoid the impact here for such a generator?  My understanding is you're working on a replacement set of APIs, but that we'll need to switch over to using them wholesale in order to get the benefits?  Do you know when they'll be available?