### PR TITLE
Fix System.Runtime tests for single file runner

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
+    <DefineConstants>$(DefineConstants);SINGLE_FILE_TEST_RUNNER</DefineConstants>
+
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'publish'))</BundleDir>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(BundleDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -82,18 +82,7 @@ namespace System.Reflection.Tests
         public void FullyQualifiedName()
         {
 #if SINGLE_FILE_TEST_RUNNER
-            // Documented to either throw or return <Unknown>, so both are fine.
-            string name;
-            try
-            {
-                name = Module.FullyQualifiedName;
-            }
-            catch
-            {
-                return;
-            }
-
-            Assert.Equal("<Unknown>", name, ignoreCase: true);
+            Assert.Equal("<Unknown>", Module.FullyQualifiedName);
 #else
             var loc = AssemblyPathHelper.GetAssemblyLocation(Assembly.GetExecutingAssembly());
 

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -81,6 +81,20 @@ namespace System.Reflection.Tests
         [Fact]
         public void FullyQualifiedName()
         {
+#if SINGLE_FILE_TEST_RUNNER
+            // Documented to either throw or return <Unknown>, so both are fine.
+            string name;
+            try
+            {
+                name = Module.FullyQualifiedName;
+            }
+            catch
+            {
+                return;
+            }
+
+            Assert.Equal("<Unknown>", name, ignoreCase: true);
+#else
             var loc = AssemblyPathHelper.GetAssemblyLocation(Assembly.GetExecutingAssembly());
 
             // Browser will include the path (/), so strip it
@@ -90,12 +104,17 @@ namespace System.Reflection.Tests
             }
 
             Assert.Equal(loc, Module.FullyQualifiedName);
+#endif
         }
 
         [Fact]
         public void Name()
         {
+#if SINGLE_FILE_TEST_RUNNER
+            Assert.Equal("<Unknown>", Module.Name, ignoreCase: true);
+#else
             Assert.Equal("system.runtime.tests.dll", Module.Name, ignoreCase: true);
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
Allows us to test the documented single file behaviors.

Not adding a new `PlatformDetection` thing for this since we don't really have a way to detect single file that wouldn't end us up testing a tautology.