### PR TITLE
Add MonoAOTCompiler MSBuild Task Workload

### DIFF
--- a/src/mono/nuget/Directory.Build.props
+++ b/src/mono/nuget/Directory.Build.props
@@ -4,6 +4,9 @@
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
 
   <PropertyGroup>
+    <WorkloadTasksAssemblyPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WorkloadBuildTasks', 'Debug', '$(NetCoreAppToolCurrent)'))WorkloadBuildTasks.dll</WorkloadTasksAssemblyPath>
+  </PropertyGroup>
+  <PropertyGroup>
     <PackageIndexFile>$(MSBuildThisFileDirectory)packageIndex.json</PackageIndexFile>
     <PackagePlatform>AnyCPU</PackagePlatform>
 

--- a/src/mono/nuget/Directory.Build.targets
+++ b/src/mono/nuget/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
+  <UsingTask TaskName="GenerateFileFromTemplate" AssemblyFile="$(WorkloadTasksAssemblyPath)" />
   <Import Project="..\Directory.Build.targets" />
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />
 </Project>

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/Microsoft.NET.Runtime.MonoAOTCompiler.Workload.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/Microsoft.NET.Runtime.MonoAOTCompiler.Workload.pkgproj
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <PropertyGroup>
+    <PackageDescription>The workload that contains the MonoAOTCompiler MSBuild task</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageFile Include="WorkloadManifest.json" TargetPath="\" />
+    <PackageFile Include="WorkloadManifest.targets" TargetPath="\" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/Microsoft.NET.Runtime.MonoAOTCompiler.Workload.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/Microsoft.NET.Runtime.MonoAOTCompiler.Workload.pkgproj
@@ -5,10 +5,26 @@
     <PackageDescription>The workload that contains the MonoAOTCompiler MSBuild task</PackageDescription>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageFile Include="WorkloadManifest.json" TargetPath="\" />
-    <PackageFile Include="WorkloadManifest.targets" TargetPath="\" />
-  </ItemGroup>
+  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+    <PropertyGroup>
+      <WorkloadManifestPath>$(IntermediateOutputPath)WorkloadManifest.json</WorkloadManifestPath>
+      <PackagePathVersion>PackageVersion=$(PackageVersion);</PackagePathVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_WorkloadManifestValues Include="PackageVersion" Value="$(PackageVersion)" />
+    </ItemGroup>
+
+    <GenerateFileFromTemplate
+      TemplateFile="WorkloadManifest.json.in"
+      Properties="@(_WorkloadManifestValues)"
+      OutputPath="$(WorkloadManifestPath)" />
+
+    <ItemGroup>
+      <PackageFile Include="$(WorkloadManifestPath)" Pack="true" PackagePath="\" />
+      <PackageFile Include="WorkloadManifest.targets" TargetPath="\" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.json
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "workloads": {
+      "microsoft-net-runtime-monoaotcompiler-workload": {
+        "description": "The MonoAOTCompiler MSBuild task workload",
+        "packs": [
+          "Microsoft.NET.Runtime.MonoAOTCompiler.Task"
+        ]
+      }
+    },
+    "packs": {
+      "Microsoft.NET.Runtime.MonoAOTCompiler.Task": {
+        "kind": "Sdk",
+        "version": "6.0.0-preview.4.21205.3"
+      }
+    }
+  }
+  

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.json.in
@@ -11,7 +11,7 @@
     "packs": {
       "Microsoft.NET.Runtime.MonoAOTCompiler.Task": {
         "kind": "Sdk",
-        "version": "6.0.0-preview.4.21205.3"
+        "version": "${PackageVersion}"
       }
     }
   }

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Workload/WorkloadManifest.targets
@@ -1,0 +1,3 @@
+<Project>
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
+</Project>

--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsMobile)' == 'true'">
+    <ProjectReference Include="Microsoft.NET.Runtime.MonoAOTCompiler.Workload\Microsoft.NET.Runtime.MonoAOTCompiler.Workload.pkgproj" />
     <ProjectReference Include="Microsoft.NET.Runtime.MonoAOTCompiler.Task\Microsoft.NET.Runtime.MonoAOTCompiler.Task.pkgproj" />
   </ItemGroup>
 </Project>

--- a/src/tasks/WorkloadBuildTasks/GenerateFileFromTemplate.cs
+++ b/src/tasks/WorkloadBuildTasks/GenerateFileFromTemplate.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+/// <summary>
+/// <para>
+/// Generates a new file at <see cref="OutputPath"/>.
+/// </para>
+/// <para>
+/// The <see cref="TemplateFile"/> can define variables for substitution using <see cref="Properties"/>.
+/// </para>
+/// <example>
+/// The input file might look like this:
+/// <code>
+/// 2 + 2 = ${Sum}
+/// </code>
+/// When the task is invoked like this, it will produce "2 + 2 = 4"
+/// <code>
+/// &lt;GenerateFileFromTemplate Properties="Sum=4;OtherValue=123;" ... &gt;
+/// </code>
+/// </example>
+/// </summary>
+public class GenerateFileFromTemplate : Task
+{
+    /// <summary>
+    /// The template file.
+    /// Variable syntax: ${VarName}
+    /// If your template file needs to output this format, you can escape the dollar sign with a backtick, e.g. `${NotReplaced}
+    /// </summary>
+    [NotNull]
+    [Required]
+    public string? TemplateFile { get; set; }
+
+    /// <summary>
+    /// The destination for the generated file.
+    /// </summary>
+    [NotNull]
+    [Required]
+    public string? OutputPath { get; set; }
+
+    /// <summary>
+    /// Key=value pairs of values
+    /// </summary>
+    [NotNull]
+    [Required]
+    public ITaskItem[]? Properties { get; set; }
+
+    public override bool Execute()
+    {
+        string outputPath = Path.GetFullPath(OutputPath);
+        if (!File.Exists(TemplateFile))
+        {
+            Log.LogError($"File {TemplateFile} does not exist");
+            return false;
+        }
+
+        var template = File.ReadAllText(TemplateFile);
+        var values = new Dictionary<string, string>();
+        foreach (ITaskItem item in Properties)
+            values.Add(item.ItemSpec, item.GetMetadata("Value"));
+
+        var result = Replace(template, values);
+        string? dir = Path.GetDirectoryName(outputPath);
+        if (dir != null)
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(outputPath, result);
+
+        return true;
+    }
+
+    public string Replace(string template, IDictionary<string, string> values)
+    {
+        var sb = new StringBuilder();
+        var varNameSb = new StringBuilder();
+        var line = 1;
+        for (var i = 0; i < template.Length; i++)
+        {
+            var ch = template[i];
+            var nextCh = i + 1 >= template.Length
+                    ? '\0'
+                    : template[i + 1];
+
+            // count lines in the template file
+            if (ch == '\n')
+            {
+                line++;
+            }
+
+            if (ch == '`' && (nextCh == '$' || nextCh == '`'))
+            {
+                // skip the backtick for known escape characters
+                i++;
+                sb.Append(nextCh);
+                continue;
+            }
+
+            if (ch != '$' || nextCh != '{')
+            {
+                // variables begin with ${. Moving on.
+                sb.Append(ch);
+                continue;
+            }
+
+            varNameSb.Clear();
+            i += 2;
+            for (; i < template.Length; i++)
+            {
+                ch = template[i];
+                if (ch != '}')
+                {
+                    varNameSb.Append(ch);
+                }
+                else
+                {
+                    // Found the end of the variable substitution
+                    var varName = varNameSb.ToString();
+                    if (values.TryGetValue(varName, out var value))
+                    {
+                        sb.Append(value);
+                    }
+                    else
+                    {
+                        Log.LogWarning(null, null, null, TemplateFile,
+                            line, 0, 0, 0,
+                            message: $"No property value is available for '{varName}'");
+                    }
+
+                    varNameSb.Clear();
+                    break;
+                }
+            }
+
+            if (varNameSb.Length > 0)
+            {
+                Log.LogWarning(null, null, null, TemplateFile,
+                            line, 0, 0, 0,
+                            message: "Expected closing bracket for variable placeholder. No substitution will be made.");
+                sb.Append("${").Append(varNameSb);
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
+++ b/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn),CA1050</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCoreVersion)" />
+  </ItemGroup>
+
+  <Target Name="PublishBuilder"
+          AfterTargets="Build"
+          DependsOnTargets="Publish" />
+
+</Project>


### PR DESCRIPTION
We were originally publishing the MonoAOTCompiler nuget and having Blazor, iOS, and Android include it as part of their workload.  Unfortunately, the workload spec does not allow multiple pack references to the same nuget from different manifests.  To get around this 1-1 relationship, we can supply a workload that can be consumed by other workloads via the extends key.

Resolves https://github.com/dotnet/sdk/issues/16700