### PR TITLE
Add radix supports for number ToString and Parse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2160,14 +2160,31 @@ namespace System
         }
 
         // Parses value in base fromBase.  fromBase can only
-        // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
+        // be 2 - 36.  If fromBase is 16, the number may be preceded
         // by 0x; any other leading or trailing characters cause an error.
         //
         public static short ToInt16(string? value, int fromBase)
         {
             if (fromBase != 2 && fromBase != 8 && fromBase != 10 && fromBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (fromBase < 2 || fromBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                var status = ParseNumbers.TryStringToInt(value, fromBase, out var result);
+                switch (status)
+                {
+                    case Number.ParsingStatus.Failed:
+                        throw new FormatException(SR.Format_InvalidString);
+                    case Number.ParsingStatus.Overflow:
+                        ThrowInt16OverflowException();
+                        break;
+                }
+                if (result >= short.MinValue && result <= short.MaxValue)
+                {
+                    return (short)result;
+                }
+                ThrowInt16OverflowException();
             }
 
             if (value == null)
@@ -2185,7 +2202,7 @@ namespace System
         }
 
         // Parses value in base fromBase.  fromBase can only
-        // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
+        // be 2 - 36.  If fromBase is 16, the number may be preceded
         // by 0x; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
@@ -2193,7 +2210,27 @@ namespace System
         {
             if (fromBase != 2 && fromBase != 8 && fromBase != 10 && fromBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (fromBase < 2 || fromBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                var status = ParseNumbers.TryStringToInt(value, fromBase, out var result);
+                switch (status)
+                {
+                    case Number.ParsingStatus.Failed:
+                        throw new FormatException(SR.Format_InvalidString);
+                    case Number.ParsingStatus.Overflow:
+                        ThrowUInt16OverflowException();
+                        break;
+                }
+                try
+                {
+                    return (ushort)result;
+                }
+                catch (InvalidCastException)
+                {
+                    ThrowUInt16OverflowException();
+                }
             }
 
             if (value == null)
@@ -2208,14 +2245,27 @@ namespace System
         }
 
         // Parses value in base fromBase.  fromBase can only
-        // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
+        // be 2 - 36.  If fromBase is 16, the number may be preceded
         // by 0x; any other leading or trailing characters cause an error.
         //
         public static int ToInt32(string? value, int fromBase)
         {
             if (fromBase != 2 && fromBase != 8 && fromBase != 10 && fromBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (fromBase < 2 || fromBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                var status = ParseNumbers.TryStringToInt(value, fromBase, out var result);
+                switch (status)
+                {
+                    case Number.ParsingStatus.Failed:
+                        throw new FormatException(SR.Format_InvalidString);
+                    case Number.ParsingStatus.Overflow:
+                        ThrowInt32OverflowException();
+                        break;
+                }
+                return result;
             }
             return value != null ?
                 ParseNumbers.StringToInt(value.AsSpan(), fromBase, ParseNumbers.IsTight) :
@@ -2223,7 +2273,7 @@ namespace System
         }
 
         // Parses value in base fromBase.  fromBase can only
-        // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
+        // be 2 - 36.  If fromBase is 16, the number may be preceded
         // by 0x; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
@@ -2231,7 +2281,27 @@ namespace System
         {
             if (fromBase != 2 && fromBase != 8 && fromBase != 10 && fromBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (fromBase < 2 || fromBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                var status = ParseNumbers.TryStringToLong(value, fromBase, out var result);
+                switch (status)
+                {
+                    case Number.ParsingStatus.Failed:
+                        throw new FormatException(SR.Format_InvalidString);
+                    case Number.ParsingStatus.Overflow:
+                        ThrowUInt32OverflowException();
+                        break;
+                }
+                try
+                {
+                    return (uint)result;
+                }
+                catch (InvalidCastException)
+                {
+                    ThrowUInt32OverflowException();
+                }
             }
             return value != null ?
                 (uint)ParseNumbers.StringToInt(value.AsSpan(), fromBase, ParseNumbers.TreatAsUnsigned | ParseNumbers.IsTight) :
@@ -2239,14 +2309,27 @@ namespace System
         }
 
         // Parses value in base fromBase.  fromBase can only
-        // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
+        // be 2 - 36.  If fromBase is 16, the number may be preceded
         // by 0x; any other leading or trailing characters cause an error.
         //
         public static long ToInt64(string? value, int fromBase)
         {
             if (fromBase != 2 && fromBase != 8 && fromBase != 10 && fromBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (fromBase < 2 || fromBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                var status = ParseNumbers.TryStringToLong(value, fromBase, out var result);
+                switch (status)
+                {
+                    case Number.ParsingStatus.Failed:
+                        throw new FormatException(SR.Format_InvalidString);
+                    case Number.ParsingStatus.Overflow:
+                        ThrowInt64OverflowException();
+                        break;
+                }
+                return result;
             }
             return value != null ?
                 ParseNumbers.StringToLong(value.AsSpan(), fromBase, ParseNumbers.IsTight) :
@@ -2284,7 +2367,11 @@ namespace System
         {
             if (toBase != 2 && toBase != 8 && toBase != 10 && toBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (toBase < 2 && toBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                return ParseNumbers.IntToString(value, toBase);
             }
             return ParseNumbers.IntToString((int)value, toBase, -1, ' ', ParseNumbers.PrintAsI2);
         }
@@ -2294,7 +2381,11 @@ namespace System
         {
             if (toBase != 2 && toBase != 8 && toBase != 10 && toBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (toBase < 2 && toBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                return ParseNumbers.IntToString(value, toBase);
             }
             return ParseNumbers.IntToString(value, toBase, -1, ' ', 0);
         }
@@ -2304,9 +2395,41 @@ namespace System
         {
             if (toBase != 2 && toBase != 8 && toBase != 10 && toBase != 16)
             {
-                throw new ArgumentException(SR.Arg_InvalidBase);
+                if (toBase < 2 && toBase > 36)
+                {
+                    throw new ArgumentException(SR.Arg_InvalidBase);
+                }
+                return ParseNumbers.LongToString(value, toBase);
             }
             return ParseNumbers.LongToString(value, toBase, -1, ' ', 0);
+        }
+
+        // Convert the Single value to a string in base toBase
+        public static string ToString(float value, int toBase)
+        {
+            if (toBase == 10)
+            {
+                return value.ToString();
+            }
+            if (toBase < 2 && toBase > 36)
+            {
+                throw new ArgumentException(SR.Arg_InvalidBase);
+            }
+            return ParseNumbers.DoubleToString(value, toBase);
+        }
+
+        // Convert the Double value to a string in base toBase
+        public static string ToString(double value, int toBase)
+        {
+            if (toBase == 10)
+            {
+                return value.ToString();
+            }
+            if (toBase < 2 && toBase > 36)
+            {
+                throw new ArgumentException(SR.Arg_InvalidBase);
+            }
+            return ParseNumbers.DoubleToString(value, toBase);
         }
 
         public static string ToBase64String(byte[] inArray)

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -276,6 +276,11 @@ namespace System
             return Number.FormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider));
         }
 
+        public string ToString(int toBase)
+        {
+            return Convert.ToString(m_value, toBase);
+        }
+
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return Number.TryFormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -87,6 +87,11 @@ namespace System
             return Number.FormatInt32(m_value, 0x0000FFFF, format, provider);
         }
 
+        public string ToString(int toBase)
+        {
+            return Convert.ToString(m_value, toBase);
+        }
+
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return Number.TryFormatInt32(m_value, 0x0000FFFF, format, provider, destination, out charsWritten);
@@ -141,6 +146,14 @@ namespace System
             return (short)i;
         }
 
+        // Parses an integer from a String in base fromBase.
+        //
+        public static short Parse(string s, int fromBase)
+        {
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return Convert.ToInt16(s, fromBase);
+        }
+
         public static bool TryParse([NotNullWhen(true)] string? s, out short result)
         {
             if (s == null)
@@ -188,6 +201,17 @@ namespace System
             }
             result = (short)i;
             return true;
+        }
+
+        public static bool TryParse(string? s, int fromBase, out short result)
+        {
+            if (ParseNumbers.TryStringToInt(s, fromBase, out var num) == Number.ParsingStatus.OK && num >= MinValue && num <= MaxValue)
+            {
+                result = (short)num;
+                return true;
+            }
+            result = default;
+            return false;
         }
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -97,6 +97,11 @@ namespace System
             return Number.FormatInt32(m_value, ~0, format, provider);
         }
 
+        public string ToString(int toBase)
+        {
+            return Convert.ToString(m_value, toBase);
+        }
+
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return Number.TryFormatInt32(m_value, ~0, format, provider, destination, out charsWritten);
@@ -142,6 +147,14 @@ namespace System
             return Number.ParseInt32(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
+        // Parses an integer from a String in base fromBase.
+        //
+        public static int Parse(string s, int fromBase)
+        {
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return Convert.ToInt32(s, fromBase);
+        }
+
         // Parses an integer from a String. Returns false rather
         // than throwing exceptin if input is invalid
         //
@@ -181,6 +194,11 @@ namespace System
         {
             NumberFormatInfo.ValidateParseStyleInteger(style);
             return Number.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out result) == Number.ParsingStatus.OK;
+        }
+
+        public static bool TryParse(string? s, int fromBase, out int result)
+        {
+            return ParseNumbers.TryStringToInt(s, fromBase, out result) == Number.ParsingStatus.OK;
         }
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -94,6 +94,11 @@ namespace System
             return Number.FormatInt64(m_value, format, provider);
         }
 
+        public string ToString(int toBase)
+        {
+            return Convert.ToString(m_value, toBase);
+        }
+
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return Number.TryFormatInt64(m_value, format, provider, destination, out charsWritten);
@@ -135,6 +140,14 @@ namespace System
             return Number.ParseInt64(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
+        // Parses an integer from a String in base fromBase.
+        //
+        public static long Parse(string s, int fromBase)
+        {
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return Convert.ToInt64(s, fromBase);
+        }
+
         public static bool TryParse([NotNullWhen(true)] string? s, out long result)
         {
             if (s == null)
@@ -168,6 +181,11 @@ namespace System
         {
             NumberFormatInfo.ValidateParseStyleInteger(style);
             return Number.TryParseInt64(s, style, NumberFormatInfo.GetInstance(provider), out result) == Number.ParsingStatus.OK;
+        }
+
+        public static bool TryParse(string? s, int fromBase, out long result)
+        {
+            return ParseNumbers.TryStringToLong(s, fromBase, out result) == Number.ParsingStatus.OK;
         }
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -268,6 +268,11 @@ namespace System
             return Number.FormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider));
         }
 
+        public string ToString(int toBase)
+        {
+            return Convert.ToString(m_value, toBase);
+        }
+
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return Number.TryFormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);


### PR DESCRIPTION
#50491

Add following methods.

- `string Int16.ToString(int toBase)`
- `string Int32.ToString(int toBase)`
- `string Int64.ToString(int toBase)`
- `string Single.ToString(int toBase)`
- `string Double.ToString(int toBase)`
- `string Int16.Parse(string s, int fromBase)`
- `string Int32.Parse(string s, int fromBase)`
- `string Int64.Parse(string s, int fromBase)`
- `bool Int16.TryParse(string? s, int fromBase, out short result)`
- `bool Int32.TryParse(string? s, int fromBase, out int result)`
- `bool Int64.TryParse(string? s, int fromBase, out long result)`
- `string Convert.ToString(float value, int toBase)`
- `string Convert.ToString(double value, int toBase)`

Update following methods.

- `string Convert.ToString(short value, int toBase)`
- `string Convert.ToString(int value, int toBase)`
- `string Convert.ToString(long value, int toBase)`
- `short Convert.ToInt16(string s, int fromBase)`
- `int Convert.ToInt32(string s, int fromBase)`
- `long Convert.ToInt64(string s, int fromBase)`

Following are the radixes supported.

| Old impl | New impl |
| ---------------- | ---------------- |
| 2, 8, 10 and 16 | 2 - 36 |
