### PR TITLE
Fix Crossgen2 compilation failures in several type generator tests

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -221,8 +221,9 @@ namespace Internal.JitInterface
 
         public bool Equals(MethodWithToken methodWithToken)
         {
-            bool equals = Method == methodWithToken.Method && Token.Equals(methodWithToken.Token) && ConstrainedType == methodWithToken.ConstrainedType &&
-                   Unboxing == methodWithToken.Unboxing;
+            bool equals = Method == methodWithToken.Method && Token.Equals(methodWithToken.Token)
+                && OwningType == methodWithToken.OwningType && ConstrainedType == methodWithToken.ConstrainedType
+                && Unboxing == methodWithToken.Unboxing;
             if (equals)
             {
                 Debug.Assert(OwningTypeNotDerivedFromToken == methodWithToken.OwningTypeNotDerivedFromToken);


### PR DESCRIPTION
As the PR

https://github.com/dotnet/runtime/pull/44041

effectively decoupled OwningType from Method in MethodWithToken,
I believe we now need to include OwningType in the Equals check,
otherwise we may (and sometimes do) crash in the assertion failure
checking that OwningType matches between instances.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 