### PR TITLE
[AndroidCrypto] Handle setting non-default SslProtocols

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.ProtocolSupport.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.ProtocolSupport.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+
+internal static partial class Interop
+{
+    internal static partial class AndroidCrypto
+    {
+        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLGetSupportedProtocols")]
+        internal static extern SslProtocols SSLGetSupportedProtocols();
+    }
+}

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Win32.SafeHandles;
@@ -74,6 +75,15 @@ internal static partial class Interop
             string targetHost)
         {
             int ret = SSLStreamConfigureParametersImpl(sslHandle, targetHost);
+            if (ret != SUCCESS)
+                throw new SslException();
+        }
+
+        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamSetEnabledProtocols")]
+        private static extern int SSLStreamSetEnabledProtocols(SafeSslHandle sslHandle, ref SslProtocols protocols, int length);
+        internal static void SSLStreamSetEnabledProtocols(SafeSslHandle sslHandle, ReadOnlySpan<SslProtocols> protocols)
+        {
+            int ret = SSLStreamSetEnabledProtocols(sslHandle, ref MemoryMarshal.GetReference(protocols), protocols.Length);
             if (ret != SUCCESS)
                 throw new SslException();
         }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -52,7 +52,7 @@ namespace System
 
         public static bool IsSuperUser => IsBrowser || IsWindows ? false : libc.geteuid() == 0;
 
-        public static Version OpenSslVersion => !IsOSXLike && !IsWindows ?
+        public static Version OpenSslVersion => !IsOSXLike && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :
             throw new PlatformNotSupportedException();
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -374,7 +374,11 @@ namespace System
             }
             else if (IsAndroid)
             {
+#if NETFRAMEWORK
+                return false;
+#else
                 return AndroidGetSslProtocolSupport(SslProtocols.Tls13);
+#endif
             }
             else if (IsOpenSslSupported)
             {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -281,12 +281,6 @@ namespace System
                 // Alternatively the returned values must have been some other types.
                 return !IsWindows10Version2004OrGreater;
             }
-            else if (IsAndroid)
-            {
-#pragma warning disable 0618 // 'SslProtocols.Ssl3' is obsolete
-                return AndroidGetSslProtocolSupport(SslProtocols.Ssl3);
-#pragma warning restore 0618
-            }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));
         }

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -28,7 +28,7 @@
     <Compile Include="System\PlatformDetection.cs" />
     <Compile Include="System\PlatformDetection.Unix.cs" />
     <Compile Include="System\PlatformDetection.Windows.cs" />
-    <!-- 
+    <!--
       Interop.Library is not designed to support runtime checks therefore we are picking the Windows
       variant from the Common folder and adding the missing members manually.
     -->
@@ -65,6 +65,11 @@
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslGetProtocolSupport.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEUid.cs"
              Link="Common\Interop\Unix\Interop.GetEUid.cs" />
+  </ItemGroup>
+  <!-- Android imports -->
+  <ItemGroup>
+    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.ProtocolSupport.cs"
+             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.ProtocolSupport.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />

--- a/src/libraries/Native/Unix/Common/pal_ssl_types.h
+++ b/src/libraries/Native/Unix/Common/pal_ssl_types.h
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include <stdint.h>
+
+// Matches managed System.Security.Authentication.SslProtocols
+enum
+{
+    PAL_SslProtocol_None = 0,
+    PAL_SslProtocol_Ssl2 = 12,
+    PAL_SslProtocol_Ssl3 = 48,
+    PAL_SslProtocol_Tls10 = 192,
+    PAL_SslProtocol_Tls11 = 768,
+    PAL_SslProtocol_Tls12 = 3072,
+    PAL_SslProtocol_Tls13 = 12288,
+};
+typedef int32_t PAL_SslProtocol;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -405,6 +405,8 @@ jmethodID g_SSLEngineWrap;
 jmethodID g_SSLEngineUnwrap;
 jmethodID g_SSLEngineCloseOutbound;
 jmethodID g_SSLEngineGetHandshakeStatus;
+jmethodID g_SSLEngineGetSupportedProtocols;
+jmethodID g_SSLEngineSetEnabledProtocols;
 jmethodID g_SSLEngineSetSSLParameters;
 
 // java/nio/ByteBuffer
@@ -976,6 +978,8 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SSLEngineUnwrap =                 GetMethod(env, false, g_SSLEngine, "unwrap", "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
     g_SSLEngineGetHandshakeStatus =     GetMethod(env, false, g_SSLEngine, "getHandshakeStatus", "()Ljavax/net/ssl/SSLEngineResult$HandshakeStatus;");
     g_SSLEngineCloseOutbound =          GetMethod(env, false, g_SSLEngine, "closeOutbound", "()V");
+    g_SSLEngineGetSupportedProtocols =  GetMethod(env, false, g_SSLEngine, "getSupportedProtocols", "()[Ljava/lang/String;");
+    g_SSLEngineSetEnabledProtocols =    GetMethod(env, false, g_SSLEngine, "setEnabledProtocols", "([Ljava/lang/String;)V");
     g_SSLEngineSetSSLParameters =       GetMethod(env, false, g_SSLEngine, "setSSLParameters", "(Ljavax/net/ssl/SSLParameters;)V");
 
     g_ByteBuffer =                          GetClassGRef(env, "java/nio/ByteBuffer");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -419,6 +419,8 @@ extern jmethodID g_SSLEngineWrap;
 extern jmethodID g_SSLEngineUnwrap;
 extern jmethodID g_SSLEngineCloseOutbound;
 extern jmethodID g_SSLEngineGetHandshakeStatus;
+extern jmethodID g_SSLEngineGetSupportedProtocols;
+extern jmethodID g_SSLEngineSetEnabledProtocols;
 extern jmethodID g_SSLEngineSetSSLParameters;
 
 // java/nio/ByteBuffer

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
@@ -3,34 +3,55 @@
 
 #include "pal_ssl.h"
 
-int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol)
+PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void)
 {
     JNIEnv* env = GetJNIEnv();
-    jobject sslCtxObj = (*env)->CallStaticObjectMethod(env, g_sslCtxClass, g_sslCtxGetDefaultMethod);
-    jobject sslParametersObj = (*env)->CallObjectMethod(env, sslCtxObj, g_sslCtxGetDefaultSslParamsMethod);
-    jobjectArray protocols = (jobjectArray)(*env)->CallObjectMethod(env, sslParametersObj, g_SSLParametersGetProtocols);
+    PAL_SslProtocol supported = 0;
+    INIT_LOCALS(loc, context, params, protocols);
 
-    int protocolsCount = (*env)->GetArrayLength(env, protocols);
-    int supported = 0;
-    for (int i = 0; i < protocolsCount; i++)
+    // SSLContext context = SSLContext.getDefault();
+    // SSLParameters params = context.getDefaultSSLParameters();
+    // String[] protocols = params.getProtocols();
+    loc[context] = (*env)->CallStaticObjectMethod(env, g_sslCtxClass, g_sslCtxGetDefaultMethod);
+    loc[params] = (*env)->CallObjectMethod(env, loc[context], g_sslCtxGetDefaultSslParamsMethod);
+    loc[protocols] = (*env)->CallObjectMethod(env, loc[params], g_SSLParametersGetProtocols);
+
+    const char tlsv1[] = "TLSv1";
+    size_t tlsv1Len = (sizeof(tlsv1) - 1) / sizeof(char);
+
+    int count = (*env)->GetArrayLength(env, loc[protocols]);
+    for (int i = 0; i < count; i++)
     {
-        jstring protocolStr = (jstring) ((*env)->GetObjectArrayElement(env, protocols, i));
-        const char* protocolStrPtr = (*env)->GetStringUTFChars(env, protocolStr, NULL);
-        if ((!strcmp(protocolStrPtr, "TLSv1")   && protocol == PAL_SSL_TLS)   ||
-            (!strcmp(protocolStrPtr, "TLSv1.1") && protocol == PAL_SSL_TLS11) ||
-            (!strcmp(protocolStrPtr, "TLSv1.2") && protocol == PAL_SSL_TLS12) ||
-            (!strcmp(protocolStrPtr, "TLSv1.3") && protocol == PAL_SSL_TLS13))
+        jstring protocol = (*env)->GetObjectArrayElement(env, loc[protocols], i);
+        const char* protocolStr = (*env)->GetStringUTFChars(env, protocol, NULL);
+        if (strncmp(protocolStr, tlsv1, tlsv1Len) == 0)
         {
-            supported = 1;
-            (*env)->ReleaseStringUTFChars(env, protocolStr, protocolStrPtr);
-            (*env)->DeleteLocalRef(env, protocolStr);
-            break;
+            if (strlen(protocolStr) == tlsv1Len)
+            {
+                supported |= PAL_SslProtocol_Tls10;
+            }
+            else if (strcmp(protocolStr + tlsv1Len, ".1") == 0)
+            {
+                supported |= PAL_SslProtocol_Tls11;
+            }
+            else if (strcmp(protocolStr + tlsv1Len, ".2") == 0)
+            {
+                supported |= PAL_SslProtocol_Tls12;
+            }
+            else if (strcmp(protocolStr + tlsv1Len, ".3") == 0)
+            {
+                supported |= PAL_SslProtocol_Tls13;
+            }
         }
-        (*env)->ReleaseStringUTFChars(env, protocolStr, protocolStrPtr);
-        (*env)->DeleteLocalRef(env, protocolStr);
+        else if (strcmp(protocolStr, "SSLv3") == 0)
+        {
+            supported |= PAL_SslProtocol_Ssl3;
+        }
+
+        (*env)->ReleaseStringUTFChars(env, protocol, protocolStr);
+        (*env)->DeleteLocalRef(env, protocol);
     }
-    (*env)->DeleteLocalRef(env, sslCtxObj);
-    (*env)->DeleteLocalRef(env, sslParametersObj);
-    (*env)->DeleteLocalRef(env, protocols);
+
+    RELEASE_LOCALS(loc, env);
     return supported;
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
@@ -17,10 +17,10 @@ PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void)
     loc[protocols] = (*env)->CallObjectMethod(env, loc[params], g_SSLParametersGetProtocols);
 
     const char tlsv1[] = "TLSv1";
-    size_t tlsv1Len = (sizeof(tlsv1) - 1) / sizeof(char);
+    size_t tlsv1Len = (sizeof(tlsv1) / sizeof(*tlsv1)) - 1;
 
-    int count = (*env)->GetArrayLength(env, loc[protocols]);
-    for (int i = 0; i < count; i++)
+    jsize count = (*env)->GetArrayLength(env, loc[protocols]);
+    for (int32_t i = 0; i < count; i++)
     {
         jstring protocol = (*env)->GetObjectArrayElement(env, loc[protocols], i);
         const char* protocolStr = (*env)->GetStringUTFChars(env, protocol, NULL);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
@@ -43,10 +43,6 @@ PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void)
                 supported |= PAL_SslProtocol_Tls13;
             }
         }
-        else if (strcmp(protocolStr, "SSLv3") == 0)
-        {
-            supported |= PAL_SslProtocol_Ssl3;
-        }
 
         (*env)->ReleaseStringUTFChars(env, protocol, protocolStr);
         (*env)->DeleteLocalRef(env, protocol);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.h
@@ -4,16 +4,9 @@
 #pragma once
 
 #include "pal_jni.h"
+#include <pal_ssl_types.h>
 
-typedef enum
-{
-    PAL_SSL_NONE  = 0,
-    PAL_SSL_SSL2  = 12,
-    PAL_SSL_SSL3  = 48,
-    PAL_SSL_TLS   = 192,
-    PAL_SSL_TLS11 = 768,
-    PAL_SSL_TLS12 = 3072,
-    PAL_SSL_TLS13 = 12288,
-} SslProtocols;
-
-PALEXPORT int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol);
+/*
+Get the supported protocols
+*/
+PALEXPORT PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -765,8 +765,6 @@ static jstring GetSslProtocolAsString(JNIEnv* env, PAL_SslProtocol protocol)
 {
     switch (protocol)
     {
-        case PAL_SslProtocol_Ssl3:
-            return JSTRING("SSLv3");
         case PAL_SslProtocol_Tls10:
             return JSTRING("TLSv1");
         case PAL_SslProtocol_Tls11:

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -83,7 +83,8 @@ static jobject ExpandBuffer(JNIEnv* env, jobject oldBuffer, int32_t newCapacity)
     // ByteBuffer newBuffer = ByteBuffer.allocate(newCapacity);
     // newBuffer.put(oldBuffer);
     IGNORE_RETURN((*env)->CallObjectMethod(env, oldBuffer, g_ByteBufferFlip));
-    jobject newBuffer = ToGRef(env, (*env)->CallStaticObjectMethod(env, g_ByteBuffer, g_ByteBufferAllocate, newCapacity));
+    jobject newBuffer =
+        ToGRef(env, (*env)->CallStaticObjectMethod(env, g_ByteBuffer, g_ByteBufferAllocate, newCapacity));
     IGNORE_RETURN((*env)->CallObjectMethod(env, newBuffer, g_ByteBufferPutBuffer, oldBuffer));
     ReleaseGRef(env, oldBuffer);
     return newBuffer;
@@ -137,8 +138,8 @@ static PAL_SSLStreamStatus DoWrap(JNIEnv* env, SSLStream* sslStream, int* handsh
         {
             // Expand buffer
             // int newCapacity = sslSession.getPacketBufferSize() + netOutBuffer.remaining();
-            int32_t newCapacity = (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetPacketBufferSize)
-                + (*env)->CallIntMethod(env, sslStream->netOutBuffer, g_ByteBufferRemaining);
+            int32_t newCapacity = (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetPacketBufferSize) +
+                                  (*env)->CallIntMethod(env, sslStream->netOutBuffer, g_ByteBufferRemaining);
             sslStream->netOutBuffer = ExpandBuffer(env, sslStream->netOutBuffer, newCapacity);
             return SSLStreamStatus_OK;
         }
@@ -216,8 +217,9 @@ static PAL_SSLStreamStatus DoUnwrap(JNIEnv* env, SSLStream* sslStream, int* hand
         {
             // Expand buffer
             // int newCapacity = sslSession.getApplicationBufferSize() + appInBuffer.remaining();
-            int32_t newCapacity = (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetApplicationBufferSize)
-                + (*env)->CallIntMethod(env, sslStream->appInBuffer, g_ByteBufferRemaining);
+            int32_t newCapacity =
+                (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetApplicationBufferSize) +
+                (*env)->CallIntMethod(env, sslStream->appInBuffer, g_ByteBufferRemaining);
             sslStream->appInBuffer = ExpandBuffer(env, sslStream->appInBuffer, newCapacity);
             return SSLStreamStatus_OK;
         }
@@ -291,14 +293,13 @@ SSLStream* AndroidCryptoNative_SSLStreamCreate(void)
     return sslStream;
 }
 
-static int32_t AddCertChainToStore(
-    JNIEnv* env,
-    jobject store,
-    uint8_t* pkcs8PrivateKey,
-    int32_t pkcs8PrivateKeyLen,
-    PAL_KeyAlgorithm algorithm,
-    jobject* /*X509Certificate[]*/ certs,
-    int32_t certsLen)
+static int32_t AddCertChainToStore(JNIEnv* env,
+                                   jobject store,
+                                   uint8_t* pkcs8PrivateKey,
+                                   int32_t pkcs8PrivateKeyLen,
+                                   PAL_KeyAlgorithm algorithm,
+                                   jobject* /*X509Certificate[]*/ certs,
+                                   int32_t certsLen)
 {
     int32_t ret = FAIL;
     INIT_LOCALS(loc, keyBytes, keySpec, algorithmName, keyFactory, privateKey, certArray, alias);
@@ -327,7 +328,8 @@ static int32_t AddCertChainToStore(
 
     // KeyFactory keyFactory = KeyFactory.getInstance(algorithmName);
     // PrivateKey privateKey = keyFactory.generatePrivate(spec);
-    loc[keyFactory] = (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[algorithmName]);
+    loc[keyFactory] =
+        (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[algorithmName]);
     loc[privateKey] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGenPrivateMethod, loc[keySpec]);
 
     // X509Certificate[] certArray = new X509Certificate[certsLen];
@@ -350,7 +352,11 @@ cleanup:
     return ret;
 }
 
-SSLStream* AndroidCryptoNative_SSLStreamCreateWithCertificates(uint8_t* pkcs8PrivateKey, int32_t pkcs8PrivateKeyLen, PAL_KeyAlgorithm algorithm, jobject* /*X509Certificate[]*/ certs, int32_t certsLen)
+SSLStream* AndroidCryptoNative_SSLStreamCreateWithCertificates(uint8_t* pkcs8PrivateKey,
+                                                               int32_t pkcs8PrivateKeyLen,
+                                                               PAL_KeyAlgorithm algorithm,
+                                                               jobject* /*X509Certificate[]*/ certs,
+                                                               int32_t certsLen)
 {
     SSLStream* sslStream = NULL;
     JNIEnv* env = GetJNIEnv();
@@ -379,7 +385,8 @@ SSLStream* AndroidCryptoNative_SSLStreamCreateWithCertificates(uint8_t* pkcs8Pri
     (*env)->CallVoidMethod(env, loc[keyStore], g_KeyStoreLoad, NULL, NULL);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
-    int32_t status = AddCertChainToStore(env, loc[keyStore], pkcs8PrivateKey, pkcs8PrivateKeyLen, algorithm, certs, certsLen);
+    int32_t status =
+        AddCertChainToStore(env, loc[keyStore], pkcs8PrivateKey, pkcs8PrivateKeyLen, algorithm, certs, certsLen);
     if (status != SUCCESS)
         goto cleanup;
 
@@ -410,11 +417,8 @@ cleanup:
     return sslStream;
 }
 
-int32_t AndroidCryptoNative_SSLStreamInitialize(SSLStream* sslStream,
-                                                   bool isServer,
-                                                   STREAM_READER streamReader,
-                                                   STREAM_WRITER streamWriter,
-                                                   int32_t appBufferSize)
+int32_t AndroidCryptoNative_SSLStreamInitialize(
+    SSLStream* sslStream, bool isServer, STREAM_READER streamReader, STREAM_WRITER streamWriter, int32_t appBufferSize)
 {
     assert(sslStream != NULL);
     assert(sslStream->sslContext != NULL);
@@ -437,7 +441,8 @@ int32_t AndroidCryptoNative_SSLStreamInitialize(SSLStream* sslStream,
 
     // int applicationBufferSize = sslSession.getApplicationBufferSize();
     // int packetBufferSize = sslSession.getPacketBufferSize();
-    int32_t applicationBufferSize = (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetApplicationBufferSize);
+    int32_t applicationBufferSize =
+        (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetApplicationBufferSize);
     int32_t packetBufferSize = (*env)->CallIntMethod(env, sslStream->sslSession, g_SSLSessionGetPacketBufferSize);
 
     // ByteBuffer appInBuffer =  ByteBuffer.allocate(Math.max(applicationBufferSize, appBufferSize));
@@ -512,7 +517,8 @@ PAL_SSLStreamStatus AndroidCryptoNative_SSLStreamHandshake(SSLStream* sslStream)
     return DoHandshake(env, sslStream);
 }
 
-PAL_SSLStreamStatus AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream, uint8_t* buffer, int32_t length, int32_t* read)
+PAL_SSLStreamStatus
+AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream, uint8_t* buffer, int32_t length, int32_t* read)
 {
     assert(sslStream != NULL);
     assert(read != NULL);
@@ -775,7 +781,8 @@ static jstring GetSslProtocolAsString(JNIEnv* env, PAL_SslProtocol protocol)
     }
 }
 
-int32_t AndroidCryptoNative_SSLStreamSetEnabledProtocols(SSLStream* sslStream, PAL_SslProtocol* protocols, int32_t count)
+int32_t
+AndroidCryptoNative_SSLStreamSetEnabledProtocols(SSLStream* sslStream, PAL_SslProtocol* protocols, int32_t count)
 {
     assert(sslStream != NULL);
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -6,6 +6,8 @@
 #include "pal_jni.h"
 #include "pal_x509.h"
 
+#include <pal_ssl_types.h>
+
 typedef void (*STREAM_WRITER)(uint8_t*, int32_t);
 typedef int (*STREAM_READER)(uint8_t*, int32_t*);
 
@@ -140,6 +142,15 @@ Returns 1 on success, 0 otherwise
 PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetPeerCertificates(SSLStream* sslStream,
                                                                    jobject** /*X509Certificate[]*/ out,
                                                                    int* outLen);
+
+/*
+Set enabled protocols
+  - protocols : array of protocols to enable
+  - count     : number of elements in protocols
+
+Returns 1 on success, 0 otherwise
+*/
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamSetEnabledProtocols(SSLStream* sslStream, PAL_SslProtocol* protocols, int32_t count);
 
 /*
 Verify hostname using the peer certificate for the current session

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -9,7 +9,7 @@
 #include <pal_ssl_types.h>
 
 typedef void (*STREAM_WRITER)(uint8_t*, int32_t);
-typedef int (*STREAM_READER)(uint8_t*, int32_t*);
+typedef int32_t (*STREAM_READER)(uint8_t*, int32_t*);
 
 typedef struct SSLStream
 {
@@ -47,7 +47,11 @@ Create an SSL context with the specified certificates
 
 Returns NULL on failure
 */
-PALEXPORT SSLStream* AndroidCryptoNative_SSLStreamCreateWithCertificates(uint8_t* pkcs8PrivateKey, int32_t pkcs8PrivateKeyLen, PAL_KeyAlgorithm algorithm, jobject* /*X509Certificate[]*/ certs, int32_t certsLen);
+PALEXPORT SSLStream* AndroidCryptoNative_SSLStreamCreateWithCertificates(uint8_t* pkcs8PrivateKey,
+                                                                         int32_t pkcs8PrivateKeyLen,
+                                                                         PAL_KeyAlgorithm algorithm,
+                                                                         jobject* /*X509Certificate[]*/ certs,
+                                                                         int32_t certsLen);
 
 /*
 Initialize an SSL context
@@ -58,11 +62,8 @@ Initialize an SSL context
 
 Returns 1 on success, 0 otherwise
 */
-PALEXPORT int32_t AndroidCryptoNative_SSLStreamInitialize(SSLStream* sslStream,
-                                                             bool isServer,
-                                                             STREAM_READER streamReader,
-                                                             STREAM_WRITER streamWriter,
-                                                             int32_t appBufferSize);
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamInitialize(
+    SSLStream* sslStream, bool isServer, STREAM_READER streamReader, STREAM_WRITER streamWriter, int32_t appBufferSize);
 
 /*
 Set configuration parameters
@@ -108,7 +109,9 @@ Get the negotiated application protocol for the current session
 
 Returns 1 on success, 0 otherwise
 */
-PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream, uint8_t* out, int32_t* outLen);
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream,
+                                                                      uint8_t* out,
+                                                                      int32_t* outLen);
 
 /*
 Get the name of the cipher suite for the current session
@@ -150,7 +153,9 @@ Set enabled protocols
 
 Returns 1 on success, 0 otherwise
 */
-PALEXPORT int32_t AndroidCryptoNative_SSLStreamSetEnabledProtocols(SSLStream* sslStream, PAL_SslProtocol* protocols, int32_t count);
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamSetEnabledProtocols(SSLStream* sslStream,
+                                                                   PAL_SslProtocol* protocols,
+                                                                   int32_t count);
 
 /*
 Verify hostname using the peer certificate for the current session

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -62,7 +62,7 @@ PALEXPORT int32_t AndroidCryptoNative_SSLStreamInitialize(SSLStream* sslStream,
                                                              bool isServer,
                                                              STREAM_READER streamReader,
                                                              STREAM_WRITER streamWriter,
-                                                             int appBufferSize);
+                                                             int32_t appBufferSize);
 
 /*
 Set configuration parameters
@@ -87,8 +87,8 @@ Unless data from a previous incomplete read is present, this will invoke the STR
 */
 PALEXPORT PAL_SSLStreamStatus AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream,
                                                                 uint8_t* buffer,
-                                                                int length,
-                                                                int* read);
+                                                                int32_t length,
+                                                                int32_t* read);
 /*
 Encodes bytes from a buffer
   - buffer : data to encode
@@ -96,7 +96,7 @@ Encodes bytes from a buffer
 
 This will invoke the STREAM_WRITER callback with the processed data.
 */
-PALEXPORT PAL_SSLStreamStatus AndroidCryptoNative_SSLStreamWrite(SSLStream* sslStream, uint8_t* buffer, int length);
+PALEXPORT PAL_SSLStreamStatus AndroidCryptoNative_SSLStreamWrite(SSLStream* sslStream, uint8_t* buffer, int32_t length);
 
 /*
 Release the SSL context
@@ -108,7 +108,7 @@ Get the negotiated application protocol for the current session
 
 Returns 1 on success, 0 otherwise
 */
-PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream, uint8_t* out, int* outLen);
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream, uint8_t* out, int32_t* outLen);
 
 /*
 Get the name of the cipher suite for the current session
@@ -141,7 +141,7 @@ Returns 1 on success, 0 otherwise
 */
 PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetPeerCertificates(SSLStream* sslStream,
                                                                    jobject** /*X509Certificate[]*/ out,
-                                                                   int* outLen);
+                                                                   int32_t* outLen);
 
 /*
 Set enabled protocols

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -329,7 +329,7 @@ int32_t AndroidCryptoNative_X509StoreEnumerateCertificates(jobject /*KeyStore*/ 
 static bool SystemAliasFilter(JNIEnv* env, jstring alias)
 {
     const char systemPrefix[] = "system:";
-    size_t prefixLen = (sizeof(systemPrefix) - 1) / sizeof(char);
+    size_t prefixLen = (sizeof(systemPrefix) / sizeof(*systemPrefix)) - 1;
 
     const char* aliasPtr = (*env)->GetStringUTFChars(env, alias, NULL);
     bool isSystem = (strncmp(aliasPtr, systemPrefix, prefixLen) == 0);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "pal_compiler.h"
+#include <pal_ssl_types.h>
 #include <Security/Security.h>
 #include <Security/SecureTransport.h>
 
@@ -26,18 +27,6 @@ enum
     PAL_TlsIo_Renegotiate = 4,
 };
 typedef int32_t PAL_TlsIo;
-
-enum
-{
-    PAL_SslProtocol_None = 0,
-    PAL_SslProtocol_Ssl2 = 12,
-    PAL_SslProtocol_Ssl3 = 48,
-    PAL_SslProtocol_Tls10 = 192,
-    PAL_SslProtocol_Tls11 = 768,
-    PAL_SslProtocol_Tls12 = 3072,
-    PAL_SslProtocol_Tls13 = 12288,
-};
-typedef int32_t PAL_SslProtocol;
 
 /*
 Create an SSL context, for the Server or Client role as determined by isServer.

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -422,6 +422,9 @@
   <data name="net_security_sslprotocol_contiguous" xml:space="preserve">
     <value>The requested combination of SslProtocols ({0}) is not valid for this platform because it skips intermediate versions.</value>
   </data>
+  <data name="net_security_sslprotocol_notsupported" xml:space="preserve">
+    <value>The requested SslProtocols ({0}) are not supported on this platform.</value>
+  </data>
   <data name="net_encryptionpolicy_notsupported" xml:space="preserve">
     <value>The '{0}' encryption policy is not supported on this platform.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -335,11 +335,14 @@
              Link="Common\Interop\Android\Interop.JObjectLifetime.cs" />
     <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.cs"
              Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.cs" />
+    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.ProtocolSupport.cs"
+             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.Ssl.ProtocolSupport.cs" />
     <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs"
              Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs" />
     <Compile Include="System\Net\CertificateValidationPal.Android.cs" />
     <Compile Include="System\Net\Security\Pal.Android\SafeDeleteSslContext.cs" />
     <Compile Include="System\Net\Security\Pal.Managed\SafeFreeSslCredentials.cs" />
+    <Compile Include="System\Net\Security\Pal.Managed\SslProtocolsValidation.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Android.cs" />
     <Compile Include="System\Net\Security\SslStreamCertificateContext.Linux.cs" />
     <Compile Include="System\Net\Security\SslStreamPal.Android.cs" />
@@ -373,6 +376,7 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
     <Compile Include="System\Net\CertificateValidationPal.OSX.cs" />
     <Compile Include="System\Net\Security\Pal.Managed\SafeFreeSslCredentials.cs" />
+    <Compile Include="System\Net\Security\Pal.Managed\SslProtocolsValidation.cs" />
     <Compile Include="System\Net\Security\Pal.OSX\SafeDeleteSslContext.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.OSX.cs" />
     <Compile Include="System\Net\Security\SslStreamCertificateContext.OSX.cs" />

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -20,9 +20,6 @@ namespace System.Net
         private const int InitialBufferSize = 2048;
         private static readonly SslProtocols[] s_orderedSslProtocols = new SslProtocols[]
         {
-#pragma warning disable 0618 // 'SslProtocols.Ssl3' is obsolete
-            SslProtocols.Ssl3,
-#pragma warning restore 0618
             SslProtocols.Tls,
             SslProtocols.Tls11,
             SslProtocols.Tls12,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -205,6 +205,15 @@ namespace System.Net
             SafeFreeSslCredentials credential,
             SslAuthenticationOptions authOptions)
         {
+            switch (credential.Policy)
+            {
+                case EncryptionPolicy.RequireEncryption:
+                case EncryptionPolicy.AllowNoEncryption:
+                    break;
+                default:
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_encryptionpolicy_notsupported, credential.Policy));
+            }
+
             bool isServer = authOptions.IsServer;
 
             if (authOptions.ApplicationProtocols != null

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SslProtocolsValidation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SslProtocolsValidation.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Authentication;
+
+namespace System.Net
+{
+    internal static class SslProtocolsValidation
+    {
+        public static (int MinIndex, int MaxIndex) ValidateContiguous(this SslProtocols protocols, SslProtocols[] orderedSslProtocols)
+        {
+            // A contiguous range of protocols is required.  Find the min and max of the range,
+            // or throw if it's non-contiguous or if no protocols are specified.
+
+            // First, mark all of the specified protocols.
+            Span<bool> protocolSet = stackalloc bool[orderedSslProtocols.Length];
+            for (int i = 0; i < orderedSslProtocols.Length; i++)
+            {
+                protocolSet[i] = (protocols & orderedSslProtocols[i]) != 0;
+            }
+
+            int minIndex = -1;
+            int maxIndex = -1;
+
+            // Loop through them, starting from the lowest.
+            for (int min = 0; min < protocolSet.Length; min++)
+            {
+                if (protocolSet[min])
+                {
+                    // We found the first one that's set; that's the bottom of the range.
+                    minIndex = min;
+
+                    // Now loop from there to look for the max of the range.
+                    for (int max = min + 1; max < protocolSet.Length; max++)
+                    {
+                        if (!protocolSet[max])
+                        {
+                            // We found the first one after the min that's not set; the top of the range
+                            // is the one before this (which might be the same as the min).
+                            maxIndex = max - 1;
+
+                            // Finally, verify that nothing beyond this one is set, as that would be
+                            // a discontiguous set of protocols.
+                            for (int verifyNotSet = max + 1; verifyNotSet < protocolSet.Length; verifyNotSet++)
+                            {
+                                if (protocolSet[verifyNotSet])
+                                {
+                                    throw new PlatformNotSupportedException(SR.Format(SR.net_security_sslprotocol_contiguous, protocols));
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            // If no protocols were set, throw.
+            if (minIndex == -1)
+            {
+                throw new PlatformNotSupportedException(SR.net_securityprotocolnotsupported);
+            }
+
+            // If we didn't find an unset protocol after the min, go all the way to the last one.
+            if (maxIndex == -1)
+            {
+                maxIndex = orderedSslProtocols.Length - 1;
+            }
+
+            return (minIndex, maxIndex);
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Android.cs
@@ -14,8 +14,7 @@ namespace System.Net.Security
             string protocolString = Interop.AndroidCrypto.SSLStreamGetProtocol(sslContext);
             SslProtocols protocol = protocolString switch
             {
-#pragma warning disable 0618 // Ssl2 and Ssl3 are deprecated.
-                "SSLv2" => SslProtocols.Ssl2,
+#pragma warning disable 0618 // 'SslProtocols.Ssl3' is obsolete
                 "SSLv3" => SslProtocols.Ssl3,
 #pragma warning restore
                 "TLSv1" => SslProtocols.Tls,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -41,8 +41,8 @@ namespace System.Net.Security.Tests
                 return true;
             }
 
-            // On macOS, the null cipher (no encryption) is not supported.
-            if (OperatingSystem.IsMacOS())
+            // On macOS and Android, the null cipher (no encryption) is not supported.
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsAndroid())
             {
                 return false;
             }


### PR DESCRIPTION
- Set enabled `SslProtocols`
  - Throw PNSE if requested combination is not contiguous - matches macOS behaviour. Android actually does allow specifying a non-contiguous set, but it will only respect the lowest contiguous set and ignore the rest, so it seemed more consistent with our APIs to explicitly throw.
  - `Ssl2` and `Ssl3` are not supported, `Tls13` is only supported on some (newer) versions
- Always enlarge buffer when `wrap`/`unwrap` gives `BUFFER_OVERFLOW`
- Fix some missed local ref deletes
- Throw PNSE  if `EncryptionPolicy.NoEncryption` is requested (not supported on Android)
- Update test utilities to properly check for support for `Ssl3` and `Tls13` on Android

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs @wfurt