### PR TITLE
some small proxy-related fixes

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -325,6 +325,11 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ProxyTunnelRequest_GetAsync_Success()
         {
+            if (IsWinHttpHandler)
+            {
+                return;
+            }
+
             const string Content = "Hello world";
 
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
@@ -354,6 +359,11 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ProxyTunnelRequest_MaxConnectionsSetButDoesNotApplyToProxyConnect_Success()
         {
+            if (IsWinHttpHandler)
+            {
+                return;
+            }
+
             const string Content = "Hello world";
 
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
@@ -403,6 +413,11 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ProxyTunnelRequest_OriginServerSendsProxyAuthChallenge_NoProxyAuthPerformed()
         {
+            if (IsWinHttpHandler)
+            {
+                return;
+            }
+
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
             {
                 HttpClientHandler handler = CreateHttpClientHandler();

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -322,21 +322,108 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop("Uses external server")]
         [Fact]
-        public async Task Proxy_SendSecureRequestThruProxy_ConnectTunnelUsed()
+        public async Task ProxyTunnelRequest_GetAsync_Success()
         {
+            const string Content = "Hello world";
+
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
                 handler.Proxy = new WebProxy(proxyServer.Uri);
+                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                 using (HttpClient client = CreateHttpClient(handler))
-                using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.SecureRemoteEchoServer))
                 {
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    _output.WriteLine($"Proxy request line: {proxyServer.Requests[0].RequestLine}");
-                    Assert.Contains("CONNECT", proxyServer.Requests[0].RequestLine);
+                    var options = new LoopbackServer.Options { UseSsl = true };
+                    await LoopbackServer.CreateServerAsync(async (server, uri) =>
+                    {
+                        Task<HttpResponseMessage> clientTask = client.GetAsync(uri);
+                        await server.AcceptConnectionSendResponseAndCloseAsync(content: Content);
+                        using (var response = await clientTask)
+                        {
+                            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                            Assert.Equal(Content, await response.Content.ReadAsStringAsync());
+                        }
+                    }, options);
                 }
+
+                Assert.Contains("CONNECT", proxyServer.Requests[0].RequestLine);
+            }
+        }
+
+        [ActiveIssue("TODO")]
+        [Fact]
+        public async Task ProxyTunnelRequest_MaxConnectionsSetButDoesNotApplyToProxyConnect_Success()
+        {
+            const string Content = "Hello world";
+
+            using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+                handler.Proxy = new WebProxy(proxyServer.Uri);
+                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+                handler.MaxConnectionsPerServer = 1;
+                using (HttpClient client = CreateHttpClient(handler))
+                {
+                    var options = new LoopbackServer.Options { UseSsl = true };
+                    await LoopbackServer.CreateServerAsync(async (server1, uri1) =>
+                    {
+                        await LoopbackServer.CreateServerAsync(async (server2, uri2) =>
+                        {
+                            Task<HttpResponseMessage> clientTask1 = client.GetAsync(uri1);
+                            Task<HttpResponseMessage> clientTask2 = client.GetAsync(uri2);
+                            await server1.AcceptConnectionAsync(async connection1 =>
+                            {
+                                await server2.AcceptConnectionAsync(async connection2 =>
+                                {
+                                    await connection1.HandleRequestAsync(content: Content);
+                                    await connection2.HandleRequestAsync(content: Content);
+                                });
+                            });
+
+                            using (var response1 = await clientTask1)
+                            {
+                                Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                                Assert.Equal(Content, await response1.Content.ReadAsStringAsync());
+                            }
+
+                            using (var response2 = await clientTask2)
+                            {
+                                Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+                                Assert.Equal(Content, await response2.Content.ReadAsStringAsync());
+                            }
+                        }, options);
+                    }, options);
+                }
+
+                Assert.Contains("CONNECT", proxyServer.Requests[0].RequestLine);
+                Assert.Contains("CONNECT", proxyServer.Requests[1].RequestLine);
+            }
+        }
+
+        [Fact]
+        public async Task ProxyTunnelRequest_OriginServerSendsProxyAuthChallenge_NoProxyAuthPerformed()
+        {
+            using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
+            {
+                HttpClientHandler handler = CreateHttpClientHandler();
+                handler.Proxy = new WebProxy(proxyServer.Uri) { Credentials = ConstructCredentials(new NetworkCredential("username", "password"), proxyServer.Uri, BasicAuth, true) };
+                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+                using (HttpClient client = CreateHttpClient(handler))
+                {
+                    var options = new LoopbackServer.Options { UseSsl = true };
+                    await LoopbackServer.CreateServerAsync(async (server, uri) =>
+                    {
+                        Task<HttpResponseMessage> clientTask = client.GetAsync(uri);
+                        await server.AcceptConnectionSendResponseAndCloseAsync(statusCode: HttpStatusCode.ProxyAuthenticationRequired, additionalHeaders: "Proxy-Authenticate: Basic");
+                        using (var response = await clientTask)
+                        {
+                            Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
+                        }
+                    }, options);
+                }
+
+                Assert.Contains("CONNECT", proxyServer.Requests[0].RequestLine);
             }
         }
 
@@ -375,7 +462,6 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.OK, clientTask.Result.StatusCode);
                 }
             }, options);
-
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -342,6 +342,8 @@ namespace System.Net.Http.Functional.Tests
                     var options = new LoopbackServer.Options { UseSsl = true };
                     await LoopbackServer.CreateServerAsync(async (server, uri) =>
                     {
+                        Assert.Equal(proxyServer.Uri, handler.Proxy.GetProxy(uri));
+                        
                         Task<HttpResponseMessage> clientTask = client.GetAsync(uri);
                         await server.AcceptConnectionSendResponseAndCloseAsync(content: Content);
                         using (var response = await clientTask)
@@ -379,6 +381,9 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await LoopbackServer.CreateServerAsync(async (server2, uri2) =>
                         {
+                            Assert.Equal(proxyServer.Uri, handler.Proxy.GetProxy(uri1));
+                            Assert.Equal(proxyServer.Uri, handler.Proxy.GetProxy(uri2));
+
                             Task<HttpResponseMessage> clientTask1 = client.GetAsync(uri1);
                             Task<HttpResponseMessage> clientTask2 = client.GetAsync(uri2);
                             await server1.AcceptConnectionAsync(async connection1 =>
@@ -428,6 +433,8 @@ namespace System.Net.Http.Functional.Tests
                     var options = new LoopbackServer.Options { UseSsl = true };
                     await LoopbackServer.CreateServerAsync(async (server, uri) =>
                     {
+                        Assert.Equal(proxyServer.Uri, handler.Proxy.GetProxy(uri));
+
                         Task<HttpResponseMessage> clientTask = client.GetAsync(uri);
                         await server.AcceptConnectionSendResponseAndCloseAsync(statusCode: HttpStatusCode.ProxyAuthenticationRequired, additionalHeaders: "Proxy-Authenticate: Basic");
                         using (var response = await clientTask)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -351,7 +351,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("TODO")]
         [Fact]
         public async Task ProxyTunnelRequest_MaxConnectionsSetButDoesNotApplyToProxyConnect_Success()
         {

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackProxyServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackProxyServer.cs
@@ -143,7 +143,12 @@ namespace System.Net.Test.Common
             }
 
             var request = new ReceivedRequest();
-            _requests.Add(request);
+
+            // Avoid concurrent writes to the request list
+            lock (_requests)
+            {
+                _requests.Add(request);
+            }
 
             request.RequestLine = line;
             string[] requestTokens = request.RequestLine.Split(' ');

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -105,13 +105,12 @@ namespace System.Net.Http
         /// <param name="port">The port with which this pool is associated.</param>
         /// <param name="sslHostName">The SSL host with which this pool is associated.</param>
         /// <param name="proxyUri">The proxy this pool targets (optional).</param>
-        /// <param name="maxConnections">The maximum number of connections allowed to be associated with the pool at any given time.</param>
-        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri, int maxConnections)
+        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri)
         {
             _poolManager = poolManager;
             _kind = kind;
             _proxyUri = proxyUri;
-            _maxConnections = maxConnections;
+            _maxConnections = Settings._maxConnectionsPerServer;
 
             if (host != null)
             {
@@ -173,6 +172,11 @@ namespace System.Net.Http
                     Debug.Assert(port != 0);
                     Debug.Assert(sslHostName == null);
                     Debug.Assert(proxyUri != null);
+
+                    // Don't enforce the max connections limit on proxy tunnels; this would mean that connections to different origin servers
+                    // would compete for the same limited number of connections.
+                    // We will still enforce this limit on the user of the tunnel (i.e. ProxyTunnel or SslProxyTunnel).
+                    _maxConnections = int.MaxValue;
 
                     _http2Enabled = false;
                     _http3Enabled = false;
@@ -1179,7 +1183,6 @@ namespace System.Net.Http
 
             return connection.SendAsync(request, async, cancellationToken);
         }
-
 
         public ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1172,11 +1172,11 @@ namespace System.Net.Http
             }
         }
 
-        public bool DoProxyAuth() => (_kind == HttpConnectionKind.Proxy || _kind == HttpConnectionKind.ProxyConnect);
+        private bool DoProxyAuth => (_kind == HttpConnectionKind.Proxy || _kind == HttpConnectionKind.ProxyConnect);
 
         public Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpConnection connection, HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            if (DoProxyAuth() && ProxyCredentials is not null)
+            if (DoProxyAuth && ProxyCredentials is not null)
             {
                 return AuthenticationHelper.SendWithNtProxyAuthAsync(request, ProxyUri!, async, ProxyCredentials, connection, this, cancellationToken);
             }
@@ -1186,7 +1186,7 @@ namespace System.Net.Http
 
         public ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
-            if (DoProxyAuth() && ProxyCredentials is not null)
+            if (DoProxyAuth && ProxyCredentials is not null)
             {
                 return AuthenticationHelper.SendWithProxyAuthAsync(request, _proxyUri!, async, ProxyCredentials, doRequestAuth, this, cancellationToken);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -39,9 +39,7 @@ namespace System.Net.Http
         private readonly Timer? _cleaningTimer;
         /// <summary>Heart beat timer currently used for Http2 ping only.</summary>
         private readonly Timer? _heartBeatTimer;
-        /// <summary>The maximum number of connections allowed per pool. <see cref="int.MaxValue"/> indicates unlimited.</summary>
-        private readonly int _maxConnectionsPerServer;
-        // Temporary
+
         private readonly HttpConnectionSettings _settings;
         private readonly IWebProxy? _proxy;
         private readonly ICredentials? _proxyCredentials;
@@ -60,7 +58,6 @@ namespace System.Net.Http
         public HttpConnectionPoolManager(HttpConnectionSettings settings)
         {
             _settings = settings;
-            _maxConnectionsPerServer = settings._maxConnectionsPerServer;
             _pools = new ConcurrentDictionary<HttpConnectionKey, HttpConnectionPool>();
 
             // As an optimization, we can sometimes avoid the overheads associated with
@@ -321,7 +318,7 @@ namespace System.Net.Http
             HttpConnectionPool? pool;
             while (!_pools.TryGetValue(key, out pool))
             {
-                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, key.SslHostName, key.ProxyUri, _maxConnectionsPerServer);
+                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, key.SslHostName, key.ProxyUri);
 
                 if (_cleaningTimer == null)
                 {


### PR DESCRIPTION
Don't apply the max connections limit for ProxyConnect connections (i.e. the CONNECT we make to the proxy to create a proxy tunnel). The max connections limit is still applied for the user of the tunnel, which is where it makes sense.

Also, fix some logic with NT proxy auth where we could have tried to perform proxy authentication against an origin server if the origin server sent us a 407 (proxy auth challenge). The logic is now consistent with the HTTP proxy auth.

Add relevant tests and do some test cleanup.

Fixes #48363
