### PR TITLE
Revert "Switch to VS preview pool for public builds (#50993)"

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -131,7 +131,7 @@ jobs:
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
           name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          queue: BuildPool.Windows.10.Amd64.VS2019.Open
 
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:


### PR DESCRIPTION
Reverts dotnet/runtime#50993, the underlying Azure issue was fixed.

Closes https://github.com/dotnet/runtime/issues/50746