### PR TITLE
[AndroidCrypto] Use new test certs for System.Net

### DIFF
--- a/src/libraries/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.Certificates.cs
@@ -37,10 +37,9 @@ namespace System.Net.Test.Common
                 {
                     try
                     {
-                        string contosoPfxSuffix = PlatformSupport.IsRC2Supported ? ".pfx" : ".noRC2.pfx";
-                        byte[] serverCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, $"testservereku.contoso.com{contosoPfxSuffix}"));
-                        byte[] clientCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, $"testclienteku.contoso.com{contosoPfxSuffix}"));
-                        byte[] noEKUCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, $"testnoeku.contoso.com{contosoPfxSuffix}"));
+                        byte[] serverCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, "testservereku.contoso.com.pfx"));
+                        byte[] clientCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, "testclienteku.contoso.com.pfx"));
+                        byte[] noEKUCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, "testnoeku.contoso.com.pfx"));
                         byte[] selfSignedServerCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, "testselfsignedservereku.contoso.com.pfx"));
                         byte[] selfSignedClientCertificateBytes = File.ReadAllBytes(Path.Combine(TestDataFolder, "testselfsignedclienteku.contoso.com.pfx"));
 
@@ -64,7 +63,7 @@ namespace System.Net.Test.Common
                     }
                 }
             }
-            
+
             // These Get* methods make a copy of the certificates so that consumers own the lifetime of the
             // certificates handed back.  Consumers are expected to dispose of their certs when done with them.
 


### PR DESCRIPTION
With https://github.com/dotnet/runtime-assets/pull/128, the System.Net.TestData certs under TestDataCertificates all use 3DES.

cc @jkoritzinsky @steveisok @wfurt 