### PR TITLE
Update lpFirst and lpTop to reflect accurate compacted blocks

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1996,6 +1996,20 @@ void Compiler::fgUpdateLoopsAfterCompacting(BasicBlock* block, BasicBlock* bNext
         {
             optLoopTable[loopNum].lpEntry = block;
         }
+
+        /* Check the loop's first block */
+
+        if (optLoopTable[loopNum].lpFirst == bNext)
+        {
+            optLoopTable[loopNum].lpFirst = block;
+        }
+
+        /* Check the loop top */
+
+        if (optLoopTable[loopNum].lpTop == bNext)
+        {
+            optLoopTable[loopNum].lpTop = block;
+        }
     }
 }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1997,9 +1997,19 @@ void Compiler::fgUpdateLoopsAfterCompacting(BasicBlock* block, BasicBlock* bNext
             optLoopTable[loopNum].lpEntry = block;
         }
 
-        /* Do not compact first/top block in loop */
-        assert(optLoopTable[loopNum].lpFirst != bNext);
-        assert(optLoopTable[loopNum].lpTop != bNext);
+        /* Check the loop's first block */
+
+        if (optLoopTable[loopNum].lpFirst == bNext)
+        {
+            optLoopTable[loopNum].lpFirst = block;
+        }
+
+        /* Check the loop top */
+
+        if (optLoopTable[loopNum].lpTop == bNext)
+        {
+            optLoopTable[loopNum].lpTop = block;
+        }
     }
 }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1997,19 +1997,9 @@ void Compiler::fgUpdateLoopsAfterCompacting(BasicBlock* block, BasicBlock* bNext
             optLoopTable[loopNum].lpEntry = block;
         }
 
-        /* Check the loop's first block */
-
-        if (optLoopTable[loopNum].lpFirst == bNext)
-        {
-            optLoopTable[loopNum].lpFirst = block;
-        }
-
-        /* Check the loop top */
-
-        if (optLoopTable[loopNum].lpTop == bNext)
-        {
-            optLoopTable[loopNum].lpTop = block;
-        }
+        /* Do not compact first/top block in loop */
+        assert(optLoopTable[loopNum].lpFirst != bNext);
+        assert(optLoopTable[loopNum].lpTop != bNext);
     }
 }
 


### PR DESCRIPTION
Update `lpTop` and `lpFirst` when blocks are compacted.

Fixes: #46241