### PR TITLE
[mono] Remove owns_vtable_slot (), its incorrect, and its not needed …

### DIFF
--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -153,13 +153,6 @@ mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer addr)
 }
 #endif
 
-// FIXME: Is this still needed ?
-static gboolean
-owns_vtable_slot (gpointer vtable_slot)
-{
-	return mono_mem_manager_mp_contains_addr (mono_mem_manager_get_ambient (), vtable_slot);
-}
-
 gpointer
 mono_create_ftnptr_arg_trampoline (gpointer arg, gpointer addr)
 {
@@ -514,9 +507,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 				/*
 				 * We found AOT compiled code for the method, skip the rest.
 				 */
-				if (owns_vtable_slot (vtable_slot))
-					*vtable_slot = addr;
-
+				*vtable_slot = addr;
 				return mono_create_ftnptr (addr);
 			}
 
@@ -697,7 +688,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 	vtable_slot = orig_vtable_slot;
 
 	if (vtable_slot) {
-		if (vtable_slot_to_patch && (mono_aot_is_got_entry (code, (guint8*)vtable_slot_to_patch) || owns_vtable_slot (vtable_slot_to_patch))) {
+		if (vtable_slot_to_patch) {
 			g_assert (*vtable_slot_to_patch);
 			*vtable_slot_to_patch = mono_get_addr_from_ftnptr (addr);
 		}
@@ -830,9 +821,7 @@ mono_vcall_trampoline (host_mgreg_t *regs, guint8 *code, int slot, guint8 *tramp
 		addr = mono_aot_get_method_from_vt_slot (vt, slot, error);
 		goto_if_nok (error, leave);
 		if (addr && !m_class_is_valuetype (vt->klass)) {
-			if (owns_vtable_slot (vtable_slot))
-				*vtable_slot = addr;
-
+			*vtable_slot = addr;
 			res = mono_create_ftnptr (addr);
 			goto leave;
 		}


### PR DESCRIPTION
…any more.

Fixes https://github.com/dotnet/runtime/issues/51109.