### PR TITLE
Optimization for parsing single-character version components

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -354,6 +354,15 @@ namespace System
 
         private static bool TryParseComponent(ReadOnlySpan<char> component, string componentName, bool throwOnFailure, out int parsedComponent)
         {
+            if(component.Length == 1)
+            {
+                var value = component[0] - '0';
+                if(value >= 0 && value <= 9)
+                {
+                    parsedComponent = value;
+                    return true;
+                }
+            }
             if (throwOnFailure)
             {
                 if ((parsedComponent = int.Parse(component, NumberStyles.Integer, CultureInfo.InvariantCulture)) < 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -357,7 +357,7 @@ namespace System
             if (component.Length == 1)
             {
                 int value = component[0] - '0';
-                if (value >= 0 && value <= 9)
+                if ((uint)value <= 9)
                 {
                     parsedComponent = value;
                     return true;

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -356,7 +356,7 @@ namespace System
         {
             if (component.Length == 1)
             {
-                var value = component[0] - '0';
+                int value = component[0] - '0';
                 if (value >= 0 && value <= 9)
                 {
                     parsedComponent = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -354,10 +354,10 @@ namespace System
 
         private static bool TryParseComponent(ReadOnlySpan<char> component, string componentName, bool throwOnFailure, out int parsedComponent)
         {
-            if(component.Length == 1)
+            if (component.Length == 1)
             {
                 var value = component[0] - '0';
-                if(value >= 0 && value <= 9)
+                if (value >= 0 && value <= 9)
                 {
                     parsedComponent = value;
                     return true;


### PR DESCRIPTION
It is very common for Version components to be a single digit number. This optimizes for that case, avoiding the call to int.Parse, which has a bit of overhead to deal with style and culture that don't apply to single-digit values. This results in ~3x improvement for parsing versions that fit the criteria.

Benchmarks:
|     Method |               string |      Mean |    Error |   StdDev |
|----------- |--------------------- |----------:|---------:|---------:|
| VersionBCL |                  1.2 |  43.64 ns | 1.936 ns | 1.716 ns |
| VersionOpt |                  1.2 |  16.40 ns | 0.157 ns | 0.154 ns |
| VersionBCL |                1.2.3 |  59.92 ns | 0.382 ns | 0.339 ns |
| VersionOpt |                1.2.3 |  22.82 ns | 0.246 ns | 0.242 ns |
| VersionBCL |              1.2.3.4 |  77.74 ns | 0.284 ns | 0.237 ns |
| VersionOpt |              1.2.3.4 |  27.88 ns | 0.209 ns | 0.196 ns |
| VersionBCL |          12.34.56.78 |  80.20 ns | 0.305 ns | 0.285 ns |
| VersionOpt |          12.34.56.78 |  75.24 ns | 0.349 ns | 0.327 ns |
| VersionBCL | 21474(...)83647 [43] | 107.81 ns | 0.508 ns | 0.499 ns |
| VersionOpt | 21474(...)83647 [43] | 103.39 ns | 0.445 ns | 0.416 ns |

 I can't offer an explanation for why the 12.34.56.78 and int.MaxValue, cases are also faster here. I'd expect them to be ever so slightly slower, it must have something to do with the construction of the benchmark project.
