### PR TITLE
Singlefile: enabling compression for managed assemblies.

### DIFF
--- a/eng/native/configurepaths.cmake
+++ b/eng/native/configurepaths.cmake
@@ -1,3 +1,4 @@
 get_filename_component(CLR_REPO_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../.. ABSOLUTE)
 set(CLR_ENG_NATIVE_DIR ${CMAKE_CURRENT_LIST_DIR})
 get_filename_component(CLR_SRC_NATIVE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../src/native ABSOLUTE)
+get_filename_component(CLR_SRC_LIBS_NATIVE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../src/libraries/Native ABSOLUTE)

--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -126,7 +126,7 @@ CORECLR_HOSTING_API(coreclr_execute_assembly,
 //
 // Callback types used by the hosts
 //
-typedef bool(CORECLR_CALLING_CONVENTION BundleProbeFn)(const char* path, int64_t* offset, int64_t* size);
+typedef bool(CORECLR_CALLING_CONVENTION BundleProbeFn)(const char* path, int64_t* offset, int64_t* size, int64_t* compressedSize);
 typedef const void* (CORECLR_CALLING_CONVENTION PInvokeOverrideFn)(const char* libraryName, const char* entrypointName);
 
 

--- a/src/coreclr/inc/bundle.h
+++ b/src/coreclr/inc/bundle.h
@@ -19,13 +19,15 @@ struct BundleFileLocation
 {
     INT64 Size;
     INT64 Offset;
+    INT64 UncompresedSize;
 
     BundleFileLocation()
     { 
         LIMITED_METHOD_CONTRACT;
 
-        Size = 0; 
+        Size = 0;
         Offset = 0; 
+        UncompresedSize = 0;
     }
 
     static BundleFileLocation Invalid() { LIMITED_METHOD_CONTRACT; return BundleFileLocation(); }

--- a/src/coreclr/inc/pedecoder.h
+++ b/src/coreclr/inc/pedecoder.h
@@ -236,7 +236,7 @@ class PEDecoder
     BOOL IsILOnly() const;
     CHECK CheckILOnly() const;
 
-    void LayoutILOnly(void *base, BOOL allowFullPE = FALSE) const;
+    void LayoutILOnly(void *base) const;
 
     // Strong name & hashing support
 

--- a/src/coreclr/inc/pedecoder.h
+++ b/src/coreclr/inc/pedecoder.h
@@ -236,7 +236,7 @@ class PEDecoder
     BOOL IsILOnly() const;
     CHECK CheckILOnly() const;
 
-    void LayoutILOnly(void *base) const;
+    void LayoutILOnly(void *base, bool enableExecution) const;
 
     // Strong name & hashing support
 

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -1724,12 +1724,11 @@ CHECK PEDecoder::CheckILOnlyEntryPoint() const
 
 #ifndef DACCESS_COMPILE
 
-void PEDecoder::LayoutILOnly(void *base, BOOL allowFullPE) const
+void PEDecoder::LayoutILOnly(void *base) const
 {
     CONTRACT_VOID
     {
         INSTANCE_CHECK;
-        PRECONDITION(allowFullPE || CheckILOnlyFormat());
         PRECONDITION(CheckZeroedMemory(base, VAL32(FindNTHeaders()->OptionalHeader.SizeOfImage)));
         // Ideally we would require the layout address to honor the section alignment constraints.
         // However, we do have 8K aligned IL only images which we load on 32 bit platforms. In this

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -107,7 +107,6 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     onstackreplacement.cpp
     pefile.cpp
     peimage.cpp
-    peimagelayout.cpp
     perfmap.cpp
     perfinfo.cpp
     pgo.cpp
@@ -891,6 +890,11 @@ endif(CLR_CMAKE_TARGET_WIN32)
 set (VM_SOURCES_WKS_SPECIAL
     codeman.cpp
     ceemain.cpp
+    peimagelayout.cpp
+)
+
+list(APPEND VM_SOURCES_DAC
+    peimagelayout.cpp
 )
 
 # gcdecode.cpp is included by both JIT and VM. to avoid duplicate definitions we need to

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -5,6 +5,11 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${ARCH_SOURCES_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../interop/inc)
 
+# needed when zLib compression is used
+if(NOT CLR_CMAKE_TARGET_WIN32)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/Native/Unix/Common)
+endif()
+
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -6,8 +6,9 @@ include_directories(${ARCH_SOURCES_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../interop/inc)
 
 # needed when zLib compression is used
+include_directories(${CLR_SRC_LIBS_NATIVE_DIR}/AnyOS/zlib)
 if(NOT CLR_CMAKE_TARGET_WIN32)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/Native/Unix/Common)
+    include_directories(${CLR_SRC_LIBS_NATIVE_DIR}/Unix/Common)
 endif()
 
 add_definitions(-DUNICODE)

--- a/src/coreclr/vm/bundle.cpp
+++ b/src/coreclr/vm/bundle.cpp
@@ -80,7 +80,21 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
         }
     }
 
-    m_probe(utf8Path, &loc.Offset, &loc.Size);
+    INT64 fileSize;
+    INT64 compressedSize;
+
+    m_probe(utf8Path, &loc.Offset, &fileSize, &compressedSize);
+
+    if (compressedSize)
+    {
+        loc.Size = compressedSize;
+        loc.UncompresedSize = fileSize;
+    }
+    else
+    {
+        loc.Size = fileSize;
+        loc.UncompresedSize = 0;
+    }
 
     return loc;
 }

--- a/src/coreclr/vm/bundle.cpp
+++ b/src/coreclr/vm/bundle.cpp
@@ -80,8 +80,8 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
         }
     }
 
-    INT64 fileSize;
-    INT64 compressedSize;
+    INT64 fileSize = 0;
+    INT64 compressedSize = 0;
 
     m_probe(utf8Path, &loc.Offset, &fileSize, &compressedSize);
 

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -887,7 +887,9 @@ void PEImage::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
 
 PEImage::PEImage():
+    m_path(),
     m_refCount(1),
+    m_bundleFileLocation(),
     m_bIsTrustedNativeImage(FALSE),
     m_bInHashMap(FALSE),
 #ifdef METADATATRACKER_DATA

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -148,6 +148,7 @@ public:
     HANDLE GetFileHandle();
     INT64 GetOffset() const;
     INT64 GetSize() const;
+    INT64 GetUncompressedSize() const;
 
     void SetFileHandle(HANDLE hFile);
     HRESULT TryOpenFile();

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -59,6 +59,12 @@ inline INT64 PEImage::GetSize() const
     return m_bundleFileLocation.Size;
 }
 
+inline INT64 PEImage::GetUncompressedSize() const
+{
+    LIMITED_METHOD_CONTRACT;
+    return m_bundleFileLocation.UncompresedSize;
+}
+
 inline void PEImage::SetModuleFileNameHintForDAC()
 {
     LIMITED_METHOD_DAC_CONTRACT;

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -101,7 +101,7 @@ PEImageLayout* PEImageLayout::Map(PEImage* pOwner)
     }
     CONTRACT_END;
 
-    PEImageLayoutHolder pAlloc = pOwner->GetUncompressedSize() ?
+    PEImageLayoutHolder pAlloc = pOwner->GetUncompressedSize() != 0 ?
         LoadConverted(pOwner, /* isInBundle */ true):
         new MappedImageLayout(pOwner);
 
@@ -754,7 +754,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
 #if defined(CORECLR_EMBEDDED)
             // The mapping we have just created refers to the region in the bundle that contains compressed data.
             // We will create another anonymous memory-only mapping and uncompress file there.
-            // The flat image will refer to the anonimous mapping instead and we will release the original mapping.
+            // The flat image will refer to the anonymous mapping instead and we will release the original mapping.
             HandleHolder anonMap = WszCreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, uncompressedSize >> 32, (DWORD)uncompressedSize, NULL);
             if (anonMap == NULL)
                 ThrowLastError();

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -424,23 +424,17 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source, BOOL isInBundl
         (source->HasNativeHeader() || source->HasReadyToRunHeader()) &&
         g_fAllowNativeImages;
     
-    DWORD mapAccess;
-    DWORD viewAccess;
+    DWORD mapAccess = PAGE_READWRITE;
+    DWORD viewAccess = FILE_MAP_ALL_ACCESS;
+
+#if !defined(CROSSGEN_COMPILE) && !defined(TARGET_UNIX)
     if (enableExecution)
     {
+        // to make sections executable on Windows the view must have EXECUTE permissions
         mapAccess = PAGE_EXECUTE_READWRITE;
-
-#if defined(CROSSGEN_COMPILE) || defined(TARGET_UNIX)
-        viewAccess = FILE_MAP_ALL_ACCESS;
-#else
         viewAccess = FILE_MAP_EXECUTE | FILE_MAP_WRITE;
+    }
 #endif
-    }
-    else
-    {
-        mapAccess = PAGE_READWRITE;
-        viewAccess = FILE_MAP_ALL_ACCESS;
-    }
 
     m_FileMap.Assign(WszCreateFileMapping(INVALID_HANDLE_VALUE, NULL,
         mapAccess, 0,

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -16,7 +16,7 @@
 #if defined(CORECLR_EMBEDDED)
 extern "C"
 {
-#include "../../../libraries/Native/AnyOS/zlib/pal_zlib.h"
+#include "pal_zlib.h"
 }
 #endif
 

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -113,7 +113,6 @@ public:
     virtual ~ConvertedImageLayout();
 #endif
 private:
-    bool m_isInBundle;
     PT_RUNTIME_FUNCTION m_pExceptionDir;
 };
 

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -74,6 +74,7 @@ namespace Microsoft.NET.HostModel.Bundle
             {
                 case FileType.Symbols:
                 case FileType.NativeBinary:
+                case FileType.Assembly:
                     return true;
 
                 default:

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -19,8 +19,9 @@ set(SKIP_VERSIONING 1)
 include_directories(..)
 include_directories(../../json)
 
+include_directories(${CLR_SRC_LIBS_NATIVE_DIR}/AnyOS/zlib)
 if(NOT CLR_CMAKE_TARGET_WIN32)
-    include_directories(../../../../libraries/Native/Unix/Common)
+    include_directories(${CLR_SRC_LIBS_NATIVE_DIR}/Unix/Common)
 endif()
 
 set(SOURCES

--- a/src/native/corehost/bundle/extractor.cpp
+++ b/src/native/corehost/bundle/extractor.cpp
@@ -10,7 +10,7 @@
 #if defined(NATIVE_LIBS_EMBEDDED)
 extern "C"
 {
-#include "../../../libraries/Native/AnyOS/zlib/pal_zlib.h"
+#include "pal_zlib.h"
 }
 #endif
 

--- a/src/native/corehost/bundle/file_entry.h
+++ b/src/native/corehost/bundle/file_entry.h
@@ -37,6 +37,7 @@ namespace bundle
         file_entry_t()
             : m_offset(0)
             , m_size(0)
+            , m_compressedSize(0)
             , m_type(file_type_t::__last)
             , m_relative_path()
             , m_disabled(false)

--- a/src/native/corehost/bundle/runner.cpp
+++ b/src/native/corehost/bundle/runner.cpp
@@ -61,7 +61,7 @@ const file_entry_t*  runner_t::probe(const pal::string_t &relative_path) const
     return nullptr;
 }
 
-bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size) const
+bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size, int64_t* compressedSize) const
 {
     const bundle::file_entry_t* entry = probe(relative_path);
 
@@ -76,6 +76,7 @@ bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_
 
     *offset = entry->offset();
     *size = entry->size();
+    *compressedSize = entry->compressedSize();
 
     return true;
 }

--- a/src/native/corehost/bundle/runner.h
+++ b/src/native/corehost/bundle/runner.h
@@ -27,7 +27,7 @@ namespace bundle
         const pal::string_t& extraction_path() const { return m_extraction_path; }
         bool has_base(const pal::string_t& base) const { return base.compare(base_path()) == 0; }
 
-        bool probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size) const;
+        bool probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size, int64_t* compressedSize) const;
         const file_entry_t* probe(const pal::string_t& relative_path) const;
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -23,7 +23,7 @@ namespace
     // This function is an API exported to the runtime via the BUNDLE_PROBE property.
     // This function used by the runtime to probe for bundled assemblies
     // This function assumes that the currently executing app is a single-file bundle.
-    bool STDMETHODCALLTYPE bundle_probe(const char* path, int64_t* offset, int64_t* size)
+    bool STDMETHODCALLTYPE bundle_probe(const char* path, int64_t* offset, int64_t* size, int64_t* compressedSize)
     {
         if (path == nullptr)
         {
@@ -40,7 +40,7 @@ namespace
             return false;
         }
 
-        return bundle::runner_t::app()->probe(file_path, offset, size);
+        return bundle::runner_t::app()->probe(file_path, offset, size, compressedSize);
     }
 
 #if defined(NATIVE_LIBS_EMBEDDED)


### PR DESCRIPTION
The second part of singlefile compression change which enables compression/decompression of managed assemblies. 


=== Implementation details:

When creating a PE layout for a compressed file, we start with the same steps as before - with memory mapping the region of the singlefile app that contains the file we need. No changes here.

For obvious reasons we cannot use the direct mapping as-is since that contains compressed data. So we create another intermediate anonymous (memory-only) mapping of appropriate size and decompress the file into the mapping. 
After that we can release the original mapping/view that were created for the compressed data.

The PE layout with the anonymous mapping will manage the life time of the decompressed data (same as before) and can be used when flat image is sufficient, or can be further transformed into "mapped" executable form if the file contains native executable sections (such as R2R). 

Such conversion was already performed on Windows, while Unix could always get away with virtually mapping to the original data with appropriate alignment and access. Now the conversion will be used on Unix as well (when the original data is compressed).
