### PR TITLE
Make sure SingleFileHostIncludeFilename list exists.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -18,6 +18,9 @@
     <SingleFileHostIncludeFilename Include="somefile.dll" />
   -->
   <ItemGroup>
+    <!-- include at least one item. Otherwise there will be no opt-in list and everything will be included -->
+    <SingleFileHostIncludeFilename Include="NONE" />
+
     <!-- LINUX -->
 
     <!-- OSX -->


### PR DESCRIPTION
`SingleFileHostIncludeFilename` mechanism is designed that in the absence of the "opt-in" list it falls back to backwards-compatible behavior where every one native file is "opted-in"
Once we switched all platforms to superhost, our list disappeared, which triggered the compat behavior.

I am adding a dummy item to the list to make sure we have a list. 
(an item does not need to be real since the list is applied as a filter)

Fixes:https://github.com/dotnet/sdk/issues/16487