### PR TITLE
Make composite MVID checks resilient to failures

### DIFF
--- a/src/coreclr/vm/assemblyloadcontext.cpp
+++ b/src/coreclr/vm/assemblyloadcontext.cpp
@@ -24,12 +24,17 @@ NativeImage *AssemblyLoadContext::LoadNativeImage(Module *componentModule, LPCUT
     AssemblyLoadContext *loadContext = componentModule->GetFile()->GetAssemblyLoadContext();
     PTR_LoaderAllocator moduleLoaderAllocator = componentModule->GetLoaderAllocator();
 
-    NativeImage *nativeImage = NativeImage::Open(componentModule, nativeImageName, loadContext, moduleLoaderAllocator);
-    m_nativeImages.Append(nativeImage);
+    bool isNewNativeImage;
+    NativeImage *nativeImage = NativeImage::Open(componentModule, nativeImageName, loadContext, moduleLoaderAllocator, &isNewNativeImage);
 
-    for (COUNT_T assemblyIndex = 0; assemblyIndex < m_loadedAssemblies.GetCount(); assemblyIndex++)
+    if (isNewNativeImage && nativeImage != nullptr)
     {
-        nativeImage->CheckAssemblyMvid(m_loadedAssemblies[assemblyIndex]);
+        m_nativeImages.Append(nativeImage);
+
+        for (COUNT_T assemblyIndex = 0; assemblyIndex < m_loadedAssemblies.GetCount(); assemblyIndex++)
+        {
+            nativeImage->CheckAssemblyMvid(m_loadedAssemblies[assemblyIndex]);
+        }
     }
 
     return nativeImage;

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -114,13 +114,15 @@ NativeImage *NativeImage::Open(
     Module *componentModule,
     LPCUTF8 nativeImageFileName,
     AssemblyLoadContext *pAssemblyLoadContext,
-    LoaderAllocator *pLoaderAllocator)
+    LoaderAllocator *pLoaderAllocator,
+    /* out */ bool *isNewNativeImage)
 {
     STANDARD_VM_CONTRACT;
 
     NativeImage *pExistingImage = AppDomain::GetCurrentDomain()->GetNativeImage(nativeImageFileName);
     if (pExistingImage != nullptr)
     {
+        *isNewNativeImage = false;
         return pExistingImage->GetAssemblyLoadContext() == pAssemblyLoadContext ? pExistingImage : nullptr;
     }
 
@@ -216,10 +218,12 @@ NativeImage *NativeImage::Open(
     if (pExistingImage == nullptr)
     {
         // No pre-existing image, new image has been stored in the map
+        *isNewNativeImage = true;
         amTracker.SuppressRelease();
         return image.Extract();
     }
     // Return pre-existing image if it was loaded into the same ALC, null otherwise
+    *isNewNativeImage = false;
     return (pExistingImage->GetAssemblyLoadContext() == pAssemblyLoadContext ? pExistingImage : nullptr);
 }
 #endif

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -105,7 +105,8 @@ public:
         Module *componentModule,
         LPCUTF8 nativeImageFileName,
         AssemblyLoadContext *pAssemblyLoadContext,
-        LoaderAllocator *pLoaderAllocator);
+        LoaderAllocator *pLoaderAllocator,
+        /* out */ bool *isNewNativeImage);
 
     Crst *EagerFixupsLock() { return &m_eagerFixupsLock; }
     bool EagerFixupsHaveRun() const { return m_eagerFixupsHaveRun; }


### PR DESCRIPTION
I noticed that several ALC-related CoreCLR tests fail in Crossgen2
composite mode. I tracked this down to a missing null check.
In addition to that, we were erroneously putting the composite
image to the validation list even when it had been loaded previously.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 