### PR TITLE
lockless buffer reservation/release in EventPipe

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1219,6 +1219,15 @@ ep_rt_atomic_dec_int64_t (volatile int64_t *value)
 	return static_cast<int64_t>(InterlockedDecrement64 ((volatile LONG64 *)(value)));
 }
 
+static
+inline
+size_t
+ep_rt_atomic_compare_exchange_size_t (volatile size_t *target, size_t expected, size_t value)
+{
+	STATIC_CONTRACT_NOTHROW;
+	return static_cast<size_t>(InterlockedCompareExchangeT<size_t> (target, value, expected));
+}
+
 /*
  * EventPipe.
  */

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -783,6 +783,14 @@ ep_rt_atomic_dec_int64_t (volatile int64_t *value)
 	return (int64_t)mono_atomic_dec_i64 ((volatile gint64 *)value);
 }
 
+static
+inline
+size_t
+ep_rt_atomic_compare_exchange_size_t (volatile size_t *target, size_t expected, size_t value)
+{
+	return (size_t)(mono_atomic_cas_i32 ((volatile gint32 *)(target), (gint32)(value), (gint32)(expected)));
+}
+
 /*
  * EventPipe.
  */

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -248,6 +248,44 @@ ep_buffer_list_get_and_remove_head (EventPipeBufferList *buffer_list)
 	return ret_buffer;
 }
 
+bool
+ep_buffer_manager_try_reserve_buffer(
+	EventPipeBufferManager *buffer_manager,
+	uint32_t request_size)
+{
+	uint64_t iters = 0;
+	size_t old_size_of_all_buffers;
+	size_t new_size_of_all_buffers;
+	do {
+		old_size_of_all_buffers = buffer_manager->size_of_all_buffers;
+		new_size_of_all_buffers = old_size_of_all_buffers + request_size;
+		iters++;
+		if (iters % 100 == 0) {
+			ep_rt_thread_sleep (0); // yield the thread to the scheduler in case we're in high contention
+		}
+	} while (new_size_of_all_buffers <= buffer_manager->max_size_of_all_buffers && ep_rt_atomic_compare_exchange_size_t (&buffer_manager->size_of_all_buffers, old_size_of_all_buffers, new_size_of_all_buffers) != old_size_of_all_buffers);
+
+	return new_size_of_all_buffers <= buffer_manager->max_size_of_all_buffers;
+}
+
+void
+ep_buffer_manager_release_buffer(
+	EventPipeBufferManager *buffer_manager,
+	uint32_t size)
+{
+	uint64_t iters = 0;
+	size_t old_size_of_all_buffers;
+	size_t new_size_of_all_buffers;
+	do {
+		old_size_of_all_buffers = buffer_manager->size_of_all_buffers;
+		new_size_of_all_buffers = old_size_of_all_buffers - size;
+		iters++;
+		if (iters % 100 == 0) {
+			ep_rt_thread_sleep (0); // yield the thread to the scheduler in case we're in high contention
+		}
+	} while (new_size_of_all_buffers >= 0 && ep_rt_atomic_compare_exchange_size_t (&buffer_manager->size_of_all_buffers, old_size_of_all_buffers, new_size_of_all_buffers) != old_size_of_all_buffers);
+}
+
 #ifdef EP_CHECKED_BUILD
 bool
 ep_buffer_list_ensure_consistency (EventPipeBufferList *buffer_list)
@@ -416,6 +454,39 @@ buffer_manager_allocate_buffer_for_thread (
 	EventPipeBufferList *thread_buffer_list = NULL;
 	EventPipeSequencePoint* sequence_point = NULL;
 	bool allocate_new_buffer = false;
+	uint32_t sequence_number = 0;
+
+	// Pick a buffer size by multiplying the base buffer size by the number of buffers already allocated for this thread.
+	uint32_t size_multiplier = ep_thread_session_state_get_buffer_count_estimate(thread_session_state) + 1;
+	EP_ASSERT(size_multiplier > 0);
+
+	// Pick the base buffer size based.  Checked builds have a smaller size to stress the allocate/steal path more.
+#ifdef EP_CHECKED_BUILD
+	uint32_t base_buffer_size = 30 * 1024; // 30K
+#else
+	uint32_t base_buffer_size = 100 * 1024; // 100K
+#endif
+	uint32_t buffer_size = base_buffer_size * size_multiplier;
+	EP_ASSERT(buffer_size > 0);
+
+
+	buffer_size = EP_MAX (request_size, buffer_size);
+
+	// Don't allow the buffer size to exceed 1MB.
+	const uint32_t max_buffer_size = 1024 * 1024;
+	buffer_size = EP_MIN (buffer_size, max_buffer_size);
+
+
+	// Make sure that buffer size >= request size so that the buffer size does not
+	// determine the max event size.
+	EP_ASSERT (request_size <= buffer_size);
+
+	// Make the buffer size fit into with pagesize-aligned block, since ep_rt_valloc0 expects page-aligned sizes to be passed as arguments
+	buffer_size = (buffer_size + ep_rt_system_get_alloc_granularity () - 1) & ~(uint32_t)(ep_rt_system_get_alloc_granularity () - 1);
+
+	// Attempt to reserve the necessary buffer size
+	EP_ASSERT(buffer_size > 0);
+	ep_return_null_if_nok(ep_buffer_manager_try_reserve_buffer(buffer_manager, buffer_size));
 
 	// Allocating a buffer requires us to take the lock.
 	EP_SPIN_LOCK_ENTER (&buffer_manager->rt_lock, section1)
@@ -429,62 +500,28 @@ buffer_manager_allocate_buffer_for_thread (
 			thread_buffer_list = NULL;
 		}
 
-		// Determine if policy allows us to allocate another buffer
-		size_t available_buffer_size;
-		available_buffer_size = buffer_manager->max_size_of_all_buffers - buffer_manager->size_of_all_buffers;
-		if (request_size <= available_buffer_size)
-			allocate_new_buffer = true;
+		// The sequence counter is exclusively mutated on this thread so this is a thread-local read.
+		sequence_number = ep_thread_session_state_get_volatile_sequence_number (thread_session_state);
+		new_buffer = ep_buffer_alloc (buffer_size, ep_thread_session_state_get_thread (thread_session_state), sequence_number);
+		ep_raise_error_if_nok_holding_spin_lock (new_buffer != NULL, section1);
 
-		if (allocate_new_buffer) {
-			// Pick a buffer size by multiplying the base buffer size by the number of buffers already allocated for this thread.
-			uint32_t size_multiplier = ep_thread_session_state_get_buffer_list (thread_session_state)->buffer_count + 1;
-
-			// Pick the base buffer size based.  Checked builds have a smaller size to stress the allocate/steal path more.
-#ifdef EP_CHECKED_BUILD
-			uint32_t base_buffer_size = 30 * 1024; // 30K
-#else
-			uint32_t base_buffer_size = 100 * 1024; // 100K
-#endif
-			uint32_t buffer_size = base_buffer_size * size_multiplier;
-
-			// Make sure that buffer size >= request size so that the buffer size does not
-			// determine the max event size.
-			EP_ASSERT (request_size <= available_buffer_size);
-
-			buffer_size = EP_MAX (request_size, buffer_size);
-			buffer_size = EP_MIN ((uint32_t)buffer_size, (uint32_t)available_buffer_size);
-
-			// Don't allow the buffer size to exceed 1MB.
-			const uint32_t max_buffer_size = 1024 * 1024;
-			buffer_size = EP_MIN (buffer_size, max_buffer_size);
-
-			// Make the buffer size fit into with pagesize-aligned block, since ep_rt_valloc0 expects page-aligned sizes to be passed as arguments
-			buffer_size = (buffer_size + ep_rt_system_get_alloc_granularity () - 1) & ~(uint32_t)(ep_rt_system_get_alloc_granularity () - 1);
-
-			// The sequence counter is exclusively mutated on this thread so this is a thread-local read.
-			uint32_t sequence_number = ep_thread_session_state_get_volatile_sequence_number (thread_session_state);
-			new_buffer = ep_buffer_alloc (buffer_size, ep_thread_session_state_get_thread (thread_session_state), sequence_number);
-			ep_raise_error_if_nok_holding_spin_lock (new_buffer != NULL, section1);
-
-			buffer_manager->size_of_all_buffers += buffer_size;
-			if (buffer_manager->sequence_point_alloc_budget != 0) {
-				// sequence point bookkeeping
-				if (buffer_size >= buffer_manager->remaining_sequence_point_alloc_budget) {
-					sequence_point = ep_sequence_point_alloc ();
-					if (sequence_point) {
-						buffer_manager_init_sequence_point_thread_list (buffer_manager, sequence_point);
-						ep_raise_error_if_nok_holding_spin_lock (buffer_manager_enqueue_sequence_point (buffer_manager, sequence_point), section1);
-						sequence_point = NULL;
-					}
-					buffer_manager->remaining_sequence_point_alloc_budget = buffer_manager->sequence_point_alloc_budget;
-				} else {
-					buffer_manager->remaining_sequence_point_alloc_budget -= buffer_size;
+		if (buffer_manager->sequence_point_alloc_budget != 0) {
+			// sequence point bookkeeping
+			if (buffer_size >= buffer_manager->remaining_sequence_point_alloc_budget) {
+				sequence_point = ep_sequence_point_alloc ();
+				if (sequence_point) {
+					buffer_manager_init_sequence_point_thread_list (buffer_manager, sequence_point);
+					ep_raise_error_if_nok_holding_spin_lock (buffer_manager_enqueue_sequence_point (buffer_manager, sequence_point), section1);
+					sequence_point = NULL;
 				}
+				buffer_manager->remaining_sequence_point_alloc_budget = buffer_manager->sequence_point_alloc_budget;
+			} else {
+				buffer_manager->remaining_sequence_point_alloc_budget -= buffer_size;
 			}
-#ifdef EP_CHECKED_BUILD
-			buffer_manager->num_buffers_allocated++;
-#endif // EP_CHECKED_BUILD
 		}
+#ifdef EP_CHECKED_BUILD
+		buffer_manager->num_buffers_allocated++;
+#endif // EP_CHECKED_BUILD
 
 		// Set the buffer on the thread.
 		if (new_buffer != NULL)
@@ -506,6 +543,8 @@ ep_on_error:
 	ep_buffer_free (new_buffer);
 	new_buffer = NULL;
 
+	ep_buffer_manager_release_buffer(buffer_manager, buffer_size);
+
 	ep_exit_error_handler ();
 }
 
@@ -518,7 +557,7 @@ buffer_manager_deallocate_buffer (
 	EP_ASSERT (buffer_manager != NULL);
 
 	if (buffer) {
-		buffer_manager->size_of_all_buffers -= ep_buffer_get_size (buffer);
+		ep_buffer_manager_release_buffer(buffer_manager, ep_buffer_get_size (buffer));
 		ep_buffer_free (buffer);
 #ifdef EP_CHECKED_BUILD
 		buffer_manager->num_buffers_allocated--;

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -453,7 +453,6 @@ buffer_manager_allocate_buffer_for_thread (
 	EventPipeBuffer *new_buffer = NULL;
 	EventPipeBufferList *thread_buffer_list = NULL;
 	EventPipeSequencePoint* sequence_point = NULL;
-	bool allocate_new_buffer = false;
 	uint32_t sequence_number = 0;
 
 	// Pick a buffer size by multiplying the base buffer size by the number of buffers already allocated for this thread.

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -260,7 +260,7 @@ ep_buffer_manager_try_reserve_buffer(
 		old_size_of_all_buffers = buffer_manager->size_of_all_buffers;
 		new_size_of_all_buffers = old_size_of_all_buffers + request_size;
 		iters++;
-		if (iters % 100 == 0) {
+		if (iters % 64 == 0) {
 			ep_rt_thread_sleep (0); // yield the thread to the scheduler in case we're in high contention
 		}
 	} while (new_size_of_all_buffers <= buffer_manager->max_size_of_all_buffers && ep_rt_atomic_compare_exchange_size_t (&buffer_manager->size_of_all_buffers, old_size_of_all_buffers, new_size_of_all_buffers) != old_size_of_all_buffers);
@@ -280,7 +280,7 @@ ep_buffer_manager_release_buffer(
 		old_size_of_all_buffers = buffer_manager->size_of_all_buffers;
 		new_size_of_all_buffers = old_size_of_all_buffers - size;
 		iters++;
-		if (iters % 100 == 0) {
+		if (iters % 64 == 0) {
 			ep_rt_thread_sleep (0); // yield the thread to the scheduler in case we're in high contention
 		}
 	} while (new_size_of_all_buffers >= 0 && ep_rt_atomic_compare_exchange_size_t (&buffer_manager->size_of_all_buffers, old_size_of_all_buffers, new_size_of_all_buffers) != old_size_of_all_buffers);

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -114,7 +114,7 @@ struct _EventPipeBufferManager_Internal {
 	EventPipeBuffer *current_buffer;
 	EventPipeBufferList *current_buffer_list;
 	// The total allocation size of buffers under management.
-	size_t size_of_all_buffers;
+	volatile size_t size_of_all_buffers;
 	// The maximum allowable size of buffers under management.
 	// Attempted allocations above this threshold result in
 	// dropped events.
@@ -169,6 +169,18 @@ void
 ep_buffer_manager_init_sequence_point_thread_list (
 	EventPipeBufferManager *buffer_manager,
 	EventPipeSequencePoint *sequence_point);
+
+// Attempt to reserve space for a buffer
+bool
+ep_buffer_manager_try_reserve_buffer(
+	EventPipeBufferManager *buffer_manager,
+	uint32_t request_size);
+
+// Release a reserved buffer budget
+void
+ep_buffer_manager_release_buffer(
+	EventPipeBufferManager *buffer_manager,
+	uint32_t size);
 
 // Write an event to the input thread's current event buffer.
 // An optional event_thread can be provided for sample profiler events.

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -170,18 +170,6 @@ ep_buffer_manager_init_sequence_point_thread_list (
 	EventPipeBufferManager *buffer_manager,
 	EventPipeSequencePoint *sequence_point);
 
-// Attempt to reserve space for a buffer
-bool
-ep_buffer_manager_try_reserve_buffer(
-	EventPipeBufferManager *buffer_manager,
-	uint32_t request_size);
-
-// Release a reserved buffer budget
-void
-ep_buffer_manager_release_buffer(
-	EventPipeBufferManager *buffer_manager,
-	uint32_t size);
-
 // Write an event to the input thread's current event buffer.
 // An optional event_thread can be provided for sample profiler events.
 // This is because the thread that writes the events is not the same as the "event thread".

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -177,6 +177,10 @@ static
 int64_t
 ep_rt_atomic_dec_int64_t (volatile int64_t *value);
 
+static
+size_t
+ep_rt_atomic_compare_exchange_size_t (volatile size_t *target, size_t expected, size_t value);
+
 /*
  * EventPipe.
  */

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -375,6 +375,13 @@ ep_on_error:
 	ep_exit_error_handler ();
 }
 
+uint32_t
+ep_thread_session_state_get_buffer_count_estimate(const EventPipeThreadSessionState *thread_session_state)
+{
+	// this is specifically unprotected and allowed to be incorrect due to memory ordering
+	return thread_session_state->buffer_list == NULL ? 0 : thread_session_state->buffer_list->buffer_count;
+}
+
 void
 ep_thread_session_state_free (EventPipeThreadSessionState *thread_session_state)
 {

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -379,7 +379,13 @@ uint32_t
 ep_thread_session_state_get_buffer_count_estimate(const EventPipeThreadSessionState *thread_session_state)
 {
 	// this is specifically unprotected and allowed to be incorrect due to memory ordering
-	return thread_session_state->buffer_list == NULL ? 0 : thread_session_state->buffer_list->buffer_count;
+	//
+	// buffer_list won't become NULL after getting this reference in the scope of this function.
+	//
+	// buffer_list is only set to NULL when the session is being freed
+	// when this code won't be called.
+	EventPipeBufferList *buffer_list = thread_session_state->buffer_list;
+	return buffer_list == NULL ? 0 : buffer_list->buffer_count;
 }
 
 void

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -263,6 +263,9 @@ struct _EventPipeThreadSessionState_Internal {
 	// a buffer for this session. It is set back to null when
 	// event writing is suspended during session disable.
 	// protected by the buffer manager lock.
+	// This field can be read outside the lock when
+	// the buffer allocation logic is estimating how many
+	// buffers a given thread has used (see: ep_thread_session_state_get_buffer_count_estimate and its uses).
 	EventPipeBufferList *buffer_list;
 #ifdef EP_CHECKED_BUILD
 	// protected by the buffer manager lock.

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -311,6 +311,9 @@ ep_thread_session_state_free (EventPipeThreadSessionState *thread_session_state)
 EventPipeThread *
 ep_thread_session_state_get_thread (const EventPipeThreadSessionState *thread_session_state);
 
+uint32_t
+ep_thread_session_state_get_buffer_count_estimate(const EventPipeThreadSessionState *thread_session_state);
+
 // _Requires_lock_held (thread)
 EventPipeBuffer *
 ep_thread_session_state_get_write_buffer (const EventPipeThreadSessionState *thread_session_state);


### PR DESCRIPTION
\<insert associated issues here\>

# Description

Makes the reservation of a buffer lockless. Allocating the buffer still requires us to take the lock, but now we can fail buffer creation without taking the lock.

Prior to this change, when the buffer limit is reached and the event rate is still high, we would end up having all the writing threads waiting on the buffer manager lock to request a new buffer. The writing threads would wait on that lock, even if the buffer request was going to fail. This would cause a lock caravan slowing down event writing and reducing the number of events that actually get written to the wire.

With this change, the reservation is outside the lock, allowing the saturated scenario above to make more progress. This increases the throughput in high event count and high thread count scenarios.

# Performance Changes

The following all show statistics for stress runs with the following characteristics:

* 32 writing threads
* Each thread wrote events _as fast as possible_. (This is a pathological case to exacerbate the performance bottleneck this patch addresses)
* The reader app used `Stream.CopyAsync` to copy the EventPipe stream directly to disk
* 10 iterations
* 60 second duration
* 200 byte event payloads
* no rundown
* 256 MB buffer limit

## macOS

### 2017 MacBook Pro 17" 2.8 GHz quad core i7 w/ 16GB RAM

Baseline (current main):
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       11,072,411.00|       13,079,154.00|       12,401,127.50|          643,711.50|
| Events Dropped                    |       32,538,988.00|       35,485,877.00|       34,470,364.50|          795,709.42|
| Throughput Efficiency (%)         |               24.45|               27.93|               26.45|                1.06|
| Event Throughput (events/sec)     |          182,240.01|          215,463.05|          204,987.46|           10,736.56|
| Data Throughput (Bytes/sec)       |       36,448,002.97|       43,092,610.63|       40,997,491.94|        2,147,312.69|
| Duration (seconds)                |           58.767485|           60.757299|           60.501883|            0.578701|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

Patch:
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       19,104,384.00|       21,163,737.00|       20,334,391.00|          557,927.82|
| Events Dropped                    |       43,920,738.00|       45,595,905.00|       44,732,740.60|          574,846.22|
| Throughput Efficiency (%)         |               30.20|               32.40|               31.25|                0.64|
| Event Throughput (events/sec)     |          322,641.99|          348,899.30|          335,552.91|            7,591.05|
| Data Throughput (Bytes/sec)       |       64,528,398.99|       69,779,859.40|       67,110,581.37|        1,518,210.23|
| Duration (seconds)                |           58.975128|           60.899348|           60.594507|            0.543102|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

**Result: +63.9% events read, +47.9% total events attempted**

## Windows

### 4x12 core Intel Xeon E7 v2 2.7 GHz (48 physical cores, 96 logical cores) w/ 128 GB RAM

baseline:
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       24,523,483.00|       28,032,820.00|       26,366,913.80|          877,321.92|
| Events Dropped                    |       12,221,072.00|       14,262,520.00|       13,237,912.30|          723,179.17|
| Throughput Efficiency (%)         |               65.18|               68.07|               66.59|                0.92|
| Event Throughput (events/sec)     |          404,859.18|          462,877.70|          434,570.92|           14,670.50|
| Data Throughput (Bytes/sec)       |       80,971,836.92|       92,575,540.29|       86,914,184.11|        2,934,099.06|
| Duration (seconds)                |           60.540638|           61.162813|           60.674750|            0.228717|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

Patch:
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       28,808,525.00|       33,337,792.00|       31,523,538.30|        1,478,407.18|
| Events Dropped                    |       14,582,096.00|       25,968,323.00|       20,683,726.20|        3,643,488.96|
| Throughput Efficiency (%)         |               54.09|               69.57|               60.62|                5.05|
| Event Throughput (events/sec)     |          476,325.06|          551,206.96|          519,749.05|           24,465.25|
| Data Throughput (Bytes/sec)       |       95,265,012.24|      110,241,392.72|      103,949,809.85|        4,893,049.37|
| Duration (seconds)                |           60.480809|           61.137813|           60.652365|            0.217341|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

**result: +20% events read, +32% total events attempted**

### 4 core Intel i7-7700 3.6 GHz w/ 64 GB RAM

baseline:
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       27,723,669.00|       37,027,704.00|       31,361,220.80|        3,351,993.48|
| Events Dropped                    |       31,783,330.00|       41,237,280.00|       36,677,955.00|        3,375,436.52|
| Throughput Efficiency (%)         |               40.25|               53.81|               46.09|                4.87|
| Event Throughput (events/sec)     |          445,067.36|          592,066.10|          500,029.90|           53,178.85|
| Data Throughput (Bytes/sec)       |       89,013,472.18|      118,413,219.60|      100,005,980.29|       10,635,770.67|
| Duration (seconds)                |           62.110903|           63.407405|           62.714577|            0.412705|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

patch:
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       35,809,958.00|       66,600,955.00|       56,755,392.90|        8,427,113.79|
| Events Dropped                    |       26,834,785.00|       62,535,559.00|       37,961,868.60|        9,799,860.05|
| Throughput Efficiency (%)         |               36.41|               71.28|               60.06|                9.58|
| Event Throughput (events/sec)     |          533,595.16|          991,750.07|          844,763.18|          125,675.32|
| Data Throughput (Bytes/sec)       |      106,719,032.35|      198,350,013.34|      168,952,636.67|       25,135,063.65|
| Duration (seconds)                |           66.828682|           67.733301|           67.186452|            0.250799|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

**result: +80% events read, +40% total events attempted**

CC @noahfalk @sywhang @lateralusX 