### PR TITLE
Crossgen2 pipeline optimize

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -183,14 +183,25 @@ namespace ILCompiler
             }
         }
 
-        private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding)
+        private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null)
         {
+            PEReader peReader = null;
             MemoryMappedViewAccessor mappedViewAccessor = null;
             PdbSymbolReader pdbReader = null;
             try
             {
-                PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
-                pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder()) ?? OpenAssociatedSymbolFile(filePath, peReader);
+                if (oldModuleData == null)
+                {
+                    peReader = OpenPEFile(filePath, out mappedViewAccessor);
+                    pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder()) ?? OpenAssociatedSymbolFile(filePath, peReader);
+                }
+                else
+                {
+                    filePath = oldModuleData.FilePath;
+                    peReader = oldModuleData.Module.PEReader;
+                    mappedViewAccessor = oldModuleData.MappedViewAccessor;
+                    pdbReader = oldModuleData.Module.PdbReader;
+                }
 
                 EcmaModule module = EcmaModule.Create(this, peReader, containingAssembly: null, pdbReader);
 
@@ -234,6 +245,14 @@ namespace ILCompiler
                     mappedViewAccessor.Dispose();
                 if (pdbReader != null)
                     pdbReader.Dispose();
+            }
+        }
+
+        protected void InheritOpenModules(CompilerTypeSystemContext oldTypeSystemContext)
+        {
+            foreach (ModuleData oldModuleData in ModuleHashtable.Enumerator.Get(oldTypeSystemContext._moduleHashtable))
+            {
+                AddModule(null, null, true, oldModuleData);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -186,11 +186,6 @@ namespace Internal.TypeSystem.Ecma
             _moduleResolver = customModuleResolver != null ? customModuleResolver : context;
         }
 
-        public void CleanResolvedTokens()
-        {
-            _resolvedTokens = new EcmaObjectLookupHashtable(this);
-        }
-
         public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly, IModuleResolver customModuleResolver = null)
         {
             MetadataReader metadataReader = CreateMetadataReader(context, peReader);

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -186,6 +186,11 @@ namespace Internal.TypeSystem.Ecma
             _moduleResolver = customModuleResolver != null ? customModuleResolver : context;
         }
 
+        public void CleanResolvedTokens()
+        {
+            _resolvedTokens = new EcmaObjectLookupHashtable(this);
+        }
+
         public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly, IModuleResolver customModuleResolver = null)
         {
             MetadataReader metadataReader = CreateMetadataReader(context, peReader);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -19,6 +19,8 @@ namespace ILCompiler
 {
     public sealed class ReadyToRunCodegenCompilationBuilder : CompilationBuilder
     {
+        private static bool _isJitInitialized = false;
+
         private readonly IEnumerable<string> _inputFiles;
         private readonly string _compositeRootPath;
         private bool _ibcTuning;
@@ -277,7 +279,11 @@ namespace ILCompiler
             if (_ibcTuning)
                 corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBINSTR);
 
-            JitConfigProvider.Initialize(_context.Target, corJitFlags, _ryujitOptions, _jitPath);
+            if (!_isJitInitialized)
+            {
+                JitConfigProvider.Initialize(_context.Target, corJitFlags, _ryujitOptions, _jitPath);
+                _isJitInitialized = true;
+            }
 
             return new ReadyToRunCodegenCompilation(
                 graph,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -26,17 +26,12 @@ namespace ILCompiler
         private VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
         private VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
 
-        public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode, bool bubbleIncludesCorelib)
+        public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode, bool bubbleIncludesCorelib, CompilerTypeSystemContext oldTypeSystemContext = null)
             : base(details, genericsMode)
         {
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
-            Reconstruct(details, bubbleIncludesCorelib);
-        }
-
-        public void Reconstruct(TargetDetails details, bool bubbleIncludesCorelib)
-        {
             // Only the Arm64 JIT respects the OS rules for vector type abi currently
             _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, (details.Architecture == TargetArchitecture.ARM64) ? true : bubbleIncludesCorelib);
 
@@ -48,6 +43,11 @@ namespace ILCompiler
 
             // No architecture has completely stable handling of Vector<T> in the abi (Arm64 may change to SVE)
             _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, _vectorFieldLayoutAlgorithm, matchingVectorType, bubbleIncludesCorelib);
+
+            if (oldTypeSystemContext != null)
+            {
+                InheritOpenModules(oldTypeSystemContext);
+            }
         }
 
         public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -32,6 +32,11 @@ namespace ILCompiler
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
+            Reconstruct(details, bubbleIncludesCorelib);
+        }
+
+        public void Reconstruct(TargetDetails details, bool bubbleIncludesCorelib)
+        {
             // Only the Arm64 JIT respects the OS rules for vector type abi currently
             _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, (details.Architecture == TargetArchitecture.ARM64) ? true : bubbleIncludesCorelib);
 

--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -33,6 +33,8 @@ namespace ILCompiler
         public bool Composite;
         public bool CompileNoMethods;
         public bool EmbedPgoData;
+        public bool OutNearInput;
+        public bool SingleFileCompilation;
 
         public string DgmlLogFileName;
         public bool GenerateFullDgmlLog;
@@ -100,6 +102,8 @@ namespace ILCompiler
                 syntax.DefineOption("inputbubble", ref InputBubble, SR.InputBubbleOption);
                 syntax.DefineOption("composite", ref Composite, SR.CompositeBuildMode);
                 syntax.DefineOption("compile-no-methods", ref CompileNoMethods, SR.CompileNoMethodsOption);
+                syntax.DefineOption("out-near-input", ref OutNearInput, SR.OutNearInputOption);
+                syntax.DefineOption("single-file-compilation", ref SingleFileCompilation, SR.SingleFileCompilationOption);
                 syntax.DefineOption("tuning", ref Tuning, SR.TuningImageOption);
                 syntax.DefineOption("partial", ref Partial, SR.PartialImageOption);
                 syntax.DefineOption("compilebubblegenerics", ref CompileBubbleGenerics, SR.BubbleGenericsOption);

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -201,6 +201,9 @@
   <data name="OptimizeSpeedOption" xml:space="preserve">
     <value>Enable optimizations, favor code speed</value>
   </data>
+  <data name="OutNearInputOption" xml:space="preserve">
+    <value>Create output files near input files with ni.dll suffix</value>
+  </data>
   <data name="OutputFilePath" xml:space="preserve">
     <value>Output file path</value>
   </data>
@@ -227,6 +230,9 @@
   </data>
   <data name="PrintReproInstructionsOption" xml:space="preserve">
     <value>When compiling each method, print out the set of arguments needed to compile that method only</value>
+  </data>
+  <data name="SingleFileCompilationOption" xml:space="preserve">
+    <value>Compile each of the input files separately</value>
   </data>
   <data name="SingleMethodGenericArgs" xml:space="preserve">
     <value>Single method compilation: generic arguments to the method</value>


### PR DESCRIPTION
This commit optimizes crossgen2 pipeline mode described in #37411. The optimization consists of *loop-invariant-code-motion*: move input dll loading out from loop.

### Crossgen2 compilation of system dlls time compare

| Architecture | script | pipeline | pipeline optimize |
| :-----: | :-: | :-: | :-: | 
| x64 | 1m36.235s | 0m17.818s | 0m14.668s |
| armel | 13m30.493s | 3m48.829s | 3m36.691s |

<details><summary> Time measurement details </summary>

Time is first `real` line of `time` command output.

**Script**
Command line to measure time:
```
time ../ngen_r2r.sh  ./ true "-O"
```
`ngen_r2r.sh` first compiles `System.Private.CoreLib.dll`, then `crossgen2/*.dll`, then all other dlls.
Runtime state is 8fc5789cad3fce1ff42c46790d350382d7a27ce0.

**Pipeline**
Command line to measure time:
```
find ./ -name "*.ni.dll" -exec rm {} \;; time ./corerun ./crossgen2/crossgen2.dll -r:./*.dll -r:./crossgen2/*.dll --out-near-input ./crossgen2/*.dll ./*.dll  --single-file-compilation -O
```
Runtime state as in **script** + [Initial implementation of crossgen2 pipeline mode](https://github.com/dotnet/runtime/commit/51457f73f61048a827458b999bb01a6c6eecacfe).

**Pipeline optimize**
Same cmdline as Pipeline. 
Runtime state as in **pipeline** + [[crossgen2] Optimize pipeline mode](https://github.com/dotnet/runtime/commit/f61635bb9a083d8baf8796eda228e2a509ccd0e6).

</details>

### Crossgen2 compilation of system dlls time compare with options `--inputbubble --compilebubblegenerics`

| Architecture | script | pipeline | pipeline optimize |
| :-----: | :-: | :-: | :-: | 
| x64 | 1m43.536s | 0m30.380s | 0m25.035s |
| armel | 16m13.457s | 6m48.416s | 6m11.085s |

<details><summary> Time measurement details </summary>

**Script**
Command line to measure time:
```
time ../ngen_r2r.sh  ./ true "-O --inputbubble --compilebubblegenerics"
```
Script for armel compiles `ILCompiler.ReadyToRun.dll` and `ILCompiler.TypeSystem.ReadyToRun.dll` without `--inputbubble --compilebubblegenerics` due to issue #48466.

**Pipeline**
Command line to measure time:
```
find ./ -name "*.ni.dll" -exec rm {} \;; time ./corerun ./crossgen2/crossgen2.dll -r:./*.dll -r:./crossgen2/*.dll --out-near-input ./crossgen2/*.dll ./*.dll  --single-file-compilation -O --inputbubble --compilebubblegenerics
```

**Pipeline optimize**
Same cmdline as Pipeline. 

</details>

As part of work on pipeline mode we fixed a memory leak #49764, it allows us to finish compilation of all system dlls at one crossgen2 start and obtain time compare.

cc @jkotas @davidwrighton @MichalStrehovsky @gbalykov @alpencolt 