### PR TITLE
Fix native stack size alignment on macOS arm64

### DIFF
--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3660,6 +3660,8 @@ static void CreateNDirectStubWorker(StubState*               pss,
         }
 #endif // TARGET_X86
 
+        nativeStackSize = ALIGN_UP(nativeStackSize, TARGET_POINTER_SIZE);
+
         if (!FitsInU2(nativeStackSize))
             COMPlusThrow(kMarshalDirectiveException, IDS_EE_SIGTOOCOMPLEX);
 


### PR DESCRIPTION
We were setting an unaligned stack size to the MethodDesc of ILStub. The
lowest two bits actually overlap with two flags in the extended flags,
so the size is expected to be aligned at least to 4 to not to overwrite
the flags. On macOS arm64, the computed native stack size can be misaligned,
so this change adds explicit alignment before storing the stack size to
the MethodDesc.