### PR TITLE
Update logic around BB_MAX_WEIGHT

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -647,9 +647,9 @@ struct BasicBlock : private LIR::Range
         }
     }
 
-    bool isMaxBBWeight()
+    bool isMaxBBWeight() const
     {
-        return (bbWeight == BB_MAX_WEIGHT);
+        return (bbWeight >= BB_MAX_WEIGHT);
     }
 
     // Returns "true" if the block is empty. Empty here means there are no statement

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19067,7 +19067,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     InlineCallsiteFrequency frequency = InlineCallsiteFrequency::UNUSED;
 
     // If this is a prejit root, or a maximally hot block...
-    if ((pInlineInfo == nullptr) || (pInlineInfo->iciBlock->bbWeight >= BB_MAX_WEIGHT))
+    if ((pInlineInfo == nullptr) || (pInlineInfo->iciBlock->isMaxBBWeight()))
     {
         frequency = InlineCallsiteFrequency::HOT;
     }

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -657,7 +657,7 @@ const char* refCntWtd2str(BasicBlock::weight_t refCntWtd)
 
     nump = (nump == num1) ? num2 : num1;
 
-    if (refCntWtd == BB_MAX_WEIGHT)
+    if (refCntWtd >= BB_MAX_WEIGHT)
     {
         sprintf_s(temp, bufSize, "MAX   ");
     }


### PR DESCRIPTION
Consider any weight greater or equal to be a max weight. Rule of thumb
is that you can assign BB_MAX_WEIGHT but for comparsions one should always
use an inequality or call the helper method.

Fixes #50808.