### PR TITLE
Revert "Disable Net5CompatFileStream by default (#50166)"

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/Net5CompatSwitchTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/Net5CompatSwitchTests.cs
@@ -20,7 +20,7 @@ namespace System.IO.Tests
                     .GetField("_strategy", BindingFlags.NonPublic | BindingFlags.Instance)
                     .GetValue(fileStream);
 
-                Assert.Contains("Net5Compat", strategy.GetType().FullName);
+                Assert.DoesNotContain("Net5Compat", strategy.GetType().FullName);
             }
 
             File.Delete(filePath);

--- a/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/runtimeconfig.template.json
+++ b/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/runtimeconfig.template.json
@@ -1,5 +1,5 @@
 {
     "configProperties": {
-        "System.IO.UseNet5CompatFileStream": true
+        "System.IO.UseNet5CompatFileStream": false
     }
 }

--- a/src/libraries/System.IO/tests/Net5CompatTests/runtimeconfig.template.json
+++ b/src/libraries/System.IO/tests/Net5CompatTests/runtimeconfig.template.json
@@ -1,5 +1,5 @@
 {
     "configProperties": {
-        "System.IO.UseNet5CompatFileStream": true
+        "System.IO.UseNet5CompatFileStream": false
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -7,7 +7,7 @@ namespace System.IO.Strategies
 {
     internal static partial class FileStreamHelpers
     {
-        // It's enabled by default. We are going to change that once we fix #16354, #25905 and #24847.
+        // It's enabled by default. We are going to change that once we fix #51141.
         internal static bool UseNet5CompatStrategy { get; } = GetNet5CompatFileStreamSetting();
 
         private static bool GetNet5CompatFileStreamSetting()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -7,7 +7,21 @@ namespace System.IO.Strategies
 {
     internal static partial class FileStreamHelpers
     {
-        internal static bool UseNet5CompatStrategy { get; } = AppContextConfigHelper.GetBooleanConfig("System.IO.UseNet5CompatFileStream", "DOTNET_SYSTEM_IO_USENET5COMPATFILESTREAM");
+        // It's enabled by default. We are going to change that once we fix #16354, #25905 and #24847.
+        internal static bool UseNet5CompatStrategy { get; } = GetNet5CompatFileStreamSetting();
+
+        private static bool GetNet5CompatFileStreamSetting()
+        {
+            if (AppContext.TryGetSwitch("System.IO.UseNet5CompatFileStream", out bool fileConfig))
+            {
+                return fileConfig;
+            }
+
+            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_IO_USENET5COMPATFILESTREAM");
+            return envVar is null
+                ? true // Net5Compat is currently enabled by default;
+                : bool.IsTrueStringIgnoreCase(envVar) || envVar.Equals("1");
+        }
 
         internal static FileStreamStrategy ChooseStrategy(FileStream fileStream, SafeFileHandle handle, FileAccess access, FileShare share, int bufferSize, bool isAsync)
             => WrapIfDerivedType(fileStream, ChooseStrategyCore(handle, access, share, bufferSize, isAsync));


### PR DESCRIPTION
Partially addresses https://github.com/dotnet/runtime/issues/51141

Unblocks https://github.com/dotnet/sdk/pull/16810

This reverts commit 8b2ad5bccff29715d924d0c2d191bc978aaaf320 to unblock dotnet/sdk.