### PR TITLE
Remove extraneous CMake version requirement.

### DIFF
--- a/src/coreclr/pal/tests/CMakeLists.txt
+++ b/src/coreclr/pal/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14.5)
-
 # Compile options
 add_definitions(-DLP64COMPATIBLE)
 add_definitions(-DCORECLR)


### PR DESCRIPTION
cc:@omajid can you validate that you can build with this change?
Fixes #50803