### PR TITLE
WinHttpHandler: Add support for bidirectional streaming

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -61,6 +61,7 @@ internal static partial class Interop
 
         public const uint WINHTTP_FLAG_SECURE = 0x00800000;
         public const uint WINHTTP_FLAG_ESCAPE_DISABLE = 0x00000040;
+        public const uint WINHTTP_FLAG_AUTOMATIC_CHUNKING = 0x00000200;
 
         public const uint WINHTTP_QUERY_FLAG_NUMBER = 0x20000000;
         public const uint WINHTTP_QUERY_VERSION = 18;

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -100,6 +100,8 @@ namespace System.Net.Test.Common
                 // The contents of what we send don't really matter, as long as it is interpreted by SocketsHttpHandler as an invalid response.
                 await _connectionStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/2.0 400 Bad Request\r\n\r\n"));
                 _connectionSocket.Shutdown(SocketShutdown.Send);
+
+                throw new Exception("HTTP/1.1 request sent to HTTP/2 connection.");
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -100,7 +100,8 @@ namespace System.Net.Test.Common
                 // The contents of what we send don't really matter, as long as it is interpreted by SocketsHttpHandler as an invalid response.
                 await _connectionStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/2.0 400 Bad Request\r\n\r\n"));
                 _connectionSocket.Shutdown(SocketShutdown.Send);
-
+                // If WinHTTP doesn't support streaming a request without a length then it will fallback
+                // to HTTP/1.1. Throwing an exception to detect this case in WinHttpHandler tests. 
                 throw new Exception("HTTP/1.1 request sent to HTTP/2 connection.");
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -347,13 +347,13 @@ namespace System.Net.Test.Common
             }
         }
 
-        public async Task<int> ReadRequestHeaderAsync()
+        public async Task<int> ReadRequestHeaderAsync(bool expectEndOfStream = true)
         {
-            HeadersFrame frame = await ReadRequestHeaderFrameAsync();
+            HeadersFrame frame = await ReadRequestHeaderFrameAsync(expectEndOfStream);
             return frame.StreamId;
         }
 
-        public async Task<HeadersFrame> ReadRequestHeaderFrameAsync()
+        public async Task<HeadersFrame> ReadRequestHeaderFrameAsync(bool expectEndOfStream = true)
         {
             // Receive HEADERS frame for request.
             Frame frame = await ReadFrameAsync(_timeout).ConfigureAwait(false);
@@ -363,8 +363,25 @@ namespace System.Net.Test.Common
             }
 
             Assert.Equal(FrameType.Headers, frame.Type);
-            Assert.Equal(FrameFlags.EndHeaders | FrameFlags.EndStream, frame.Flags);
+            Assert.Equal(FrameFlags.EndHeaders, frame.Flags & FrameFlags.EndHeaders);
+            if (expectEndOfStream)
+            {
+                Assert.Equal(FrameFlags.EndStream, frame.Flags & FrameFlags.EndStream);
+            }
             return (HeadersFrame)frame;
+        }
+
+        public async Task<Frame> ReadDataFrameAsync()
+        {
+            // Receive DATA frame for request.
+            Frame frame = await ReadFrameAsync(_timeout).ConfigureAwait(false);
+            if (frame == null)
+            {
+                throw new IOException("Failed to read Data frame.");
+            }
+
+            Assert.Equal(FrameType.Data, frame.Type);
+            return frame;
         }
 
         private static (int bytesConsumed, int value) DecodeInteger(ReadOnlySpan<byte> headerBlock, byte prefixMask)
@@ -729,11 +746,16 @@ namespace System.Net.Test.Common
             await WriteFrameAsync(pingAck).ConfigureAwait(false);
         }
 
-        public async Task SendDefaultResponseHeadersAsync(int streamId)
+        public async Task SendDefaultResponseHeadersAsync(int streamId, bool endStream = false)
         {
             byte[] headers = new byte[] { 0x88 };   // Encoding for ":status: 200"
+            FrameFlags flags = FrameFlags.EndHeaders;
+            if (endStream)
+            {
+                flags = flags | FrameFlags.EndStream;
+            }
 
-            HeadersFrame headersFrame = new HeadersFrame(headers, FrameFlags.EndHeaders, 0, 0, 0, streamId);
+            HeadersFrame headersFrame = new HeadersFrame(headers, flags, 0, 0, 0, streamId);
             await WriteFrameAsync(headersFrame).ConfigureAwait(false);
         }
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -82,6 +82,7 @@
     <Compile Include="System\Net\Http\WinHttpAuthHelper.cs" />
     <Compile Include="System\Net\Http\WinHttpCertificateHelper.cs" />
     <Compile Include="System\Net\Http\WinHttpChannelBinding.cs" />
+    <Compile Include="System\Net\Http\WinHttpChunkMode.cs" />
     <Compile Include="System\Net\Http\WinHttpCookieContainerAdapter.cs" />
     <Compile Include="System\Net\Http\WinHttpException.cs" />
     <Compile Include="System\Net\Http\WinHttpHandler.cs" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpChunkMode.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpChunkMode.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Http
+{
+    internal enum WinHttpChunkMode
+    {
+        None,
+        Manual,
+        Automatic
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -966,16 +966,14 @@ namespace System.Net.Http
                         // This order is important because the response could be returned immediately
                         // with END_STREAM flag on headers. Trying to send request body after that
                         // can cause the request to go into a bad state.
-                        var valueTask = InternalReceiveResponseHeadersAsync(state);
+                        var receivedResponseTask = InternalReceiveResponseHeadersAsync(state);
 
                         if (state.RequestMessage.Content != null)
                         {
                             sendRequestBodyTask = InternalSendRequestBodyAsync(state, chunkedModeForSend);
                         }
 
-                        var value = await valueTask;
-
-                        bool receivedResponse = value != 0;
+                        bool receivedResponse = await receivedResponseTask != 0;
                         if (receivedResponse)
                         {
                             // If we're manually handling cookies, we need to add them to the container after

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -668,7 +668,7 @@ namespace System.Net.Http
                             // Current .NET Desktop HttpClientHandler uses 'Content-Length' semantics and
                             // buffers the content as well in some cases.  But the WinHttpHandler can't access
                             // the protected internal TryComputeLength() method of the content.  So, it
-                            // will use'Transfer-Encoding: chunked' semantics.
+                            // will use 'Transfer-Encoding: chunked' semantics.
                             chunkedMode = WinHttpChunkMode.Manual;
                             requestMessage.Headers.TransferEncodingChunked = true;
                         }
@@ -1049,7 +1049,7 @@ namespace System.Net.Http
             {
                 int lastError = Marshal.GetLastWin32Error();
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"error={lastError}");
-                if (lastError != Interop.WinHttp.ERROR_INVALID_PARAMETER)
+                if (lastError != Interop.WinHttp.ERROR_INVALID_PARAMETER || chunkedModeForSend != WinHttpChunkMode.Automatic)
                 {
                     ThrowOnInvalidHandle(requestHandle, nameof(Interop.WinHttp.WinHttpOpenRequest));
                 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1045,6 +1045,8 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_DEFAULT_ACCEPT_TYPES,
                 GetRequestFlags(state, chunkedModeForSend));
 
+            // It is possible the request was made with the WINHTTP_FLAG_AUTOMATIC_CHUNKING flag
+            // and the platform doesn't support that flag.
             if (requestHandle.IsInvalid)
             {
                 int lastError = Marshal.GetLastWin32Error();
@@ -1055,7 +1057,7 @@ namespace System.Net.Http
                 }
 
                 // Platform doesn't support WINHTTP_FLAG_AUTOMATIC_CHUNKING. Revert to manual chunking.
-                // Note that WinHttp downgrades HTTP/2 requests to HTTP/1.1 with manual chunking.
+                // Note that manual chunking with WinHttp downgrades HTTP/2 requests to HTTP/1.1.
                 chunkedModeForSend = WinHttpChunkMode.Manual;
                 state.RequestMessage.Headers.TransferEncodingChunked = true;
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -19,14 +19,19 @@ namespace System.Net.Http
 
         private volatile bool _disposed;
         private readonly WinHttpRequestState _state;
-        private readonly bool _chunkedMode;
+        private readonly SafeWinHttpHandle _requestHandle;
+        private readonly WinHttpChunkMode _chunkedMode;
 
         private GCHandle _cachedSendPinnedBuffer;
 
-        internal WinHttpRequestStream(WinHttpRequestState state, bool chunkedMode)
+        internal WinHttpRequestStream(WinHttpRequestState state, WinHttpChunkMode chunkedMode)
         {
             _state = state;
             _chunkedMode = chunkedMode;
+
+            // Take copy of handle from state.
+            // The state's request handle will be set to null once the response stream starts.
+            _requestHandle = _state.RequestHandle;
         }
 
         public override bool CanRead
@@ -160,9 +165,15 @@ namespace System.Net.Http
 
         internal async Task EndUploadAsync(CancellationToken token)
         {
-            if (_chunkedMode)
+            switch (_chunkedMode)
             {
-                await InternalWriteDataAsync(s_endChunk, 0, s_endChunk.Length, token).ConfigureAwait(false);
+                case WinHttpChunkMode.Manual:
+                    await InternalWriteDataAsync(s_endChunk, 0, s_endChunk.Length, token).ConfigureAwait(false);
+                    break;
+                case WinHttpChunkMode.Automatic:
+                    // Send empty DATA frame with END_STREAM flag.
+                    await InternalWriteEndDataAsync(token).ConfigureAwait(false);
+                    break;
             }
         }
 
@@ -195,7 +206,7 @@ namespace System.Net.Http
                 return Task.CompletedTask;
             }
 
-            return _chunkedMode ?
+            return _chunkedMode == WinHttpChunkMode.Manual ?
                 InternalWriteChunkedModeAsync(buffer, offset, count, token) :
                 InternalWriteDataAsync(buffer, offset, count, token);
         }
@@ -205,7 +216,7 @@ namespace System.Net.Http
             // WinHTTP does not fully support chunked uploads. It simply allows one to omit the 'Content-Length' header
             // and instead use the 'Transfer-Encoding: chunked' header. The caller is still required to encode the
             // request body according to chunking rules.
-            Debug.Assert(_chunkedMode);
+            Debug.Assert(_chunkedMode == WinHttpChunkMode.Manual);
             Debug.Assert(count > 0);
 
             byte[] chunkSize = Encoding.UTF8.GetBytes($"{count:x}\r\n");
@@ -236,9 +247,30 @@ namespace System.Net.Http
             lock (_state.Lock)
             {
                 if (!Interop.WinHttp.WinHttpWriteData(
-                    _state.RequestHandle,
+                    _requestHandle,
                     Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
                     (uint)count,
+                    IntPtr.Zero))
+                {
+                    _state.TcsInternalWriteDataToRequestStream.TrySetException(
+                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpWriteData))));
+                }
+            }
+
+            return _state.TcsInternalWriteDataToRequestStream.Task;
+        }
+
+        private Task<bool> InternalWriteEndDataAsync(CancellationToken token)
+        {
+            _state.TcsInternalWriteDataToRequestStream =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            lock (_state.Lock)
+            {
+                if (!Interop.WinHttp.WinHttpWriteData(
+                    _requestHandle,
+                    IntPtr.Zero,
+                    0,
                     IntPtr.Zero))
                 {
                     _state.TcsInternalWriteDataToRequestStream.TrySetException(

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
                 int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
 
-                var frame = await connection.ReadDataFrameAsync();
+                Frame frame = await connection.ReadDataFrameAsync();
 
                 // Response header.
                 await connection.SendDefaultResponseHeadersAsync(streamId);
@@ -81,7 +81,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 using Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Read response data.
-                var buffer = new byte[1024];
+                byte[] buffer = new byte[1024];
                 int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
@@ -129,7 +129,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
                 int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
 
-                var frame = await connection.ReadDataFrameAsync();
+                Frame frame = await connection.ReadDataFrameAsync();
 
                 // Response header.
                 await connection.SendDefaultResponseHeadersAsync(streamId);
@@ -140,11 +140,11 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Read response data.
-                var buffer = new byte[1024];
-                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                byte[] buffer = new byte[1024];
+                int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
                 // Server sends RST_STREAM.
@@ -181,7 +181,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
                 int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
 
-                var frame = await connection.ReadDataFrameAsync();
+                Frame frame = await connection.ReadDataFrameAsync();
 
                 // Response header.
                 await connection.SendDefaultResponseHeadersAsync(streamId);
@@ -192,11 +192,11 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Read response data.
-                var buffer = new byte[1024];
-                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                byte[] buffer = new byte[1024];
+                int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
                 // Server sends RST_STREAM.
@@ -233,7 +233,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
                 int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
 
-                var frame = await connection.ReadDataFrameAsync();
+                Frame frame = await connection.ReadDataFrameAsync();
 
                 // Response header.
                 await connection.SendDefaultResponseHeadersAsync(streamId);
@@ -244,11 +244,11 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Read response data.
-                var buffer = new byte[1024];
-                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                byte[] buffer = new byte[1024];
+                int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
                 // Client sends DATA with END_STREAM
@@ -290,21 +290,21 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     await completeStreamTcs.Task;
                 });
 
-                var serverActions = RunServer();
+                Task serverActions = RunServer();
 
                 HttpResponseMessage response = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
                 await serverActions;
 
-                var requestStream = await requestStreamTcs.Task;
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                Stream requestStream = await requestStreamTcs.Task;
+                Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Successfully because endstream hasn't been read yet.
                 await requestStream.WriteAsync(new byte[50]);
 
-                var buffer = new byte[50];
-                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                byte[] buffer = new byte[50];
+                int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
                 readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -78,11 +78,11 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                using Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                 // Read response data.
                 var buffer = new byte[1024];
-                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                int readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(DataBytes.Length, readCount);
 
                 // Finish sending request data.

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -1,0 +1,347 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net.Http.Functional.Tests;
+using System.Net.Http.Headers;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
+{
+    public class BidirectionStreamingTest : HttpClientHandlerTestBase
+    {
+        public BidirectionStreamingTest(ITestOutputHelper output) : base(output)
+        { }
+
+        // Build number suggested by the WinHttp team.
+        // It can be reduced after the backport of WINHTTP_QUERY_FLAG_TRAILERS is finished,
+        // and the patches are rolled out to CI machines.
+        public static bool OsSupportsWinHttpTrailingHeaders => Environment.OSVersion.Version >= new Version(10, 0, 19622, 0);
+
+        public static bool TestsEnabled => OsSupportsWinHttpTrailingHeaders && PlatformDetection.SupportsAlpn;
+
+        protected override Version UseVersion => new Version(2, 0);
+
+        protected static byte[] DataBytes = Encoding.ASCII.GetBytes("data");
+
+        protected static Frame MakeDataFrame(int streamId, byte[] data, bool endStream = false) =>
+            new DataFrame(data, (endStream ? FrameFlags.EndStream : FrameFlags.None), 0, streamId);
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public Task WriteRequestAfterReadResponse_SendLength() =>
+            WriteRequestAfterReadResponseCore(sendLength: true);
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public Task WriteRequestAfterReadResponse_NoLength() =>
+            WriteRequestAfterReadResponseCore(sendLength: false);
+
+        private async Task WriteRequestAfterReadResponseCore(bool sendLength)
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                int? length = sendLength ? 100 : (int?)null;
+
+                HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                message.Version = new Version(2, 0);
+                message.Content = new StreamingContent(async s =>
+                {
+                    await s.WriteAsync(new byte[50]);
+
+                    await tcs.Task;
+
+                    await s.WriteAsync(new byte[50]);
+                }, length);
+
+                Task<HttpResponseMessage> sendTask = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
+
+                var frame = await connection.ReadDataFrameAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: false));
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Read response data.
+                var buffer = new byte[1024];
+                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                // Finish sending request data.
+                tcs.SetResult(null);
+
+                frame = await connection.ReadDataFrameAsync();
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: true));
+
+                // Finish reading response data.
+                readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(0, readCount);
+            }
+        }
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public async Task AfterReadResponseServerError_ClientWrite()
+        {
+            TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                message.Version = new Version(2, 0);
+                message.Content = new StreamingContent(async s =>
+                {
+                    requestStreamTcs.SetResult(s);
+
+                    await completeStreamTcs.Task;
+                });
+
+                Task<HttpResponseMessage> sendTask = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                Stream requestStream = await requestStreamTcs.Task;
+                await requestStream.WriteAsync(new byte[50]);
+
+                int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
+
+                var frame = await connection.ReadDataFrameAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: false));
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Read response data.
+                var buffer = new byte[1024];
+                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                // Server sends RST_STREAM.
+                await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.EndStream, 0, streamId));
+
+                await Assert.ThrowsAsync<IOException>(() => requestStream.WriteAsync(new byte[50]).AsTask());
+            }
+        }
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public async Task AfterReadResponseServerError_ClientRead()
+        {
+            TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                message.Version = new Version(2, 0);
+                message.Content = new StreamingContent(async s =>
+                {
+                    requestStreamTcs.SetResult(s);
+
+                    await completeStreamTcs.Task;
+                });
+
+                Task<HttpResponseMessage> sendTask = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                Stream requestStream = await requestStreamTcs.Task;
+                await requestStream.WriteAsync(new byte[50]);
+
+                int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
+
+                var frame = await connection.ReadDataFrameAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: false));
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Read response data.
+                var buffer = new byte[1024];
+                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                // Server sends RST_STREAM.
+                await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.EndStream, 0, streamId));
+
+                await Assert.ThrowsAsync<IOException>(() => responseStream.ReadAsync(buffer, 0, buffer.Length));
+            }
+        }
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public async Task AfterReadResponseCompleteClient_ServerGetsEndStream()
+        {
+            TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                message.Version = new Version(2, 0);
+                message.Content = new StreamingContent(async s =>
+                {
+                    requestStreamTcs.SetResult(s);
+
+                    await completeStreamTcs.Task;
+                });
+
+                Task<HttpResponseMessage> sendTask = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                Stream requestStream = await requestStreamTcs.Task;
+                await requestStream.WriteAsync(new byte[50]);
+
+                int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
+
+                var frame = await connection.ReadDataFrameAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: false));
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Read response data.
+                var buffer = new byte[1024];
+                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                // Client sends DATA with END_STREAM
+                completeStreamTcs.SetResult(null);
+
+                // Server reads DATA with END_STREAM
+                frame = await connection.ReadDataFrameAsync();
+                Assert.True(frame.EndStreamFlag);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: true));
+
+                // Finish reading response data.
+                readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(0, readCount);
+            }
+        }
+
+        [ConditionalFact(nameof(TestsEnabled))]
+        public async Task ReadAndWriteAfterServerHasSentEndStream_Success()
+        {
+            TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                message.Version = new Version(2, 0);
+                message.Content = new StreamingContent(async s =>
+                {
+                    await s.WriteAsync(new byte[50]);
+
+                    requestStreamTcs.SetResult(s);
+
+                    await completeStreamTcs.Task;
+                });
+
+                var serverActions = RunServer();
+
+                HttpResponseMessage response = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await serverActions;
+
+                var requestStream = await requestStreamTcs.Task;
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Successfully because endstream hasn't been read yet.
+                await requestStream.WriteAsync(new byte[50]);
+
+                var buffer = new byte[50];
+                var readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(DataBytes.Length, readCount);
+
+                readCount = await responseStream.ReadAsync(buffer, 0, buffer.Length);
+                Assert.Equal(0, readCount);
+
+                async Task RunServer()
+                {
+                    Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+                    int streamId = await connection.ReadRequestHeaderAsync(expectEndOfStream: false);
+                    await connection.SendDefaultResponseHeadersAsync(streamId, endStream: false);
+                    await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: true));
+                };
+            }
+        }
+
+        private class StreamingContent : HttpContent
+        {
+            private readonly Func<Stream, Task> _writeFunc;
+            private readonly long? _length;
+
+            public StreamingContent(Func<Stream, Task> writeFunc, long? length = null)
+            {
+                _writeFunc = writeFunc;
+                _length = length;
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                return _writeFunc(stream);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = _length.GetValueOrDefault();
+                return _length.HasValue;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -34,22 +34,13 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             new DataFrame(data, (endStream ? FrameFlags.EndStream : FrameFlags.None), 0, streamId);
 
         [ConditionalFact(nameof(TestsEnabled))]
-        public Task WriteRequestAfterReadResponse_SendLength() =>
-            WriteRequestAfterReadResponseCore(sendLength: true);
-
-        [ConditionalFact(nameof(TestsEnabled))]
-        public Task WriteRequestAfterReadResponse_NoLength() =>
-            WriteRequestAfterReadResponseCore(sendLength: false);
-
-        private async Task WriteRequestAfterReadResponseCore(bool sendLength)
+        public async Task WriteRequestAfterReadResponse()
         {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())
             {
-                int? length = sendLength ? 100 : (int?)null;
-
                 HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, server.Address);
                 message.Version = new Version(2, 0);
                 message.Content = new StreamingContent(async s =>
@@ -59,7 +50,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     await tcs.Task;
 
                     await s.WriteAsync(new byte[50]);
-                }, length);
+                }, length: null);
 
                 Task<HttpResponseMessage> sendTask = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -21,11 +21,10 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         { }
 
         // Build number suggested by the WinHttp team.
-        // It can be reduced after the backport of WINHTTP_QUERY_FLAG_TRAILERS is finished,
-        // and the patches are rolled out to CI machines.
-        public static bool OsSupportsWinHttpTrailingHeaders => Environment.OSVersion.Version >= new Version(10, 0, 19622, 0);
+        // It can be reduced if bidirectional streaming is backported.
+        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0);
 
-        public static bool TestsEnabled => OsSupportsWinHttpTrailingHeaders && PlatformDetection.SupportsAlpn;
+        public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn;
 
         protected override Version UseVersion => new Version(2, 0);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;net48-windows</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
@@ -144,6 +144,7 @@
     <Compile Include="PlatformHandlerTest.cs" />
     <Compile Include="ClientCertificateTest.cs" />
     <Compile Include="TrailingHeadersTest.cs" />
+    <Compile Include="BidirectionStreamingTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>$(NoWarn);0436</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -65,6 +65,8 @@
              Link="ProductionCode\WinHttpAuthHelper.cs" />
     <Compile Include="..\..\src\System\Net\Http\WinHttpChannelBinding.cs"
              Link="ProductionCode\WinHttpChannelBinding.cs" />
+    <Compile Include="..\..\src\System\Net\Http\WinHttpChunkMode.cs"
+             Link="ProductionCode\WinHttpChunkMode.cs" />
     <Compile Include="..\..\src\System\Net\Http\WinHttpCookieContainerAdapter.cs"
              Link="ProductionCode\WinHttpCookieContainerAdapter.cs" />
     <Compile Include="..\..\src\System\Net\Http\WinHttpException.cs"

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpRequestStreamTest.cs
@@ -312,7 +312,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             handle.Context = state.ToIntPtr();
             state.RequestHandle = handle;
 
-            return new WinHttpRequestStream(state, false);
+            return new WinHttpRequestStream(state, WinHttpChunkMode.None);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44784
Fixes https://github.com/dotnet/runtime/issues/46413

TODO:
* OS detection
* Verify that waiting for headers before fully writing request works on current OS