### PR TITLE
Fix for RoslynPad crash found in targeted preview testing

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -107,12 +107,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 Debug.Assert(_methodArgument.Unboxing == false);
 
+                bool useInstantiatingStub = (_methodArgument.Method.IsSharedByGenericInstantiations &&
+                    (_methodArgument.Method.Signature.IsStatic || _methodArgument.Method.HasInstantiation));
+
                 dataBuilder.EmitMethodSignature(
                     _methodArgument,
                     enforceDefEncoding: false,
                     enforceOwningType: false,
                     context: innerContext,
-                    isInstantiatingStub: true);
+                    isInstantiatingStub: useInstantiatingStub);
             }
             else if (_typeArgument != null)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -107,15 +107,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 Debug.Assert(_methodArgument.Unboxing == false);
 
-                bool useInstantiatingStub = (_methodArgument.Method.IsSharedByGenericInstantiations &&
-                    (_methodArgument.Method.Signature.IsStatic || _methodArgument.Method.HasInstantiation));
-
                 dataBuilder.EmitMethodSignature(
                     _methodArgument,
                     enforceDefEncoding: false,
                     enforceOwningType: false,
                     context: innerContext,
-                    isInstantiatingStub: useInstantiatingStub);
+                    isInstantiatingStub: true);
             }
             else if (_typeArgument != null)
             {
@@ -143,7 +140,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append(": ");
             if (_methodArgument != null)
             {
+                sb.Append(nameMangler.GetMangledTypeName(_methodArgument.OwningType));
+                sb.Append("::");
                 sb.Append(nameMangler.GetMangledMethodName(_methodArgument.Method));
+                if (_methodArgument.ConstrainedType != null)
+                {
+                    sb.Append("@");
+                    sb.Append(nameMangler.GetMangledTypeName(_methodArgument.ConstrainedType));
+                }
                 if (!_methodArgument.Token.IsNull)
                 {
                     sb.Append(" [");

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -499,7 +499,7 @@ namespace ILCompiler.DependencyAnalysis
                 return LookupKind == other.LookupKind &&
                     FixupKind == other.FixupKind &&
                     RuntimeDeterminedTypeHelper.Equals(TypeArgument, other.TypeArgument) &&
-                    RuntimeDeterminedTypeHelper.Equals(MethodArgument?.Method ?? null, other.MethodArgument?.Method ?? null) &&
+                    RuntimeDeterminedTypeHelper.Equals(MethodArgument, other.MethodArgument) &&
                     RuntimeDeterminedTypeHelper.Equals(FieldArgument, other.FieldArgument) &&
                     MethodContext.Equals(other.MethodContext);
             }
@@ -514,7 +514,7 @@ namespace ILCompiler.DependencyAnalysis
                 return unchecked(((int)LookupKind << 24) +
                     (int)FixupKind +
                     (TypeArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(TypeArgument) : 0) +
-                    (MethodArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(MethodArgument.Method) : 0) +
+                    (MethodArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(MethodArgument) : 0) +
                     (FieldArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(FieldArgument) : 0) +
                     MethodContext.GetHashCode());
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 
+using Internal.JitInterface;
 using Internal.TypeSystem;
 using Internal.Text;
 
@@ -38,6 +39,11 @@ namespace ILCompiler
             if (type1 == type2)
             {
                 return true;
+            }
+
+            if (type1 == null || type2 == null)
+            {
+                return false;
             }
 
             RuntimeDeterminedType runtimeDeterminedType1 = type1 as RuntimeDeterminedType;
@@ -91,6 +97,11 @@ namespace ILCompiler
             {
                 return true;
             }
+            if (method1 == null || method2 == null)
+            {
+                return false;
+            }
+
             if (!Equals(method1.OwningType, method2.OwningType) ||
                 method1.Signature.Length != method2.Signature.Length ||
                 !Equals(method1.Instantiation, method2.Instantiation) ||
@@ -106,6 +117,22 @@ namespace ILCompiler
                 }
             }
             return true;
+        }
+
+        public static bool Equals(MethodWithToken methodWithToken1, MethodWithToken methodWithToken2)
+        {
+            if (methodWithToken1 == methodWithToken2)
+            {
+                return true;
+            }
+            if (methodWithToken1 == null || methodWithToken2 == null)
+            {
+                return false;
+            }
+            return Equals(methodWithToken1.Method, methodWithToken2.Method)
+                && Equals(methodWithToken1.OwningType, methodWithToken2.OwningType)
+                && Equals(methodWithToken1.ConstrainedType, methodWithToken2.ConstrainedType)
+                && methodWithToken1.Unboxing == methodWithToken2.Unboxing;
         }
 
         public static bool Equals(FieldDesc field1, FieldDesc field2)
@@ -132,6 +159,10 @@ namespace ILCompiler
 
         public static int GetHashCode(TypeDesc type)
         {
+            if (type == null)
+            {
+                return 0;
+            }
             if (type is RuntimeDeterminedType runtimeDeterminedType)
             {
                 return runtimeDeterminedType.RuntimeDeterminedDetailsType.Index ^
@@ -142,12 +173,29 @@ namespace ILCompiler
 
         public static int GetHashCode(MethodDesc method)
         {
+            if (method == null)
+            {
+                return 0;
+            }
             return unchecked(GetHashCode(method.OwningType) + 97 * (
                 method.GetTypicalMethodDefinition().GetHashCode() + 31 * GetHashCode(method.Instantiation)));
         }
 
+        public static int GetHashCode(MethodWithToken method)
+        {
+            if (method == null)
+            {
+                return 0;
+            }
+            return unchecked(GetHashCode(method.Method) + 31 * GetHashCode(method.OwningType) + 97 * GetHashCode(method.ConstrainedType));
+        }
+
         public static int GetHashCode(FieldDesc field)
         {
+            if (field == null)
+            {
+                return 0;
+            }
             return unchecked(GetHashCode(field.OwningType) + 97 * GetHashCode(field.FieldType) + 31 * field.Name.GetHashCode());
         }
     }


### PR DESCRIPTION
I found out that the crash was caused by an incompletely handled
corner case in generic lookup - for method generic lookups, we
were always requesting instantiation stubs even when not appropriate.
I have updated the condition for emitting an instantiation stub,
please review it and let me know if you think the check is incomplete.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/50472