### PR TITLE
Print Native Stacktrace on mono_llvm_cpp_throw_exception when profiler is enabled.

### DIFF
--- a/src/mono/mono/mini/llvm-runtime.cpp
+++ b/src/mono/mono/mini/llvm-runtime.cpp
@@ -16,7 +16,7 @@ mono_llvm_cpp_throw_exception (void)
 	gint32 *ex = NULL;
 
 	if (mono_trace_is_enabled ())
-		mono_runtime_printf_err ("Native Stacktrace (mono_llvm_cpp_throw_exception)"); 
+		mono_runtime_printf_err ("Native Stacktrace (mono_llvm_cpp_throw_exception)\n"); 
 		
 	/* The generated code catches an int32* */
 	throw ex;

--- a/src/mono/mono/mini/llvm-runtime.cpp
+++ b/src/mono/mono/mini/llvm-runtime.cpp
@@ -2,6 +2,11 @@
 #include "llvm-runtime.h"
 
 #include <glib.h>
+#include <mono/utils/mono-logger-internals.h>
+
+#include <mono/metadata/mono-debug.h>
+#include <mono/metadata/profiler.h>
+#include "trace.h"
 
 extern "C" {
 
@@ -10,6 +15,9 @@ mono_llvm_cpp_throw_exception (void)
 {
 	gint32 *ex = NULL;
 
+	if (mono_trace_is_enabled ())
+		mono_runtime_printf_err ("Native Stacktrace (mono_llvm_cpp_throw_exception)"); 
+		
 	/* The generated code catches an int32* */
 	throw ex;
 }

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -3445,7 +3445,7 @@ mono_print_thread_dump_internal (void *sigctx, MonoContext *start_ctx)
 	mono_walk_stack_with_ctx (print_stack_frame_to_string, &ctx, MONO_UNWIND_LOOKUP_ALL, text);
 
 #if HOST_WASM
-	mono_runtime_printf_err ("%s", text->str); //to print the native callstack
+	mono_runtime_printf_err ("%s\n", text->str); //to print the native callstack
 #else
 	mono_runtime_printf ("%s", text->str);
 #endif	

--- a/src/mono/mono/mini/trace.h
+++ b/src/mono/mono/mini/trace.h
@@ -21,7 +21,10 @@ void
 mono_trace_tail_method (MonoMethod *method, MonoJitInfo *ji, MonoMethod *target);
 
 void mono_trace_enable (gboolean enable);
+
+G_EXTERN_C
 gboolean mono_trace_is_enabled (void);
+
 gboolean mono_trace_eval_exception (MonoClass *klass);
 
 #endif /* __MONO_TRACE_H__ */


### PR DESCRIPTION
Print call stack when profiler is enabled in a mono_llvm_cpp_throw_exception (void).
This was asked by @jeromelaban