### PR TITLE
Disable SendRecvPollSync_TcpListener_Socket on Windows 8

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -479,7 +479,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows8x))]
         [MemberData(nameof(LoopbacksAndBuffers))]
         public async Task SendRecvPollSync_TcpListener_Socket(IPAddress listenAt, bool pollBeforeOperation)
         {


### PR DESCRIPTION
Fixes #24444

This test is failing only on Windows 8.1 ([Kusto](https://dataexplorer.azure.com/clusters/engsrvprod/databases/engineeringdata?query=H4sIAAAAAAAAA21OTUvDQBC991cMPSnsIaXnCHoQWrRoE/BY1t1Hss1mJuxOlII/3m1EvDiXmcf7mNci6xF5jppXX3SWwDQE9nVgRqK9vGcSvu6d/4d/kzTsFOMi+gWL8rNHAj1De/FU17RuwP4I9/EiMTYXdqfWTU8hK0rOqRE3QNcrKmPZ00+jxfdoQ/wjGrVJ4emObCc328rfll8xjEFpU1VVAVOSM5zS64wZ3pQKOdsO5mp1Q5usK/dCHuyIjaGHZNn1hu5TN49gzYbay4RvhIYWOBkBAAA=))

cc @antonfirsov this is the test we discussed last week. The failures are always the same:
https://github.com/dotnet/runtime/blob/03be59b0cb4ee4914dc4c195bc7fd839d7b46d44/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs#L515