### PR TITLE
Avoid intermediate allocations in MethodInfo/ConstructorInfo.Invoke

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -458,19 +458,15 @@ namespace System.Reflection.Emit
 
             // if we are here we passed all the previous checks. Time to look at the arguments
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
-            object retValue;
-            if (actualCount > 0)
-            {
-                object[] arguments = CheckArguments(parameters!, binder, invokeAttr, culture, sig);
-                retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, false, wrapExceptions);
-                // copy out. This should be made only if ByRef are present.
-                for (int index = 0; index < arguments.Length; index++)
-                    parameters![index] = arguments[index];
-            }
-            else
-            {
-                retValue = RuntimeMethodHandle.InvokeMethod(null, null, sig, false, wrapExceptions);
-            }
+
+            StackAllocedArguments stackArgs = default;
+            Span<object> arguments = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
+            object retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, false, wrapExceptions);
+
+            // copy out. This should be made only if ByRef are present.
+            // n.b. cannot use Span<T>.CopyTo, as parameters.GetType() might not actually be typeof(object[])
+            for (int index = 0; index < arguments.Length; index++)
+                parameters![index] = arguments[index];
 
             GC.KeepAlive(this);
             return retValue;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -460,8 +460,8 @@ namespace System.Reflection.Emit
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object> arguments = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
-            object retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, false, wrapExceptions);
+            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            object? retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, false, wrapExceptions);
 
             // copy out. This should be made only if ByRef are present.
             // n.b. cannot use Span<T>.CopyTo, as parameters.GetType() might not actually be typeof(object[])

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -103,7 +103,7 @@ namespace System.Reflection
         {
             internal const int MaxStackAllocArgCount = 8;
             internal object _arg0;
-#pragma warning disable CA1823 // accessed via 'CheckArguments' ref arithmetic
+#pragma warning disable CA1823, CS0169, IDE0051 // accessed via 'CheckArguments' ref arithmetic
             private object _arg1;
             private object _arg2;
             private object _arg3;
@@ -111,7 +111,7 @@ namespace System.Reflection
             private object _arg5;
             private object _arg6;
             private object _arg7;
-#pragma warning restore CA1823
+#pragma warning restore CA1823, CS0169, IDE0051
         }
         #endregion
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -65,21 +65,26 @@ namespace System.Reflection
             return parameterTypes;
         }
 
-        private protected Span<object> CheckArguments(ref StackAllocedArguments stackArgs, object[] parameters, Binder? binder,
+        private protected Span<object?> CheckArguments(ref StackAllocedArguments stackArgs, object?[]? parameters, Binder? binder,
             BindingFlags invokeAttr, CultureInfo? culture, Signature sig)
         {
             Debug.Assert(Unsafe.SizeOf<StackAllocedArguments>() == StackAllocedArguments.MaxStackAllocArgCount * Unsafe.SizeOf<object>(),
                 "MaxStackAllocArgCount not properly defined.");
 
+            if (parameters is null)
+            {
+                return default; // allow caller to provide null input
+            }
+
             // copy the arguments into a temporary buffer (or a new array) so we detach from any user changes
-            Span<object> copyOfParameters = (parameters.Length <= StackAllocedArguments.MaxStackAllocArgCount)
+            Span<object?> copyOfParameters = (parameters.Length <= StackAllocedArguments.MaxStackAllocArgCount)
                     ? MemoryMarshal.CreateSpan(ref stackArgs._arg0, parameters.Length)
-                    : new Span<object>(new object[parameters.Length]);
+                    : new Span<object?>(new object?[parameters.Length]);
 
             ParameterInfo[]? p = null;
             for (int i = 0; i < parameters.Length; i++)
             {
-                object arg = parameters[i];
+                object? arg = parameters[i];
                 RuntimeType argRT = sig.Arguments[i];
 
                 if (arg == Type.Missing)
@@ -102,15 +107,15 @@ namespace System.Reflection
         private protected struct StackAllocedArguments
         {
             internal const int MaxStackAllocArgCount = 8;
-            internal object _arg0;
+            internal object? _arg0;
 #pragma warning disable CA1823, CS0169, IDE0051 // accessed via 'CheckArguments' ref arithmetic
-            private object _arg1;
-            private object _arg2;
-            private object _arg3;
-            private object _arg4;
-            private object _arg5;
-            private object _arg6;
-            private object _arg7;
+            private object? _arg1;
+            private object? _arg2;
+            private object? _arg3;
+            private object? _arg4;
+            private object? _arg5;
+            private object? _arg6;
+            private object? _arg7;
 #pragma warning restore CA1823, CS0169, IDE0051
         }
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -112,16 +112,12 @@ namespace System.Reflection
         // struct instance if there's sufficient space; otherwise CheckArguments will allocate a temp array.
         private protected struct StackAllocedArguments
         {
-            internal const int MaxStackAllocArgCount = 8;
+            internal const int MaxStackAllocArgCount = 4;
             internal object? _arg0;
 #pragma warning disable CA1823, CS0169, IDE0051 // accessed via 'CheckArguments' ref arithmetic
             private object? _arg1;
             private object? _arg2;
             private object? _arg3;
-            private object? _arg4;
-            private object? _arg5;
-            private object? _arg6;
-            private object? _arg7;
 #pragma warning restore CA1823, CS0169, IDE0051
         }
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
@@ -26,52 +27,61 @@ namespace System.Reflection
         private IntPtr m_handle;
         private MethodAttributes m_methodAttributes;
         private BindingFlags m_bindingFlags;
-        private volatile Signature? m_signature;
+        private Signature? m_signature;
         private INVOCATION_FLAGS m_invocationFlags;
 
         internal INVOCATION_FLAGS InvocationFlags
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if ((m_invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED) == 0)
+                INVOCATION_FLAGS flags = m_invocationFlags;
+                if ((flags & INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED) == 0)
                 {
-                    INVOCATION_FLAGS invocationFlags = INVOCATION_FLAGS.INVOCATION_FLAGS_IS_CTOR; // this is a given
-
-                    Type? declaringType = DeclaringType;
-
-                    //
-                    // first take care of all the NO_INVOKE cases.
-                    if (declaringType == typeof(void) ||
-                         (declaringType != null && declaringType.ContainsGenericParameters) ||
-                         ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
+                    [MethodImpl(MethodImplOptions.NoInlining)] // move lazy invocation flags population out of the hot path
+                    INVOCATION_FLAGS LazyCreateInvocationFlags()
                     {
-                        // We don't need other flags if this method cannot be invoked
-                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
-                    }
-                    else if (IsStatic)
-                    {
-                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR |
-                                           INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
-                    }
-                    else if (declaringType != null && declaringType.IsAbstract)
-                    {
-                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
-                    }
-                    else
-                    {
-                        // Check for byref-like types
-                        if (declaringType != null && declaringType.IsByRefLike)
-                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS;
+                        INVOCATION_FLAGS invocationFlags = INVOCATION_FLAGS.INVOCATION_FLAGS_IS_CTOR; // this is a given
 
-                        // Check for attempt to create a delegate class.
-                        if (typeof(Delegate).IsAssignableFrom(DeclaringType))
-                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR;
-                    }
+                        Type? declaringType = DeclaringType;
 
-                    m_invocationFlags = invocationFlags | INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED;
+                        //
+                        // first take care of all the NO_INVOKE cases.
+                        if (declaringType == typeof(void) ||
+                             (declaringType != null && declaringType.ContainsGenericParameters) ||
+                             ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
+                        {
+                            // We don't need other flags if this method cannot be invoked
+                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
+                        }
+                        else if (IsStatic)
+                        {
+                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR |
+                                               INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
+                        }
+                        else if (declaringType != null && declaringType.IsAbstract)
+                        {
+                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
+                        }
+                        else
+                        {
+                            // Check for byref-like types
+                            if (declaringType != null && declaringType.IsByRefLike)
+                                invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS;
+
+                            // Check for attempt to create a delegate class.
+                            if (typeof(Delegate).IsAssignableFrom(DeclaringType))
+                                invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR;
+                        }
+
+                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED;
+                        m_invocationFlags = invocationFlags; // accesses are guaranteed atomic
+                        return invocationFlags;
+                    }
+                    flags = LazyCreateInvocationFlags();
                 }
 
-                return m_invocationFlags;
+                return flags;
             }
         }
         #endregion
@@ -95,7 +105,27 @@ namespace System.Reflection
         internal override bool CacheEquals(object? o) =>
             o is RuntimeConstructorInfo m && m.m_handle == m_handle;
 
-        private Signature Signature => m_signature ??= new Signature(this, m_declaringType);
+        private Signature Signature
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Signature? signature = m_signature;
+                if (signature is null)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)] // move lazy sig generation out of the hot path
+                    Signature LazyCreateSignature()
+                    {
+                        Signature newSig = new Signature(this, m_declaringType);
+                        Volatile.Write(ref m_signature, newSig);
+                        return newSig;
+                    }
+                    signature = LazyCreateSignature();
+                }
+
+                return signature;
+            }
+        }
 
         private RuntimeType ReflectedTypeInternal => m_reflectedTypeCache.GetRuntimeType();
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -315,8 +315,8 @@ namespace System.Reflection
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object> arguments = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
-            object retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, sig, false, wrapExceptions);
+            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            object? retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, sig, false, wrapExceptions);
 
             // copy out. This should be made only if ByRef are present.
             // n.b. cannot use Span<T>.CopyTo, as parameters.GetType() might not actually be typeof(object[])
@@ -369,8 +369,8 @@ namespace System.Reflection
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object> arguments = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
-            object retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, true, wrapExceptions);
+            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            object retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, true, wrapExceptions)!; // ctor must return non-null
 
             // copy out. This should be made only if ByRef are present.
             // n.b. cannot use Span<T>.CopyTo, as parameters.GetType() might not actually be typeof(object[])

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -35,52 +35,52 @@ namespace System.Reflection
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
+                [MethodImpl(MethodImplOptions.NoInlining)] // move lazy invocation flags population out of the hot path
+                INVOCATION_FLAGS LazyCreateInvocationFlags()
+                {
+                    INVOCATION_FLAGS invocationFlags = INVOCATION_FLAGS.INVOCATION_FLAGS_IS_CTOR; // this is a given
+
+                    Type? declaringType = DeclaringType;
+
+                    //
+                    // first take care of all the NO_INVOKE cases.
+                    if (declaringType == typeof(void) ||
+                         (declaringType != null && declaringType.ContainsGenericParameters) ||
+                         ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
+                    {
+                        // We don't need other flags if this method cannot be invoked
+                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
+                    }
+                    else if (IsStatic)
+                    {
+                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR |
+                                           INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
+                    }
+                    else if (declaringType != null && declaringType.IsAbstract)
+                    {
+                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
+                    }
+                    else
+                    {
+                        // Check for byref-like types
+                        if (declaringType != null && declaringType.IsByRefLike)
+                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS;
+
+                        // Check for attempt to create a delegate class.
+                        if (typeof(Delegate).IsAssignableFrom(DeclaringType))
+                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR;
+                    }
+
+                    invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED;
+                    m_invocationFlags = invocationFlags; // accesses are guaranteed atomic
+                    return invocationFlags;
+                }
+
                 INVOCATION_FLAGS flags = m_invocationFlags;
                 if ((flags & INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED) == 0)
                 {
-                    [MethodImpl(MethodImplOptions.NoInlining)] // move lazy invocation flags population out of the hot path
-                    INVOCATION_FLAGS LazyCreateInvocationFlags()
-                    {
-                        INVOCATION_FLAGS invocationFlags = INVOCATION_FLAGS.INVOCATION_FLAGS_IS_CTOR; // this is a given
-
-                        Type? declaringType = DeclaringType;
-
-                        //
-                        // first take care of all the NO_INVOKE cases.
-                        if (declaringType == typeof(void) ||
-                             (declaringType != null && declaringType.ContainsGenericParameters) ||
-                             ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
-                        {
-                            // We don't need other flags if this method cannot be invoked
-                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
-                        }
-                        else if (IsStatic)
-                        {
-                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR |
-                                               INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
-                        }
-                        else if (declaringType != null && declaringType.IsAbstract)
-                        {
-                            invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
-                        }
-                        else
-                        {
-                            // Check for byref-like types
-                            if (declaringType != null && declaringType.IsByRefLike)
-                                invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS;
-
-                            // Check for attempt to create a delegate class.
-                            if (typeof(Delegate).IsAssignableFrom(DeclaringType))
-                                invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR;
-                        }
-
-                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_INITIALIZED;
-                        m_invocationFlags = invocationFlags; // accesses are guaranteed atomic
-                        return invocationFlags;
-                    }
                     flags = LazyCreateInvocationFlags();
                 }
-
                 return flags;
             }
         }
@@ -110,20 +110,15 @@ namespace System.Reflection
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Signature? signature = m_signature;
-                if (signature is null)
+                [MethodImpl(MethodImplOptions.NoInlining)] // move lazy sig generation out of the hot path
+                Signature LazyCreateSignature()
                 {
-                    [MethodImpl(MethodImplOptions.NoInlining)] // move lazy sig generation out of the hot path
-                    Signature LazyCreateSignature()
-                    {
-                        Signature newSig = new Signature(this, m_declaringType);
-                        Volatile.Write(ref m_signature, newSig);
-                        return newSig;
-                    }
-                    signature = LazyCreateSignature();
+                    Signature newSig = new Signature(this, m_declaringType);
+                    Volatile.Write(ref m_signature, newSig);
+                    return newSig;
                 }
 
-                return signature;
+                return m_signature ?? LazyCreateSignature();
             }
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -385,10 +385,10 @@ namespace System.Reflection
         public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             StackAllocedArguments stackArgs = default; // try to avoid intermediate array allocation if possible
-            Span<object> arguments = InvokeArgumentsCheck(ref stackArgs, obj, invokeAttr, binder, parameters, culture);
+            Span<object?> arguments = InvokeArgumentsCheck(ref stackArgs, obj, invokeAttr, binder, parameters, culture);
 
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
-            object retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, Signature, false, wrapExceptions);
+            object? retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, Signature, false, wrapExceptions);
 
             // copy out. This should be made only if ByRef are present.
             // n.b. cannot use Span<T>.CopyTo, as parameters.GetType() might not actually be typeof(object[])
@@ -400,7 +400,7 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        private Span<object> InvokeArgumentsCheck(ref StackAllocedArguments stackArgs, object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
+        private Span<object?> InvokeArgumentsCheck(ref StackAllocedArguments stackArgs, object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             Signature sig = Signature;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -361,12 +361,6 @@ namespace System.Reflection
             // only test instance methods
             if ((m_methodAttributes & MethodAttributes.Static) == 0)
             {
-                CheckConsistencyInstance(target);
-            }
-
-            [MethodImpl(MethodImplOptions.NoInlining)] // move check out of hot path when invoking static methods
-            void CheckConsistencyInstance(object? target)
-            {
                 if (!m_declaringType.IsInstanceOfType(target))
                 {
                     if (target == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -964,14 +964,14 @@ namespace System
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern object InvokeMethod(object? target, ref object arguments, Signature sig, bool constructor, bool wrapExceptions);
+        private static extern object? InvokeMethod(object? target, ref object? arguments, Signature sig, bool constructor, bool wrapExceptions);
 
-        internal static unsafe object InvokeMethod(object? target, Span<object> arguments, Signature sig, bool constructor, bool wrapExceptions)
+        internal static unsafe object? InvokeMethod(object? target, Span<object?> arguments, Signature sig, bool constructor, bool wrapExceptions)
         {
             // Native InvokeMethod needs the 'ref object' passed in to point to a pinned memory address (pinned array, stack-allocated
             // struct, etc). We'll cast the object ref as a byte ref so that we can pin it, then we'll pass in the now-pinned object ref.
-            ref object refToFirstArgElement = ref MemoryMarshal.GetReference(arguments);
-            fixed (byte* unused = &Unsafe.As<object, byte>(ref refToFirstArgElement))
+            ref object? refToFirstArgElement = ref MemoryMarshal.GetReference(arguments);
+            fixed (byte* unused = &Unsafe.As<object?, byte>(ref refToFirstArgElement))
             {
                 return InvokeMethod(target, ref refToFirstArgElement, sig, constructor, wrapExceptions);
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -964,18 +964,7 @@ namespace System
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern object? InvokeMethod(object? target, ref object? arguments, Signature sig, bool constructor, bool wrapExceptions);
-
-        internal static unsafe object? InvokeMethod(object? target, Span<object?> arguments, Signature sig, bool constructor, bool wrapExceptions)
-        {
-            // Native InvokeMethod needs the 'ref object' passed in to point to a pinned memory address (pinned array, stack-allocated
-            // struct, etc). We'll cast the object ref as a byte ref so that we can pin it, then we'll pass in the now-pinned object ref.
-            ref object? refToFirstArgElement = ref MemoryMarshal.GetReference(arguments);
-            fixed (byte* unused = &Unsafe.As<object?, byte>(ref refToFirstArgElement))
-            {
-                return InvokeMethod(target, ref refToFirstArgElement, sig, constructor, wrapExceptions);
-            }
-        }
+        internal static extern object? InvokeMethod(object? target, in Span<object?> arguments, Signature sig, bool constructor, bool wrapExceptions);
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void GetMethodInstantiation(RuntimeMethodHandleInternal method, ObjectHandleOnStack types, Interop.BOOL fAsRuntimeTypeArray);

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -739,6 +739,78 @@ public:
 
 #define OFFSETOF__PtrArray__m_Array_              ARRAYBASE_SIZE
 
+/* Corresponds to the managed Span<T> and ReadOnlySpan<T> types.
+   This should only ever be passed from the managed to the unmanaged world byref,
+   as any copies of this struct made within the unmanaged world will not observe
+   potential GC relocations of the source data. As a result we've deleted ctors
+   which allow making byval copies of the span. */
+template < class KIND >
+class Span
+{
+private:
+    /* Keep fields below in sync with managed Span / ReadOnlySpan layout. */
+    KIND* _pointer;
+    unsigned int _length;
+
+public:
+    class ControlledMutabilityRef
+    {
+    private:
+        KIND* _pointer;
+
+    public:
+        __inline ControlledMutabilityRef(KIND* ptr)
+            : _pointer(ptr)
+        {
+        }
+
+        // Turns the pointer into a const ref, allowing safe dereferencing.
+        __inline operator const KIND&() const
+        {
+            return *_pointer;
+        }
+
+        // Forwards operator->() to the underlying element as non-const.
+        __inline KIND operator->() const
+        {
+            return *_pointer;
+        }
+    };
+
+    Span() = delete;
+    Span(const Span&) = delete;
+    Span& operator=(const Span&) = delete;
+
+    // !! CAUTION !!
+    // The reference address may be on the managed heap. If KIND is a reference type,
+    // ensure caller is using a helper like SetObjectReference instead of assigning
+    // values directly to the reference location.
+    KIND& GetAt(SIZE_T index)
+    {
+        LIMITED_METHOD_CONTRACT;
+        SUPPORTS_DAC;
+        _ASSERTE(index < GetLength());
+        return _pointer[index];
+    }
+
+    // Returns a controlled-mutability reference.
+    // The reference can be manipulated but cannot be reassigned.
+    // Gives "const Span<T>" semantics similar to "ReadOnlySpan<T>".
+    const ControlledMutabilityRef GetAt(SIZE_T index) const
+    {
+        LIMITED_METHOD_CONTRACT;
+        SUPPORTS_DAC;
+        _ASSERTE(index < GetLength());
+        return ControlledMutabilityRef{ &_pointer[index] };
+    }
+
+    // Gets the length (in elements) of this span.
+    __inline SIZE_T GetLength() const
+    {
+        return _length;
+    }
+};
+
 /* a TypedByRef is a structure that is used to implement VB's BYREF variants.
    it is basically a tuple of an address of some data along with a TypeHandle
    that indicates the type of the address */

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -478,7 +478,7 @@ void CallDescrWorkerReflectionWrapper(CallDescrData * pCallDescrData, Frame * pF
     PAL_ENDTRY
 } // CallDescrWorkerReflectionWrapper
 
-OBJECTREF InvokeArrayConstructor(TypeHandle th, MethodDesc* pMeth, const Span<OBJECTREF>* objs, int argCnt)
+OBJECTREF InvokeArrayConstructor(TypeHandle th, MethodDesc* pMeth, Span<OBJECTREF>* objs, int argCnt)
 {
     CONTRACTL {
         THROWS;

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -270,7 +270,7 @@ class RuntimeMethodHandle {
 public:
     static FCDECL1(ReflectMethodObject*, GetCurrentMethod, StackCrawlMark* stackMark);
 
-    static FCDECL5(Object*, InvokeMethod, Object *target, Object** pinnedObjs, SignatureNative* pSig, CLR_BOOL fConstructor, CLR_BOOL fWrapExceptions);
+    static FCDECL5(Object*, InvokeMethod, Object *target, Span<OBJECTREF>* objs, SignatureNative* pSig, CLR_BOOL fConstructor, CLR_BOOL fWrapExceptions);
 
     struct StreamingContextData {
         Object * additionalContext;  // additionalContex was changed from OBJECTREF to Object to avoid having a

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -270,7 +270,7 @@ class RuntimeMethodHandle {
 public:
     static FCDECL1(ReflectMethodObject*, GetCurrentMethod, StackCrawlMark* stackMark);
 
-    static FCDECL5(Object*, InvokeMethod, Object *target, PTRArray *objs, SignatureNative* pSig, CLR_BOOL fConstructor, CLR_BOOL fWrapExceptions);
+    static FCDECL5(Object*, InvokeMethod, Object *target, Object** pinnedObjs, SignatureNative* pSig, CLR_BOOL fConstructor, CLR_BOOL fWrapExceptions);
 
     struct StreamingContextData {
         Object * additionalContext;  // additionalContex was changed from OBJECTREF to Object to avoid having a


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/12832.

The managed reflection stack creates a defensive copy of the _parameters_ `object[]` array on calls to `MethodInfo.Invoke` and `ConstructorInfo.Invoke` to prevent the parameter values changing between the initial type safety check and the real invocation of the target method. This PR special-cases "small" arrays (currently defined as \<= 8 arguments) and creates a stack-based defensive copy instead of a heap-based defensive copy. This saves up to 88 bytes of heap allocations (on x64) per `MethodInfo.Invoke` or `ConstructorInfo.Invoke` call.

If 9 or more parameters are present, we fall back to the normal "allocate an array on the heap" code path.

|                Method |        Job | Toolchain | ArgCount |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |----------- |---------- |--------- |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| **MethodInfoInvoke** | **Job-ZXIRIY** |      **main** |        **0** |  **69.00 ns** | **1.142 ns** | **1.068 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| MethodInfoInvoke | Job-TABAFA |     proto |        0 |  64.27 ns | 0.509 ns | 0.451 ns |  0.93 |    0.02 |      - |     - |     - |         - |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
|      ConstructorInfoInvoke | Job-ZXIRIY |      main |        0 |  90.13 ns | 0.719 ns | 0.672 ns |  1.00 |    0.00 | 0.0029 |     - |     - |      24 B |
|      ConstructorInfoInvoke | Job-TABAFA |     proto |        0 |  91.63 ns | 0.337 ns | 0.298 ns |  1.02 |    0.01 | 0.0029 |     - |     - |      24 B |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
| **MethodInfoInvoke** | **Job-ZXIRIY** |      **main** |        **1** | **123.50 ns** | **2.510 ns** | **5.917 ns** |  **1.00** |    **0.00** | **0.0038** |     **-** |     **-** |      **32 B** |
| MethodInfoInvoke | Job-TABAFA |     proto |        1 | 114.30 ns | 1.356 ns | 1.202 ns |  0.93 |    0.04 |      - |     - |     - |         - |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
|      ConstructorInfoInvoke | Job-ZXIRIY |      main |        1 | 142.11 ns | 1.344 ns | 1.191 ns |  1.00 |    0.00 | 0.0067 |     - |     - |      56 B |
|      ConstructorInfoInvoke | Job-TABAFA |     proto |        1 | 131.96 ns | 1.575 ns | 1.474 ns |  0.93 |    0.01 | 0.0029 |     - |     - |      24 B |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
| **MethodInfoInvoke** | **Job-ZXIRIY** |      **main** |        **8** | **358.50 ns** | **2.529 ns** | **2.365 ns** |  **1.00** |    **0.00** | **0.0105** |     **-** |     **-** |      **88 B** |
| MethodInfoInvoke | Job-TABAFA |     proto |        8 | 358.44 ns | 6.179 ns | 5.478 ns |  1.00 |    0.02 |      - |     - |     - |         - |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
|      ConstructorInfoInvoke | Job-ZXIRIY |      main |        8 | 383.78 ns | 4.111 ns | 3.846 ns |  1.00 |    0.00 | 0.0134 |     - |     - |     112 B |
|      ConstructorInfoInvoke | Job-TABAFA |     proto |        8 | 377.16 ns | 1.993 ns | 1.864 ns |  0.98 |    0.01 | 0.0029 |     - |     - |      24 B |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
| **MethodInfoInvoke** | **Job-ZXIRIY** |      **main** |       **10** | **438.32 ns** | **5.554 ns** | **5.196 ns** |  **1.00** |    **0.00** | **0.0124** |     **-** |     **-** |     **104 B** |
| MethodInfoInvoke | Job-TABAFA |     proto |       10 | 434.74 ns | 3.087 ns | 2.888 ns |  0.99 |    0.01 | 0.0124 |     - |     - |     104 B |
|                       |            |           |          |           |          |          |       |         |        |       |       |           |
|      ConstructorInfoInvoke | Job-ZXIRIY |      main |       10 | 454.83 ns | 1.713 ns | 1.431 ns |  1.00 |    0.00 | 0.0153 |     - |     - |     128 B |
|      ConstructorInfoInvoke | Job-TABAFA |     proto |       10 | 465.04 ns | 4.878 ns | 4.563 ns |  1.02 |    0.01 | 0.0153 |     - |     - |     128 B |

I also took this opportunity to refactor some code that was on the `Invoke` hot paths, such as lazy initialization of the `InvocationFlags` and `Signature` properties. These help offset some of the cost of setting up the struct-based argument holder.