### PR TITLE
Rent correct buffer size for SslStream.Encrypt

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -55,6 +55,10 @@ namespace System.Net.Security
             _ssl = sslStream;
         }
 
+        internal int HeaderSize => _headerSize;
+
+        internal int TrailerSize => _trailerSize;
+
         //
         // SecureChannel properties
         //

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -37,7 +37,7 @@ namespace System.Net.Security
         private object _handshakeLock => _sslAuthenticationOptions!;
         private volatile TaskCompletionSource<bool>? _handshakeWaiter;
 
-        private const int FrameOverhead = 32;
+        private const int FrameOverhead = 64;
         private const int ReadBufferSize = 4096 * 4 + FrameOverhead;         // We read in 16K chunks + headers.
         private const int InitialHandshakeBufferSize = 4096 + FrameOverhead; // try to fit at least 4K ServerCertificate
         private ArrayBuffer _handshakeBuffer;
@@ -635,7 +635,7 @@ namespace System.Net.Security
             where TIOAdapter : struct, IReadWriteAdapter
         {
             // For rented buffer size:
-            //     Prior to handshake; when _context is not yet set, we will use FrameOverhead.
+            //     When _context is not yet set, we will use FrameOverhead estimation.
             //     After we will use whichever is greater of (Header + Trailer) or FrameOverhead.
             int bufferSize = Math.Max(
                 _context is not null ? checked(buffer.Length + _context.HeaderSize + _context.TrailerSize) : 0,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -634,7 +634,8 @@ namespace System.Net.Security
         private ValueTask WriteSingleChunk<TIOAdapter>(TIOAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TIOAdapter : struct, IReadWriteAdapter
         {
-            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length + FrameOverhead);
+            int bufferSize = Math.Max(_context is not null ? checked(buffer.Length + _context.HeaderSize + _context.TrailerSize) : 0, buffer.Length + FrameOverhead);
+            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
             byte[] outBuffer = rentedBuffer;
 
             SecurityStatusPal status;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security
         }
 
         public static SecurityStatusPal EncryptMessage(
-            SafeDeleteContext securityContext,
+            SafeDeleteSslContext securityContext,
             ReadOnlyMemory<byte> input,
             int headerSize,
             int trailerSize,
@@ -83,8 +83,7 @@ namespace System.Net.Security
 
             try
             {
-                SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
-                SafeSslHandle sslHandle = sslContext.SslContext;
+                SafeSslHandle sslHandle = securityContext.SslContext;
 
                 unsafe
                 {
@@ -104,13 +103,13 @@ namespace System.Net.Security
                                 Interop.AppleCrypto.CreateExceptionForOSStatus((int)status));
                         }
 
-                        if (sslContext.BytesReadyForConnection <= output?.Length)
+                        if (securityContext.BytesReadyForConnection <= output?.Length)
                         {
-                            resultSize = sslContext.ReadPendingWrites(output, 0, output.Length);
+                            resultSize = securityContext.ReadPendingWrites(output, 0, output.Length);
                         }
                         else
                         {
-                            output = sslContext.ReadPendingWrites()!;
+                            output = securityContext.ReadPendingWrites()!;
                             resultSize = output.Length;
                         }
 
@@ -138,17 +137,16 @@ namespace System.Net.Security
         }
 
         public static SecurityStatusPal DecryptMessage(
-            SafeDeleteContext securityContext,
+            SafeDeleteSslContext securityContext,
             byte[] buffer,
             ref int offset,
             ref int count)
         {
             try
             {
-                SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
-                SafeSslHandle sslHandle = sslContext.SslContext;
+                SafeSslHandle sslHandle = securityContext.SslContext;
 
-                sslContext.Write(buffer.AsSpan(offset, count));
+                securityContext.Write(buffer.AsSpan(offset, count));
 
                 unsafe
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -42,12 +42,12 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificateContext?.Certificate, protocols, policy);
         }
 
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
+        public static SecurityStatusPal EncryptMessage(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
             return EncryptDecryptHelper(securityContext, input, offset: 0, size: 0, encrypt: true, output: ref output, resultSize: out resultSize);
         }
 
-        public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)
+        public static SecurityStatusPal DecryptMessage(SafeDeleteSslContext securityContext, byte[] buffer, ref int offset, ref int count)
         {
             SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, false, ref buffer, out int resultSize);
             if (retVal.ErrorCode == SecurityStatusPalErrorCode.OK ||
@@ -150,13 +150,13 @@ namespace System.Net.Security
             return Interop.Ssl.SslGetAlpnSelected(((SafeDeleteSslContext)context).SslContext);
         }
 
-        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
+        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
         {
             resultSize = 0;
             try
             {
                 Interop.Ssl.SslErrorCode errorCode = Interop.Ssl.SslErrorCode.SSL_ERROR_NONE;
-                SafeSslHandle scHandle = ((SafeDeleteSslContext)securityContext).SslContext;
+                SafeSslHandle scHandle = securityContext.SslContext;
 
                 if (encrypt)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -250,11 +250,7 @@ namespace System.Net.Security
         public static unsafe SecurityStatusPal EncryptMessage(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
             // Ensure that there is sufficient space for the message output.
-            int bufferSizeNeeded = checked(input.Length + headerSize + trailerSize);
-            if (output == null || output.Length < bufferSizeNeeded)
-            {
-                output = new byte[bufferSizeNeeded];
-            }
+            Debug.Assert(output is not null && output.Length >= checked(input.Length + headerSize + trailerSize));
 
             // Copy the input into the output buffer to prepare for SCHANNEL's expectations
             input.Span.CopyTo(new Span<byte>(output, headerSize, input.Length));

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -250,7 +250,11 @@ namespace System.Net.Security
         public static unsafe SecurityStatusPal EncryptMessage(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
             // Ensure that there is sufficient space for the message output.
-            Debug.Assert(output is not null && output.Length >= checked(input.Length + headerSize + trailerSize));
+            int bufferSizeNeeded = checked(input.Length + headerSize + trailerSize);
+            if (output == null || output.Length < bufferSizeNeeded)
+            {
+                output = new byte[bufferSizeNeeded];
+            }
 
             // Copy the input into the output buffer to prepare for SCHANNEL's expectations
             input.Span.CopyTo(new Span<byte>(output, headerSize, input.Length));


### PR DESCRIPTION
Seen in https://github.com/dotnet/runtime/issues/50921#issuecomment-817133642

`WriteSingleChunk` rents a buffer the size of `buffer.Length + FrameOverhead`; however after the handshake the overhead is `_headerSize + _trailerSize` which can be different and causes Encrypt to ignore the buffer and allocate its own of the correct size.

https://github.com/dotnet/runtime/blob/125253b7d7fd964e32d1a40637ee723853b9fb8e/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs#L253-L257

Change to rent `buffer.Length + _headerSize + _trailerSize` when these values are available.

Also drop some unnecessary casting in the Pal layers by receiving the correct type rather than a less derived one.

Before

![image](https://user-images.githubusercontent.com/1142958/114289996-0b377600-9a74-11eb-9831-408e7632ca35.png)

After

![image](https://user-images.githubusercontent.com/1142958/114290010-1e4a4600-9a74-11eb-9c3e-2b62905adb57.png)

/cc @karelz @dotnet/ncl

Resolves https://github.com/dotnet/runtime/issues/51076