### PR TITLE
[sdb][coop] Switch to GC Safe before calling debugger transport callbacks

### DIFF
--- a/src/mono/mono/mini/debugger-agent.h
+++ b/src/mono/mono/mini/debugger-agent.h
@@ -43,7 +43,7 @@ mono_debugger_agent_parse_options (char *options);
 void
 mono_debugger_agent_stub_init (void);
 
-MONO_API gboolean
+MONO_API MONO_RT_EXTERNAL_ONLY gboolean
 mono_debugger_agent_transport_handshake (void);
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50966

Under hybrid suspend, if we call the debugger callbacks like `transport_recv`
in GC Unsafe (cooperative) mode, we could get a GC suspend deadlock: the
suspend initiator will be waiting for the debugger thread to self-suspend, but
the debugger thread will be blocked in `recv` until it receives a debugger
command (which probably will not come since from the debugger's point of view
nothing is happening in the debuggee, so there's no event to respond to).

The socket transport already had GC safe transitions, but since the runtime
allows external embedders to register their own protocols, we need the GC state
transitions around the calls to the callbacks, not around the I/O operations.

The tricky bit is `transport_connect` - as far as I can tell it's always called
after the MonoThreadInfo has been initialized and the current thread has been
attached to the runtime - so thread state transitions should work. (The tricky
one is `transport_connect` which happens early in startup in some
configurations.  But in that case `finish_agent_init` is called by
`debugger_agent_init` which also calls `mono_gc_base_init` which sets up the
thread state and attaches the thread)

As followup work, we will need to adjust net7+ watchOS in
https://github.com/xamarin/xamarin-macios _not_ to do a transition to GC Safe
in its `sdb_send` and `sdb_recv` functions.