### PR TITLE
Disable failing test for GCStress.

### DIFF
--- a/src/tests/baseservices/threading/threadpool/unregister/regression_749068.csproj
+++ b/src/tests/baseservices/threading/threadpool/unregister/regression_749068.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/13453 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="regression_749068.cs" />


### PR DESCRIPTION
Tracked with https://github.com/dotnet/runtime/issues/13453.

/cc @BruceForstall 