### PR TITLE
Fix handling of not found exported types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -595,7 +595,10 @@ namespace Internal.TypeSystem.Ecma
                 var module = (ModuleDesc)implementation;
                 string nameSpace = _metadataReader.GetString(exportedType.Namespace);
                 string name = _metadataReader.GetString(exportedType.Name);
-                return module.GetType(nameSpace, name, NotFoundBehavior.ReturnResolutionFailure);
+                MetadataType resolvedType = module.GetType(nameSpace, name, NotFoundBehavior.ReturnResolutionFailure);
+                if (resolvedType == null)
+                    return ModuleDesc.GetTypeResolutionFailure;
+                return resolvedType;
             }
             else
             if (implementation is MetadataType)


### PR DESCRIPTION
This was missed in #50437.

Wonder if we should have just introduced a new overload of GetType that returns `object`. This "return resolution failure that we then need to not forget to check" looks like a potential bug farm.

```csharp
public MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
{
    /* the obvious implementation that calls the virtual method */
}

public abstract object GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior)
```