### PR TITLE
[wasm] Copy icu libs to runtime pack

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -226,7 +226,7 @@
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)src"
           SkipUnchangedFiles="true" />
 
-    <Copy SourceFiles="@(IcuDataFiles)"
+    <Copy SourceFiles="@(IcuDataFiles);@(ICULibNativeFiles)"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
On Windows we were missing native icu libs in the runtime pack.