### PR TITLE
Fix resolution code for scenarios where values are copied from stack

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -9194,13 +9194,16 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                         stackToRegIntervals[otherTargetReg] = otherInterval;
                         targetRegsToDo &= ~otherTargetRegMask;
 
-                        // Now, move the interval that is going to targetReg, and add its "fromReg" to
-                        // "targetRegsReady", only if it was one of the target register we originally determined.
+                        // Now, move the interval that is going to targetReg.
                         addResolution(block, insertionPoint, sourceIntervals[sourceReg], targetReg, fromReg);
                         JITDUMP(" (%s)\n", resolveTypeName[resolveType]);
                         location[sourceReg] = REG_NA;
 
-                        if (source[fromReg] != REG_NA)
+                        // Add its "fromReg" to "targetRegsReady", only if:
+                        // - It was one of the target register we originally determined.
+                        // - It is not the eventual target (otherTargetReg) because its
+                        //   value will be retrieved from STK.
+                        if (source[fromReg] != REG_NA && fromReg != otherTargetReg)
                         {
                             regMaskTP fromRegMask = genRegMask(fromReg);
                             targetRegsReady |= fromRegMask;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -9026,7 +9026,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
             assert(targetReg < REG_COUNT);
             regNumber sourceReg = (regNumber)source[targetReg];
             assert(sourceReg < REG_COUNT);
-            regNumber fromReg   = (regNumber)location[sourceReg];
+            regNumber fromReg = (regNumber)location[sourceReg];
             // stack to reg movs should be done last as part of "targetRegsFromStack"
             assert(fromReg < REG_STK);
             Interval* interval = sourceIntervals[sourceReg];
@@ -9061,9 +9061,9 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                 {
                     // We may have freed up the other half of a double where the lower half
                     // was already free.
-                    regNumber lowerHalfReg    = REG_PREV(fromReg);
-                    regNumber lowerHalfSrcReg = (regNumber)source[lowerHalfReg];
-                    regNumber lowerHalfSrcLoc = (regNumber)location[lowerHalfReg];
+                    regNumber lowerHalfReg     = REG_PREV(fromReg);
+                    regNumber lowerHalfSrcReg  = (regNumber)source[lowerHalfReg];
+                    regNumber lowerHalfSrcLoc  = (regNumber)location[lowerHalfReg];
                     regMaskTP lowerHalfRegMask = genRegMask(lowerHalfReg);
                     // Necessary conditions:
                     // - There is a source register for this reg (lowerHalfSrcReg != REG_NA)
@@ -9071,7 +9071,8 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                     // - The source interval isn't yet completed (sourceIntervals[lowerHalfSrcReg] != nullptr)
                     // - It's not in the ready set               ((targetRegsReady & lowerHalfRegMask) ==
                     //                                            RBM_NONE)
-                    // - It's not resolved from stack             ((targetRegsFromStack & lowerHalfRegMask) != lowerHalfRegMask)
+                    // - It's not resolved from stack            ((targetRegsFromStack & lowerHalfRegMask) !=
+                    //                                            lowerHalfRegMask)
                     if ((lowerHalfSrcReg != REG_NA) && (lowerHalfSrcLoc == REG_NA) &&
                         (sourceIntervals[lowerHalfSrcReg] != nullptr) &&
                         ((targetRegsReady & lowerHalfRegMask) == RBM_NONE) &&

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -702,9 +702,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
             <Issue>https://github.com/dotnet/runtime/issues/10001</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/fp/exgen/10w5d_cs_ro/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48892</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- MacOS specific CoreCLR -->


### PR DESCRIPTION
During resolution, when we decide to resolve a `targetReg` "RA" which is the source of
another register "RB" that is also participating in resolution, we would spill "RA" and
add resolution move from "RX" -> "RA". However, we were not recording the fact that resolution of "RB"
now has to happen from `REG_STK` because the value was spilled from "RA" -> `REG_STK`.

Also, when we perform resolution, we add back the source register into `targetRegsReady`
(data structure to tell which `targetReg`s are ready for resolution). This is not needed if
that source register was never one of the `targetReg`s we decided to resolve or it was already marked as being resolved from the stack.

I have updated few asserts to make sure that we stay in bound of various array data structures.

No asmdiff.

Fixes: https://github.com/dotnet/runtime/issues/48892