### PR TITLE
Make JsonConsoleFormatter default for console logging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Logging.Console
                 logFormatter = options.Format switch
                 {
                     ConsoleLoggerFormat.Systemd => _formatters[ConsoleFormatterNames.Systemd],
-                    _ => _formatters[ConsoleFormatterNames.Simple],
+                    _ => ContainerUtils.IsContainer ? _formatters[ConsoleFormatterNames.Json]: _formatters[ConsoleFormatterNames.Simple]
                 };
                 if (options.FormatterName == null)
                 {
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Logging.Console
                 logFormatter = _options.CurrentValue.Format switch
                 {
                     ConsoleLoggerFormat.Systemd => _formatters[ConsoleFormatterNames.Systemd],
-                    _ => _formatters[ConsoleFormatterNames.Simple],
+                    _ => ContainerUtils.IsContainer ? _formatters[ConsoleFormatterNames.Json]: _formatters[ConsoleFormatterNames.Simple]
                 };
 #pragma warning restore CS0618
 
@@ -157,7 +157,16 @@ namespace Microsoft.Extensions.Logging.Console
         private void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
         {
             // kept for deprecated apis:
-            if (formatter is SimpleConsoleFormatter defaultFormatter)
+            if (ContainerUtils.IsContainer && formatter is JsonConsoleFormatter jsonFormatter)
+            {
+                jsonFormatter.FormatterOptions = new JsonConsoleFormatterOptions()
+                {
+                    IncludeScopes = deprecatedFromOptions.IncludeScopes,
+                    TimestampFormat = deprecatedFromOptions.TimestampFormat,
+                    UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp,
+                };
+            }
+            else if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
                 defaultFormatter.FormatterOptions = new SimpleConsoleFormatterOptions()
                 {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -157,16 +157,7 @@ namespace Microsoft.Extensions.Logging.Console
         private void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
         {
             // kept for deprecated apis:
-            if (ContainerUtils.IsContainer && formatter is JsonConsoleFormatter jsonFormatter)
-            {
-                jsonFormatter.FormatterOptions = new JsonConsoleFormatterOptions()
-                {
-                    IncludeScopes = deprecatedFromOptions.IncludeScopes,
-                    TimestampFormat = deprecatedFromOptions.TimestampFormat,
-                    UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp,
-                };
-            }
-            else if (formatter is SimpleConsoleFormatter defaultFormatter)
+            if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
                 defaultFormatter.FormatterOptions = new SimpleConsoleFormatterOptions()
                 {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
@@ -11,13 +11,12 @@ namespace Microsoft.Extensions.Logging.Console
 {
     internal static class ContainerUtils
     {
-        private static Lazy<bool> _isContainer = new Lazy<bool>(IsProcessRunningInContainer);
         private const string RunningInContainerVariableName = "DOTNET_RUNNING_IN_CONTAINER";
         private const string DeprecatedRunningInContainerVariableName = "DOTNET_RUNNING_IN_CONTAINERS";
 
-        public static bool IsContainer => _isContainer.Value;
+        public static bool IsContainer { get; } = IsProcessRunningInContainer();
 
-        private static bool IsProcessRunningInContainer()
+        public static bool IsProcessRunningInContainer()
         {
             // Official .NET Core images (Windows and Linux) set this. So trust it if it's there.
             // We check both DOTNET_RUNNING_IN_CONTAINER (the current name) and DOTNET_RUNNING_IN_CONTAINERS (a deprecated name used in some images).

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Extensions.Logging.Console
                     return true;
                 }
             }
-            
             return false;
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal static class ContainerUtils
+    {
+        private static Lazy<bool> _isContainer = new Lazy<bool>(IsProcessRunningInContainer);
+        private const string RunningInContainerVariableName = "DOTNET_RUNNING_IN_CONTAINER";
+        private const string DeprecatedRunningInContainerVariableName = "DOTNET_RUNNING_IN_CONTAINERS";
+
+        public static bool IsContainer => _isContainer.Value;
+
+        private static bool IsProcessRunningInContainer()
+        {
+            // Official .NET Core images (Windows and Linux) set this. So trust it if it's there.
+            // We check both DOTNET_RUNNING_IN_CONTAINER (the current name) and DOTNET_RUNNING_IN_CONTAINERS (a deprecated name used in some images).
+            if (GetBooleanEnvVar(RunningInContainerVariableName) || GetBooleanEnvVar(DeprecatedRunningInContainerVariableName))
+            {
+                return true;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // we currently don't have a good way to detect if running in a Windows container
+                return false;
+            }
+
+            // Try to detect docker using the cgroups process 1 is in.
+            const string procFile = "/proc/1/cgroup";
+            if (!File.Exists(procFile))
+            {
+                return false;
+            }
+
+            var lines = File.ReadAllLines(procFile);
+            // typically the last line in the file is "1:name=openrc:/docker"
+            return lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
+        }
+
+        private static bool GetBooleanEnvVar(string envVarName)
+        {
+            var value = Environment.GetEnvironmentVariable(envVarName);
+            return string.Equals(value, "1", StringComparison.Ordinal) ||
+                string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ContainerUtils.cs
@@ -38,9 +38,17 @@ namespace Microsoft.Extensions.Logging.Console
                 return false;
             }
 
-            var lines = File.ReadAllLines(procFile);
             // typically the last line in the file is "1:name=openrc:/docker"
-            return lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
+            string[] lines = File.ReadAllLines(procFile);
+            for (int i = lines.Length - 1; i >= 0; i--)
+            {
+                if (lines[i].EndsWith("name=openrc:/docker", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            
+            return false;
         }
 
         private static bool GetBooleanEnvVar(string envVarName)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
             // Act & Assert
             Assert.Equal("NonExistentFormatter", logger.Options.FormatterName);
-            Assert.Equal(ConsoleFormatterNames.Simple, logger.Formatter.Name);
+            var expectedFormatterName = ContainerUtils.IsContainer ? 
+                ConsoleFormatterNames.Json : ConsoleFormatterNames.Simple;
+            Assert.Equal(expectedFormatterName, logger.Formatter.Name);
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -419,13 +419,24 @@ namespace Microsoft.Extensions.Logging.Test
 #pragma warning disable CS0618
             Assert.True(logger.Options.DisableColors);
 #pragma warning restore CS0618
-            var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
-            
-            Assert.False(formatter.FormatterOptions.SingleLine);                    // ignored
-            Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);  // ignore FormatterOptions, using deprecated one
-            Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
-            Assert.False(formatter.FormatterOptions.IncludeScopes);                 // setup using lambda wins over config
-            Assert.Equal(LoggerColorBehavior.Disabled, formatter.FormatterOptions.ColorBehavior);                  // setup using lambda
+            if (ContainerUtils.IsContainer)
+            {
+                var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
+
+                Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);  // ignore FormatterOptions, using deprecated one
+                Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
+                Assert.False(formatter.FormatterOptions.IncludeScopes);                 // setup using lambda wins over config
+            }
+            else
+            {
+                var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
+
+                Assert.False(formatter.FormatterOptions.SingleLine);                    // ignored
+                Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);  // ignore FormatterOptions, using deprecated one
+                Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
+                Assert.False(formatter.FormatterOptions.IncludeScopes);                 // setup using lambda wins over config
+                Assert.Equal(LoggerColorBehavior.Disabled, formatter.FormatterOptions.ColorBehavior);                  // setup using lambda
+            }
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -462,13 +473,24 @@ namespace Microsoft.Extensions.Logging.Test
 #pragma warning disable CS0618
             Assert.True(logger.Options.DisableColors);
 #pragma warning restore CS0618
-            var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
+            if (!ContainerUtils.IsContainer || formatterName.Equals(ConsoleFormatterNames.Simple, StringComparison.OrdinalIgnoreCase))
+            {
+                var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
 
-            Assert.True(formatter.FormatterOptions.SingleLine);                    // picked from FormatterOptions
-            Assert.Equal("HH:mm ", formatter.FormatterOptions.TimestampFormat);     // ignore deprecated, using FormatterOptions instead
-            Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
-            Assert.True(formatter.FormatterOptions.IncludeScopes);                  // ignore deprecated set in lambda use FormatterOptions instead
-            Assert.Equal(LoggerColorBehavior.Default, formatter.FormatterOptions.ColorBehavior);                 // ignore deprecated set in lambda, defaulted to false
+                Assert.True(formatter.FormatterOptions.SingleLine);                    // picked from FormatterOptions
+                Assert.Equal("HH:mm ", formatter.FormatterOptions.TimestampFormat);     // ignore deprecated, using FormatterOptions instead
+                Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
+                Assert.True(formatter.FormatterOptions.IncludeScopes);                  // ignore deprecated set in lambda use FormatterOptions instead
+                Assert.Equal(LoggerColorBehavior.Default, formatter.FormatterOptions.ColorBehavior);                 // ignore deprecated set in lambda, defaulted to false
+            }
+            else
+            {
+                var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
+
+                Assert.Equal("HH:mm ", formatter.FormatterOptions.TimestampFormat);     // ignore deprecated, using FormatterOptions instead
+                Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
+                Assert.True(formatter.FormatterOptions.IncludeScopes);                  // ignore deprecated set in lambda use FormatterOptions instead
+            }
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Extensions.Logging.Test
             {
                 var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
 
-                Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);  // ignore FormatterOptions, using deprecated one
+                Assert.Equal("HH:mm ", formatter.FormatterOptions.TimestampFormat);  // ignore deprecated one, pick from FormarrerOptions
                 Assert.False(formatter.FormatterOptions.UseUtcTimestamp);               // not set anywhere, defaulted to false
                 Assert.False(formatter.FormatterOptions.IncludeScopes);                 // setup using lambda wins over config
             }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -256,9 +256,18 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 case ConsoleLoggerFormat.Default:
                 {
                     Assert.Null(logger.Options.FormatterName);
-                    Assert.Equal(ConsoleFormatterNames.Simple, logger.Formatter.Name);
-                    var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
-                    Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);
+                    if (ContainerUtils.IsContainer)
+                    {
+                        Assert.Equal(ConsoleFormatterNames.Json, logger.Formatter.Name);
+                        var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
+                        Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);
+                    }
+                    else
+                    {
+                        Assert.Equal(ConsoleFormatterNames.Simple, logger.Formatter.Name);
+                        var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
+                        Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);
+                    }
                 }
                 break;
                 case ConsoleLoggerFormat.Systemd:
@@ -1306,8 +1315,19 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var consoleLoggerProvider = Assert.IsType<ConsoleLoggerProvider>(loggerProvider);
             var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
             Assert.NotNull(logger.ScopeProvider);
-            var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
-            Assert.True(formatter.FormatterOptions.IncludeScopes);
+
+            ConsoleFormatterOptions formatterOptions;
+            if (ContainerUtils.IsContainer)
+            {
+                var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
+                formatterOptions = formatter.FormatterOptions;
+            }
+            else
+            {
+                var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
+                formatterOptions = formatter.FormatterOptions;
+            }
+            Assert.True(formatterOptions.IncludeScopes);
         }
 
         public static TheoryData<ConsoleLoggerFormat, LogLevel> FormatsAndLevels

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [InlineData(null, 1)]
         [InlineData("missingFormatter", 0)]
         [InlineData("missingFormatter", 1)]
-        public void Options_FormatterNameNull_UsesDeprecatedProperties(string formatterName, int formatNumber)
+        public void Options_FormatterNameNull_UsesDeprecatedProperties_UnlessDefaultsToJsonInContainer(string formatterName, int formatNumber)
         {
             // Arrange
             ConsoleLoggerFormat format = (ConsoleLoggerFormat)formatNumber;
@@ -260,7 +260,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     {
                         Assert.Equal(ConsoleFormatterNames.Json, logger.Formatter.Name);
                         var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
-                        Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);
+                        Assert.Null(formatter.FormatterOptions.TimestampFormat);
                     }
                     else
                     {
@@ -1301,7 +1301,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49110 ", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
-        public void ConsoleLoggerOptions_IncludeScopes_IsReadFromLoggingConfiguration()
+        public void ConsoleLoggerOptions_IncludeScopes_IsReadFromLoggingConfiguration_UnlessDefaultsToJsonInContainer()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>("Console:IncludeScopes", "true") }).Build();
 
@@ -1316,18 +1316,16 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
             Assert.NotNull(logger.ScopeProvider);
 
-            ConsoleFormatterOptions formatterOptions;
             if (ContainerUtils.IsContainer)
             {
                 var formatter = Assert.IsType<JsonConsoleFormatter>(logger.Formatter);
-                formatterOptions = formatter.FormatterOptions;
+                Assert.False(formatter.FormatterOptions.IncludeScopes);
             }
             else
             {
                 var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
-                formatterOptions = formatter.FormatterOptions;
+                Assert.True(formatter.FormatterOptions.IncludeScopes);
             }
-            Assert.True(formatterOptions.IncludeScopes);
         }
 
         public static TheoryData<ConsoleLoggerFormat, LogLevel> FormatsAndLevels


### PR DESCRIPTION
ContainerUtils logic taken from https://github.com/dotnet/aspnetcore/blob/c925f99cddac0df90ed0bc4a07ecda6b054a0b02/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs#L15

This is a requested breaking change that we are trying to add earlier in previews of .NET 6.

The request is to make the default console formatter in containers to be Json, e.g.:

```
{"EventId":37,"LogLevel":"Warning","Category":"Microsoft.AspNetCore.Server.HttpSys.MessagePump","Message":"Overriding address(es) \u0027\u0027. Binding to endpoints added to UrlPrefixes instead.","State":{"Message":"Overriding address(es) \u0027\u0027. Binding to endpoints added to UrlPrefixes instead.","{OriginalFormat}":"Overriding address(es) \u0027\u0027. Binding to endpoints added to UrlPrefixes instead."}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7000/","State":{"Message":"Now listening on: http://localhost:7000/","address":"http://localhost:7000/","{OriginalFormat}":"Now listening on: {address}"}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7001/","State":{"Message":"Now listening on: http://localhost:7001/","address":"http://localhost:7001/","{OriginalFormat}":"Now listening on: {address}"}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:7002/","State":{"Message":"Now listening on: http://localhost:7002/","address":"http://localhost:7002/","{OriginalFormat}":"Now listening on: {address}"}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Application started. Press Ctrl\u002BC to shut down.","State":{"Message":"Application started. Press Ctrl\u002BC to shut down.","{OriginalFormat}":"Application started. Press Ctrl\u002BC to shut down."}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Hosting environment: Development","State":{"Message":"Hosting environment: Development","envName":"Development","{OriginalFormat}":"Hosting environment: {envName}"}}
{"EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Content root path: C:\\Users\\shirh\\source\\temp\\web50","State":{"Message":"Content root path: C:\\Users\\shirh\\source\\temp\\web50","contentRoot":"C:\\Users\\shirh\\source\\temp\\web50","{OriginalFormat}":"Content root path: {contentRoot}"}}
```
In order to achieve this, `ContainerUtils` with logic taken from dotnet/aspnetcore was added which uses environment variables to detect if running in a container.

The default console formatter has always been the simple multi-line formatter, e.g.:

```
warn: Microsoft.AspNetCore.Server.HttpSys.MessagePump[37]
      Overriding address(es) ''. Binding to endpoints added to UrlPrefixes instead.
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:7000/
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:7001/
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:7002/
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\Users\shirh\source\temp\web50
```

A related note, in .NET 5 we obsoleted ConsoleLoggerOptions properties (https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/obsolete-consoleloggeroptions-properties), one of which was the enum `ConsoleLoggerFormat` (0 for Default, and 1 for Systemd).

After this change, if running in a container and we don't want Json to be the formatter, then the FormatterName needs to be set, rather than us relying on the deprecated `ConsoleLoggerFormat` value. (The above doc page explains how)

cc: @richlander @MichaelSimons @shirhatti 

Fixes #47322