### PR TITLE
Make TranscodingStream resilient against partial reads

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
@@ -312,18 +312,28 @@ namespace System.Text
 
                 try
                 {
-                    // Beware: Use our constant value instead of 'rentedBytes.Length' for the count
-                    // parameter below. The reason for this is that the array pool could've returned
-                    // a larger-than-expected array, but our worst-case expansion calculations
-                    // performed earlier didn't take that into account.
+                    int pendingReadDataPopulatedJustNow;
+                    bool isEofReached;
 
-                    int innerBytesReadJustNow = _innerStream.Read(rentedBytes, 0, DefaultReadByteBufferSize);
-                    bool isEofReached = (innerBytesReadJustNow == 0);
+                    do
+                    {
+                        // Beware: Use our constant value instead of 'rentedBytes.Length' for the count
+                        // parameter below. The reason for this is that the array pool could've returned
+                        // a larger-than-expected array, but our worst-case expansion calculations
+                        // performed earlier didn't take that into account.
 
-                    // convert bytes [inner] -> chars, then convert chars -> bytes [this]
+                        int innerBytesReadJustNow = _innerStream.Read(rentedBytes, 0, DefaultReadByteBufferSize);
+                        isEofReached = (innerBytesReadJustNow == 0);
 
-                    int charsDecodedJustNow = _innerDecoder.GetChars(rentedBytes, 0, innerBytesReadJustNow, rentedChars, 0, flush: isEofReached);
-                    int pendingReadDataPopulatedJustNow = _thisEncoder.GetBytes(rentedChars, 0, charsDecodedJustNow, _readBuffer, 0, flush: isEofReached);
+                        // Convert bytes [inner] -> chars, then convert chars -> bytes [this].
+                        // We can't return 0 to our caller until inner stream EOF has been reached. But if the
+                        // inner stream returns a non-empty but incomplete buffer, GetBytes may return 0 anyway
+                        // since it can't yet make forward progress on the input data. If this happens, we'll
+                        // loop so that we don't return 0 to our caller until we truly see inner stream EOF.
+
+                        int charsDecodedJustNow = _innerDecoder.GetChars(rentedBytes, 0, innerBytesReadJustNow, rentedChars, 0, flush: isEofReached);
+                        pendingReadDataPopulatedJustNow = _thisEncoder.GetBytes(rentedChars, 0, charsDecodedJustNow, _readBuffer, 0, flush: isEofReached);
+                    } while (!isEofReached && pendingReadDataPopulatedJustNow == 0);
 
                     _readBufferOffset = 0;
                     _readBufferCount = pendingReadDataPopulatedJustNow;
@@ -381,18 +391,28 @@ namespace System.Text
 
                     try
                     {
-                        // Beware: Use our constant value instead of 'rentedBytes.Length' when creating
-                        // the Mem<byte> struct. The reason for this is that the array pool could've returned
-                        // a larger-than-expected array, but our worst-case expansion calculations
-                        // performed earlier didn't take that into account.
+                        int pendingReadDataPopulatedJustNow;
+                        bool isEofReached;
 
-                        int innerBytesReadJustNow = await _innerStream.ReadAsync(rentedBytes.AsMemory(0, DefaultReadByteBufferSize), cancellationToken).ConfigureAwait(false);
-                        bool isEofReached = (innerBytesReadJustNow == 0);
+                        do
+                        {
+                            // Beware: Use our constant value instead of 'rentedBytes.Length' when creating
+                            // the Mem<byte> struct. The reason for this is that the array pool could've returned
+                            // a larger-than-expected array, but our worst-case expansion calculations
+                            // performed earlier didn't take that into account.
 
-                        // convert bytes [inner] -> chars, then convert chars -> bytes [this]
+                            int innerBytesReadJustNow = await _innerStream.ReadAsync(rentedBytes.AsMemory(0, DefaultReadByteBufferSize), cancellationToken).ConfigureAwait(false);
+                            isEofReached = (innerBytesReadJustNow == 0);
 
-                        int charsDecodedJustNow = _innerDecoder.GetChars(rentedBytes, 0, innerBytesReadJustNow, rentedChars, 0, flush: isEofReached);
-                        int pendingReadDataPopulatedJustNow = _thisEncoder.GetBytes(rentedChars, 0, charsDecodedJustNow, _readBuffer, 0, flush: isEofReached);
+                            // Convert bytes [inner] -> chars, then convert chars -> bytes [this].
+                            // We can't return 0 to our caller until inner stream EOF has been reached. But if the
+                            // inner stream returns a non-empty but incomplete buffer, GetBytes may return 0 anyway
+                            // since it can't yet make forward progress on the input data. If this happens, we'll
+                            // loop so that we don't return 0 to our caller until we truly see inner stream EOF.
+
+                            int charsDecodedJustNow = _innerDecoder.GetChars(rentedBytes, 0, innerBytesReadJustNow, rentedChars, 0, flush: isEofReached);
+                            pendingReadDataPopulatedJustNow = _thisEncoder.GetBytes(rentedChars, 0, charsDecodedJustNow, _readBuffer, 0, flush: isEofReached);
+                        } while (!isEofReached && pendingReadDataPopulatedJustNow == 0);
 
                         _readBufferOffset = 0;
                         _readBufferCount = pendingReadDataPopulatedJustNow;

--- a/src/libraries/System.Text.Encoding/tests/Encoding/TranscodingStreamTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/TranscodingStreamTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipelines;
 using System.IO.Tests;
 using System.Threading;
 using System.Threading.Tasks;
@@ -466,6 +468,56 @@ namespace System.Text.Tests
                 sink.Write(buffer.AsSpan(0..numBytesRead));
                 return numBytesRead;
             });
+        }
+
+        [Fact]
+        public async Task ReadAsync_LoopsWhenPartialDataReceived()
+        {
+            // Validates that the TranscodingStream will loop instead of returning 0
+            // if the inner stream read partial data and GetBytes cannot make forward progress.
+
+            using AsyncComms comms = new AsyncComms();
+            Stream transcodingStream = Encoding.CreateTranscodingStream(comms.ReadStream, Encoding.UTF8, Encoding.UTF8);
+
+            // First, ensure that writing [ C0 ] (always invalid UTF-8) to the stream
+            // causes the reader to return immediately with fallback behavior.
+
+            byte[] readBuffer = new byte[1024];
+            comms.WriteBytes(new byte[] { 0xC0 });
+
+            int numBytesRead = await transcodingStream.ReadAsync(readBuffer.AsMemory());
+            Assert.Equal(new byte[] { 0xEF, 0xBF, 0xBD }, readBuffer[0..numBytesRead]); // fallback substitution
+
+            // Next, ensure that writing [ C2 ] (partial UTF-8, needs more data) to the stream
+            // causes the reader to asynchronously loop, returning "not yet complete".
+
+            readBuffer = new byte[1024];
+            comms.WriteBytes(new byte[] { 0xC2 });
+
+            ValueTask<int> task = transcodingStream.ReadAsync(readBuffer.AsMemory());
+            Assert.False(task.IsCompleted);
+            comms.WriteBytes(new byte[] { 0x80 }); // [ C2 80 ] is valid UTF-8
+
+            numBytesRead = await task; // should complete successfully
+            Assert.Equal(new byte[] { 0xC2, 0x80 }, readBuffer[0..numBytesRead]);
+
+            // Finally, ensure that writing [ C2 ] (partial UTF-8, needs more data) to the stream
+            // followed by EOF causes the reader to perform substitution before returning EOF.
+
+            readBuffer = new byte[1024];
+            comms.WriteBytes(new byte[] { 0xC2 });
+
+            task = transcodingStream.ReadAsync(readBuffer.AsMemory());
+            Assert.False(task.IsCompleted);
+            comms.WriteEof();
+
+            numBytesRead = await task; // should complete successfully
+            Assert.Equal(new byte[] { 0xEF, 0xBF, 0xBD }, readBuffer[0..numBytesRead]); // fallback substitution
+
+            // Next call really should return "EOF reached"
+
+            readBuffer = new byte[1024];
+            Assert.Equal(0, await transcodingStream.ReadAsync(readBuffer.AsMemory()));
         }
 
         [Fact]
@@ -973,6 +1025,50 @@ namespace System.Text.Tests
             public override int GetMaxCharCount(int byteCount) => byteCount;
 
             public override byte[] GetPreamble() => Array.Empty<byte>();
+        }
+
+        // A helper type that allows synchronously writing to a stream while asynchronously
+        // reading from it.
+        private sealed class AsyncComms : IDisposable
+        {
+            private readonly BlockingCollection<byte[]> _blockingCollection;
+            private readonly PipeWriter _writer;
+
+            public AsyncComms()
+            {
+                _blockingCollection = new BlockingCollection<byte[]>();
+                var pipe = new Pipe();
+                ReadStream = pipe.Reader.AsStream();
+                _writer = pipe.Writer;
+                Task.Run(_DrainWorker);
+            }
+
+            public Stream ReadStream { get; }
+
+            public void Dispose()
+            {
+                _blockingCollection.Dispose();
+            }
+
+            public void WriteBytes(ReadOnlySpan<byte> bytes)
+            {
+                _blockingCollection.Add(bytes.ToArray());
+            }
+
+            public void WriteEof()
+            {
+                _blockingCollection.Add(null);
+            }
+
+            private async Task _DrainWorker()
+            {
+                byte[] buffer;
+                while ((buffer = _blockingCollection.Take()) is not null)
+                {
+                    await _writer.WriteAsync(buffer);
+                }
+                _writer.Complete();
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -93,5 +93,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.IO.Pipelines\src\System.IO.Pipelines.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/49127.

If the call to `Encoder.GetBytes` return __0__, this doesn't necessarily mean that EOF has been reached. It could be that we did read data from the inner stream, but it wasn't enough data for us to make forward progress. If we let this __0__ return value propagate up to our caller, we'll incorrectly signal to them that we saw EOF.

The fix is to add a defensive loop, only breaking out of the loop when: (a) we really do see EOF from the inner stream; _or_ (b) the call to `GetBytes` was able to make non-zero forward progress.

/cc @tarekgh as FYI, and thanks @eiriktsarpalis for your minimal repro in the linked issue!

Note to reviewers: recommend reviewing with [_ignore whitespace changes_](https://github.com/dotnet/runtime/pull/50886/files?diff=split&w=1).