### PR TITLE
Disposing scopes more than once should work

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -176,6 +176,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // try to return to the pool while somebody is trying to access ResolvedServices.
             lock (_scopeLock)
             {
+                // Don't attempt to dispose if we're already disposed
+                if (_state == null)
+                {
+                    return;
+                }
+
                 // ResolvedServices is never cleared for singletons because there might be a compilation running in background
                 // trying to get a cached singleton service. If it doesn't find it
                 // it will try to create a new one which will result in an ObjectDisposedException.

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
@@ -21,6 +21,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.Throws<ObjectDisposedException>(() => serviceProviderEngineScope.ResolvedServices);
         }
 
+        [Fact]
+        public void DoubleDisposeWorks()
+        {
+            var engine = new FakeEngine();
+            var serviceProviderEngineScope = new ServiceProviderEngineScope(engine);
+            serviceProviderEngineScope.ResolvedServices.Add(new ServiceCacheKey(typeof(IFakeService), 0), null);
+            serviceProviderEngineScope.Dispose();
+            serviceProviderEngineScope.Dispose();
+        }
+
         private class FakeEngine : ServiceProviderEngine
         {
             public FakeEngine() :


### PR DESCRIPTION
- Recently introduced a regression where disposing DI scopes multiple times throws.

See https://github.com/dotnet/aspnetcore/pull/31576 where this was found.