### PR TITLE
Fix the buffering bug that blocks SDK

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
@@ -161,6 +161,31 @@ namespace System.IO.Tests
             Assert.Equal(2, stream.Length);
             Assert.Equal(2, createdFromHandle.Length);
         }
+
+        [Fact]
+        public async Task WriteByteFlushesTheBufferWhenItBecomesFull()
+        {
+            string filePath;
+            List<byte> writtenBytes = new List<byte>();
+
+            using (FileStream stream = (FileStream)await CreateWriteOnlyStreamCore(Array.Empty<byte>()))
+            {
+                filePath = stream.Name;
+
+                stream.WriteByte(0);
+                writtenBytes.Add(0);
+
+                byte[] bytes = new byte[BufferSize - 1];
+                stream.Write(bytes.AsSpan());
+                writtenBytes.AddRange(bytes);
+
+                stream.WriteByte(1);
+                writtenBytes.Add(1);
+            }
+
+            byte[] allBytes = File.ReadAllBytes(filePath);
+            Assert.Equal(writtenBytes.ToArray(), allBytes);
+        }
     }
 
     public class UnbufferedSyncFileStreamStandaloneConformanceTests : FileStreamStandaloneConformanceTests

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -602,7 +602,7 @@ namespace System.IO.Strategies
                 ClearReadBufferBeforeWrite();
                 EnsureBufferAllocated();
             }
-            else if (_writePos == _bufferSize - 1)
+            else
             {
                 FlushWrite();
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51141

I was able to identify the issue (after figuring out which process out of many should be debugged in the SDK repo):

![obraz](https://user-images.githubusercontent.com/6011991/114471050-4068d300-9bf0-11eb-9ff7-0e16d2a040d5.png)

Write a failing test:

![obraz](https://user-images.githubusercontent.com/6011991/114471002-29c27c00-9bf0-11eb-9cd8-15e304480645.png)

And provide a fix;

![obraz](https://user-images.githubusercontent.com/6011991/114471095-537ba300-9bf0-11eb-9916-62368a5afa9c.png)

Some details: it's possible that `_writePos == _bufferSize` and in such case the next call to any of the `Write` methods is supposed to flush the write buffer. 