### PR TITLE
[mono] Enable explicit null checks on tvOS and watchOS

### DIFF
--- a/src/mono/mono/mini/mini-amd64.h
+++ b/src/mono/mono/mini/mini-amd64.h
@@ -479,6 +479,10 @@ typedef struct {
 #define MONO_ARCH_NEED_DIV_CHECK 1
 #endif
 
+#if defined(TARGET_TVOS) || defined(TARGET_WATCHOS)
+#define MONO_ARCH_EXPLICIT_NULL_CHECKS 1
+#endif
+
 /* Used for optimization, not complete */
 #define MONO_ARCH_IS_OP_MEMBASE(opcode) ((opcode) == OP_X86_PUSH_MEMBASE)
 

--- a/src/mono/mono/mini/mini-arm.h
+++ b/src/mono/mono/mini/mini-arm.h
@@ -404,6 +404,10 @@ typedef struct MonoCompileArch {
 
 #define MONO_ARCH_INIT_TOP_LMF_ENTRY(lmf)
 
+#if defined(TARGET_TVOS) || defined(TARGET_WATCHOS)
+#define MONO_ARCH_EXPLICIT_NULL_CHECKS 1
+#endif
+
 void
 mono_arm_throw_exception (MonoObject *exc, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips);
 

--- a/src/mono/mono/mini/mini-arm64.h
+++ b/src/mono/mono/mini/mini-arm64.h
@@ -204,6 +204,10 @@ typedef struct {
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 
+#if defined(TARGET_TVOS) || defined(TARGET_WATCHOS)
+#define MONO_ARCH_EXPLICIT_NULL_CHECKS 1
+#endif
+
 /* Relocations */
 #define MONO_R_ARM64_B 1
 #define MONO_R_ARM64_BCC 2


### PR DESCRIPTION
The implicit checks do not work due to platform limitations in the signal handling. It's possible there are other configuration issues, but this should unblock tvOS testing.

Fixes https://github.com/dotnet/runtime/issues/50453