### PR TITLE
Fix handling of unmanaged member function pointers in Crossgen2

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -654,6 +654,7 @@ namespace Internal.JitInterface
             if (memberFunctionVariant)
             {
                 callConv = GetMemberFunctionCallingConventionVariant(found ? callConv : (CorInfoCallConvExtension)PlatformDefaultUnmanagedCallingConvention());
+                found = true;
             }
 
             return found;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/51007

Without setting found to true we lose the transformed calling
convention (StdcallMemberFunction) and we end up lying to JIT
that getSize is an unmanaged static function pointer so that
JIT doesn't emit proper code for passing the "this" pointer
to the PInvoke.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 