### PR TITLE
Reenable resolve Apple Silicon tests

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -748,28 +748,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/48786</Issue>
         </ExcludeList>
-        <!-- Intermittent failures disable to improve pass rate -->
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/regressions/Dev11/154243/dynamicmethodliveness/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/Github/runtime_32848/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Generics/Coverage/**">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)Loader/classloader/TypeGeneratorTests/**">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)tracing/eventcounter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/50238</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)readytorun/crossgen2/**">
-            <Issue>https://github.com/dotnet/runtime/issues/49365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)readytorun/determinism/crossgen2determinism/**">
-            <Issue>https://github.com/dotnet/runtime/issues/52529</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
- Remove duplicate disables from Apple Silicon disables
- Remove resolved failures.  Local testing on My `M1` with `macOS 11.3 beta 6` shows these are resolved on the latest tip.

Fixes #46365
Fixes #50238