### PR TITLE
ensure that sync Connect calls ShouldRetrySyncOperation

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1480,7 +1480,8 @@ namespace System.Net.Sockets
             SocketError errorCode;
             int observedSequenceNumber;
             _sendQueue.IsReady(this, out observedSequenceNumber);
-            if (SocketPal.TryStartConnect(_socket, socketAddress, socketAddressLen, out errorCode))
+            if (SocketPal.TryStartConnect(_socket, socketAddress, socketAddressLen, out errorCode) ||
+                !ShouldRetrySyncOperation(out errorCode))
             {
                 _socket.RegisterConnectResult(errorCode);
                 return errorCode;


### PR DESCRIPTION
I believe this is the root of the issue in #50380.

Other sync socket calls (send, recv, etc) call ShouldRetrySyncOperation in order to distinguish between a timeout on a sync socket vs EAGAIN on a socket that's been forced into nonblocking mode. The Connect operation isn't, which means that we are misinterpreting some timeouts as meaning that the socket is now nonblocking.

Fixes #50380