### PR TITLE
Mark the Crossgen2 regression test GitHub_49982 ilasm-incompatible

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_49982/test49982.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_49982/test49982.csproj
@@ -9,6 +9,9 @@
 
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
+
+    <!-- ilasm round-trip testing doesn't make sense for this test -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />


### PR DESCRIPTION
We're doing the same thing for other Crossgen2 tests like crossgen2smoke. Fixes the issue discussed in the PR thread

https://github.com/dotnet/runtime/pull/50951

Thanks

Tomas