### PR TITLE
Drop unnecessary fields from SocketAsyncEventArgs

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSARecvFrom.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSARecvFrom.cs
@@ -43,7 +43,7 @@ internal static partial class Interop
 
         internal static unsafe SocketError WSARecvFrom(
             SafeHandle socketHandle,
-            WSABuffer[] buffers,
+            ReadOnlySpan<WSABuffer> buffers,
             int bufferCount,
             out int bytesTransferred,
             ref SocketFlags socketFlags,
@@ -53,7 +53,7 @@ internal static partial class Interop
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null && buffers.Length > 0);
-            fixed (WSABuffer* buffersPtr = &buffers[0])
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
             {
                 return WSARecvFrom(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);
             }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
@@ -43,7 +43,7 @@ internal static partial class Interop
 
         internal static unsafe SocketError WSASendTo(
             SafeHandle socketHandle,
-            WSABuffer[] buffers,
+            ReadOnlySpan<WSABuffer> buffers,
             int bufferCount,
             [Out] out int bytesTransferred,
             SocketFlags socketFlags,
@@ -53,7 +53,7 @@ internal static partial class Interop
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null && buffers.Length > 0);
-            fixed (WSABuffer* buffersPtr = &buffers[0])
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
             {
                 return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
             }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -303,8 +303,8 @@ namespace System.Net.NetworkInformation.Tests
                 }
 
                 Assert.Equal(
-                    (await receivedTask).PacketInformation.Interface,
-                    ipv6 ? NetworkInterface.IPv6LoopbackInterfaceIndex : NetworkInterface.LoopbackInterfaceIndex);
+                    ipv6 ? NetworkInterface.IPv6LoopbackInterfaceIndex : NetworkInterface.LoopbackInterfaceIndex,
+                    (await receivedTask).PacketInformation.Interface);
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -287,9 +287,9 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.ThreadPool" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Threading.Thread" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -146,7 +146,7 @@ namespace System.Net.Sockets
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     internal unsafe delegate SocketError WSARecvMsgDelegate(
                 SafeSocketHandle socketHandle,
-                IntPtr msg,
+                Interop.Winsock.WSAMsg* msg,
                 out int bytesTransferred,
                 NativeOverlapped* overlapped,
                 IntPtr completionRoutine);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -251,14 +251,14 @@ namespace System.Net.Sockets
             return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, out bytesSent, overlapped);
         }
 
-        internal unsafe SocketError WSARecvMsg(SafeSocketHandle socketHandle, IntPtr msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)
+        internal unsafe SocketError WSARecvMsg(SafeSocketHandle socketHandle, Interop.Winsock.WSAMsg* msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)
         {
             WSARecvMsgDelegate recvMsg = GetDynamicWinsockMethods().GetWSARecvMsgDelegate(socketHandle);
 
             return recvMsg(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal unsafe SocketError WSARecvMsgBlocking(SafeSocketHandle socketHandle, IntPtr msg, out int bytesTransferred)
+        internal unsafe SocketError WSARecvMsgBlocking(SafeSocketHandle socketHandle, Interop.Winsock.WSAMsg* msg, out int bytesTransferred)
         {
             WSARecvMsgDelegate recvMsg = GetDynamicWinsockMethods().GetWSARecvMsgDelegate(_handle);
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -420,12 +420,6 @@ namespace System.Net.Sockets
 
         public static unsafe IPPacketInformation GetIPPacketInformation(Interop.Winsock.ControlDataIPv6* controlBuffer)
         {
-            if (controlBuffer->length == (UIntPtr)sizeof(Interop.Winsock.ControlData))
-            {
-                // IPv4 client connectiong to dual mode socket.
-                return GetIPPacketInformation((Interop.Winsock.ControlData*)controlBuffer);
-            }
-
             IPAddress address = controlBuffer->length != UIntPtr.Zero ?
                 new IPAddress(new ReadOnlySpan<byte>(controlBuffer->address, Interop.Winsock.IPv6AddressLength)) :
                 IPAddress.IPv6None;
@@ -468,7 +462,7 @@ namespace System.Net.Sockets
 
                     if (socket.WSARecvMsgBlocking(
                         handle,
-                        (IntPtr)(&wsaMsg),
+                        &wsaMsg,
                         out bytesTransferred) == SocketError.SocketError)
                     {
                         return GetLastSocketError();
@@ -484,7 +478,7 @@ namespace System.Net.Sockets
 
                     if (socket.WSARecvMsgBlocking(
                         handle,
-                        (IntPtr)(&wsaMsg),
+                        &wsaMsg,
                         out bytesTransferred) == SocketError.SocketError)
                     {
                         return GetLastSocketError();
@@ -499,7 +493,7 @@ namespace System.Net.Sockets
 
                     if (socket.WSARecvMsgBlocking(
                         handle,
-                        (IntPtr)(&wsaMsg),
+                        &wsaMsg,
                         out bytesTransferred) == SocketError.SocketError)
                     {
                         return GetLastSocketError();


### PR DESCRIPTION
Shrinks the size by 3 pointers on Windows (28 bytes)

Moving the 2 x `WSABuffer[]?`, 1 x `byte[]?` to stack rather than heap.