### PR TITLE
[Android][libraries] Skip failing Android tests with ActiveIssues and proj level skips

### DIFF
--- a/src/libraries/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/IEnumerable.Generic.Serialization.Tests.cs
@@ -11,6 +11,7 @@ namespace System.Collections.Tests
     {
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(ValidCollectionSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void IGenericSharedAPI_SerializeDeserialize(int count)
         {
             IEnumerable<T> expected = GenericIEnumerableFactory(count);

--- a/src/libraries/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs
@@ -13,6 +13,7 @@ namespace System.Collections.Tests
     {
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(ValidCollectionSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void IGenericSharedAPI_SerializeDeserialize(int count)
         {
             IEnumerable expected = NonGenericIEnumerableFactory(count);

--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -47,6 +47,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task FlushAsync_DuringReadAsync()
         {
             byte[] buffer = new byte[32];
@@ -74,6 +75,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task FlushAsync_DuringFlushAsync()
         {
             byte[] buffer = null;
@@ -115,6 +117,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public virtual async Task Dispose_WithUnfinishedReadAsync()
         {
             string compressedPath = CompressedTestFile(UncompressedTestFile());
@@ -133,6 +136,7 @@ namespace System.IO.Compression
 
         [Theory]
         [MemberData(nameof(UncompressedTestFiles))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read(string testFile)
         {
             var uncompressedStream = await LocalMemoryStream.readAppFileAsync(testFile);
@@ -168,6 +172,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read_EndOfStreamPosition()
         {
             var compressedStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));
@@ -187,6 +192,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read_BaseStreamSlowly()
         {
             string testFile = UncompressedTestFile();
@@ -321,6 +327,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task TestLeaveOpenAfterValidDecompress()
         {
             //Create the Stream
@@ -395,6 +402,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task BaseStream_Modify(CompressionMode mode)
         {
             using (var baseStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile())))
@@ -426,6 +434,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task BaseStream_ValidAfterDisposeWithTrueLeaveOpen(CompressionMode mode)
         {
             var ms = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -24,12 +24,14 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50580", TestPlatforms.Android)]
         public static void GenerateMinKey()
         {
             GenerateKey(dsa => GetMin(dsa.LegalKeySizes));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration), nameof(HasSecondMinSize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50580", TestPlatforms.Android)]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(dsa => GetSecondMin(dsa.LegalKeySizes));

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
         };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52319", TestPlatforms.Android)]
         public void ProviderThrowsInvalidDataExceptionWhenLoadFails()
         {
             var tempFile = Path.GetTempFileName();

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Configuration.Ini.Test
         [Theory]
         [InlineData(null)]
         [InlineData("")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50867", TestPlatforms.Android)]
         public void AddIniFile_ThrowsIfFilePathIsNullOrEmpty(string path)
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Configuration.Ini.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50867", TestPlatforms.Android)]
         public void AddIniFile_ThrowsIfFileDoesNotExistAtPath()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
@@ -229,6 +229,7 @@ DefaultConnection=TestConnectionString
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50867", TestPlatforms.Android)]
         public void IniConfiguration_Throws_On_Missing_Configuration_File()
         {
             var exception = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddIniFile("NotExistingConfig.ini").Build());

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.Configuration.Json
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void AddJsonFile_ThrowsIfFileDoesNotExistAtPath()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Configuration.Json
         [Theory]
         [InlineData(null)]
         [InlineData("")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void AddJsonFile_ThrowsIfFilePathIsNullOrEmpty(string path)
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void JsonConfiguration_Throws_On_Missing_Configuration_File()
         {
             var config = new ConfigurationBuilder().AddJsonFile("NotExistingConfig.json", optional: false);

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void ThrowExceptionWhenUnexpectedEndFoundBeforeFinishParsing()
         {
             var json = @"{
@@ -166,6 +167,7 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void ThrowExceptionWhenMissingCurlyBeforeFinishParsing()
         {
             var json = @"
@@ -214,6 +216,7 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50868", TestPlatforms.Android)]
         public void ThrowFormatExceptionWhenFileIsEmpty()
         {
             var exception = Assert.Throws<FormatException>(() => LoadProvider(@""));

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationExtensionsTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
     public class XmlConfigurationExtensionsTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50870", TestPlatforms.Android)]
         public void AddXmlFile_ThrowsIfFileDoesNotExistAtPath()
         {
             var config = new ConfigurationBuilder().AddXmlFile("NotExistingConfig.xml");

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -561,6 +561,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50870", TestPlatforms.Android)]
         public void ThrowExceptionWhenFindDTD()
         {
             var xml =

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -690,6 +690,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50870", TestPlatforms.Android)]
         public void XmlConfiguration_Throws_On_Missing_Configuration_File()
         {
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddXmlFile("NotExistingConfig.xml", optional: false).Build());

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -821,6 +821,7 @@ IniKey1=IniValue2");
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50866", TestPlatforms.Android)]
         public void LoadIncorrectJsonFile_ThrowException()
         {
             var json = @"{

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonReaderTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonReaderTest.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50872", TestPlatforms.Android)]
         public void ReadsRuntimeTargetInfoWithCommentsIsInvalid()
         {
             var exception = Assert.ThrowsAny<JsonException>(() => Read(
@@ -307,6 +308,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50872", TestPlatforms.Android)]
         public void RejectsMissingLibrary()
         {
             var exception = Assert.Throws<InvalidOperationException>(() => Read(

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void Build_PrimaryHandlerIsNull_ThrowsException()
         {
             // Arrange
@@ -90,6 +91,7 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void Build_AdditionalHandlerIsNull_ThrowsException()
         {
             // Arrange
@@ -107,6 +109,7 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void Build_AdditionalHandlerHasNonNullInnerHandler_ThrowsException()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact] // Verifies that AddHttpClient does not override any existing registration
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void AddHttpClient_DoesNotRegisterDefaultClientIfAlreadyRegistered()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/HttpMessageHandlerBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/HttpMessageHandlerBuilderTest.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Http.Test
     public class HttpMessageHandlerBuilderTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void Build_AdditionalHandlerIsNull_ThrowsException()
         {
             // Arrange
@@ -29,6 +30,7 @@ namespace Microsoft.Extensions.Http.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50873", TestPlatforms.Android)]
         public void Build_AdditionalHandlerHasNonNullInnerHandler_ThrowsException()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [InlineData(LoggerColorBehavior.Default)]
         [InlineData(LoggerColorBehavior.Enabled)]
         [InlineData(LoggerColorBehavior.Disabled)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50575", TestPlatforms.Android)]
         public void Log_WritingScopes_LogsWithCorrectColorsWhenColorEnabled(LoggerColorBehavior colorBehavior)
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFilterTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFilterTest.cs
@@ -431,6 +431,7 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50875", TestPlatforms.Android)]
         public void MultipleWildcardsAreNotAllowed()
         {
             var options = new LoggerFilterOptions()

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
@@ -254,6 +254,7 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50875", TestPlatforms.Android)]
         public void DefineMessage_WithNoParameters_ThrowsException_WhenFormatString_HasNamedParameters()
         {
             // Arrange
@@ -275,6 +276,7 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData(4)]
         [InlineData(5)]
         [InlineData(6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50875", TestPlatforms.Android)]
         public void DefineMessage_ThrowsException_WhenExpectedFormatStringParameterCount_NotFound(
             int expectedNamedParameterCount)
         {
@@ -319,6 +321,7 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50875", TestPlatforms.Android)]
         public void DefineScope_WithNoParameters_ThrowsException_WhenFormatString_HasNamedParameters()
         {
             // Arrange
@@ -340,6 +343,7 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData(4)]
         [InlineData(5)]
         [InlineData(6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50875", TestPlatforms.Android)]
         public void DefineScope_ThrowsException_WhenExpectedFormatStringParameterCount_NotFound(
             int expectedNamedParameterCount)
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsFactoryTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsFactoryTests.cs
@@ -352,6 +352,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50877", TestPlatforms.Android)]
         public void ConfigureOptionsThrowsWithAction()
         {
             var services = new ServiceCollection();
@@ -361,6 +362,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50877", TestPlatforms.Android)]
         public void ConfigureOptionsThrowsIfNothingFound()
         {
             var services = new ServiceCollection();

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -734,6 +734,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Substring_InvalidOffsetAndLength()
         {
             // Arrange
@@ -745,6 +746,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Substring_OffsetAndLengthOverflows()
         {
             // Arrange
@@ -816,6 +818,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Subsegment_InvalidOffsetAndLength()
         {
             // Arrange
@@ -827,6 +830,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Subsegment_OffsetAndLengthOverflows()
         {
             // Arrange

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualBasic.Tests
         // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
         // path that followed the symlink.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void ChDir()
         {
             var savedDirectory = System.IO.Directory.GetCurrentDirectory();
@@ -84,6 +85,7 @@ namespace Microsoft.VisualBasic.Tests
 
         // Can't get current directory on OSX before setting it.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void CurDir()
         {
             Assert.Equal(FileSystem.CurDir(), System.IO.Directory.GetCurrentDirectory());

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/InteractionTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/InteractionTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.VisualBasic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void Command()
         {
             var expected = Environment.CommandLine;

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -296,6 +296,7 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
         // path that followed the symlink.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
@@ -614,6 +614,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void MetadataAttributes()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -1468,6 +1469,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void RegionsSnippetsAndLinePragmas()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -2588,6 +2590,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void ProviderSupports()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
@@ -580,6 +580,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void MetadataAttributes()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -1399,6 +1400,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void RegionsSnippetsAndLinePragmas()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -2360,6 +2362,7 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void ProviderSupports()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))

--- a/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
@@ -97,6 +97,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50576", TestPlatforms.Android)]
         public static void ExternalCancel_AddToAny()
         {
             for (int test = 0; test < 3; test++)

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1984,7 +1984,7 @@ namespace System.Collections.Immutable.Tests
 
         [Theory]
         [MemberData(nameof(IStructuralEquatableGetHashCodeData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50579", TestPlatforms.Android)]
         public void IStructuralEquatableGetHashCode(IEnumerable<int> source, IEqualityComparer comparer)
         {
             var array = source.ToImmutableArray();

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -399,6 +399,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50579", TestPlatforms.Android)]
         public void Indexer_KeyNotFoundException_ContainsKeyInMessage()
         {
             var map = ImmutableDictionary.Create<string, string>()

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -457,6 +457,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50579", TestPlatforms.Android)]
         public void Indexer_KeyNotFoundException_ContainsKeyInMessage()
         {
             var map = ImmutableSortedDictionary.Create<string, string>()

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationExceptionTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationExceptionTests.cs
@@ -81,6 +81,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50882", TestPlatforms.Android)]
         public void Ctor_SerializationInfo_StreamingContext()
         {
             using (var stream = new MemoryStream())

--- a/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/CategoryAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/CategoryAttributeTests.cs
@@ -9,6 +9,7 @@ namespace System.ComponentModel.Tests
     public class CategoryAttributeTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_Default()
         {
             var attribute = new CategoryAttribute();
@@ -23,6 +24,7 @@ namespace System.ComponentModel.Tests
         [InlineData("Misc", true)]
         [InlineData("misc", false)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws a NullReferenceException")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_String(string category, bool expectedIsDefaultAttribute)
         {
             var attribute = new CategoryAttribute(category);
@@ -59,6 +61,7 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Equals_Object_ReturnsExpected(CategoryAttribute attribute, object other, bool expected)
         {
             Assert.Equal(expected, attribute.Equals(other));
@@ -87,6 +90,7 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [MemberData(nameof(Properties_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Properties_Get_ReturnsExpected(Func<CategoryAttribute> attributeThunk, string expectedCategory)
         {
             CategoryAttribute attribute = attributeThunk();
@@ -125,6 +129,7 @@ namespace System.ComponentModel.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("value")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void GetLocalizedString_InvokeNoSuchValue_ReturnsNull(string value)
         {
             var attribute = new SubCategoryAttribute();

--- a/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidAsynchronousStateExceptionTests.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidAsynchronousStateExceptionTests.cs
@@ -43,6 +43,7 @@ namespace System.ComponentModel.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_SerializationInfo_StreamingContext()
         {
             using (var stream = new MemoryStream())

--- a/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidEnumArgumentExceptionTests.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidEnumArgumentExceptionTests.cs
@@ -88,6 +88,7 @@ namespace System.ComponentModel.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_SerializationInfo_StreamingContext()
         {
             using (var stream = new MemoryStream())

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionDependencyTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionDependencyTests.cs
@@ -37,6 +37,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50917", TestPlatforms.Android)]
         public void Satisfied_Invoke_ReturnsExpected()
         {
             var contract = new CompositionContract(typeof(int));

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/ExportDescriptorPromiseTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/ExportDescriptorPromiseTests.cs
@@ -252,6 +252,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50917", TestPlatforms.Android)]
         public void ToString_Invoke_ReturnsExpected()
         {
             var promise = new ExportDescriptorPromise(new CompositionContract(typeof(int)), "Origin", true, () => Enumerable.Empty<CompositionDependency>(), depdendencies =>

--- a/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
+++ b/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
@@ -279,6 +279,7 @@ namespace System.Composition.Runtime.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50918", TestPlatforms.Android)]
         public void ToString_Get_ReturnsExpected(CompositionContract contract, string expected)
         {
             Assert.Equal(expected, contract.ToString());

--- a/src/libraries/System.Composition/tests/CardinalityTests.cs
+++ b/src/libraries/System.Composition/tests/CardinalityTests.cs
@@ -31,6 +31,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void RequestingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB));
@@ -41,6 +42,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void ImportingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB), typeof(UsesLog));

--- a/src/libraries/System.Composition/tests/ContractTests.cs
+++ b/src/libraries/System.Composition/tests/ContractTests.cs
@@ -67,6 +67,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void FormattingTheContractPrintsConstraintKeysAndValues()
         {
             var mcd = new CompositionContract(typeof(AType), null, new Dictionary<string, object> { { "A", 1 }, { "B", "C" } });

--- a/src/libraries/System.Composition/tests/DiscoveryTests.cs
+++ b/src/libraries/System.Composition/tests/DiscoveryTests.cs
@@ -56,6 +56,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void InstanceExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRule)));
@@ -63,6 +64,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void PropertyExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRuleProperty)));
@@ -122,6 +124,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MultipleImportAttributesAreDetected()
         {
             var c = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
+++ b/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
@@ -63,6 +63,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingTopLevelExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -71,6 +72,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingTopLevelNamedExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -79,6 +81,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingDependencyMessageIsInformative()
         {
             var cc = CreateContainer(typeof(UserOfUnregistered));
@@ -89,6 +92,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void CycleMessageIsInformative()
         {
             var cc = CreateContainer(typeof(CycleA), typeof(CycleB), typeof(CycleC));
@@ -102,6 +106,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void CardinalityViolationMessageIsInformative()
         {
             var cc = CreateContainer(typeof(ShouldBeOne), typeof(ButThereIsAnother), typeof(RequiresOnlyOne));

--- a/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
+++ b/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
@@ -77,6 +77,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void AConcreteTypeWithUnsupportedConstructorsCannotBeUsedAsAMetadataView()
         {
             var cc = new ContainerConfiguration()
@@ -101,6 +102,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void UnsupportedMetadataViewMessageIsInformative()
         {
             var cc = new ContainerConfiguration().WithParts(typeof(ImportsWithMetadataInterface), typeof(ExportsWithMetadata)).CreateContainer();

--- a/src/libraries/System.Composition/tests/OpenGenericsTests.cs
+++ b/src/libraries/System.Composition/tests/OpenGenericsTests.cs
@@ -123,6 +123,7 @@ namespace System.Composition.UnitTests
         // In future, the set of allowable generic type mappings will be expanded (see
         // ignored tests above).
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void TypesWithMismatchedGenericParameterListsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithKey<,>)));
@@ -130,6 +131,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void TypesWithNonGenericExportsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithNonGenericExport<>)));

--- a/src/libraries/System.Composition/tests/SharingTests.cs
+++ b/src/libraries/System.Composition/tests/SharingTests.cs
@@ -318,6 +318,7 @@ namespace System.Composition.UnitTests
         /// we fail only when we create instance of B.. is that correct.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void BoundaryExposedBoundaryButNoneImported()
         {
             try

--- a/src/libraries/System.Console/tests/TermInfo.cs
+++ b/src/libraries/System.Console/tests/TermInfo.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Xunit;
 
 [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class TermInfo
 {
     // Names of internal members accessed via reflection

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
@@ -67,6 +67,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
         public void Debug_WriteLineNull_IndentsEmptyStringProperly()
         {
             Debug.Indent();
@@ -208,6 +209,7 @@ namespace System.Diagnostics.Tests
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
         public void IndentLevel_Set_GetReturnsExpected(int indentLevel, int expectedIndentLevel)
         {
             Debug.IndentLevel = indentLevel;

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -196,6 +196,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
         public void Trace_ClearTraceListeners_StopsWritingToDebugger()
         {
             VerifyLogged(() => Debug.Write("pizza"), "pizza");
@@ -229,6 +230,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
         public void TraceWriteLineIf()
         {
             VerifyLogged(() => Trace.WriteLineIf(true, 5), "5" + Environment.NewLine);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -1268,6 +1268,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50924", TestPlatforms.Android)]
         public void NoExceptionThrownWhenProcessingStaticActivityProperties()
         {
             // Ensures that no exception is thrown when static properties on the Activity type are passed to EventListener.

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
     public class ActivityTests : IDisposable
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
@@ -160,6 +160,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         [InlineData("<Escaped Message>", "&lt;Escaped Message&gt;")]
         [InlineData("&\"\'", "&amp;\"\'")]
         [InlineData("Hello\n\r", "Hello\n\r")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50925", TestPlatforms.Android)]
         public void WriteTest(string message, string expectedXml)
         {
             string file = GetTestFilePath();
@@ -186,6 +187,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         [Theory]
         [InlineData("Fail:", null)]
         [InlineData("Fail:", "the process failed when running")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50925", TestPlatforms.Android)]
         public void FailTest(string message, string detailMessage)
         {
             string file = GetTestFilePath();

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -283,6 +283,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Compare_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void Compare(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
             Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -174,6 +174,7 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -112,6 +112,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsPrefix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsPrefix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -112,6 +112,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsSuffix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsSuffix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -151,6 +151,7 @@ namespace System.Globalization.Tests
         [Theory]
         [MemberData(nameof(LastIndexOf_TestData))]
         [MemberData(nameof(LastIndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void LastIndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -370,6 +370,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(SortKey_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expectedSign)
         {
             SortKey sk1 = compareInfo.GetSortKey(string1, options);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
@@ -27,6 +27,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(EnglishName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void EnglishName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
@@ -27,6 +27,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NativeName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void NativeName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -128,6 +128,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NativeName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void NativeName(string name, string expected)
         {
             Assert.Equal(expected, new RegionInfo(name).NativeName);
@@ -154,6 +155,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(EnglishName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void EnglishName(string name, string[] expected)
         {
             string result = new RegionInfo(name).EnglishName;
@@ -211,6 +213,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(RegionInfo_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void MiscTest(int lcid, int geoId, string currencyEnglishName, string currencyShortName, string alternativeCurrencyEnglishName, string currencyNativeName, string threeLetterISORegionName, string threeLetterWindowsRegionName)
         {
             RegionInfo ri = new RegionInfo(lcid); // create it with lcid

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -305,6 +305,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToLower_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToLower(string name, string str, string expected)
         {
             TestToLower(name, str, expected);
@@ -428,6 +429,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToUpper(string name, string str, string expected)
         {
             TestToUpper(name, str, expected);

--- a/src/libraries/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
@@ -10,6 +10,7 @@ namespace System.IO.Pipelines.Tests
     public class FlushAsyncCompletionTests : PipeTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public void AwaitingFlushAsyncAwaitableTwiceCompletesReaderWithException()
         {
             async Task Await(ValueTask<FlushResult> a)

--- a/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
@@ -71,6 +71,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task DoubleFlushAsyncThrows()
         {
             Pipe.Writer.WriteEmpty(65);

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -220,6 +220,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task AdvanceAfterCompleteThrows()
         {
             await _pipe.Writer.WriteAsync(new byte[1]);
@@ -710,6 +711,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task DoubleAsyncReadThrows()
         {
             ValueTask<ReadResult> readTask1 = _pipe.Reader.ReadAsync();
@@ -746,6 +748,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task AdvanceWithoutReadThrows()
         {
             await _pipe.Writer.WriteAsync(new byte[3]);

--- a/src/libraries/System.IO.Pipelines/tests/ReadAsyncCompletionTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/ReadAsyncCompletionTests.cs
@@ -9,6 +9,7 @@ namespace System.IO.Pipelines.Tests
     public class ReadAsyncCompletionTests : PipeTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public void AwaitingReadAsyncAwaitableTwiceCompletesWriterWithException()
         {
             async Task Await(ValueTask<ReadResult> a)

--- a/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -244,6 +244,7 @@ namespace System.Dynamic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void NonIndexerParameterizedGetterAndSetterIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, true);
@@ -254,6 +255,7 @@ namespace System.Dynamic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void NonIndexerParameterizedGetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, false);
@@ -264,6 +266,7 @@ namespace System.Dynamic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void NonIndexerParameterizedSetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(false, true);

--- a/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -13,6 +13,7 @@ namespace System.Net.Mail.Tests
     public class LoggingTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
@@ -54,6 +54,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void TestConstructorWithStringArgument()
         {
             string msg;
@@ -91,6 +92,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void TestConstructorWithStatusCodeAndStringArgument()
         {
             string msg;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.NameResolution.Tests
     public class LoggingTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -29,6 +30,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public void GetHostEntry_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
@@ -63,6 +65,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public async Task GetHostEntryAsync_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
@@ -112,6 +115,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public void GetHostEntry_ValidName_NoErrors()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Verbose))

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/TelemetryTest.cs
@@ -13,6 +13,7 @@ namespace System.Net.NameResolution.Tests
     public class TelemetryTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).Assembly.GetType("System.Net.NameResolutionTelemetry", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -98,7 +98,6 @@ namespace System.Net.NameResolution.PalTests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/47591", TestPlatforms.Android)]
         public void TryGetAddrInfo_ExternalHost(bool justAddresses)
         {
             string hostName = "microsoft.com";

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -116,6 +116,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public async Task GetUnicastAddresses_NotEmpty()
         {
             IPGlobalProperties props = IPGlobalProperties.GetIPGlobalProperties();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -20,6 +20,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_GetNetworkInterfaces_AtLeastOne()
         {
             Assert.NotEqual<int>(0, NetworkInterface.GetAllNetworkInterfaces().Length);
@@ -131,6 +132,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_StaticLoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv4Support());
@@ -154,6 +156,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_StaticLoopbackIndex_ExceptionIfV4NotSupported()
         {
             Assert.True(Capability.IPv4Support());
@@ -163,6 +166,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_StaticIPv6LoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv6Support());
@@ -187,6 +191,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_StaticIPv6LoopbackIndex_ExceptionIfV6NotSupported()
         {
             Assert.True(Capability.IPv6Support());
@@ -267,6 +272,7 @@ namespace System.Net.NetworkInformation.Tests
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public void BasicTest_GetIsNetworkAvailable_Success()
         {
             Assert.True(NetworkInterface.GetIsNetworkAvailable());
@@ -277,6 +283,7 @@ namespace System.Net.NetworkInformation.Tests
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Expected behavior is different on OSX or FreeBSD")]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public async Task NetworkInterface_LoopbackInterfaceIndex_MatchesReceivedPackets(bool ipv6)
         {
             using (var client = new Socket(SocketType.Dgram, ProtocolType.Udp))

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -130,6 +130,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithIPAddress(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
@@ -170,6 +171,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithIPAddress_AddressAsString(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
@@ -201,6 +203,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithIPAddressAndTimeout()
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
@@ -260,6 +263,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithIPAddressAndTimeoutAndBuffer_Unix()
         {
             byte[] buffer = TestSettings.PayloadAsBytes;
@@ -348,6 +352,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithIPAddressAndTimeoutAndBufferAndPingOptions_Unix(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
@@ -409,6 +414,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithHost()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -435,6 +441,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithHostAndTimeout()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -494,6 +501,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithHostAndTimeoutAndBuffer_Unix()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -578,6 +586,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public void SendPingWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -642,6 +651,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public async Task Sends_ReuseInstance_Hostname()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/UnixPingUtilityTests.cs
@@ -46,6 +46,7 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData(50)]
         [InlineData(1000)]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Tests un-priviledged Ping support on Unix
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50574", TestPlatforms.Android)]
         public static async Task PacketSizeIsRespected(int payloadSize)
         {
             var stdOutLines = new List<string>();

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -12,6 +12,7 @@ namespace System.Net.Primitives.Functional.Tests
     public class LoggingTest
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50571", TestPlatforms.Android)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(IPAddress).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -88,6 +88,7 @@ namespace System.Net.Tests
         public abstract Task<Stream> GetRequestStreamAsync(WebRequest request);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task ReadFile_ContainsExpectedContent()
         {
             string path = Path.GetTempFileName();
@@ -125,6 +126,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task WriteFile_ContainsExpectedContent()
         {
             string path = Path.GetTempFileName();
@@ -151,6 +153,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task WriteThenReadFile_WriteAccessResultsInNullResponseStream()
         {
             string path = Path.GetTempFileName();
@@ -183,6 +186,7 @@ namespace System.Net.Tests
         protected virtual bool EnableConcurrentReadWriteTests => true;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task RequestAfterResponse_throws()
         {
             string path = Path.GetTempFileName();

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -324,6 +324,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task ContentLength_Get_ExpectSameAsGetResponseStream(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1364,6 +1365,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task GetResponseAsync_GetResponseStream_ContainsHost(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1410,6 +1412,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task GetResponseAsync_PostRequestStream_ContainsData(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1455,6 +1458,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1494,6 +1498,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1512,6 +1517,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1611,6 +1617,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task ResponseUri_GetResponseAsync_ExpectSameUri(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1634,6 +1641,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task SimpleScenario_UseGETVerb_Success(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1650,6 +1658,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task SimpleScenario_UsePOSTVerb_Success(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1672,6 +1681,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(bool useSsl)
         {
             const string ContentType = "text/plain; charset=utf-8";

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1992,6 +1992,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void HttpWebRequest_Serialize_Fails()
         {
             using (MemoryStream fs = new MemoryStream())

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -123,6 +123,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task HttpWebResponse_Serialize_ExpectedResult()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -10,6 +10,7 @@ namespace System.Net.Tests
     {
         [Fact]
         [SkipOnCoreClr("System.Net.Tests are flaky", RuntimeConfiguration.Checked)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -490,36 +490,42 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
             DualModeConnectAsync_IPEndPointToHost_Fails_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
             DualModeConnectAsync_IPEndPointToHost_Fails_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
@@ -878,18 +884,21 @@ namespace System.Net.Sockets.Tests
     public class DualModeAcceptAsync : DualModeBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
@@ -932,6 +941,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void Equals_NonDefaultValue_Success()
         {
             IPPacketInformation packetInfo = GetNonDefaultIPPacketInformation();
@@ -41,6 +42,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void GetHashCode_NonDefaultValue_Succes()
         {
             IPPacketInformation packetInfo = GetNonDefaultIPPacketInformation();

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -20,6 +20,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -65,6 +65,7 @@ namespace System.Net.Sockets.Tests
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void IOControl_SIOCATMARK_Unix_Success()
         {
             using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -961,6 +961,7 @@ namespace System.Net.Sockets.Tests
 
         [Theory(Timeout = 40000)]
         [MemberData(nameof(TcpReceiveSendGetsCanceledByDispose_Data))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, bool ipv6Server, bool dualModeClient)
         {
             // RHEL7 kernel has a bug preventing close(AF_UNKNOWN) to succeed with IPv6 sockets.

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -506,6 +506,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void GetSetRawSocketOption_Roundtrips(AddressFamily family)
         {
             int SOL_SOCKET;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Socket).Assembly.GetType("System.Net.Sockets.SocketsTelemetry", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -463,6 +463,7 @@ namespace System.Net.Sockets.Tests
 
         [ConditionalFact(nameof(PlatformSupportsUnixDomainSockets))]
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Linux)] // Don't support abstract socket addresses.
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public void UnixDomainSocketEndPoint_UsingAbstractSocketAddressOnUnsupported_Throws()
         {
             // An abstract socket address starts with a zero byte.

--- a/src/libraries/System.ObjectModel/tests/KeyedCollection/Serialization.cs
+++ b/src/libraries/System.ObjectModel/tests/KeyedCollection/Serialization.cs
@@ -18,6 +18,7 @@ namespace System.Collections.ObjectModel.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50933", TestPlatforms.Android)]
         public void SerializeDeserialize_Roundtrips(TestCollection c)
         {
             TestCollection clone = BinaryFormatterHelpers.Clone(c);

--- a/src/libraries/System.ObjectModel/tests/ObservableCollection/ObservableCollection_Serialization.cs
+++ b/src/libraries/System.ObjectModel/tests/ObservableCollection/ObservableCollection_Serialization.cs
@@ -19,6 +19,7 @@ namespace System.Collections.ObjectModel.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50933", TestPlatforms.Android)]
         public void SerializeDeserialize_Roundtrips(ObservableCollection<int> c)
         {
             ObservableCollection<int> clone = BinaryFormatterHelpers.Clone(c);

--- a/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionary_SerializationTests.cs
+++ b/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionary_SerializationTests.cs
@@ -18,6 +18,7 @@ namespace System.Collections.ObjectModel.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50933", TestPlatforms.Android)]
         public void SerializeDeserialize_Roundtrips(ReadOnlyDictionary<string, string> d)
         {
             ReadOnlyDictionary<string, string> clone = BinaryFormatterHelpers.Clone(d);

--- a/src/libraries/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_SerializationTests.cs
+++ b/src/libraries/System.ObjectModel/tests/ReadOnlyObservableCollection/ReadOnlyObservableCollection_SerializationTests.cs
@@ -19,6 +19,7 @@ namespace System.Collections.ObjectModel.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50933", TestPlatforms.Android)]
         public void SerializeDeserialize_Roundtrips(ReadOnlyObservableCollection<int> c)
         {
             ReadOnlyObservableCollection<int> clone = BinaryFormatterHelpers.Clone(c);

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3403,6 +3403,7 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 5, Desc = "WriteCData with ]]>", Priority = 1)]
                 [Fact]
+                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void WriteCDataWithTwoClosingBrackets_5()
                 {
                     XDocument doc = new XDocument();
@@ -3598,6 +3599,7 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 6, Desc = "WriteComment with -- in value", Priority = 1)]
                 [Fact]
+                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void WriteCommentWithDoubleHyphensInValue()
                 {
                     XDocument doc = new XDocument();
@@ -4203,6 +4205,7 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 11, Desc = "Include PI end tag ?> as part of the text value", Priority = 1)]
                 [Fact]
+                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void IncludePIEndTagAsPartOfTextValue()
                 {
                     XDocument doc = new XDocument();

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
@@ -17,6 +17,7 @@ namespace System.Xml.Tests
         private static string _invalidCharInThisEncoding = "Invalid character in the given encoding";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAndInvalidChar()
         {
             // {60, 0, 0, 0} is a normal char, {0, 34, 1, 0}  is a surrogate char {62, 100, 60, 47} is an invalid char
@@ -29,6 +30,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithNormalCharAndInvalidChar()
         {
             // {60, 0, 0, 0, 65, 0, 0, 0} are normal chars, {62, 100, 60, 47} is an invalid char, similar bytes used below tests
@@ -41,6 +43,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAndInvalidChar_ValidXmlStructure()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0, 0, 34, 1, 0, 62, 100, 60, 47, 60, 0, 0, 0, 47, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0 };
@@ -52,6 +55,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAsElementName()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 0, 34, 1, 0, 65, 0, 0, 0, 97, 0, 0, 0 };
@@ -84,6 +88,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void BytesStartingWithInvalidChar()
         {
             var bytes = new byte[] { 62, 100, 60, 47, 60, 0, 0, 0, 0, 34, 1, 0, 65, 0, 0, 0, 97, 0, 0, 0 };
@@ -94,6 +99,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void BytesEndingWithInvalidChar()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 97, 0, 0, 0, 62, 100, 60, 47};
@@ -114,6 +120,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithIncompleteBytes()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 65, 0, 0, 0, 97, 62, 10};

--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -265,6 +265,7 @@ namespace System.Resources.Extensions.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34495", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34008", TestPlatforms.Linux, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50934", TestPlatforms.Android)]
         public static void BinaryFormattedResources()
         {
             var values = TestData.BinaryFormatted;
@@ -303,6 +304,7 @@ namespace System.Resources.Extensions.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34495", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34008", TestPlatforms.Linux, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50934", TestPlatforms.Android)]
         public static void BinaryFormattedResourcesWithoutTypeName()
         {
             var values = TestData.BinaryFormatted;
@@ -437,6 +439,7 @@ namespace System.Resources.Extensions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50934", TestPlatforms.Android)]
         public static void CanReadViaResourceManager()
         {
             ResourceManager resourceManager = new ResourceManager(typeof(TestData));
@@ -475,6 +478,7 @@ namespace System.Resources.Extensions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50934", TestPlatforms.Android)]
         public static void EmbeddedResourcesAreUpToDate()
         {
             // this is meant to catch a case where our embedded test resources are out of date with respect to the current writer.

--- a/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -232,6 +232,7 @@ namespace System.Resources.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(EnglishNonStringResourceData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50935", TestPlatforms.Android)]
         public static void GetObject(string key, object expectedValue, bool requiresBinaryFormatter)
         {
             _ = requiresBinaryFormatter;
@@ -305,6 +306,7 @@ namespace System.Resources.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(EnglishNonStringResourceData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50935", TestPlatforms.Android)]
         public static void GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter)
         {
             _ = requiresBinaryFormatter;
@@ -317,6 +319,7 @@ namespace System.Resources.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(EnglishNonStringResourceData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50935", TestPlatforms.Android)]
         public static void GetResourceSet_NonStringsIgnoreCase(string key, object expectedValue, bool requiresBinaryFormatter)
         {
             _ = requiresBinaryFormatter;

--- a/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -96,7 +96,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49931", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49868", TestPlatforms.Android)]
         public static void CreateWithCulturesTest(string lowerForm, string upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -196,7 +196,7 @@ namespace System.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
         [MemberData(nameof(CreateFromCultureAndOptionsStringSortData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49931", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49868", TestPlatforms.Android)]
         public static void CreateFromCultureAndOptions(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -208,7 +208,7 @@ namespace System.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49931", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49868", TestPlatforms.Android)]
         public static void CreateFromCultureAndOptionsStringSort(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
@@ -40,6 +40,7 @@ namespace System.Numerics.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "OOM on browser due to large array allocations")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void RunGetBitLengthTestsLarge()
         {
             // Very large cases

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -660,6 +660,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void RunCtorByteArrayTests()
         {
             ulong tempUInt64;

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1307,6 +1307,7 @@ namespace System.Numerics.Tests
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
         [MemberData(nameof(Invalid_2_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void Reciprocal(double real, double imaginary)
         {
             var complex = new Complex(real, imaginary);

--- a/src/libraries/System.Runtime.Serialization.Primitives/tests/System/Runtime/Serialization/InvalidDataContractExceptionTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Primitives/tests/System/Runtime/Serialization/InvalidDataContractExceptionTests.cs
@@ -37,6 +37,7 @@ namespace System.Runtime.Serialization.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50936", TestPlatforms.Android)]
         public void Ctor_SerializationInfo_StreamingContext()
         {
             using (var memoryStream = new MemoryStream())

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -493,6 +493,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Empty", "")]
         [InlineData("Reserved Tag", "0F00")]
         [InlineData("Zero Tag", "0000")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public static void InvalidPublicKeyEncoding(string caseName, string parametersHex)
         {
             _ = caseName;
@@ -525,6 +526,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Non-Nested Data", "300206035102013001")]
         [InlineData("Indefinite Encoding", "3002060351020130800000")]
         [InlineData("Dangling LengthLength", "300206035102013081")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public static void InvalidSignatureAlgorithmEncoding(string caseName, string sigAlgHex)
         {
             _ = caseName;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -65,6 +65,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             int altWin32Error = 0);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public void EmptyPfx_NoMac()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -73,6 +74,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public void EmptyPfx_NoMac_ArbitraryPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -84,6 +86,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public void EmptyPfx_EmptyPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -95,6 +98,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public void EmptyPfx_NullPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -106,6 +110,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public void EmptyPfx_BadPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
@@ -106,6 +106,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=\"unterminated", InvalidX500NameFragment)]
         // Non-ASCII values in an E field
         [InlineData("E=\u65E5\u672C\u8A9E", InvalidIA5StringFragment)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public static void InvalidInput(string input, string messageFragment)
         {
             CryptographicException exception =

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509Certificate2PemTests.cs
@@ -29,6 +29,7 @@ MII
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public static void CreateFromPem_CryptographicException_InvalidKeyAlgorithm()
         {
             CryptographicException ce = Assert.Throws<CryptographicException>(() =>
@@ -205,6 +206,7 @@ MII
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50937", TestPlatforms.Android)]
         public static void CreateFromEncryptedPem_Rsa_InvalidPassword_Fail()
         {
             CryptographicException ce = Assert.Throws<CryptographicException>(() =>

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
@@ -11,7 +11,6 @@ namespace System.Security.Cryptography.Xml.Tests
     public static class EncryptedXmlTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49871", TestPlatforms.Android)]
         public static void DecryptWithCertificate_NotInStore()
         {
             const string SecretMessage = "Grilled cheese is tasty";

--- a/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -67,6 +67,7 @@ namespace System.Text.Encodings.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Theory]
         [MemberData(nameof(Encoding_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public static void VerifyCodePageAttributes(int codepage, string name, string bodyName, string headerName, bool isBrowserDisplay,
                                             bool isBrowserSave, bool isMailNewsDisplay, bool isMailNewsSave, int windowsCodePage)
         {
@@ -84,6 +85,7 @@ namespace System.Text.Encodings.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Theory]
         [MemberData(nameof(Normalization_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public static void NormalizationTest(int codepage, bool normalized, bool normalizedC, bool normalizedD, bool normalizedKC, bool normalizedKD)
         {
             Encoding encoding = Encoding.GetEncoding(codepage);

--- a/src/libraries/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
@@ -90,6 +90,7 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void TestEncodingNameAndCopdepageNumber()
         {
             foreach (var map in s_mapping)
@@ -101,6 +102,7 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void GetEncoding_EncodingName()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -121,6 +123,7 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void GetEncoding_WebName()
         {
             foreach (var mapping in s_codePageToWebNameMappings)

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
@@ -61,6 +61,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encode_Basic_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void Encode_Basic(string source, int index, int count, byte[] expected)
         {
             Encode_Advanced(true, source, index, count, expected);

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
@@ -54,6 +54,7 @@ namespace System.Text.Tests
         }
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void WebName(UTF7Encoding encoding)
         {
             Assert.Equal("utf-7", encoding.WebName);
@@ -61,6 +62,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void CodePage(UTF7Encoding encoding)
         {
             Assert.Equal(65000, encoding.CodePage);
@@ -68,6 +70,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void EncodingName(UTF7Encoding encoding)
         {
             Assert.NotEmpty(encoding.EncodingName); // Unicode (UTF-7) in en-US
@@ -75,6 +78,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void IsSingleByte(UTF7Encoding encoding)
         {
             Assert.False(encoding.IsSingleByte);
@@ -82,6 +86,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void Clone(UTF7Encoding encoding)
         {
             UTF7Encoding clone = (UTF7Encoding)encoding.Clone();
@@ -115,6 +120,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
         public void EqualsTest(UTF7Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -870,6 +870,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Groups_CustomCulture_TestData_Danish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_Turkish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_AzeriLatin))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36848", TestPlatforms.Android)]
         public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups)
         {
             if (cultureName is null)

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -73,6 +73,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(2)]
         [InlineData(256)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36848", TestPlatforms.Android)]
         public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length)
         {
             var turkish = new CultureInfo("tr-TR");

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexMatchTimeoutExceptionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexMatchTimeoutExceptionTests.cs
@@ -44,6 +44,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50942", TestPlatforms.Android)]
         public void SerializationRoundtrip()
         {
             const string Input = "abcdef";

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexParserTests.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexParserTests.netcoreapp.cs
@@ -97,6 +97,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50942", TestPlatforms.Android)]
         public void RegexParseException_Serializes()
         {
 #pragma warning disable RE0001 // Regex issue: Not enough )'s

--- a/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
@@ -10,6 +10,7 @@ namespace System.Threading.Channels.Tests
     public partial class ChannelClosedExceptionTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50943", TestPlatforms.Android)]
         public void Serialization_Roundtrip()
         {
             var s = new MemoryStream();

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
@@ -124,6 +124,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(2)]
         [InlineData(4)]
         [InlineData(128)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50566", TestPlatforms.Android)]
         public async Task Dop_WorkersCreatedRespectingLimitAndTaskScheduler_Sync(int dop)
         {
             static IEnumerable<int> IterateUntilSet(StrongBox<bool> box)

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -170,6 +170,7 @@ namespace System.Threading.Threads.Tests
         [InlineData("DefaultApartmentStateMain.exe", "GetApartmentStateTest")]
         [InlineData("DefaultApartmentStateMain.exe", "SetApartmentStateTest")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49568", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void ApartmentState_AttributePresent(string appName, string testName)
         {
             var psi = new ProcessStartInfo();
@@ -576,6 +577,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void IsThreadPoolThreadTest()
         {
             var isThreadPoolThread = false;
@@ -600,6 +602,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void ManagedThreadIdTest()
         {
             var e = new ManualResetEvent(false);
@@ -670,6 +673,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void PriorityTest()
         {
             var e = new ManualResetEvent(false);
@@ -688,6 +692,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void ThreadStateTest()
         {
             var e0 = new ManualResetEvent(false);
@@ -725,6 +730,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void AbortSuspendTest()
         {
             var e = new ManualResetEvent(false);
@@ -915,6 +921,7 @@ namespace System.Threading.Threads.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49521", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void InterruptTest()
         {
             // Interrupting a thread that is not blocked does not do anything, but once the thread starts blocking, it gets
@@ -990,6 +997,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void JoinTest()
         {
             var threadReady = new ManualResetEvent(false);
@@ -1041,6 +1049,7 @@ namespace System.Threading.Threads.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50577", TestPlatforms.Android)]
         public static void StartTest(bool useUnsafeStart)
         {
             void Start(Thread t)

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -72,16 +72,19 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\tests\Microsoft.Extensions.Logging.EventSource.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50880 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections/tests/System.Collections.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50916 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50923 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common/tests/System.Data.Common.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common\tests\System.Data.Common.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50926 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/49936 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -77,6 +77,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50916 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50923 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common/tests/System.Data.Common.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -36,7 +36,7 @@
 
     <!-- Tests time out intermittently -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\UnitTests\Microsoft.Extensions.Hosting.Unit.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Parallel\tests\System.Threading.Tasks.Parallel.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj" />
 
     <!-- Tests crash -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\Invariant\Invariant.Tests.csproj" />
@@ -44,12 +44,10 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Ports\tests\System.IO.Ports.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
-
-    <!-- OOM killed intermittently -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Numerics\tests\System.Runtime.Numerics.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Formatters\tests\System.Runtime.Serialization.Formatters.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
 
     <!-- Actual test failures -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests\Microsoft.Extensions.Logging.Console.Tests.csproj" />
@@ -58,20 +56,21 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Debug\tests\System.Diagnostics.Debug.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Ping\tests\FunctionalTests\System.Net.Ping.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests\tests\System.Net.Requests.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Sockets\tests\FunctionalTests\System.Net.Sockets.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encoding\tests\System.Text.Encoding.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Parallel\tests\System.Threading.Tasks.Parallel.Tests.csproj" />
+
+    <!-- Execution may be compromised -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'x86'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -65,6 +65,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50864 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.CSharp\tests\Microsoft.CSharp.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50871 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -40,27 +40,35 @@
 
     <!-- Tests crash -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\Invariant\Invariant.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem.Watcher\tests\System.IO.FileSystem.Watcher.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Ports\tests\System.IO.Ports.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Quic\tests\FunctionalTests\System.Net.Quic.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Formatters\tests\System.Runtime.Serialization.Formatters.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj" />
-    <!-- Crashes on x64 and x86 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms\tests\System.Security.Cryptography.Algorithms.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp\tests\System.Security.Cryptography.Csp.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
+    <!-- Crashes only on x86 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\tests\Microsoft.Extensions.Primitives.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
+    <!-- Crashes on x64 and x86, but not arm64 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs\tests\System.Security.Cryptography.Pkcs.Tests.csproj" />
 
     <!-- Actual test failures -->
     <!-- https://github.com/dotnet/runtime/issues/37088 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
 
     <!-- Runs an fails on arm64 https://github.com/dotnet/runtime/issues/37094 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs\tests\System.Security.Cryptography.Pkcs.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/50864 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.CSharp\tests\Microsoft.CSharp.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'x86'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -113,6 +113,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Xml\tests\Microsoft.Extensions.Configuration.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\FunctionalTests\Microsoft.Extensions.Hosting.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging\tests\DI.Common\Common\tests\Microsoft.Extensions.Logging.Testing.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Composition.Runtime\tests\System.Composition.Runtime.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Asn1\tests\System.Formats.Asn1.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.ResourceManager\tests\System.Resources.ResourceManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\System.Runtime.Serialization.Json.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -82,21 +82,34 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50946 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50947 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50948 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50950 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/51016 -->
+    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\Android\Device_Emulator\InvariantCultureOnlyMode\Android.Device_Emulator.InvariantCultureOnlyMode.Test.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'arm64'">
+    <!-- Execution may be compromised https://github.com/dotnet/runtime/issues/51017 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Xml\tests\Microsoft.Extensions.Configuration.Xml.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\FunctionalTests\Microsoft.Extensions.Hosting.Functional.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging\tests\DI.Common\Common\tests\Microsoft.Extensions.Logging.Testing.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.ResourceManager\tests\System.Resources.ResourceManager.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\System.Runtime.Serialization.Json.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'x64'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -71,6 +71,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50874 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\tests\Microsoft.Extensions.Logging.EventSource.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50880 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections/tests/System.Collections.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -92,6 +92,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50947 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50948 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -74,6 +74,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50880 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections/tests/System.Collections.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50916 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -57,23 +57,7 @@
     <!-- Runs an fails on arm64 https://github.com/dotnet/runtime/issues/37094 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
 
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests\Microsoft.Extensions.Logging.Console.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Console\tests\System.Console.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Debug\tests\System.Diagnostics.Debug.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Ping\tests\FunctionalTests\System.Net.Ping.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests\tests\System.Net.Requests.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Sockets\tests\FunctionalTests\System.Net.Sockets.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encoding\tests\System.Text.Encoding.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Parallel\tests\System.Threading.Tasks.Parallel.Tests.csproj" />
 
     <!-- Execution may be compromised -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -95,6 +95,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50948 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50950 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -80,6 +80,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50923 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common/tests/System.Data.Common.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50926 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -31,9 +31,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(RunDisabledAndroidTests)' != 'true'">
-    <!-- Test flakiness on x64 https://github.com/dotnet/runtime/issues/49937 -->
-    <ProjectExclusions Condition="'$(TargetArchitecture)' == 'x64'" Include="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
-
     <!-- Tests time out intermittently -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\UnitTests\Microsoft.Extensions.Hosting.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj" />
@@ -49,9 +46,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms\tests\System.Security.Cryptography.Algorithms.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp\tests\System.Security.Cryptography.Csp.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
-    <!-- Crashes only on x86 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\tests\Microsoft.Extensions.Primitives.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
+
     <!-- Crashes on x64 and x86, but not arm64 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs\tests\System.Security.Cryptography.Pkcs.Tests.csproj" />
 
@@ -104,7 +99,16 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'x64'">
+    <!-- Test flakiness on x64 https://github.com/dotnet/runtime/issues/49937 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'x86'">
+    <!-- Crashes only on x86 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\tests\Microsoft.Extensions.Primitives.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
+
     <!-- https://github.com/dotnet/runtime/issues/50493 -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\Android\Device_Emulator\AOT\Android.Device_Emulator.Aot.Test.csproj" />
   </ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -68,6 +68,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50871 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50874 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\tests\Microsoft.Extensions.Logging.EventSource.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -50,6 +50,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
 
     <!-- Actual test failures -->
+    <!-- https://github.com/dotnet/runtime/issues/37088 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests\Microsoft.Extensions.Logging.Console.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Console\tests\System.Console.Tests.csproj" />
@@ -63,7 +66,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests\tests\System.Net.Requests.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Sockets\tests\FunctionalTests\System.Net.Sockets.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encoding\tests\System.Text.Encoding.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -89,6 +89,9 @@
     <!-- https://github.com/dotnet/runtime/issues/50946 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50947 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -86,6 +86,9 @@
     <!-- https://github.com/dotnet/runtime/issues/49936 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/50946 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
+
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 
     <!-- Execution may be compromised -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -100,6 +100,12 @@
 
     <!-- https://github.com/dotnet/runtime/issues/51016 -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\Android\Device_Emulator\InvariantCultureOnlyMode\Android.Device_Emulator.InvariantCultureOnlyMode.Test.csproj" />
+
+    <!-- PSNE -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Console/tests/System.Console.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj" />
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'arm64'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -79,7 +79,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/49936 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/50946 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -47,11 +47,15 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Formatters\tests\System.Runtime.Serialization.Formatters.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj" />
+    <!-- Crashes on x64 and x86 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
 
     <!-- Actual test failures -->
     <!-- https://github.com/dotnet/runtime/issues/37088 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+
+    <!-- Runs an fails on arm64 https://github.com/dotnet/runtime/issues/37094 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests\Microsoft.Extensions.Logging.Console.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />


### PR DESCRIPTION
In effort to assess the state of the Android library tests, a number of tests will be skipped according to https://www.dropbox.com/scl/fi/hcv75228nu9b070x5sbso/State-of-Android-Library-Tests.paper?dl=0&rlkey=gck1s5hmz32jcom4fo1m7570k#:uid=471929463738166572469040&h2=All-Github-Android-issues-(Tha

Test suites that crash, hang, or have a significant number of failures (mostly 20+ failing unique test methods) across the different architectures of x64, x86, arm64 are skipped on at the `tests.proj` level. Otherwise, `[ActiveIssue]` attributes have been attached to either the individual test methods that fail, or the entire class if the whole test class fails. Any pre-existing `ActiveIssue` attribute associated with Android had been reassessed to either remain or be closed.

A few test suites have been skipped because they fail with some form of `PlatformNotSupportedException`.

All of the Issues can be tracked at https://github.com/dotnet/runtime/projects/48#column-9236429

The ActiveIssues and `tests.proj` exclusions have been tested on https://github.com/dotnet/runtime/pull/50095 as well.