### PR TITLE
[Release/5.0] Fix Alpine 3.13 ARM build

### DIFF
--- a/src/coreclr/src/pal/inc/pal.h
+++ b/src/coreclr/src/pal/inc/pal.h
@@ -306,11 +306,7 @@ PAL_IsDebuggerPresent();
 
 #ifndef PAL_STDCPP_COMPAT
 
-#if HOST_64BIT || _MSC_VER >= 1400
 typedef __int64 time_t;
-#else
-typedef long time_t;
-#endif
 #define _TIME_T_DEFINED
 #endif // !PAL_STDCPP_COMPAT
 

--- a/src/coreclr/src/pal/src/cruntime/misc.cpp
+++ b/src/coreclr/src/pal/src/cruntime/misc.cpp
@@ -172,7 +172,12 @@ PAL_time(PAL_time_t *tloc)
     PERF_ENTRY(time);
     ENTRY( "time( tloc=%p )\n",tloc );
 
-    result = time(tloc);
+    time_t t;
+    result = time(&t);
+    if (tloc != NULL)
+    {
+        *tloc = t;
+    }
 
     LOGEXIT( "time returning %#lx\n",result );
     PERF_EXIT(time);

--- a/src/libraries/Native/Unix/System.Native/pal_random.c
+++ b/src/libraries/Native/Unix/System.Native/pal_random.c
@@ -35,7 +35,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
     if (!sInitializedMRand)
     {
-        srand48(time(NULL));
+        srand48((long int)time(NULL));
         sInitializedMRand = true;
     }
 


### PR DESCRIPTION
Port #50105 to Release/5.0

Alpine 3.13 is the first version of Alpine Linux that uses 64 bit time_t
on both 64 and 32 bit platforms. That breaks the build as we assumed
that 32 bit platforms use always 32 bit time_t.

This change fixes it by making the PAL time_t type always 64 bit.
Everything still works fine on non-Alpine ARM / x86 Linuxes, since
it only changes the time_t type size outside of PAL.

## Customer Impact
Without this change, we cannot build MUSL ARM runtime on Alpine >= 3.13 and binaries built on Alpine < 3.13 don't work on 3.13+. We want to provide MUSL ARM Alpine 3.13 docker images for 5.0.

## Testing
CoreCLR and libraries tests

## Risk
Low, PAL defined time_t is used only to set timestamps in pewriter and ilasm and to name core dump in the createdump tool.

## Regression
No