### PR TITLE
Enable JsonSerializerOptions cache clearing for hot reload metadata update

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -233,6 +233,9 @@
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
     <Compile Include="$(CommonPath)System\Collections\Generic\ReferenceEqualityComparer.cs" Link="Common\System\Collections\Generic\ReferenceEqualityComparer.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="System\Text\Json\Serialization\JsonSerializerOptionsUpdateHandler.cs" />
+  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4'))">
     <Compile Include="System\Collections\Generic\StackExtensions.netstandard.cs" />
     <!-- Common or Common-branched source files -->
@@ -274,6 +277,7 @@
       <ItemGroup>
         <Reference Include="System.Runtime.CompilerServices.Unsafe" />
         <Reference Include="System.Text.Encodings.Web" />
+        <Reference Include="System.Runtime.Loader" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -17,13 +17,6 @@ namespace System.Text.Json
     {
         internal const int BufferSizeDefault = 16 * 1024;
 
-        /// <summary>Tracks all live JsonSerializerOptions instances.</summary>
-        /// <remarks>Instances are added to the table in their constructor.</remarks>
-        internal static readonly ConditionalWeakTable<JsonSerializerOptions, object?> s_allOptionsInstances =
-            // TODO https://github.com/dotnet/runtime/issues/51159:
-            // Look into linking this away / disabling it when hot reload isn't in use.
-            new ConditionalWeakTable<JsonSerializerOptions, object?>();
-
         internal static readonly JsonSerializerOptions s_defaultOptions = new JsonSerializerOptions();
 
         private readonly ConcurrentDictionary<Type, JsonClassInfo> _classes = new ConcurrentDictionary<Type, JsonClassInfo>();
@@ -109,7 +102,17 @@ namespace System.Text.Json
         }
 
         /// <summary>Tracks the options instance to enable all instances to be enumerated.</summary>
-        private static void TrackOptionsInstance(JsonSerializerOptions options) => s_allOptionsInstances.Add(options, null);
+        private static void TrackOptionsInstance(JsonSerializerOptions options) => TrackedOptionsInstances.All.Add(options, null);
+
+        internal static class TrackedOptionsInstances
+        {
+            /// <summary>Tracks all live JsonSerializerOptions instances.</summary>
+            /// <remarks>Instances are added to the table in their constructor.</remarks>
+            public static ConditionalWeakTable<JsonSerializerOptions, object?> All { get; } =
+                // TODO https://github.com/dotnet/runtime/issues/51159:
+                // Look into linking this away / disabling it when hot reload isn't in use.
+                new ConditionalWeakTable<JsonSerializerOptions, object?>();
+        }
 
         /// <summary>
         /// Constructs a new <see cref="JsonSerializerOptions"/> instance with a predefined set of options determined by the specified <see cref="JsonSerializerDefaults"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -12,10 +12,10 @@ namespace System.Text.Json
     /// <summary>Handler used to clear JsonSerializerOptions reflection cache upon a metadata update.</summary>
     internal static class JsonSerializerOptionsUpdateHandler
     {
-        public static void BeforeUpdate(Type? type)
+        public static void BeforeUpdate(Type[]? types)
         {
-            // Ignore the type, and just clear out all reflection caches from serializer options.
-            foreach (KeyValuePair<JsonSerializerOptions, object?> options in JsonSerializerOptions.s_allOptionsInstances)
+            // Ignore the types, and just clear out all reflection caches from serializer options.
+            foreach (KeyValuePair<JsonSerializerOptions, object?> options in JsonSerializerOptions.TrackedOptionsInstances.All)
             {
                 options.Key.ClearClasses();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Text.Json;
+
+[assembly: MetadataUpdateHandler(typeof(JsonSerializerOptionsUpdateHandler))]
+
+namespace System.Text.Json
+{
+    /// <summary>Handler used to clear JsonSerializerOptions reflection cache upon a metadata update.</summary>
+    internal static class JsonSerializerOptionsUpdateHandler
+    {
+        public static void BeforeUpdate(Type? type)
+        {
+            // Ignore the type, and just clear out all reflection caches from serializer options.
+            foreach (KeyValuePair<JsonSerializerOptions, object?> options in JsonSerializerOptions.s_allOptionsInstances)
+            {
+                options.Key.ClearClasses();
+            }
+        }
+    }
+}


### PR DESCRIPTION
cc: @tommcdon, @eerhardt, @steveharter, @layomia 