### PR TITLE
Consider failing tests a failure

### DIFF
--- a/eng/testing/RunnerTemplate.cmd
+++ b/eng/testing/RunnerTemplate.cmd
@@ -59,10 +59,11 @@ echo ----- end %DATE% %TIME% ----- exit code %ERRORLEVEL% ----------------------
 :: The helix work item should not exit with non-zero if tests ran and produced results
 :: The special console runner for runtime returns 1 when tests fail
 if %ERRORLEVEL%==1 (
-  exit /b 0
-) else (
-  exit /b %ERRORLEVEL%
+  if not "%HELIX_WORKITEM_PAYLOAD%"=="" (
+    exit /b 0
+  )
 )
+exit /b %ERRORLEVEL%
 :: ========================= END Test Execution =================================
 
 :usage

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -225,8 +225,11 @@ popd >/dev/null
 # The helix work item should not exit with non-zero if tests ran and produced results
 # The special console runner for runtime returns 1 when tests fail
 if [ "$test_exitcode" == "1" ]; then
-  exit 0
-else
-  exit $test_exitcode
+  if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
+    exit 0
+  fi
+fi
+
+exit $test_exitcode
 fi
 


### PR DESCRIPTION
When running `build libs.tests -test` locally, I see the build succeeding even though there's failing tests. This seems to be caused by Helix specific logic in the runner template. It should not apply when we're not running in Helix.