### PR TITLE
make emsdk installation instructions clear on which version need to be installed

### DIFF
--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -4,7 +4,7 @@
 
 If you haven't already done so, please read [this document](../../README.md#Build_Requirements) to understand the build requirements for your operating system.
 
-The [expected version](..\..\..\..\src\mono\wasm\emscripten-version.txt) of Emscripten SDK (emsdk) needs to be installed.  
+The [expected version](..\..\..\..\src\mono\wasm\emscripten-version.txt) of Emscripten SDK (emsdk) needs to be installed.
 * Run `make -C src/mono/wasm provision-wasm` to install emsdk into `src/mono/wasm/emsdk`.
 * Alternatively follow the [installation guide](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install).
 Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`

--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -4,7 +4,10 @@
 
 If you haven't already done so, please read [this document](../../README.md#Build_Requirements) to understand the build requirements for your operating system.
 
-The Emscripten SDK (emsdk) needs to be installed.  Follow the installation guide [here](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install) or run `make -C src/mono/wasm provision-wasm` to install emsdk into `src/mono/wasm/emsdk`.
+The [expected version](..\..\..\..\src\mono\wasm\emscripten-version.txt) of Emscripten SDK (emsdk) needs to be installed.  
+* Run `make -C src/mono/wasm provision-wasm` to install emsdk into `src/mono/wasm/emsdk`.
+* Alternatively follow the [installation guide](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install).
+Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`
 
 Once installed the `EMSDK_PATH` environment variable needs to be set:
 

--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -4,10 +4,10 @@
 
 If you haven't already done so, please read [this document](../../README.md#Build_Requirements) to understand the build requirements for your operating system.
 
-The [expected version](..\..\..\..\src\mono\wasm\emscripten-version.txt) of Emscripten SDK (emsdk) needs to be installed.
+The **correct version** of Emscripten SDK (emsdk) needs to be installed.
 * Run `make -C src/mono/wasm provision-wasm` to install emsdk into `src/mono/wasm/emsdk`.
 * Alternatively follow the [installation guide](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install).
-Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`
+Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`. See [emscripten-version.txt](..\..\..\..\src\mono\wasm\emscripten-version.txt)
 
 Once installed the `EMSDK_PATH` environment variable needs to be set:
 

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -12,7 +12,7 @@ Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always inst
 Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if
 you are directly using the `dotnet build`, or `build.sh`.
 
-* Alternatively you can install [expected version](./emscripten-version.txt) yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html). 
+* Alternatively you can install [expected version](./emscripten-version.txt) yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html).
 Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`
 
 Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for wasm.

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -12,8 +12,8 @@ Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always inst
 Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if
 you are directly using the `dotnet build`, or `build.sh`.
 
-* Alternatively you can install [expected version](./emscripten-version.txt) yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html).
-Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`
+* Alternatively you can install **correct version** yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html).
+Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`. See [emscripten-version.txt](./emscripten-version.txt)
 
 Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for wasm.
 

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -4,15 +4,18 @@ This depends on `emsdk` to be installed.
 
 ## emsdk
 
-* You can either install it yourself (https://emscripten.org/docs/getting_started/downloads.html), and set `EMSDK_PATH` to that. Make sure to have this set whenever building, or running tests for wasm.
-
-* Or you can run `make provision-wasm`, which will install it to `$reporoot/src/mono/wasm/emsdk`.
+* You can run `make provision-wasm`, which will install it to `$reporoot/src/mono/wasm/emsdk`.
 Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always install into `$reporoot/src/mono/wasm/emsdk`.
 
 `EMSDK_PATH` is set to `$reporoot/src/mono/wasm/emsdk` by default, by the Makefile.
 
 Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if
 you are directly using the `dotnet build`, or `build.sh`.
+
+* Alternatively you can install [expected version](./emscripten-version.txt) yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html). 
+Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.12`
+
+Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for wasm.
 
 ### Windows dependencies
 


### PR DESCRIPTION
As discussed here https://discord.com/channels/732297728826277939/732297825731215521/829090033856151665
Installing latest as per previous instructions could be incompatible with the current codebase.

