### PR TITLE
Mark PNSE-throwing methods in System.Net.NetworkInformation.IPGlobalProperties as unsupported on Android

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -134,6 +134,7 @@ namespace System.Net.NetworkInformation
         public abstract System.Net.NetworkInformation.TcpConnectionInformation[] GetActiveTcpConnections();
         [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.IPEndPoint[] GetActiveTcpListeners();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.IPEndPoint[] GetActiveUdpListeners();
         public abstract System.Net.NetworkInformation.IcmpV4Statistics GetIcmpV4Statistics();
         public abstract System.Net.NetworkInformation.IcmpV6Statistics GetIcmpV6Statistics();

--- a/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -130,7 +130,9 @@ namespace System.Net.NetworkInformation
         public abstract System.Net.NetworkInformation.NetBiosNodeType NodeType { get; }
         public virtual System.IAsyncResult BeginGetUnicastAddresses(System.AsyncCallback? callback, object? state) { throw null; }
         public virtual System.Net.NetworkInformation.UnicastIPAddressInformationCollection EndGetUnicastAddresses(System.IAsyncResult asyncResult) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.TcpConnectionInformation[] GetActiveTcpConnections();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.IPEndPoint[] GetActiveTcpListeners();
         public abstract System.Net.IPEndPoint[] GetActiveUdpListeners();
         public abstract System.Net.NetworkInformation.IcmpV4Statistics GetIcmpV4Statistics();

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
@@ -20,6 +20,7 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the Active Udp Listeners on this machine.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPEndPoint[] GetActiveUdpListeners();
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 namespace System.Net.NetworkInformation
@@ -24,11 +25,13 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the Active Tcp Listeners on this machine.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPEndPoint[] GetActiveTcpListeners();
 
         /// <summary>
         /// Gets the Active Udp Listeners on this machine.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract TcpConnectionInformation[] GetActiveTcpConnections();
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -1,15 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class LinuxIPGlobalProperties : UnixIPGlobalProperties
     {
+        [UnsupportedOSPlatform("android")]
         public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             return StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);
         }
 
+        [UnsupportedOSPlatform("android")]
         public override IPEndPoint[] GetActiveTcpListeners()
         {
             return StringParsingHelpers.ParseActiveTcpListenersFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -1,19 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.Versioning;
-
 namespace System.Net.NetworkInformation
 {
     internal sealed class LinuxIPGlobalProperties : UnixIPGlobalProperties
     {
-        [UnsupportedOSPlatform("android")]
         public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             return StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);
         }
 
-        [UnsupportedOSPlatform("android")]
         public override IPEndPoint[] GetActiveTcpListeners()
         {
             return StringParsingHelpers.ParseActiveTcpListenersFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/47911.

This is to annotate the following methods in `System.Net.NetworkInformation.IPGlobalProperties` as unsupported on Android since they throw PNSE:
- GetActiveTcpConnections();
- GetActiveTcpListeners();
- GetActiveUdpListeners();