### PR TITLE
[release/5.0] Fix polling on https connections in HttpConnectionPool

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -71,6 +71,7 @@ namespace System.Net.Http
 
         public HttpConnection(
             HttpConnectionPool pool,
+            Socket? socket,
             Stream stream,
             TransportContext? transportContext)
         {
@@ -78,11 +79,8 @@ namespace System.Net.Http
             Debug.Assert(stream != null);
 
             _pool = pool;
+            _socket = socket;
             _stream = stream;
-            if (stream is NetworkStream networkStream)
-            {
-                _socket = networkStream.Socket;
-            }
 
             _transportContext = transportContext;
 


### PR DESCRIPTION
Backport of #49474 to release/5.0

## Customer Impact

With this fix, customers with large numbers of HTTPS connections will see significantly less pinning, and avoid GC behavior caused by long-lived pins.

A customer is blocked on deploying 5.0 due to this.

## Testing

Verified in private build by customer.

## Risks

Most users of `HttpClient` will be affected by this code change, so I wouldn't say there is zero risk. However, this returns HTTPS behavior to what worked prior to 5.0, so the ramifications are well understood.