### PR TITLE
Add S.R.CompilerServices.InterpolatedStringBuilder

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -687,6 +687,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IsReadOnlyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IsVolatile.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\InterpolatedStringBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IteratorStateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\LoadHint.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -58,7 +58,7 @@ namespace System.Buffers.Text
             return TryFormatFloatingPoint<float>(value, destination, out bytesWritten, format);
         }
 
-        private static bool TryFormatFloatingPoint<T>(T value, Span<byte> destination, out int bytesWritten, StandardFormat format) where T : IFormattable, ISpanFormattable
+        private static bool TryFormatFloatingPoint<T>(T value, Span<byte> destination, out int bytesWritten, StandardFormat format) where T : ISpanFormattable
         {
             Span<char> formatText = stackalloc char[0];
 

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Byte : IComparable, IConvertible, IFormattable, IComparable<byte>, IEquatable<byte>, ISpanFormattable
+    public readonly struct Byte : IComparable, IConvertible, ISpanFormattable, IComparable<byte>, IEquatable<byte>
     {
         private readonly byte m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -179,6 +179,8 @@ namespace System
             return false;
         }
 
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString(m_value);
+
         public static char Parse(string s)
         {
             if (s == null)

--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -18,7 +18,7 @@ namespace System
     /// <summary>
     /// Represents dates with values ranging from January 1, 0001 Anno Domini (Common Era) through December 31, 9999 A.D. (C.E.) in the Gregorian calendar.
     /// </summary>
-    public readonly struct DateOnly : IComparable, IComparable<DateOnly>, IEquatable<DateOnly>, IFormattable, ISpanFormattable
+    public readonly struct DateOnly : IComparable, IComparable<DateOnly>, IEquatable<DateOnly>, ISpanFormattable
     {
         private readonly int _dayNumber;
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -43,7 +43,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly partial struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable, ISpanFormattable
+    public readonly partial struct DateTime : IComparable, ISpanFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable
     {
         // Number of 100ns ticks per time unit
         private const long TicksPerMillisecond = 10000;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -31,7 +31,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct DateTimeOffset : IComparable, IFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback, ISpanFormattable
+    public readonly struct DateTimeOffset : IComparable, ISpanFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback
     {
         // Constants
         internal const long MaxOffset = TimeSpan.TicksPerHour * 14;

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -57,7 +57,7 @@ namespace System
     [Serializable]
     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<decimal>, IEquatable<decimal>, ISpanFormattable, ISerializable, IDeserializationCallback
+    public readonly partial struct Decimal : ISpanFormattable, IComparable, IConvertible, IComparable<decimal>, IEquatable<decimal>, ISerializable, IDeserializationCallback
     {
         // Sign mask for the flags field. A value of zero in this bit indicates a
         // positive Decimal value, and a value of one in this bit indicates a

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -24,7 +24,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Double : IComparable, IConvertible, IFormattable, IComparable<double>, IEquatable<double>, ISpanFormattable
+    public readonly struct Double : IComparable, IConvertible, ISpanFormattable, IComparable<double>, IEquatable<double>
     {
         private readonly double m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -18,7 +18,7 @@ namespace System
     [Serializable]
     [NonVersionable] // This only applies to field layout
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly partial struct Guid : IFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>, ISpanFormattable
+    public readonly partial struct Guid : ISpanFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>
     {
         public static readonly Guid Empty;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -15,7 +15,7 @@ namespace System
     /// An IEEE 754 compliant float16 type.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct Half : IComparable, IFormattable, IComparable<Half>, IEquatable<Half>, ISpanFormattable
+    public readonly struct Half : IComparable, ISpanFormattable, IComparable<Half>, IEquatable<Half>
     {
         private const NumberStyles DefaultParseStyle = NumberStyles.Float | NumberStyles.AllowThousands;
 

--- a/src/libraries/System.Private.CoreLib/src/System/ISpanFormattable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ISpanFormattable.cs
@@ -3,8 +3,19 @@
 
 namespace System
 {
-    internal interface ISpanFormattable
+    /// <summary>Provides functionality to format the string representation of an object into a span.</summary>
+    public interface ISpanFormattable : IFormattable
     {
+        /// <summary>Tries to format the value of the current instance into the provided span of characters.</summary>
+        /// <param name="destination">When this method returns, this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for <paramref name="destination"/>.</param>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// An implementation of this interface should produce the same string of characters as an implementation of <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>
+        /// on the same type.
+        /// </remarks>
         bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Int16 : IComparable, IConvertible, IFormattable, IComparable<short>, IEquatable<short>, ISpanFormattable
+    public readonly struct Int16 : IComparable, IConvertible, ISpanFormattable, IComparable<short>, IEquatable<short>
     {
         private readonly short m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Int32 : IComparable, IConvertible, IFormattable, IComparable<int>, IEquatable<int>, ISpanFormattable
+    public readonly struct Int32 : IComparable, IConvertible, ISpanFormattable, IComparable<int>, IEquatable<int>
     {
         private readonly int m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Int64 : IComparable, IConvertible, IFormattable, IComparable<long>, IEquatable<long>, ISpanFormattable
+    public readonly struct Int64 : IComparable, IConvertible, ISpanFormattable, IComparable<long>, IEquatable<long>
     {
         private readonly long m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -21,7 +21,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct IntPtr : IEquatable<IntPtr>, IComparable, IComparable<IntPtr>, IFormattable, ISpanFormattable, ISerializable
+    public readonly struct IntPtr : IEquatable<IntPtr>, IComparable, IComparable<IntPtr>, ISpanFormattable, ISerializable
     {
         // WARNING: We allow diagnostic tools to directly inspect this member (_value).
         // See https://github.com/dotnet/corert/blob/master/Documentation/design-docs/diagnostics/diagnostics-tools-contract.md for more details.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InterpolatedStringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InterpolatedStringBuilder.cs
@@ -1,0 +1,596 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Provides a builder used by the language compiler to process interpolated strings into <see cref="string"/> instances.</summary>
+    public ref struct InterpolatedStringBuilder
+    {
+        // Implementation note:
+        // As this type lives in CompilerServices and is only intended to be targeted by the compiler,
+        // public APIs eschew argument validation logic in a variety of places, e.g. allowing a null input
+        // when one isn't expected to produce a NullReferenceException rather than an ArgumentNullException.
+
+        /// <summary>Expected average length of formatted data used for an individual hole.</summary>
+        /// <remarks>
+        /// This is inherited from string.Format, and could be changed based on further data.
+        /// string.Format actually uses `format.Length + args.Length * 8`, but format.Length
+        /// includes the holes themselves, e.g. "{0}", and since it's rare to have double-digit
+        /// numbers of holes, we bump the 8 up to 11 to account for the three extra characters in "{d}",
+        /// since the compiler-provided base length won't include the equivalent character count.
+        /// </remarks>
+        private const int GuessedLengthPerHole = 11;
+        /// <summary>Minimum size array to rent from the pool.</summary>
+        /// <remarks>Same as stack-allocation size used today by string.Format.</remarks>
+        private const int MinimumArrayPoolLength = 256;
+
+        /// <summary>Optional provider to pass to IFormattable.ToString or ISpanFormattable.TryFormat calls.</summary>
+        private readonly IFormatProvider? _provider;
+        /// <summary>Optional custom formatter derived from the <see cref="_provider"/>.</summary>
+        private readonly object? _customFormatter;
+        /// <summary>Array rented from the array pool and used to back <see cref="_chars"/>.</summary>
+        private char[]? _arrayToReturnToPool;
+        /// <summary>The span to write into.</summary>
+        private Span<char> _chars;
+        /// <summary>Position at which to write the next character.</summary>
+        private int _pos;
+
+        /// <summary>Initializes the builder.</summary>
+        /// <param name="initialCapacity">Approximated capacity required to support the interpolated string.  The final size may be smaller or larger.</param>
+        private InterpolatedStringBuilder(int initialCapacity)
+        {
+            _provider = null;
+            _customFormatter = null;
+            _chars = _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _pos = 0;
+        }
+
+        /// <summary>Initializes the builder.</summary>
+        /// <param name="initialCapacity">Approximated capacity required to support the interpolated string.  The final size may be smaller or larger.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        private InterpolatedStringBuilder(int initialCapacity, IFormatProvider? provider)
+        {
+            _provider = provider;
+            _customFormatter = provider?.GetFormat(typeof(ICustomFormatter));
+            _chars = _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _pos = 0;
+        }
+
+        /// <summary>Initializes the builder.</summary>
+        /// <param name="scratchBuffer">A buffer temporarily transferred to the builder for use as part of its formatting.  Contents may be overwritten.</param>
+        private InterpolatedStringBuilder(Span<char> scratchBuffer)
+        {
+            _provider = null;
+            _customFormatter = null;
+            _arrayToReturnToPool = null;
+            _chars = scratchBuffer;
+            _pos = 0;
+        }
+
+        /// <summary>Initializes the builder.</summary>
+        /// <param name="scratchBuffer">A buffer temporarily transferred to the builder for use as part of its formatting.  Contents may be overwritten.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        private InterpolatedStringBuilder(Span<char> scratchBuffer, IFormatProvider? provider)
+        {
+            _provider = provider;
+            _customFormatter = provider?.GetFormat(typeof(ICustomFormatter));
+            _arrayToReturnToPool = null;
+            _chars = scratchBuffer;
+            _pos = 0;
+        }
+
+        /// <summary>Creates a builder used to translate an interpolated string into a <see cref="string"/>.</summary>
+        /// <param name="baseLength">The number of constant characters outside of holes in the interpolated string.</param>
+        /// <param name="holeCount">The number of holes in the interpolated string.</param>
+        /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+        public static InterpolatedStringBuilder Create(int baseLength, int holeCount) =>
+            new InterpolatedStringBuilder(GetDefaultLength(baseLength, holeCount));
+
+        /// <summary>Creates a builder used to translate an interpolated string into a <see cref="string"/>.</summary>
+        /// <param name="baseLength">The number of constant characters outside of holes in the interpolated string.</param>
+        /// <param name="holeCount">The number of holes in the interpolated string.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+        public static InterpolatedStringBuilder Create(int baseLength, int holeCount, IFormatProvider? provider) =>
+            new InterpolatedStringBuilder(GetDefaultLength(baseLength, holeCount), provider);
+
+        /// <summary>Creates a builder used to translate an interpolated string into a <see cref="string"/>.</summary>
+        /// <param name="baseLength">The number of constant characters outside of holes in the interpolated string.</param>
+        /// <param name="holeCount">The number of holes in the interpolated string.</param>
+        /// <param name="scratchBuffer">A buffer temporarily transferred to the builder for use as part of its formatting.  Contents may be overwritten.</param>
+        /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+        public static InterpolatedStringBuilder Create(int baseLength, int holeCount, Span<char> scratchBuffer) =>
+            new InterpolatedStringBuilder(scratchBuffer);
+
+        /// <summary>Creates a builder used to translate an interpolated string into a <see cref="string"/>.</summary>
+        /// <param name="baseLength">The number of constant characters outside of holes in the interpolated string.</param>
+        /// <param name="holeCount">The number of holes in the interpolated string.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="scratchBuffer">A buffer temporarily transferred to the builder for use as part of its formatting.  Contents may be overwritten.</param>
+        /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+        public static InterpolatedStringBuilder Create(int baseLength, int holeCount, IFormatProvider? provider, Span<char> scratchBuffer) =>
+            new InterpolatedStringBuilder(scratchBuffer, provider);
+
+        /// <summary>Derives a default length with which to seed the builder.</summary>
+        /// <param name="baseLength">The number of constant characters outside of holes in the interpolated string.</param>
+        /// <param name="holeCount">The number of holes in the interpolated string.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetDefaultLength(int baseLength, int holeCount) =>
+            Math.Max(MinimumArrayPoolLength, baseLength + (holeCount * GuessedLengthPerHole));
+
+        /// <summary>Gets the built <see cref="string"/>.</summary>
+        /// <returns>The built string.</returns>
+        /// <remarks>
+        /// In addition to getting the built string, this clears the builder, releasing any used resources.
+        /// The method should be invoked only once and as the last thing performed on the builder.
+        /// Subsequent use is erroneous and ill-defined.
+        /// </remarks>
+        public override string ToString()
+        {
+            string result = _chars.Slice(0, _pos).ToString();
+
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // defensive clear
+            if (toReturn is not null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+
+            return result;
+        }
+
+        /// <summary>Writes the specified string to the builder.</summary>
+        /// <param name="value">The string to write.</param>
+        public void TryFormatBaseString(string value)
+        {
+            if (value.TryCopyTo(_chars.Slice(_pos)))
+            {
+                _pos += value.Length;
+            }
+            else
+            {
+                GrowThenCopyString(value);
+            }
+        }
+
+        #region TryFormatInterpolationHole
+        // Design note:
+        // The compiler requires a TryFormatInterpolationHole overload for anything that might be within a hole;
+        // if it can't find an appropriate overload, for builders in general it'll simply fail to compile.
+        // (For target-typing to string where it uses InterpolatedStringBuilder implicitly, it'll instead fall back to
+        // its other mechanisms, e.g. using string.Format.  This fallback has the benefit that if we miss a case,
+        // interpolated strings will still work, but it has the downside that a developer generally won't know
+        // if the fallback is happening and they're paying more.)
+        //
+        // At a minimum, then, we would need an overload that accepts:
+        //     (object value, int alignment = 0, string? format = null)
+        // Such an overload would provide the same expressiveness as string.Format.  However, this has several
+        // shortcomings:
+        // - Every value type in a hole would be boxed.
+        // - ReadOnlySpan<char> could not be used in holes.
+        // - Every TryFormatInterpolationHole call would have three arguments at the call site, bloating the IL further.
+        // - Every invocation would be more expensive, due to lack of specialization, every call needing to account
+        //   for alignment and format, etc.
+        //
+        // To address that, we could just have overloads for T and ReadOnlySpan<char>:
+        //     (T)
+        //     (T, int alignment)
+        //     (T, string? format)
+        //     (T, int alignment, string? format)
+        //     (ReadOnlySpan<char>)
+        //     (ReadOnlySpan<char>, int alignment)
+        //     (ReadOnlySpan<char>, string? format)
+        //     (ReadOnlySpan<char>, int alignment, string? format)
+        // but this also has shortcomings:
+        // - Some expressions that would have worked with an object overload will now force a fallback to string.Format
+        //   (or fail to compile if the builder is used in places where the fallback isn't provided), because the compiler
+        //   can't always target type to T, e.g. `b switch { true => 1, false => null }` where `b` is a bool can successfully
+        //   be passed as an argument of type `object` but not of type `T`.
+        // - Reference types get no benefit from going through the generic code paths, and actually incur some overheads
+        //   from doing so.
+        // - Nullable value types also pay a heavy price, in particular around interface checks that would generally evaporate
+        //   at compile time for value types but don't (currently) if the Nullable<T> goes through the same code paths
+        //   (see https://github.com/dotnet/runtime/issues/50915).
+        //
+        // We could try to take a more elaborate approach for InterpolatedStringBuilder, since it is the most common builder
+        // and we want to minimize overheads both at runtime and in IL size, e.g. have a complete set of overloads for each of:
+        //     (T, ...) where T : struct
+        //     (T?, ...) where T : struct
+        //     (object, ...)
+        //     (ReadOnlySpan<char>, ...)
+        //     (string, ...)
+        // but this also has shortcomings, most importantly:
+        // - If you have an unconstrained T that happens to be a value type, it'll now end up getting boxed to use the object overload.
+        //   This also necessitates the T? overload, since nullable value types don't meet a T : struct constraint, so without those
+        //   they'd all map to the object overloads as well.
+        // - Any reference type with an implicit cast to ROS<char> will fail to compile due to ambiguities between the overloads. string
+        //   is one such type, hence needing dedicated overloads for it that can be bound to more tightly.
+        //
+        // A middle ground we've settled on, which is likely to be the right approach for most other builders as well, would be the set:
+        //     (T, ...) with no constraint
+        //     (ReadOnlySpan<char>) and (ReadOnlySpan<char>, int)
+        //     (object, int alignment = 0, string? format = null)
+        //     (string) and (string, int)
+        // This would address most of the concerns, at the expense of:
+        // - Most reference types going through the generic code paths and so being a bit more expensive.
+        // - Nullable types being more expensive until https://github.com/dotnet/runtime/issues/50915 is addressed.
+        //   We could choose to add a T? where T : struct set of overloads if necessary.
+        // Strings don't require their own overloads here, but as they're expected to be very common and as we can
+        // optimize them in several ways (can copy the contents directly, don't need to do any interface checks, don't
+        // need to pay the shared generic overheads, etc.) we can add overloads specifically to optimize for them.
+        //
+        // Hole values are formatted according to the following policy:
+        // 1. If an IFormatProvider was supplied and it provides an ICustomFormatter, use ICustomFormatter.Format (even if the value is null).
+        // 2. If the type implements ISpanFormattable, use ISpanFormattable.TryFormat.
+        // 3. If the type implements IFormattable, use IFormattable.ToString.
+        // 4. Otherwise, use object.ToString.
+        // This matches the behavior of string.Format, StringBuilder.AppendFormat, etc.  The only overloads for which this doesn't
+        // apply is ReadOnlySpan<char>, which isn't supported by either string.Format nor StringBuilder.AppendFormat, but more
+        // importantly which can't be boxed to be passed to ICustomFormatter.Format.
+
+        #region TryFormatInterpolationHole T
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        public void TryFormatInterpolationHole<T>(T value)
+        {
+            // This method could delegate to TryFormatInterpolationHole with a null format, but explicitly passing
+            // default as the format to TryFormat helps to improve code quality in some cases when TryFormat is inlined,
+            // e.g. for Int32 it enables the JIT to eliminate code in the inlined method based on a length check on the format.
+
+            // If there's a custom formatter, always use it.
+            if (_customFormatter is not null)
+            {
+                FormatCustomFormatter(value, format: null);
+                return;
+            }
+
+            // Check first for IFormattable, even though we'll prefer to use ISpanFormattable, as the latter
+            // derives from the former.  For value types, it won't matter as the type checks devolve into
+            // JIT-time constants.  For reference types, they're more likely to implement IFormattable
+            // than they are to implement ISpanFormattable: if they don't implement either, we save an
+            // interface check over first checking for ISpanFormattable and then for IFormattable, and
+            // if it only implements IFormattable, we come out even: only if it implements both do we
+            // end up paying for an extra interface check.
+            string? s;
+            if (value is IFormattable)
+            {
+                // If the value can format itself directly into our buffer, do so.
+                if (value is ISpanFormattable)
+                {
+                    int charsWritten;
+                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                    {
+                        Grow();
+                    }
+
+                    _pos += charsWritten;
+                    return;
+                }
+
+                s = ((IFormattable)value).ToString(format: null, _provider); // constrained call avoiding boxing for value types
+            }
+            else
+            {
+                s = value?.ToString();
+            }
+
+            if (s is not null)
+            {
+                TryFormatBaseString(s); // use TryFormatBaseString to avoid going back through this method recursively
+            }
+        }
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="format">The format string.</param>
+        public void TryFormatInterpolationHole<T>(T value, string? format)
+        {
+            // If there's a custom formatter, always use it.
+            if (_customFormatter is not null)
+            {
+                FormatCustomFormatter(value, format);
+                return;
+            }
+
+            // Check first for IFormattable, even though we'll prefer to use ISpanFormattable, as the latter
+            // derives from the former.  For value types, it won't matter as the type checks devolve into
+            // JIT-time constants.  For reference types, they're more likely to implement IFormattable
+            // than they are to implement ISpanFormattable: if they don't implement either, we save an
+            // interface check over first checking for ISpanFormattable and then for IFormattable, and
+            // if it only implements IFormattable, we come out even: only if it implements both do we
+            // end up paying for an extra interface check.
+            string? s;
+            if (value is IFormattable)
+            {
+                // If the value can format itself directly into our buffer, do so.
+                if (value is ISpanFormattable)
+                {
+                    int charsWritten;
+                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                    {
+                        Grow();
+                    }
+
+                    _pos += charsWritten;
+                    return;
+                }
+
+                s = ((IFormattable)value).ToString(format, _provider); // constrained call avoiding boxing for value types
+            }
+            else
+            {
+                s = value?.ToString();
+            }
+
+            if (s is not null)
+            {
+                TryFormatBaseString(s); // use TryFormatBaseString to avoid going back through this method recursively
+            }
+        }
+
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        public void TryFormatInterpolationHole<T>(T value, int alignment)
+        {
+            int startingPos = _pos;
+            TryFormatInterpolationHole(value);
+            if (alignment != 0)
+            {
+                AppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+            }
+        }
+
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="format">The format string.</param>
+        /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        public void TryFormatInterpolationHole<T>(T value, int alignment, string? format)
+        {
+            int startingPos = _pos;
+            TryFormatInterpolationHole(value, format);
+            if (alignment != 0)
+            {
+                AppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+            }
+        }
+        #endregion
+
+        #region TryFormatInterpolationHole ReadOnlySpan<char>
+        /// <summary>Writes the specified character span to the builder.</summary>
+        /// <param name="value">The span to write.</param>
+        public void TryFormatInterpolationHole(ReadOnlySpan<char> value)
+        {
+            // Fast path for when the value fits in the current buffer
+            if (value.TryCopyTo(_chars.Slice(_pos)))
+            {
+                _pos += value.Length;
+            }
+            else
+            {
+                GrowThenCopySpan(value);
+            }
+        }
+
+        /// <summary>Writes the specified string of chars to the builder.</summary>
+        /// <param name="value">The span to write.</param>
+        /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        /// <param name="format">The format string.</param>
+        public void TryFormatInterpolationHole(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+        {
+            bool leftAlign = false;
+            if (alignment < 0)
+            {
+                leftAlign = true;
+                alignment = -alignment;
+            }
+
+            int paddingRequired = alignment - value.Length;
+            if (paddingRequired <= 0)
+            {
+                // The value is as large or larger than the required amount of padding,
+                // so just write the value.
+                TryFormatInterpolationHole(value);
+                return;
+            }
+
+            // Write the value along with the appropriate padding.
+            EnsureCapacityForAdditionalChars(value.Length + paddingRequired);
+            if (leftAlign)
+            {
+                value.CopyTo(_chars.Slice(_pos));
+                _pos += value.Length;
+                _chars.Slice(_pos, paddingRequired).Fill(' ');
+                _pos += paddingRequired;
+            }
+            else
+            {
+                _chars.Slice(_pos, paddingRequired).Fill(' ');
+                _pos += paddingRequired;
+                value.CopyTo(_chars.Slice(_pos));
+                _pos += value.Length;
+            }
+        }
+        #endregion
+
+        #region TryFormatInterpolationHole string
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        public void TryFormatInterpolationHole(string? value)
+        {
+            // Fast-path for no custom formatter and a non-null string that fits in the current destination buffer.
+            if (_customFormatter is null &&
+                value is not null &&
+                value.TryCopyTo(_chars.Slice(_pos)))
+            {
+                _pos += value.Length;
+            }
+            else
+            {
+                TryFormatInterpolationHoleSlow(value);
+            }
+        }
+
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <remarks>
+        /// Slow path to handle a custom formatter, potentially null value,
+        /// or a string that doesn't fit in the current buffer.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TryFormatInterpolationHoleSlow(string? value)
+        {
+            if (_customFormatter is null)
+            {
+                if (value is not null)
+                {
+                    EnsureCapacityForAdditionalChars(value.Length);
+                    value.CopyTo(_chars.Slice(_pos));
+                    _pos += value.Length;
+                }
+            }
+            else
+            {
+                FormatCustomFormatter(value, format: null);
+            }
+        }
+
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        /// <param name="format">The format string.</param>
+        public void TryFormatInterpolationHole(string? value, int alignment = 0, string? format = null) =>
+            // Format is meaningless for strings and doesn't make sense for someone to specify.  We have the overload
+            // simply to disambiguate between ROS<char> and object, just in case someone does specify a format, as
+            // string is implicitly convertible to both. Just delegate to the T-based implementation.
+            TryFormatInterpolationHole<string?>(value, alignment, format);
+        #endregion
+
+        #region TryFormatInterpolationHole object
+        /// <summary>Writes the specified value to the builder.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        /// <param name="format">The format string.</param>
+        public void TryFormatInterpolationHole(object? value, int alignment = 0, string? format = null) =>
+            // This overload is expected to be used rarely, only if either a) something strongly typed as object is
+            // formatted with both an alignment and a format, or b) the compiler is unable to target type to T. It
+            // exists purely to help make cases from (b) compile. Just delegate to the T-based implementation.
+            TryFormatInterpolationHole<object?>(value, alignment, format);
+        #endregion
+        #endregion
+
+        /// <summary>Formats the value using the custom formatter from the provider.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="format">The format string.</param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void FormatCustomFormatter<T>(T value, string? format)
+        {
+            // This case is very rare, but we need to handle it prior to the other checks in case
+            // a provider was used that supplied an ICustomFormatter which wanted to intercept the particular value.
+            // We do the cast here rather than in the ctor, even though this could be executed multiple times per
+            // formatting, to make the cast pay for play.
+            Debug.Assert(_customFormatter is not null);
+            if (((ICustomFormatter)_customFormatter).Format(format, value, _provider) is string customFormatted)
+            {
+                TryFormatBaseString(customFormatted); // use TryFormatBaseString to avoid going back through this method recursively
+            }
+        }
+
+        /// <summary>Handles adding any padding required for aligning a formatted value in a hole.</summary>
+        /// <param name="startingPos">The position at which the written value started.</param>
+        /// <param name="alignment">Non-zero minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        private void AppendOrInsertAlignmentIfNeeded(int startingPos, int alignment)
+        {
+            Debug.Assert(startingPos >= 0 && startingPos <= _pos);
+            Debug.Assert(alignment != 0);
+
+            int charsWritten = _pos - startingPos;
+
+            bool leftAlign = false;
+            if (alignment < 0)
+            {
+                leftAlign = true;
+                alignment = -alignment;
+            }
+
+            int paddingNeeded = alignment - charsWritten;
+            if (paddingNeeded > 0)
+            {
+                EnsureCapacityForAdditionalChars(paddingNeeded);
+
+                if (leftAlign)
+                {
+                    _chars.Slice(_pos, paddingNeeded).Fill(' ');
+                }
+                else
+                {
+                    _chars.Slice(startingPos, charsWritten).CopyTo(_chars.Slice(startingPos + paddingNeeded));
+                    _chars.Slice(startingPos, paddingNeeded).Fill(' ');
+                }
+
+                _pos += paddingNeeded;
+            }
+        }
+
+        /// <summary>Ensures <see cref="_chars"/> has the capacity to store <paramref name="additionalChars"/> beyond <see cref="_pos"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureCapacityForAdditionalChars(int additionalChars)
+        {
+            if (_chars.Length - _pos < additionalChars)
+            {
+                Grow(additionalChars);
+            }
+        }
+
+        /// <summary>Fallback for fast path in <see cref="TryFormatBaseString"/> when there's not enough space in the destination.</summary>
+        /// <param name="value">The string to write.</param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowThenCopyString(string value)
+        {
+            Grow(value.Length);
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        /// <summary>Fallback for <see cref="TryFormatInterpolationHole(ReadOnlySpan{char})"/> for when not enough space exists in the current buffer.</summary>
+        /// <param name="value">The span to write.</param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowThenCopySpan(ReadOnlySpan<char> value)
+        {
+            Grow(value.Length);
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        /// <summary>Grows <see cref="_chars"/> to have the capacity to store <paramref name="additionalChars"/> beyond <see cref="_pos"/>.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)] // keep consumers as streamlined as possible
+        private void Grow(int additionalChars)
+        {
+            Debug.Assert(_pos > _chars.Length - additionalChars);
+            GrowCore(Math.Max(_chars.Length * 2, _pos + additionalChars));
+        }
+
+        /// <summary>Grow the size of <see cref="_chars"/>.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)] // keep consumers as streamlined as possible
+        private void Grow() =>
+            GrowCore(Math.Max(_chars.Length * 2, _chars.Length + 1));
+
+        /// <summary>Grow the size of <see cref="_chars"/> to the specified <paramref name="newCapacity"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // but reuse this grow logic directly in both of the above grow routines
+        private void GrowCore(int newCapacity)
+        {
+            char[] newArray = ArrayPool<char>.Shared.Rent(Math.Max(MinimumArrayPoolLength, newCapacity));
+            _chars.Slice(0, _pos).CopyTo(newArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = newArray;
+
+            if (toReturn is not null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct SByte : IComparable, IConvertible, IFormattable, IComparable<sbyte>, IEquatable<sbyte>, ISpanFormattable
+    public readonly struct SByte : IComparable, IConvertible, ISpanFormattable, IComparable<sbyte>, IEquatable<sbyte>
     {
         private readonly sbyte m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -23,7 +23,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct Single : IComparable, IConvertible, IFormattable, IComparable<float>, IEquatable<float>, ISpanFormattable
+    public readonly struct Single : IComparable, IConvertible, ISpanFormattable, IComparable<float>, IEquatable<float>
     {
         private readonly float m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -24,6 +24,10 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed partial class String : IComparable, IEnumerable, IConvertible, IEnumerable<char>, IComparable<string?>, IEquatable<string?>, ICloneable
     {
+        /// <summary>Maximum length allowed for a string.</summary>
+        /// <remarks>Keep in sync with AllocateString in gchelpers.cpp.</remarks>
+        internal const int MaxLength = 0x3FFFFFDF;
+
         //
         // These fields map directly onto the fields in an EE StringObject.  See object.h for the layout.
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -919,6 +919,8 @@ namespace System.Text
 #if SYSTEM_PRIVATE_CORELIB
         bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) =>
             TryEncodeToUtf16(destination, out charsWritten);
+
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
 #endif
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1174,6 +1174,8 @@ namespace System.Text
 
         private StringBuilder AppendSpanFormattable<T>(T value) where T : ISpanFormattable
         {
+            Debug.Assert(typeof(T).Assembly.Equals(typeof(object).Assembly), "Implementation trusts the results of TryFormat because T is expected to be something known");
+
             if (value.TryFormat(RemainingCurrentChunk, out int charsWritten, format: default, provider: null))
             {
                 m_ChunkLength += charsWritten;
@@ -1183,8 +1185,10 @@ namespace System.Text
             return Append(value.ToString());
         }
 
-        internal StringBuilder AppendSpanFormattable<T>(T value, string? format, IFormatProvider? provider) where T : ISpanFormattable, IFormattable
+        internal StringBuilder AppendSpanFormattable<T>(T value, string? format, IFormatProvider? provider) where T : ISpanFormattable
         {
+            Debug.Assert(typeof(T).Assembly.Equals(typeof(object).Assembly), "Implementation trusts the results of TryFormat because T is expected to be something known");
+
             if (value.TryFormat(RemainingCurrentChunk, out int charsWritten, format, provider))
             {
                 m_ChunkLength += charsWritten;
@@ -1746,6 +1750,14 @@ namespace System.Text
                         (leftJustify || width == 0) &&
                         spanFormattableArg.TryFormat(RemainingCurrentChunk, out int charsWritten, itemFormatSpan, provider))
                     {
+                        if ((uint)charsWritten > (uint)RemainingCurrentChunk.Length)
+                        {
+                            // Untrusted ISpanFormattable implementations might return an erroneous charsWritten value,
+                            // and m_ChunkLength might end up being used in unsafe code, so fail if we get back an
+                            // out-of-range charsWritten value.
+                            FormatError();
+                        }
+
                         m_ChunkLength += charsWritten;
 
                         // Pad the end, if needed.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
@@ -43,7 +43,7 @@ namespace System.Text
             AppendFormatHelper(provider, format, new ParamsArray(args));
         }
 
-        internal void AppendSpanFormattable<T>(T value, string? format, IFormatProvider? provider) where T : ISpanFormattable, IFormattable
+        internal void AppendSpanFormattable<T>(T value, string? format, IFormatProvider? provider) where T : ISpanFormattable
         {
             if (value.TryFormat(_chars.Slice(_pos), out int charsWritten, format, provider))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -9,7 +9,7 @@ namespace System
     /// <summary>
     /// Represents a time of day, as would be read from a clock, within the range 00:00:00 to 23:59:59.9999999.
     /// </summary>
-    public readonly struct TimeOnly : IComparable, IComparable<TimeOnly>, IEquatable<TimeOnly>, IFormattable, ISpanFormattable
+    public readonly struct TimeOnly : IComparable, IComparable<TimeOnly>, IEquatable<TimeOnly>, ISpanFormattable
     {
         // represent the number of ticks map to the time of the day. 1 ticks = 100-nanosecond in time measurements.
         private readonly long _ticks;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -25,7 +25,7 @@ namespace System
     // an appropriate custom ILMarshaler to keep WInRT interop scenarios enabled.
     //
     [Serializable]
-    public readonly struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, ISpanFormattable
+    public readonly struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, ISpanFormattable
     {
         public const long TicksPerMillisecond = 10000;
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct UInt16 : IComparable, IConvertible, IFormattable, IComparable<ushort>, IEquatable<ushort>, ISpanFormattable
+    public readonly struct UInt16 : IComparable, IConvertible, ISpanFormattable, IComparable<ushort>, IEquatable<ushort>
     {
         private readonly ushort m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct UInt32 : IComparable, IConvertible, IFormattable, IComparable<uint>, IEquatable<uint>, ISpanFormattable
+    public readonly struct UInt32 : IComparable, IConvertible, ISpanFormattable, IComparable<uint>, IEquatable<uint>
     {
         private readonly uint m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct UInt64 : IComparable, IConvertible, IFormattable, IComparable<ulong>, IEquatable<ulong>, ISpanFormattable
+    public readonly struct UInt64 : IComparable, IConvertible, ISpanFormattable, IComparable<ulong>, IEquatable<ulong>
     {
         private readonly ulong m_value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -22,7 +22,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct UIntPtr : IEquatable<UIntPtr>, IComparable, IComparable<UIntPtr>, IFormattable, ISpanFormattable, ISerializable
+    public readonly struct UIntPtr : IEquatable<UIntPtr>, IComparable, IComparable<UIntPtr>, ISpanFormattable, ISerializable
     {
         private readonly unsafe void* _value; // Do not rename (binary serialization)
 

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -189,6 +189,9 @@ namespace System
             return dest.Slice(0, charsWritten).ToString();
         }
 
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) =>
+            ToString();
+
         public bool TryFormat(Span<char> destination, out int charsWritten) =>
             TryFormat(destination, DefaultFormatFieldCount, out charsWritten);
 

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -6,7 +6,7 @@
 
 namespace System.Numerics
 {
-    public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.ISpanFormattable
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -6,7 +6,7 @@
 
 namespace System.Numerics
 {
-    public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable
+    public readonly partial struct BigInteger : System.IComparable, System.IComparable<System.Numerics.BigInteger>, System.IEquatable<System.Numerics.BigInteger>, System.IFormattable, System.ISpanFormattable
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -9,7 +9,7 @@ namespace System.Numerics
 {
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Numerics, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct BigInteger : IFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>
+    public readonly struct BigInteger : IFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>, ISpanFormattable
     {
         private const uint kuMaskHighBit = unchecked((uint)int.MinValue);
         private const int kcbitUint = 32;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -9,7 +9,7 @@ namespace System.Numerics
 {
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Numerics, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct BigInteger : IFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>, ISpanFormattable
+    public readonly struct BigInteger : ISpanFormattable, IComparable, IComparable<BigInteger>, IEquatable<BigInteger>
     {
         private const uint kuMaskHighBit = unchecked((uint)int.MinValue);
         private const int kcbitUint = 32;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -1296,7 +1296,7 @@ namespace System
         public static bool TryToBase64Chars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, out int charsWritten, System.Base64FormattingOptions options = System.Base64FormattingOptions.None) { throw null; }
     }
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input);
-    public readonly struct DateOnly : System.IComparable, System.IComparable<System.DateOnly>, System.IEquatable<System.DateOnly>, System.IFormattable
+    public readonly struct DateOnly : System.IComparable, System.IComparable<System.DateOnly>, System.IEquatable<System.DateOnly>, System.ISpanFormattable
     {
         public static DateOnly MinValue { get { throw null; } }
         public static DateOnly MaxValue { get { throw null; } }
@@ -3807,7 +3807,7 @@ namespace System
     {
         public ThreadStaticAttribute() { }
     }
-    public readonly struct TimeOnly : System.IComparable, System.IComparable<System.TimeOnly>, System.IEquatable<System.TimeOnly>, System.IFormattable
+    public readonly struct TimeOnly : System.IComparable, System.IComparable<System.TimeOnly>, System.IEquatable<System.TimeOnly>, System.ISpanFormattable
     {
         public static System.TimeOnly MinValue { get { throw null; } }
         public static System.TimeOnly MaxValue { get { throw null; } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9597,21 +9597,22 @@ namespace System.Runtime.CompilerServices
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount) { throw null; }
-        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.IFormatProvider? provider) { throw null; }
-        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.Span<char> scratchBuffer) { throw null; }
-        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.IFormatProvider? provider, System.Span<char> scratchBuffer) { throw null; }
+        public void AppendLiteral(string value) { }
+        public void AppendFormatted(System.ReadOnlySpan<char> value) { }
+        public void AppendFormatted(System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { }
+        public void AppendFormatted<T>(T value) { }
+        public void AppendFormatted<T>(T value, string? format) { }
+        public void AppendFormatted<T>(T value, int alignment) { }
+        public void AppendFormatted<T>(T value, int alignment, string? format) { }
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null) { }
+        public void AppendFormatted(string? value) { throw null; }
+        public void AppendFormatted(string? value, int alignment = 0, string? format = null) { }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int literalLength, int formattedCount) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int literalLength, int formattedCount, System.IFormatProvider? provider) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int literalLength, int formattedCount, System.Span<char> scratchBuffer) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int literalLength, int formattedCount, System.IFormatProvider? provider, System.Span<char> scratchBuffer) { throw null; }
         public override string ToString() { throw null; }
-        public void TryFormatBaseString(string value) { }
-        public void TryFormatInterpolationHole(System.ReadOnlySpan<char> value) { }
-        public void TryFormatInterpolationHole(System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { }
-        public void TryFormatInterpolationHole<T>(T value) { }
-        public void TryFormatInterpolationHole<T>(T value, string? format) { }
-        public void TryFormatInterpolationHole<T>(T value, int alignment) { }
-        public void TryFormatInterpolationHole<T>(T value, int alignment, string? format) { }
-        public void TryFormatInterpolationHole(object? value, int alignment = 0, string? format = null) { }
-        public void TryFormatInterpolationHole(string? value) { throw null; }
-        public void TryFormatInterpolationHole(string? value, int alignment = 0, string? format = null) { }
+        public string ToStringAndClear() { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -683,7 +683,7 @@ namespace System
         public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
-    public readonly partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.ISpanFormattable
     {
         private readonly byte _dummyPrimitive;
         public const byte MaxValue = (byte)255;
@@ -1484,7 +1484,7 @@ namespace System
         Utc = 1,
         Local = 2,
     }
-    public readonly partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    public readonly partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.DateTimeOffset MaxValue;
@@ -1612,7 +1612,7 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
     }
-    public readonly partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    public readonly partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)4294967295, (uint)4294967295, (uint)4294967295)]
@@ -1799,7 +1799,7 @@ namespace System
         public DivideByZeroException(string? message) { }
         public DivideByZeroException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.ISpanFormattable
     {
         private readonly double _dummyPrimitive;
         public const double Epsilon = 5E-324;
@@ -2247,7 +2247,7 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
-    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.Guid Empty;
@@ -2282,7 +2282,7 @@ namespace System
         public bool TryWriteBytes(System.Span<byte> destination) { throw null; }
         bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
     }
-    public readonly partial struct Half : System.IComparable, System.IComparable<System.Half>, System.IEquatable<System.Half>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Half : System.IComparable, System.IComparable<System.Half>, System.IEquatable<System.Half>, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public static System.Half Epsilon { get { throw null; } }
@@ -2453,7 +2453,7 @@ namespace System
         public InsufficientMemoryException(string? message) { }
         public InsufficientMemoryException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.ISpanFormattable
     {
         private readonly short _dummyPrimitive;
         public const short MaxValue = (short)32767;
@@ -2494,7 +2494,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int16 result) { throw null; }
     }
-    public readonly partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public const int MaxValue = 2147483647;
@@ -2535,7 +2535,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int32 result) { throw null; }
     }
-    public readonly partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.ISpanFormattable
     {
         private readonly long _dummyPrimitive;
         public const long MaxValue = (long)9223372036854775807;
@@ -2576,7 +2576,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int64 result) { throw null; }
     }
-    public readonly partial struct IntPtr : System.IComparable, System.IComparable<System.IntPtr>, System.IEquatable<System.IntPtr>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct IntPtr : System.IComparable, System.IComparable<System.IntPtr>, System.IEquatable<System.IntPtr>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.IntPtr Zero;
@@ -3401,7 +3401,7 @@ namespace System
         public static bool operator !=(System.RuntimeTypeHandle left, object? right) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.ISpanFormattable
     {
         private readonly sbyte _dummyPrimitive;
         public const sbyte MaxValue = (sbyte)127;
@@ -3447,7 +3447,7 @@ namespace System
     {
         public SerializableAttribute() { }
     }
-    public readonly partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.ISpanFormattable
     {
         private readonly float _dummyPrimitive;
         public const float Epsilon = 1E-45f;
@@ -4638,7 +4638,7 @@ namespace System
         public TypeUnloadedException(string? message, System.Exception? innerException) { }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.ISpanFormattable
     {
         private readonly ushort _dummyPrimitive;
         public const ushort MaxValue = (ushort)65535;
@@ -4680,7 +4680,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt16 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.ISpanFormattable
     {
         private readonly uint _dummyPrimitive;
         public const uint MaxValue = (uint)4294967295;
@@ -4722,7 +4722,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt32 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.IFormattable, System.ISpanFormattable
+    public readonly partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.ISpanFormattable
     {
         private readonly ulong _dummyPrimitive;
         public const ulong MaxValue = (ulong)18446744073709551615;
@@ -4764,7 +4764,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt64 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UIntPtr : System.IComparable, System.IComparable<System.UIntPtr>, System.IEquatable<System.UIntPtr>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct UIntPtr : System.IComparable, System.IComparable<System.UIntPtr>, System.IEquatable<System.UIntPtr>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.UIntPtr Zero;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -683,7 +683,7 @@ namespace System
         public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
-    public readonly partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.IFormattable
+    public readonly partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.IFormattable, System.ISpanFormattable
     {
         private readonly byte _dummyPrimitive;
         public const byte MaxValue = (byte)255;
@@ -731,7 +731,7 @@ namespace System
         public CannotUnloadAppDomainException(string? message) { }
         public CannotUnloadAppDomainException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Char : System.IComparable, System.IComparable<char>, System.IConvertible, System.IEquatable<char>
+    public readonly partial struct Char : System.IComparable, System.IComparable<char>, System.IConvertible, System.IEquatable<char>, System.ISpanFormattable
     {
         private readonly char _dummyPrimitive;
         public const char MaxValue = '\uFFFF';
@@ -806,6 +806,8 @@ namespace System
         public static System.Char ToUpper(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
         public static System.Char ToUpperInvariant(System.Char c) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Char result) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        string System.IFormattable.ToString(string? format, IFormatProvider? formatProvider) { throw null; }
     }
     public sealed partial class CharEnumerator : System.Collections.Generic.IEnumerator<char>, System.Collections.IEnumerator, System.ICloneable, System.IDisposable
     {
@@ -1354,7 +1356,7 @@ namespace System
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
     }
-    public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.IFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.DateTime MaxValue;
@@ -1482,7 +1484,7 @@ namespace System
         Utc = 1,
         Local = 2,
     }
-    public readonly partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    public readonly partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.DateTimeOffset MaxValue;
@@ -1610,7 +1612,7 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
     }
-    public readonly partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.IFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    public readonly partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)4294967295, (uint)4294967295, (uint)4294967295)]
@@ -1797,7 +1799,7 @@ namespace System
         public DivideByZeroException(string? message) { }
         public DivideByZeroException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.IFormattable
+    public readonly partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.IFormattable, System.ISpanFormattable
     {
         private readonly double _dummyPrimitive;
         public const double Epsilon = 5E-324;
@@ -2245,7 +2247,7 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
-    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable
+    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.Guid Empty;
@@ -2278,8 +2280,9 @@ namespace System
         public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, out System.Guid result) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
     }
-    public readonly partial struct Half : System.IComparable, System.IComparable<System.Half>, System.IEquatable<System.Half>, System.IFormattable
+    public readonly partial struct Half : System.IComparable, System.IComparable<System.Half>, System.IEquatable<System.Half>, System.IFormattable, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public static System.Half Epsilon { get { throw null; } }
@@ -2450,7 +2453,7 @@ namespace System
         public InsufficientMemoryException(string? message) { }
         public InsufficientMemoryException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.IFormattable
+    public readonly partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.IFormattable, System.ISpanFormattable
     {
         private readonly short _dummyPrimitive;
         public const short MaxValue = (short)32767;
@@ -2491,7 +2494,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int16 result) { throw null; }
     }
-    public readonly partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.IFormattable
+    public readonly partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.IFormattable, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public const int MaxValue = 2147483647;
@@ -2532,7 +2535,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int32 result) { throw null; }
     }
-    public readonly partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.IFormattable
+    public readonly partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.IFormattable, System.ISpanFormattable
     {
         private readonly long _dummyPrimitive;
         public const long MaxValue = (long)9223372036854775807;
@@ -2573,7 +2576,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int64 result) { throw null; }
     }
-    public readonly partial struct IntPtr : System.IComparable, System.IComparable<System.IntPtr>, System.IEquatable<System.IntPtr>, System.IFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct IntPtr : System.IComparable, System.IComparable<System.IntPtr>, System.IEquatable<System.IntPtr>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.IntPtr Zero;
@@ -2664,6 +2667,10 @@ namespace System
     public partial interface IProgress<in T>
     {
         void Report(T value);
+    }
+    public partial interface ISpanFormattable : System.IFormattable
+    {
+        bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
     }
     public partial class Lazy<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T>
     {
@@ -3394,7 +3401,7 @@ namespace System
         public static bool operator !=(System.RuntimeTypeHandle left, object? right) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.IFormattable
+    public readonly partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.IFormattable, System.ISpanFormattable
     {
         private readonly sbyte _dummyPrimitive;
         public const sbyte MaxValue = (sbyte)127;
@@ -3440,7 +3447,7 @@ namespace System
     {
         public SerializableAttribute() { }
     }
-    public readonly partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.IFormattable
+    public readonly partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.IFormattable, System.ISpanFormattable
     {
         private readonly float _dummyPrimitive;
         public const float Epsilon = 1E-45f;
@@ -3872,7 +3879,7 @@ namespace System
         public TimeoutException(string? message) { }
         public TimeoutException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct TimeSpan : System.IComparable, System.IComparable<System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.IFormattable
+    public readonly partial struct TimeSpan : System.IComparable, System.IComparable<System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.TimeSpan MaxValue;
@@ -4631,7 +4638,7 @@ namespace System
         public TypeUnloadedException(string? message, System.Exception? innerException) { }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.IFormattable
+    public readonly partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.IFormattable, System.ISpanFormattable
     {
         private readonly ushort _dummyPrimitive;
         public const ushort MaxValue = (ushort)65535;
@@ -4673,7 +4680,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt16 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.IFormattable
+    public readonly partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.IFormattable, System.ISpanFormattable
     {
         private readonly uint _dummyPrimitive;
         public const uint MaxValue = (uint)4294967295;
@@ -4715,7 +4722,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt32 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.IFormattable
+    public readonly partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.IFormattable, System.ISpanFormattable
     {
         private readonly ulong _dummyPrimitive;
         public const ulong MaxValue = (ulong)18446744073709551615;
@@ -4757,7 +4764,7 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt64 result) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UIntPtr : System.IComparable, System.IComparable<System.UIntPtr>, System.IEquatable<System.UIntPtr>, System.IFormattable, System.Runtime.Serialization.ISerializable
+    public readonly partial struct UIntPtr : System.IComparable, System.IComparable<System.UIntPtr>, System.IEquatable<System.UIntPtr>, System.IFormattable, System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.UIntPtr Zero;
@@ -5200,7 +5207,7 @@ namespace System
         public override int GetHashCode() { throw null; }
         public override string? ToString() { throw null; }
     }
-    public sealed partial class Version : System.ICloneable, System.IComparable, System.IComparable<System.Version?>, System.IEquatable<System.Version?>
+    public sealed partial class Version : System.ICloneable, System.IComparable, System.IComparable<System.Version?>, System.IEquatable<System.Version?>, System.ISpanFormattable
     {
         public Version() { }
         public Version(int major, int minor) { }
@@ -5233,6 +5240,8 @@ namespace System
         public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Version? result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Version? result) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        string System.IFormattable.ToString(string? format, IFormatProvider? formatProvider) { throw null; }
     }
     public partial struct Void
     {
@@ -9584,6 +9593,26 @@ namespace System.Runtime.CompilerServices
         public bool AllInternalsVisible { get { throw null; } set { } }
         public string AssemblyName { get { throw null; } }
     }
+    public ref struct InterpolatedStringBuilder
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.IFormatProvider? provider) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.Span<char> scratchBuffer) { throw null; }
+        public static System.Runtime.CompilerServices.InterpolatedStringBuilder Create(int baseLength, int holeCount, System.IFormatProvider? provider, System.Span<char> scratchBuffer) { throw null; }
+        public override string ToString() { throw null; }
+        public void TryFormatBaseString(string value) { }
+        public void TryFormatInterpolationHole(System.ReadOnlySpan<char> value) { }
+        public void TryFormatInterpolationHole(System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { }
+        public void TryFormatInterpolationHole<T>(T value) { }
+        public void TryFormatInterpolationHole<T>(T value, string? format) { }
+        public void TryFormatInterpolationHole<T>(T value, int alignment) { }
+        public void TryFormatInterpolationHole<T>(T value, int alignment, string? format) { }
+        public void TryFormatInterpolationHole(object? value, int alignment = 0, string? format = null) { }
+        public void TryFormatInterpolationHole(string? value) { throw null; }
+        public void TryFormatInterpolationHole(string? value, int alignment = 0, string? format = null) { }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class IsByRefLikeAttribute : System.Attribute
@@ -10934,7 +10963,7 @@ namespace System.Text
         FormKC = 5,
         FormKD = 6,
     }
-    public readonly partial struct Rune : System.IComparable, System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>
+    public readonly partial struct Rune : System.IComparable, System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>, System.ISpanFormattable
     {
         private readonly int _dummyPrimitive;
         public Rune(char ch) { throw null; }
@@ -11000,6 +11029,8 @@ namespace System.Text
         public bool TryEncodeToUtf8(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public static bool TryGetRuneAt(string input, int index, out System.Text.Rune value) { throw null; }
         int System.IComparable.CompareTo(object? obj) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        string System.IFormattable.ToString(string? format, IFormatProvider? formatProvider) { throw null; }
     }
     public sealed partial class StringBuilder : System.Runtime.Serialization.ISerializable
     {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -220,6 +220,7 @@
     <Compile Include="System\Runtime\CompilerServices\AttributesTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\ConditionalWeakTableTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\FormattableStringFactoryTests.cs" />
+    <Compile Include="System\Runtime\CompilerServices\InterpolatedStringBuilderTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\StrongBoxTests.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttributeTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/InterpolatedStringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/InterpolatedStringBuilderTests.cs
@@ -435,7 +435,7 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal(expected, tss.ToStringState.ToStringMode);
         }
 
-        private sealed class SpanFormattableStringWrapper : IFormattable, ISpanFormattable, IHasToStringState
+        private sealed class SpanFormattableStringWrapper : ISpanFormattable, IHasToStringState
         {
             private readonly string _value;
             public ToStringState ToStringState { get; } = new ToStringState();
@@ -482,7 +482,7 @@ namespace System.Runtime.CompilerServices.Tests
             }
         }
 
-        private struct SpanFormattableInt32Wrapper : IFormattable, ISpanFormattable, IHasToStringState
+        private struct SpanFormattableInt32Wrapper : ISpanFormattable, IHasToStringState
         {
             private readonly int _value;
             public ToStringState ToStringState { get; }

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/InterpolatedStringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/InterpolatedStringBuilderTests.cs
@@ -1,0 +1,623 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace System.Runtime.CompilerServices.Tests
+{
+    public class InterpolatedStringBuilderTests
+    {
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(42, 84)]
+        [InlineData(-1, 0)]
+        [InlineData(-1, -1)]
+        [InlineData(-16, 1)]
+        public void LengthAndHoleArguments_Valid(int baseLength, int holeCount)
+        {
+            InterpolatedStringBuilder.Create(baseLength, holeCount);
+
+            Span<char> scratch1 = stackalloc char[1];
+            foreach (IFormatProvider provider in new IFormatProvider[] { null, new ConcatFormatter(), CultureInfo.InvariantCulture, CultureInfo.CurrentCulture, new CultureInfo("en-US"), new CultureInfo("fr-FR") })
+            {
+                InterpolatedStringBuilder.Create(baseLength, holeCount, provider);
+
+                InterpolatedStringBuilder.Create(baseLength, holeCount, provider, default);
+                InterpolatedStringBuilder.Create(baseLength, holeCount, provider, scratch1);
+                InterpolatedStringBuilder.Create(baseLength, holeCount, provider, Array.Empty<char>());
+                InterpolatedStringBuilder.Create(baseLength, holeCount, provider, new char[256]);
+            }
+
+            InterpolatedStringBuilder.Create(baseLength, holeCount, Span<char>.Empty);
+            InterpolatedStringBuilder.Create(baseLength, holeCount, scratch1);
+            InterpolatedStringBuilder.Create(baseLength, holeCount, Array.Empty<char>());
+            InterpolatedStringBuilder.Create(baseLength, holeCount, new char[256]);
+        }
+
+        [Fact]
+        public void ToString_Clears()
+        {
+            InterpolatedStringBuilder builder = InterpolatedStringBuilder.Create(0, 0);
+            builder.TryFormatBaseString("hi");
+            Assert.Equal("hi", builder.ToString());
+            Assert.Equal(string.Empty, builder.ToString());
+        }
+
+        [Fact]
+        public void TryFormatBaseString()
+        {
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0);
+
+            foreach (string s in new[] { "", "a", "bc", "def", "this is a long string", "!" })
+            {
+                expected.Append(s);
+                actual.TryFormatBaseString(s);
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_ReadOnlySpanChar()
+        {
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0);
+
+            foreach (string s in new[] { "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                // span
+                expected.Append(s);
+                actual.TryFormatInterpolationHole((ReadOnlySpan<char>)s);
+
+                // span, format
+                expected.AppendFormat("{0:X2}", s);
+                actual.TryFormatInterpolationHole((ReadOnlySpan<char>)s, format: "X2");
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // span, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", s);
+                    actual.TryFormatInterpolationHole((ReadOnlySpan<char>)s, alignment);
+
+                    // span, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", s);
+                    actual.TryFormatInterpolationHole((ReadOnlySpan<char>)s, alignment, "X2");
+                }
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_String()
+        {
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0);
+
+            foreach (string s in new[] { null, "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                // string
+                expected.AppendFormat("{0}", s);
+                actual.TryFormatInterpolationHole(s);
+
+                // string, format
+                expected.AppendFormat("{0:X2}", s);
+                actual.TryFormatInterpolationHole(s, "X2");
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // string, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", s);
+                    actual.TryFormatInterpolationHole(s, alignment);
+
+                    // string, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", s);
+                    actual.TryFormatInterpolationHole(s, alignment, "X2");
+                }
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_String_ICustomFormatter()
+        {
+            var provider = new ConcatFormatter();
+
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0, provider);
+
+            foreach (string s in new[] { null, "", "a" })
+            {
+                // string
+                expected.AppendFormat(provider, "{0}", s);
+                actual.TryFormatInterpolationHole(s);
+
+                // string, format
+                expected.AppendFormat(provider, "{0:X2}", s);
+                actual.TryFormatInterpolationHole(s, "X2");
+
+                // string, alignment
+                expected.AppendFormat(provider, "{0,3}", s);
+                actual.TryFormatInterpolationHole(s, 3);
+
+                // string, alignment, format
+                expected.AppendFormat(provider, "{0,-3:X2}", s);
+                actual.TryFormatInterpolationHole(s, -3, "X2");
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_ReferenceTypes()
+        {
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0);
+
+            foreach (string rawInput in new[] { null, "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                foreach (object o in new object[]
+                {
+                    rawInput, // raw string directly; ToString will return itself
+                    new StringWrapper(rawInput), // wrapper object that returns string from ToString
+                    new FormattableStringWrapper(rawInput), // IFormattable wrapper around string
+                    new SpanFormattableStringWrapper(rawInput) // ISpanFormattable wrapper around string
+                })
+                {
+                    // object
+                    expected.AppendFormat("{0}", o);
+                    actual.TryFormatInterpolationHole(o);
+                    if (o is IHasToStringState tss1)
+                    {
+                        Assert.True(string.IsNullOrEmpty(tss1.ToStringState.LastFormat));
+                        AssertModeMatchesType(tss1);
+                    }
+
+                    // object, format
+                    expected.AppendFormat("{0:X2}", o);
+                    actual.TryFormatInterpolationHole(o,  "X2");
+                    if (o is IHasToStringState tss2)
+                    {
+                        Assert.Equal("X2", tss2.ToStringState.LastFormat);
+                        AssertModeMatchesType(tss2);
+                    }
+
+                    foreach (int alignment in new[] { 0, 3, -3 })
+                    {
+                        // object, alignment
+                        expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", o);
+                        actual.TryFormatInterpolationHole(o, alignment);
+                        if (o is IHasToStringState tss3)
+                        {
+                            Assert.True(string.IsNullOrEmpty(tss3.ToStringState.LastFormat));
+                            AssertModeMatchesType(tss3);
+                        }
+
+                        // object, alignment, format
+                        expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", o);
+                        actual.TryFormatInterpolationHole(o, alignment, "X2");
+                        if (o is IHasToStringState tss4)
+                        {
+                            Assert.Equal("X2", tss4.ToStringState.LastFormat);
+                            AssertModeMatchesType(tss4);
+                        }
+                    }
+                }
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryFormatInterpolationHole_ReferenceTypes_CreateProviderFlowed(bool useScratch)
+        {
+            var provider = new CultureInfo("en-US");
+            InterpolatedStringBuilder builder = useScratch ?
+                InterpolatedStringBuilder.Create(1, 2, provider, stackalloc char[16]) :
+                InterpolatedStringBuilder.Create(1, 2, provider);
+
+            foreach (IHasToStringState tss in new IHasToStringState[] { new FormattableStringWrapper("hello"), new SpanFormattableStringWrapper("hello") })
+            {
+                builder.TryFormatInterpolationHole(tss);
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(tss, 1);
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(tss, "X2");
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(tss, 1, "X2");
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+            }
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_ReferenceTypes_ICustomFormatter()
+        {
+            var provider = new ConcatFormatter();
+
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0, provider);
+
+            foreach (string s in new[] { null, "", "a" })
+            {
+                foreach (IHasToStringState tss in new IHasToStringState[] { new FormattableStringWrapper(s), new SpanFormattableStringWrapper(s) })
+                {
+                    void AssertTss(IHasToStringState tss, string format)
+                    {
+                        Assert.Equal(format, tss.ToStringState.LastFormat);
+                        Assert.Same(provider, tss.ToStringState.LastProvider);
+                        Assert.Equal(ToStringMode.ICustomFormatterFormat, tss.ToStringState.ToStringMode);
+                    }
+
+                    // object
+                    expected.AppendFormat(provider, "{0}", tss);
+                    actual.TryFormatInterpolationHole(tss);
+                    AssertTss(tss, null);
+
+                    // object, format
+                    expected.AppendFormat(provider, "{0:X2}", tss);
+                    actual.TryFormatInterpolationHole(tss, "X2");
+                    AssertTss(tss, "X2");
+
+                    // object, alignment
+                    expected.AppendFormat(provider, "{0,3}", tss);
+                    actual.TryFormatInterpolationHole(tss, 3);
+                    AssertTss(tss, null);
+
+                    // object, alignment, format
+                    expected.AppendFormat(provider, "{0,-3:X2}", tss);
+                    actual.TryFormatInterpolationHole(tss, -3, "X2");
+                    AssertTss(tss, "X2");
+                }
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_ValueTypes()
+        {
+            void Test<T>(T t)
+            {
+                var expected = new StringBuilder();
+                InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0);
+
+                // struct
+                expected.AppendFormat("{0}", t);
+                actual.TryFormatInterpolationHole(t);
+                Assert.True(string.IsNullOrEmpty(((IHasToStringState)t).ToStringState.LastFormat));
+                AssertModeMatchesType(((IHasToStringState)t));
+
+                // struct, format
+                expected.AppendFormat("{0:X2}", t);
+                actual.TryFormatInterpolationHole(t, "X2");
+                Assert.Equal("X2", ((IHasToStringState)t).ToStringState.LastFormat);
+                AssertModeMatchesType(((IHasToStringState)t));
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // struct, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", t);
+                    actual.TryFormatInterpolationHole(t, alignment);
+                    Assert.True(string.IsNullOrEmpty(((IHasToStringState)t).ToStringState.LastFormat));
+                    AssertModeMatchesType(((IHasToStringState)t));
+
+                    // struct, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", t);
+                    actual.TryFormatInterpolationHole(t, alignment, "X2");
+                    Assert.Equal("X2", ((IHasToStringState)t).ToStringState.LastFormat);
+                    AssertModeMatchesType(((IHasToStringState)t));
+                }
+
+                Assert.Equal(expected.ToString(), actual.ToString());
+            }
+
+            Test(new FormattableInt32Wrapper(42));
+            Test(new SpanFormattableInt32Wrapper(84));
+            Test((FormattableInt32Wrapper?)new FormattableInt32Wrapper(42));
+            Test((SpanFormattableInt32Wrapper?)new SpanFormattableInt32Wrapper(84));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryFormatInterpolationHole_ValueTypes_CreateProviderFlowed(bool useScratch)
+        {
+            void Test<T>(T t)
+            {
+                var provider = new CultureInfo("en-US");
+                InterpolatedStringBuilder builder = useScratch ?
+                    InterpolatedStringBuilder.Create(1, 2, provider, stackalloc char[16]) :
+                    InterpolatedStringBuilder.Create(1, 2, provider);
+
+                builder.TryFormatInterpolationHole(t);
+                Assert.Same(provider, ((IHasToStringState)t).ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(t, 1);
+                Assert.Same(provider, ((IHasToStringState)t).ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(t, "X2");
+                Assert.Same(provider, ((IHasToStringState)t).ToStringState.LastProvider);
+
+                builder.TryFormatInterpolationHole(t, 1, "X2");
+                Assert.Same(provider, ((IHasToStringState)t).ToStringState.LastProvider);
+            }
+
+            Test(new FormattableInt32Wrapper(42));
+            Test(new SpanFormattableInt32Wrapper(84));
+            Test((FormattableInt32Wrapper?)new FormattableInt32Wrapper(42));
+            Test((SpanFormattableInt32Wrapper?)new SpanFormattableInt32Wrapper(84));
+        }
+
+        [Fact]
+        public void TryFormatInterpolationHole_ValueTypes_ICustomFormatter()
+        {
+            var provider = new ConcatFormatter();
+
+            void Test<T>(T t)
+            {
+                void AssertTss(T tss, string format)
+                {
+                    Assert.Equal(format, ((IHasToStringState)tss).ToStringState.LastFormat);
+                    Assert.Same(provider, ((IHasToStringState)tss).ToStringState.LastProvider);
+                    Assert.Equal(ToStringMode.ICustomFormatterFormat, ((IHasToStringState)tss).ToStringState.ToStringMode);
+                }
+
+                var expected = new StringBuilder();
+                InterpolatedStringBuilder actual = InterpolatedStringBuilder.Create(0, 0, provider);
+
+                // struct
+                expected.AppendFormat(provider, "{0}", t);
+                actual.TryFormatInterpolationHole(t);
+                AssertTss(t, null);
+
+                // struct, format
+                expected.AppendFormat(provider, "{0:X2}", t);
+                actual.TryFormatInterpolationHole(t, "X2");
+                AssertTss(t, "X2");
+
+                // struct, alignment
+                expected.AppendFormat(provider, "{0,3}", t);
+                actual.TryFormatInterpolationHole(t, 3);
+                AssertTss(t, null);
+
+                // struct, alignment, format
+                expected.AppendFormat(provider, "{0,-3:X2}", t);
+                actual.TryFormatInterpolationHole(t, -3, "X2");
+                AssertTss(t, "X2");
+
+                Assert.Equal(expected.ToString(), actual.ToString());
+            }
+
+            Test(new FormattableInt32Wrapper(42));
+            Test(new SpanFormattableInt32Wrapper(84));
+            Test((FormattableInt32Wrapper?)new FormattableInt32Wrapper(42));
+            Test((SpanFormattableInt32Wrapper?)new SpanFormattableInt32Wrapper(84));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Grow_Large(bool useScratch)
+        {
+            var expected = new StringBuilder();
+            InterpolatedStringBuilder builder = useScratch ?
+                InterpolatedStringBuilder.Create(3, 1000, null, stackalloc char[16]) :
+                InterpolatedStringBuilder.Create(3, 1000);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                builder.TryFormatInterpolationHole(i);
+                expected.Append(i);
+
+                builder.TryFormatInterpolationHole(i, 3);
+                expected.AppendFormat("{0,3}", i);
+            }
+
+            Assert.Equal(expected.ToString(), builder.ToString());
+        }
+
+        private static void AssertModeMatchesType<T>(T tss) where T : IHasToStringState
+        {
+            ToStringMode expected =
+                tss is ISpanFormattable ? ToStringMode.ISpanFormattableTryFormat :
+                tss is IFormattable ? ToStringMode.IFormattableToString :
+                ToStringMode.ObjectToString;
+            Assert.Equal(expected, tss.ToStringState.ToStringMode);
+        }
+
+        private sealed class SpanFormattableStringWrapper : IFormattable, ISpanFormattable, IHasToStringState
+        {
+            private readonly string _value;
+            public ToStringState ToStringState { get; } = new ToStringState();
+
+            public SpanFormattableStringWrapper(string value) => _value = value;
+
+            public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            {
+                ToStringState.LastFormat = format.ToString();
+                ToStringState.LastProvider = provider;
+                ToStringState.ToStringMode = ToStringMode.ISpanFormattableTryFormat;
+
+                if (_value is null)
+                {
+                    charsWritten = 0;
+                    return true;
+                }
+
+                if (_value.Length > destination.Length)
+                {
+                    charsWritten = 0;
+                    return false;
+                }
+
+                charsWritten = _value.Length;
+                _value.AsSpan().CopyTo(destination);
+                return true;
+            }
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                ToStringState.LastFormat = format;
+                ToStringState.LastProvider = formatProvider;
+                ToStringState.ToStringMode = ToStringMode.IFormattableToString;
+                return _value;
+            }
+
+            public override string ToString()
+            {
+                ToStringState.LastFormat = null;
+                ToStringState.LastProvider = null;
+                ToStringState.ToStringMode = ToStringMode.ObjectToString;
+                return _value;
+            }
+        }
+
+        private struct SpanFormattableInt32Wrapper : IFormattable, ISpanFormattable, IHasToStringState
+        {
+            private readonly int _value;
+            public ToStringState ToStringState { get; }
+
+            public SpanFormattableInt32Wrapper(int value)
+            {
+                ToStringState = new ToStringState();
+                _value = value;
+            }
+
+            public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            {
+                ToStringState.LastFormat = format.ToString();
+                ToStringState.LastProvider = provider;
+                ToStringState.ToStringMode = ToStringMode.ISpanFormattableTryFormat;
+
+                return _value.TryFormat(destination, out charsWritten, format, provider);
+            }
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                ToStringState.LastFormat = format;
+                ToStringState.LastProvider = formatProvider;
+                ToStringState.ToStringMode = ToStringMode.IFormattableToString;
+                return _value.ToString(format, formatProvider);
+            }
+
+            public override string ToString()
+            {
+                ToStringState.LastFormat = null;
+                ToStringState.LastProvider = null;
+                ToStringState.ToStringMode = ToStringMode.ObjectToString;
+                return _value.ToString();
+            }
+        }
+
+        private sealed class FormattableStringWrapper : IFormattable, IHasToStringState
+        {
+            private readonly string _value;
+            public ToStringState ToStringState { get; } = new ToStringState();
+
+            public FormattableStringWrapper(string s) => _value = s;
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                ToStringState.LastFormat = format;
+                ToStringState.LastProvider = formatProvider;
+                ToStringState.ToStringMode = ToStringMode.IFormattableToString;
+                return _value;
+            }
+
+            public override string ToString()
+            {
+                ToStringState.LastFormat = null;
+                ToStringState.LastProvider = null;
+                ToStringState.ToStringMode = ToStringMode.ObjectToString;
+                return _value;
+            }
+        }
+
+        private struct FormattableInt32Wrapper : IFormattable, IHasToStringState
+        {
+            private readonly int _value;
+            public ToStringState ToStringState { get; }
+
+            public FormattableInt32Wrapper(int i)
+            {
+                ToStringState = new ToStringState();
+                _value = i;
+            }
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                ToStringState.LastFormat = format;
+                ToStringState.LastProvider = formatProvider;
+                ToStringState.ToStringMode = ToStringMode.IFormattableToString;
+                return _value.ToString(format, formatProvider);
+            }
+
+            public override string ToString()
+            {
+                ToStringState.LastFormat = null;
+                ToStringState.LastProvider = null;
+                ToStringState.ToStringMode = ToStringMode.ObjectToString;
+                return _value.ToString();
+            }
+        }
+
+        private sealed class ToStringState
+        {
+            public string LastFormat { get; set; }
+            public IFormatProvider LastProvider { get; set; }
+            public ToStringMode ToStringMode { get; set; }
+        }
+
+        private interface IHasToStringState
+        {
+            ToStringState ToStringState { get; }
+        }
+
+        private enum ToStringMode
+        {
+            ObjectToString,
+            IFormattableToString,
+            ISpanFormattableTryFormat,
+            ICustomFormatterFormat,
+        }
+
+        private sealed class StringWrapper
+        {
+            private readonly string _value;
+
+            public StringWrapper(string s) => _value = s;
+
+            public override string ToString() => _value;
+        }
+
+        private sealed class ConcatFormatter : IFormatProvider, ICustomFormatter
+        {
+            public object GetFormat(Type formatType) => formatType == typeof(ICustomFormatter) ? this : null;
+
+            public string Format(string format, object arg, IFormatProvider formatProvider)
+            {
+                string s = format + " " + arg + formatProvider;
+
+                if (arg is IHasToStringState tss)
+                {
+                    // Set after using arg.ToString() in concat above
+                    tss.ToStringState.LastFormat = format;
+                    tss.ToStringState.LastProvider = formatProvider;
+                    tss.ToStringState.ToStringMode = ToStringMode.ICustomFormatterFormat;
+                }
+
+                return s;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/50601
Closes https://github.com/dotnet/runtime/issues/28945
Closes https://github.com/dotnet/runtime/issues/30547
Closes https://github.com/dotnet/runtime/issues/26374
Contributes to https://github.com/dotnet/runtime/issues/14484 (second half of this will close it)

Draft PR as the API should be reviewed on Tuesday and so may be tweaked as a result of that.

This also includes a few Create overloads in support of https://github.com/dotnet/runtime/issues/50635, but that made sense to include in the implementation and testing here.

cc: @333fred, @GrabYourPitchforks, @tannergooding, @pgovind 