### PR TITLE
Fix race in ComWrappers test

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -21,9 +21,10 @@ namespace ComWrappersTests.Common
     {
         public static int InstanceCount = 0;
 
+        private int id;
         private int value = -1;
-        public Test() { InstanceCount++; }
-        ~Test() { InstanceCount--; }
+        public Test() { id = Interlocked.Increment(ref InstanceCount); }
+        ~Test() { Interlocked.Decrement(ref InstanceCount); id = -1; }
 
         public void SetValue(int i) => this.value = i;
         public int GetValue() => this.value;


### PR DESCRIPTION
Since the finalizer thread runs concurrently with the test, we need to atomically decrement the static instance counter.

Fixes #47699 

/cc @jkoritzinsky @elinor-fung 