### PR TITLE
Include condition inside assert for forward jump loops

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -998,8 +998,8 @@ void CodeGen::genLogLabel(BasicBlock* bb)
 void CodeGen::genDefineTempLabel(BasicBlock* label)
 {
     genLogLabel(label);
-    label->bbEmitCookie =
-        GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
+    label->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
+                                                     gcInfo.gcRegByrefSetCur, false, label->bbNum);
 }
 
 // genDefineInlineTempLabel: Define an inline label that does not affect the GC

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -998,8 +998,8 @@ void CodeGen::genLogLabel(BasicBlock* bb)
 void CodeGen::genDefineTempLabel(BasicBlock* label)
 {
     genLogLabel(label);
-    label->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                     gcInfo.gcRegByrefSetCur DEBUG_ARG(label->bbNum));
+    label->bbEmitCookie =
+        GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
 }
 
 // genDefineInlineTempLabel: Define an inline label that does not affect the GC

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -999,7 +999,7 @@ void CodeGen::genDefineTempLabel(BasicBlock* label)
 {
     genLogLabel(label);
     label->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                     gcInfo.gcRegByrefSetCur, false, label->bbNum);
+                                                     gcInfo.gcRegByrefSetCur, false DEBUG_ARG(label->bbNum));
 }
 
 // genDefineInlineTempLabel: Define an inline label that does not affect the GC
@@ -1994,7 +1994,8 @@ void CodeGen::genInsertNopForUnwinder(BasicBlock* block)
         // would be executed, which we would prefer not to do.
 
         block->bbUnwindNopEmitCookie =
-            GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
+            GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur,
+                                       false DEBUG_ARG(block->bbNum));
 
         instGen(INS_nop);
     }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -998,8 +998,8 @@ void CodeGen::genLogLabel(BasicBlock* bb)
 void CodeGen::genDefineTempLabel(BasicBlock* label)
 {
     genLogLabel(label);
-    label->bbEmitCookie =
-        GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
+    label->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
+                                                     gcInfo.gcRegByrefSetCur DEBUG_ARG(label->bbNum));
 }
 
 // genDefineInlineTempLabel: Define an inline label that does not affect the GC

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -365,7 +365,9 @@ void CodeGen::genCodeForBBlist()
             // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur DEBUG_ARG(block->bbNum));
+                                                             gcInfo.gcRegByrefSetCur, FALSE);
+            JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", block->bbNum, compiler->compMethodID,
+                    GetEmitter()->emitCurIG->igNum);
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -366,6 +366,8 @@ void CodeGen::genCodeForBBlist()
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
                                                              gcInfo.gcRegByrefSetCur, FALSE);
+            JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", block->bbNum, compiler->compMethodID,
+                    GetEmitter()->emitCurIG->igNum);
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -365,7 +365,7 @@ void CodeGen::genCodeForBBlist()
             // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur, false, block->bbNum);
+                                                             gcInfo.gcRegByrefSetCur, false DEBUG_ARG(block->bbNum));
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -365,9 +365,7 @@ void CodeGen::genCodeForBBlist()
             // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur, FALSE);
-            JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", block->bbNum, compiler->compMethodID,
-                    GetEmitter()->emitCurIG->igNum);
+                                                             gcInfo.gcRegByrefSetCur, false, block->bbNum);
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -365,9 +365,7 @@ void CodeGen::genCodeForBBlist()
             // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur, FALSE);
-            JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", block->bbNum, compiler->compMethodID,
-                    GetEmitter()->emitCurIG->igNum);
+                                                             gcInfo.gcRegByrefSetCur DEBUG_ARG(block->bbNum));
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2475,7 +2475,7 @@ bool emitter::emitNoGChelper(CORINFO_METHOD_HANDLE methHnd)
  *  Mark the current spot as having a label.
  */
 
-void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs DEBUG_ARG(unsigned bbNum))
+void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BOOL isFinallyTarget)
 {
     /* Create a new IG if the current one is non-empty */
 
@@ -2496,12 +2496,17 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
     emitThisGCrefRegs = emitInitGCrefRegs = gcrefRegs;
     emitThisByrefRegs = emitInitByrefRegs = byrefRegs;
 
-#ifdef DEBUG
-    JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", bbNum, emitComp->compMethodID, emitCurIG->igNum);
+#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+    if (isFinallyTarget)
+    {
+        emitCurIG->igFlags |= IGF_FINALLY_TARGET;
+    }
+#endif // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
 
+#ifdef DEBUG
     if (EMIT_GC_VERBOSE)
     {
-        printf("GCvars=%s ", emitCurIG->igNum, VarSetOps::ToString(emitComp, GCvars));
+        printf("Label: IG%02u, GCvars=%s ", emitCurIG->igNum, VarSetOps::ToString(emitComp, GCvars));
         dumpConvertedVarSet(emitComp, GCvars);
         printf(", gcrefRegs=");
         printRegMaskInt(gcrefRegs);
@@ -3425,6 +3430,12 @@ void emitter::emitDispIGflags(unsigned flags)
     {
         printf(", byref");
     }
+#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+    if (flags & IGF_FINALLY_TARGET)
+    {
+        printf(", ftarget");
+    }
+#endif // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
     if (flags & IGF_FUNCLET_PROLOG)
     {
         printf(", funclet prolog");
@@ -5739,6 +5750,11 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             NO_WAY("Too many instruction groups");
         }
 
+        // If this instruction group is returned to from a funclet implementing a finally,
+        // on architectures where it is necessary generate GC info for the current instruction as
+        // if it were the instruction following a call.
+        emitGenGCInfoIfFuncletRetTarget(ig, cp);
+
         instrDesc* id = (instrDesc*)ig->igData;
 
 #ifdef DEBUG
@@ -6095,6 +6111,29 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     /* Return the amount of code we've generated */
 
     return actualCodeSize;
+}
+
+// See specification comment at the declaration.
+void emitter::emitGenGCInfoIfFuncletRetTarget(insGroup* ig, BYTE* cp)
+{
+#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+    // We only emit this GC information on targets where finally's are implemented via funclets,
+    // and the finally is invoked, during non-exceptional execution, via a branch with a predefined
+    // link register, rather than a "true call" for which we would already generate GC info.  Currently,
+    // this means precisely ARM.
+    if (ig->igFlags & IGF_FINALLY_TARGET)
+    {
+        // We don't actually have a call instruction in this case, so we don't have
+        // a real size for that instruction.  We'll use 1.
+        emitStackPop(cp, /*isCall*/ true, /*callInstrSize*/ 1, /*args*/ 0);
+
+        /* Do we need to record a call location for GC purposes? */
+        if (!emitFullGCinfo)
+        {
+            emitRecordGCcall(cp, /*callInstrSize*/ 1);
+        }
+    }
+#endif // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2475,7 +2475,10 @@ bool emitter::emitNoGChelper(CORINFO_METHOD_HANDLE methHnd)
  *  Mark the current spot as having a label.
  */
 
-void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BOOL isFinallyTarget)
+void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars,
+                            regMaskTP        gcrefRegs,
+                            regMaskTP        byrefRegs,
+                            bool isFinallyTarget DEBUG_ARG(unsigned bbNum))
 {
     /* Create a new IG if the current one is non-empty */
 
@@ -2504,6 +2507,8 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
 #endif // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
 
 #ifdef DEBUG
+    JITDUMP("Mapped " FMT_BB " to G_M%03u_IG%02u\n", bbNum, emitComp->compMethodID, emitCurIG->igNum);
+
     if (EMIT_GC_VERBOSE)
     {
         printf("Label: IG%02u, GCvars=%s ", emitCurIG->igNum, VarSetOps::ToString(emitComp, GCvars));

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1896,7 +1896,11 @@ private:
     // Sets the emitter's record of the currently live GC variables
     // and registers.  The "isFinallyTarget" parameter indicates that the current location is
     // the start of a basic block that is returned to after a finally clause in non-exceptional execution.
-    void* emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BOOL isFinallyTarget = FALSE);
+    void* emitAddLabel(VARSET_VALARG_TP GCvars,
+                       regMaskTP        gcrefRegs,
+                       regMaskTP        byrefRegs,
+                       bool isFinallyTarget = false DEBUG_ARG(unsigned bbNum = 0));
+
     // Same as above, except the label is added and is conceptually "inline" in
     // the current block. Thus it extends the previous block and the emitter
     // continues to track GC info as if there was no label.

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -255,11 +255,8 @@ struct insGroup
     insGroup* igLoopBackEdge; // "last" back-edge that branches back to an aligned loop head.
 #endif
 
-#define IGF_GC_VARS 0x0001    // new set of live GC ref variables
-#define IGF_BYREF_REGS 0x0002 // new set of live by-ref registers
-#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
-#define IGF_FINALLY_TARGET 0x0004 // this group is the start of a basic block that is returned to after a finally.
-#endif                            // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+#define IGF_GC_VARS 0x0001        // new set of live GC ref variables
+#define IGF_BYREF_REGS 0x0002     // new set of live by-ref registers
 #define IGF_FUNCLET_PROLOG 0x0008 // this group belongs to a funclet prolog
 #define IGF_FUNCLET_EPILOG 0x0010 // this group belongs to a funclet epilog.
 #define IGF_EPILOG 0x0020         // this group belongs to a main function epilog
@@ -495,11 +492,6 @@ protected:
     }
 
 #endif // FEATURE_EH_FUNCLETS
-
-    // If "ig" corresponds to the start of a basic block that is the
-    // target of a funclet return, generate GC information for it's start
-    // address "cp", as if it were the return address of a call.
-    void emitGenGCInfoIfFuncletRetTarget(insGroup* ig, BYTE* cp);
 
     void emitRecomputeIGoffsets();
 
@@ -1896,7 +1888,7 @@ private:
     // Sets the emitter's record of the currently live GC variables
     // and registers.  The "isFinallyTarget" parameter indicates that the current location is
     // the start of a basic block that is returned to after a finally clause in non-exceptional execution.
-    void* emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BOOL isFinallyTarget = FALSE);
+    void* emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs DEBUG_ARG(unsigned bbNum));
     // Same as above, except the label is added and is conceptually "inline" in
     // the current block. Thus it extends the previous block and the emitter
     // continues to track GC info as if there was no label.

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -255,8 +255,11 @@ struct insGroup
     insGroup* igLoopBackEdge; // "last" back-edge that branches back to an aligned loop head.
 #endif
 
-#define IGF_GC_VARS 0x0001        // new set of live GC ref variables
-#define IGF_BYREF_REGS 0x0002     // new set of live by-ref registers
+#define IGF_GC_VARS 0x0001    // new set of live GC ref variables
+#define IGF_BYREF_REGS 0x0002 // new set of live by-ref registers
+#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+#define IGF_FINALLY_TARGET 0x0004 // this group is the start of a basic block that is returned to after a finally.
+#endif                            // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
 #define IGF_FUNCLET_PROLOG 0x0008 // this group belongs to a funclet prolog
 #define IGF_FUNCLET_EPILOG 0x0010 // this group belongs to a funclet epilog.
 #define IGF_EPILOG 0x0020         // this group belongs to a main function epilog
@@ -492,6 +495,11 @@ protected:
     }
 
 #endif // FEATURE_EH_FUNCLETS
+
+    // If "ig" corresponds to the start of a basic block that is the
+    // target of a funclet return, generate GC information for it's start
+    // address "cp", as if it were the return address of a call.
+    void emitGenGCInfoIfFuncletRetTarget(insGroup* ig, BYTE* cp);
 
     void emitRecomputeIGoffsets();
 
@@ -1888,7 +1896,7 @@ private:
     // Sets the emitter's record of the currently live GC variables
     // and registers.  The "isFinallyTarget" parameter indicates that the current location is
     // the start of a basic block that is returned to after a finally clause in non-exceptional execution.
-    void* emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs DEBUG_ARG(unsigned bbNum));
+    void* emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BOOL isFinallyTarget = FALSE);
     // Same as above, except the label is added and is conceptually "inline" in
     // the current block. Thus it extends the previous block and the emitter
     // continues to track GC info as if there was no label.


### PR DESCRIPTION
Loop alignment is done for loops that are formed when we see a backward jump to the loop top. Sometimes, register allocation's resolution can insert a block in middle which might change the loop to the following form:

```
IG05:
    ...
    jmp IG18
...
...
IG18:
   ...
   jne IG05
```

For such cases, through basic block analysis, we think that we need to add `align` instruction inside `IG17` to align the loop that starts at `IG18`, but when we try to set the backedge of the loop (to calculate loop size), we cannot do that because we haven't generated those IGs. In above example, since `IG05->IG18` is a forward jump and hence we cannot set the backedge because `IG18` is not yet generated.

When we calculate loop size, if we encounter an IG that needs alignment, we had an `assert` that made sure that IG is the last one and points to a valid loop header. However, like above example, we can also have an IG inside a loop that was marked as "need alignment", but we never set its backedge and hence it won't match with any loop header. The fix was to include that condition inside the assert. To calculate `loopSize` of such loops, we would just iterate over all the IGs until we meet `loopSize` threshold, after which we will break out from loop size calculation and decide not to align the loop.

I have added little description around the assert to make sure that we remember all the scenarios.

Fixes: https://github.com/dotnet/runtime/issues/51084