### PR TITLE
JIT: Improve inliner (constant feeds constant test, foldable calls)

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -990,16 +990,14 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                     {
                         if (intrinsicID == CORINFO_INTRINSIC_StringLength)
                         {
-                            if (makeInlineObservations && pushedStack.IsStackAtLeastOneDeep())
-                            {
-                                unsigned slot0 = pushedStack.GetSlot0();
+                            assert(pushedStack.IsStackAtLeastOneDeep());
+                            unsigned slot0 = pushedStack.GetSlot0();
 
-                                if (FgStack::IsConstant(slot0) || (FgStack::IsArgument(slot0) && isInlining &&
-                                    impInlineInfo->inlArgInfo[FgStack::SlotTypeToArgNum(slot0)].argIsInvariant))
-                                {
-                                    // slot0 is an ldstr or an arg which is a string literal (we hope argIsInvariant means that)
-                                    compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_CALL);
-                                }
+                            if (FgStack::IsConstant(slot0) || (FgStack::IsArgument(slot0) && isInlining &&
+                                impInlineInfo->inlArgInfo[FgStack::SlotTypeToArgNum(slot0)].argIsInvariant))
+                            {
+                                // slot0 is an ldstr or an arg which is a string literal (we hope argIsInvariant means that)
+                                compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_CALL);
                             }
                         }
                         if (intrinsicID == CORINFO_INTRINSIC_Illegal)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -992,10 +992,11 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                         {
                             unsigned slot0 = pushedStack.GetSlot0();
 
-                            if (FgStack::IsConstant(slot0) || (FgStack::IsArgument(slot0) && isInlining &&
-                                impInlineInfo->inlArgInfo[FgStack::SlotTypeToArgNum(slot0)].argIsInvariant))
+                            if (FgStack::IsConstant(slot0) ||
+                                (FgStack::IsArgument(slot0) && isInlining &&
+                                 impInlineInfo->inlArgInfo[FgStack::SlotTypeToArgNum(slot0)].argIsInvariant))
                             {
-                                // slot0 is an ldstr or an arg which is a string literal (we hope argIsInvariant means that)
+                                // slot0 is an ldstr or an arg which is a string literal
                                 compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_CALL);
                             }
                         }

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -988,9 +988,8 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
                     if ((methodFlags & CORINFO_FLG_JIT_INTRINSIC) != 0)
                     {
-                        if (intrinsicID == CORINFO_INTRINSIC_StringLength)
+                        if ((intrinsicID == CORINFO_INTRINSIC_StringLength) && pushedStack.IsStackAtLeastOneDeep())
                         {
-                            assert(pushedStack.IsStackAtLeastOneDeep());
                             unsigned slot0 = pushedStack.GetSlot0();
 
                             if (FgStack::IsConstant(slot0) || (FgStack::IsArgument(slot0) && isInlining &&

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -66,6 +66,7 @@ INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",      
 
 // ------ Callee Information -------
 
+INLINE_OBSERVATION(FOLDABLE_CALL,             bool,   "foldable call",                        INFORMATION, CALLEE)
 INLINE_OBSERVATION(ARG_FEEDS_CONSTANT_TEST,   bool,   "argument feeds constant test",         INFORMATION, CALLEE)
 INLINE_OBSERVATION(ARG_FEEDS_TEST,            bool,   "argument feeds test",                  INFORMATION, CALLEE)
 INLINE_OBSERVATION(ARG_FEEDS_RANGE_CHECK,     bool,   "argument feeds range check",           INFORMATION, CALLEE)

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -96,6 +96,7 @@ public:
         , m_ArgFeedsConstantTest(0)
         , m_ArgFeedsRangeCheck(0)
         , m_ConstantArgFeedsConstantTest(0)
+        , m_FoldableCall(0)
         , m_CalleeNativeSizeEstimate(0)
         , m_CallsiteNativeSizeEstimate(0)
         , m_IsForceInline(false)
@@ -164,6 +165,7 @@ protected:
     unsigned                m_ArgFeedsConstantTest;
     unsigned                m_ArgFeedsRangeCheck;
     unsigned                m_ConstantArgFeedsConstantTest;
+    unsigned                m_FoldableCall;
     int                     m_CalleeNativeSizeEstimate;
     int                     m_CallsiteNativeSizeEstimate;
     bool                    m_IsForceInline : 1;


### PR DESCRIPTION
Contribution to @tannergooding's work in https://github.com/dotnet/runtime/pull/50675

```csharp
static void Test()
{
    CheckHW();
}

static void CheckHW()
{
    if (!Avx2.IsSupported)
    {
        Console.WriteLine("No AVX2 :(");
    }
}
```
Current codegen for `Test`:
```asm
G_M24707_IG01:           
       4883EC28             sub      rsp, 40
G_M24707_IG02:             
       E8EF5CFEFF           call     CheckHW()  ;; <-- not inlined
       90                   nop
G_M24707_IG03:         
       4883C428             add      rsp, 40
       C3                   ret


; weight= 79 : state  40 [ call ]
; weight= 25 : state  45 [ brtrue.s ]
; weight= 66 : state 102 [ ldstr ]
; weight= 79 : state  40 [ call ]
; weight= 19 : state  42 [ ret ]
; 
; Inline candidate looks like a wrapper method.  Multiplier increased to 1.
; Inline candidate callsite is boring.  Multiplier increased to 2.3.
; calleeNativeSizeEstimate=268
; callsiteNativeSizeEstimate=55
; benefit multiplier=2.3
; threshold=126
; Native estimate for function size exceeds threshold for inlining 26.8 > 12.6 (multiplier = 2.3)
```
New codegen for `Test`:
```asm
G_M24707_IG01:           
G_M24707_IG02:             
       C3                   ret


; weight= 79 : state  40 [ call ]
; weight= 25 : state  45 [ brtrue.s ]
; weight= 66 : state 102 [ ldstr ]
; weight= 79 : state  40 [ call ]
; weight= 19 : state  42 [ ret ]
; 
; Inline candidate looks like a wrapper method.  Multiplier increased to 1.
; Inline candidate has an arg that feeds a constant test.  Multiplier increased to 2.
; Inline candidate has 1 call(s) which is guaranteed to be folded
; Inline candidate has const arg that feeds a conditional.  Multiplier increased to 5.
; Inline candidate callsite is boring.  Multiplier increased to 6.3.
; calleeNativeSizeEstimate=268
; callsiteNativeSizeEstimate=55
; benefit multiplier=6.3
; threshold=346
; Native estimate for function size is within threshold for inlining 26.8 <= 34.6 (multiplier = 6.3)
```

As far as I understand we're going to switch to "PGO-based policy" for inliner in future but maybe some of these pieces will be useful there too?