### PR TITLE
[AndroidCrypto] Handle setting non-default application protocols

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.ProtocolSupport.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.ProtocolSupport.cs
@@ -10,5 +10,9 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLGetSupportedProtocols")]
         internal static extern SslProtocols SSLGetSupportedProtocols();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLSupportsApplicationProtocolsConfiguration")]
+        [return:MarshalAs(UnmanagedType.U1)]
+        internal static extern bool SSLSupportsApplicationProtocolsConfiguration();
     }
 }

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -68,15 +68,15 @@ internal static partial class Interop
                 throw new SslException();
         }
 
-        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamConfigureParameters")]
-        private static extern int SSLStreamConfigureParametersImpl(
+        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamSetTargetHost")]
+        private static extern int SSLStreamSetTargetHostImpl(
             SafeSslHandle sslHandle,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string targetHost);
-        internal static void SSLStreamConfigureParameters(
+        internal static void SSLStreamSetTargetHost(
             SafeSslHandle sslHandle,
             string targetHost)
         {
-            int ret = SSLStreamConfigureParametersImpl(sslHandle, targetHost);
+            int ret = SSLStreamSetTargetHostImpl(sslHandle, targetHost);
             if (ret != SUCCESS)
                 throw new SslException();
         }

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -81,6 +83,47 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamRequestClientAuthentication")]
         internal static extern void SSLStreamRequestClientAuthentication(SafeSslHandle sslHandle);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private unsafe struct ApplicationProtocolData
+        {
+            public byte* Data;
+            public int Length;
+        }
+
+        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamSetApplicationProtocols")]
+        private static unsafe extern int SSLStreamSetApplicationProtocols(SafeSslHandle sslHandle, ApplicationProtocolData[] protocolData, int count);
+        internal static unsafe void SSLStreamSetApplicationProtocols(SafeSslHandle sslHandle, List<SslApplicationProtocol> protocols)
+        {
+            int count = protocols.Count;
+            MemoryHandle[] memHandles = new MemoryHandle[count];
+            ApplicationProtocolData[] protocolData = new ApplicationProtocolData[count];
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    ReadOnlyMemory<byte> protocol = protocols[i].Protocol;
+                    memHandles[i] = protocol.Pin();
+                    protocolData[i] = new ApplicationProtocolData
+                    {
+                        Data = (byte*)memHandles[i].Pointer,
+                        Length = protocol.Length
+                    };
+                }
+                int ret = SSLStreamSetApplicationProtocols(sslHandle, protocolData, count);
+                if (ret != SUCCESS)
+                {
+                    throw new SslException();
+                }
+            }
+            finally
+            {
+                foreach (MemoryHandle memHandle in memHandles)
+                {
+                    memHandle.Dispose();
+                }
+            }
+        }
 
         [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamSetEnabledProtocols")]
         private static extern int SSLStreamSetEnabledProtocols(SafeSslHandle sslHandle, ref SslProtocols protocols, int length);

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -79,6 +79,9 @@ internal static partial class Interop
                 throw new SslException();
         }
 
+        [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamRequestClientAuthentication")]
+        internal static extern void SSLStreamRequestClientAuthentication(SafeSslHandle sslHandle);
+
         [DllImport(Interop.Libraries.CryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamSetEnabledProtocols")]
         private static extern int SSLStreamSetEnabledProtocols(SafeSslHandle sslHandle, ref SslProtocols protocols, int length);
         internal static void SSLStreamSetEnabledProtocols(SafeSslHandle sslHandle, ReadOnlySpan<SslProtocols> protocols)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -142,7 +142,14 @@ namespace System.Net.Http.Functional.Tests
 
             string GetTestSNIName()
             {
-                return $"{nameof(GetAsync_AllowedSSLVersion_Succeeds)}_{acceptedProtocol}_{requestOnlyThisProtocol}";
+                string name = $"{nameof(GetAsync_AllowedSSLVersion_Succeeds)}_{acceptedProtocol}_{requestOnlyThisProtocol}";
+                if (PlatformDetection.IsAndroid)
+                {
+                    // Android does not support underscores in host names
+                    name = name.Replace("_", string.Empty);
+                }
+
+                return name;
             }
         }
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -134,15 +134,34 @@ namespace System
         public static bool IsDomainJoinedMachine => !Environment.MachineName.Equals(Environment.UserDomainName, StringComparison.OrdinalIgnoreCase);
         public static bool IsNotDomainJoinedMachine => !IsDomainJoinedMachine;
 
+        public static bool IsOpenSslSupported => IsLinux || IsFreeBSD || Isillumos || IsSolaris;
+
         // Windows - Schannel supports alpn from win8.1/2012 R2 and higher.
         // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
         // OSX - SecureTransport doesn't expose alpn APIs. TODO https://github.com/dotnet/runtime/issues/27727
-        public static bool IsOpenSslSupported => IsLinux || IsFreeBSD || Isillumos || IsSolaris;
+        // Android - Platform supports alpn from API level 29 and higher
+        private static Lazy<bool> s_supportsAlpn = new Lazy<bool>(GetAlpnSupport);
+        private static bool GetAlpnSupport()
+        {
+            if (IsWindows && !IsWindows7 && !IsNetFramework)
+            {
+                return true;
+            }
 
-        public static bool SupportsAlpn => (IsWindows && !IsWindows7 && !IsNetFramework) ||
-            (IsOpenSslSupported &&
-            (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
+            if (IsOpenSslSupported)
+            {
+                return OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2);
+            }
 
+            if (IsAndroid)
+            {
+                return Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration();
+            }
+
+            return false;
+        }
+
+        public static bool SupportsAlpn => s_supportsAlpn.Value;
         public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsMacCatalyst || IsiOS || IstvOS;
 
         private static Lazy<bool> s_supportsTls10 = new Lazy<bool>(GetTls10Support);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -79,7 +79,6 @@ jmethodID g_sigNumMethod;
 
 // javax/net/ssl/SSLParameters
 jclass    g_SSLParametersClass;
-jmethodID g_SSLParametersCtor;
 jmethodID g_SSLParametersGetProtocols;
 jmethodID g_SSLParametersSetApplicationProtocols;
 jmethodID g_SSLParametersSetServerNames;
@@ -403,6 +402,7 @@ jmethodID g_SSLEngineCloseOutbound;
 jmethodID g_SSLEngineGetApplicationProtocol;
 jmethodID g_SSLEngineGetHandshakeStatus;
 jmethodID g_SSLEngineGetSession;
+jmethodID g_SSLEngineGetSSLParameters;
 jmethodID g_SSLEngineGetSupportedProtocols;
 jmethodID g_SSLEngineSetEnabledProtocols;
 jmethodID g_SSLEngineSetSSLParameters;
@@ -714,7 +714,6 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_sigNumMethod =            GetMethod(env, false, g_bigNumClass, "signum", "()I");
 
     g_SSLParametersClass =                      GetClassGRef(env, "javax/net/ssl/SSLParameters");
-    g_SSLParametersCtor =                       GetMethod(env, false,  g_SSLParametersClass, "<init>", "()V");
     g_SSLParametersGetProtocols =               GetMethod(env, false,  g_SSLParametersClass, "getProtocols", "()[Ljava/lang/String;");
     g_SSLParametersSetApplicationProtocols =    GetOptionalMethod(env, false,  g_SSLParametersClass, "setApplicationProtocols", "([Ljava/lang/String;)V");
     g_SSLParametersSetServerNames =             GetMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
@@ -978,6 +977,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SSLEngineGetApplicationProtocol = GetMethod(env, false, g_SSLEngine, "getApplicationProtocol", "()Ljava/lang/String;");
     g_SSLEngineGetHandshakeStatus =     GetMethod(env, false, g_SSLEngine, "getHandshakeStatus", "()Ljavax/net/ssl/SSLEngineResult$HandshakeStatus;");
     g_SSLEngineGetSession =             GetMethod(env, false, g_SSLEngine, "getSession", "()Ljavax/net/ssl/SSLSession;");
+    g_SSLEngineGetSSLParameters =       GetMethod(env, false, g_SSLEngine, "getSSLParameters", "()Ljavax/net/ssl/SSLParameters;");
     g_SSLEngineGetSupportedProtocols =  GetMethod(env, false, g_SSLEngine, "getSupportedProtocols", "()[Ljava/lang/String;");
     g_SSLEngineSetEnabledProtocols =    GetMethod(env, false, g_SSLEngine, "setEnabledProtocols", "([Ljava/lang/String;)V");
     g_SSLEngineSetSSLParameters =       GetMethod(env, false, g_SSLEngine, "setSSLParameters", "(Ljavax/net/ssl/SSLParameters;)V");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -397,17 +397,18 @@ jmethodID g_SNIHostNameCtor;
 
 // javax/net/ssl/SSLEngine
 jclass    g_SSLEngine;
-jmethodID g_SSLEngineGetApplicationProtocol;
-jmethodID g_SSLEngineSetUseClientMode;
-jmethodID g_SSLEngineGetSession;
 jmethodID g_SSLEngineBeginHandshake;
-jmethodID g_SSLEngineWrap;
-jmethodID g_SSLEngineUnwrap;
 jmethodID g_SSLEngineCloseOutbound;
+jmethodID g_SSLEngineGetApplicationProtocol;
 jmethodID g_SSLEngineGetHandshakeStatus;
+jmethodID g_SSLEngineGetSession;
 jmethodID g_SSLEngineGetSupportedProtocols;
 jmethodID g_SSLEngineSetEnabledProtocols;
 jmethodID g_SSLEngineSetSSLParameters;
+jmethodID g_SSLEngineSetUseClientMode;
+jmethodID g_SSLEngineSetWantClientAuth;
+jmethodID g_SSLEngineUnwrap;
+jmethodID g_SSLEngineWrap;
 
 // java/nio/ByteBuffer
 jclass    g_ByteBuffer;
@@ -970,17 +971,18 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SNIHostNameCtor = GetMethod(env, false, g_SNIHostName, "<init>", "(Ljava/lang/String;)V");
 
     g_SSLEngine =                       GetClassGRef(env, "javax/net/ssl/SSLEngine");
-    g_SSLEngineGetApplicationProtocol = GetMethod(env, false, g_SSLEngine, "getApplicationProtocol", "()Ljava/lang/String;");
-    g_SSLEngineSetUseClientMode =       GetMethod(env, false, g_SSLEngine, "setUseClientMode", "(Z)V");
-    g_SSLEngineGetSession =             GetMethod(env, false, g_SSLEngine, "getSession", "()Ljavax/net/ssl/SSLSession;");
     g_SSLEngineBeginHandshake =         GetMethod(env, false, g_SSLEngine, "beginHandshake", "()V");
-    g_SSLEngineWrap =                   GetMethod(env, false, g_SSLEngine, "wrap", "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
-    g_SSLEngineUnwrap =                 GetMethod(env, false, g_SSLEngine, "unwrap", "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
-    g_SSLEngineGetHandshakeStatus =     GetMethod(env, false, g_SSLEngine, "getHandshakeStatus", "()Ljavax/net/ssl/SSLEngineResult$HandshakeStatus;");
     g_SSLEngineCloseOutbound =          GetMethod(env, false, g_SSLEngine, "closeOutbound", "()V");
+    g_SSLEngineGetApplicationProtocol = GetMethod(env, false, g_SSLEngine, "getApplicationProtocol", "()Ljava/lang/String;");
+    g_SSLEngineGetHandshakeStatus =     GetMethod(env, false, g_SSLEngine, "getHandshakeStatus", "()Ljavax/net/ssl/SSLEngineResult$HandshakeStatus;");
+    g_SSLEngineGetSession =             GetMethod(env, false, g_SSLEngine, "getSession", "()Ljavax/net/ssl/SSLSession;");
     g_SSLEngineGetSupportedProtocols =  GetMethod(env, false, g_SSLEngine, "getSupportedProtocols", "()[Ljava/lang/String;");
     g_SSLEngineSetEnabledProtocols =    GetMethod(env, false, g_SSLEngine, "setEnabledProtocols", "([Ljava/lang/String;)V");
     g_SSLEngineSetSSLParameters =       GetMethod(env, false, g_SSLEngine, "setSSLParameters", "(Ljavax/net/ssl/SSLParameters;)V");
+    g_SSLEngineSetUseClientMode =       GetMethod(env, false, g_SSLEngine, "setUseClientMode", "(Z)V");
+    g_SSLEngineSetWantClientAuth =      GetMethod(env, false, g_SSLEngine, "setWantClientAuth", "(Z)V");
+    g_SSLEngineUnwrap =                 GetMethod(env, false, g_SSLEngine, "unwrap", "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
+    g_SSLEngineWrap =                   GetMethod(env, false, g_SSLEngine, "wrap", "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
 
     g_ByteBuffer =                          GetClassGRef(env, "java/nio/ByteBuffer");
     g_ByteBufferAllocate =                  GetMethod(env, true,  g_ByteBuffer, "allocate", "(I)Ljava/nio/ByteBuffer;");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -81,6 +81,7 @@ jmethodID g_sigNumMethod;
 jclass    g_SSLParametersClass;
 jmethodID g_SSLParametersCtor;
 jmethodID g_SSLParametersGetProtocols;
+jmethodID g_SSLParametersSetApplicationProtocols;
 jmethodID g_SSLParametersSetServerNames;
 
 // javax/net/ssl/SSLContext
@@ -712,10 +713,11 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_bitLengthMethod =         GetMethod(env, false, g_bigNumClass, "bitLength", "()I");
     g_sigNumMethod =            GetMethod(env, false, g_bigNumClass, "signum", "()I");
 
-    g_SSLParametersClass =          GetClassGRef(env, "javax/net/ssl/SSLParameters");
-    g_SSLParametersCtor =           GetMethod(env, false,  g_SSLParametersClass, "<init>", "()V");
-    g_SSLParametersGetProtocols =   GetMethod(env, false,  g_SSLParametersClass, "getProtocols", "()[Ljava/lang/String;");
-    g_SSLParametersSetServerNames = GetMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
+    g_SSLParametersClass =                      GetClassGRef(env, "javax/net/ssl/SSLParameters");
+    g_SSLParametersCtor =                       GetMethod(env, false,  g_SSLParametersClass, "<init>", "()V");
+    g_SSLParametersGetProtocols =               GetMethod(env, false,  g_SSLParametersClass, "getProtocols", "()[Ljava/lang/String;");
+    g_SSLParametersSetApplicationProtocols =    GetOptionalMethod(env, false,  g_SSLParametersClass, "setApplicationProtocols", "([Ljava/lang/String;)V");
+    g_SSLParametersSetServerNames =             GetMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
 
     g_sslCtxClass =                     GetClassGRef(env, "javax/net/ssl/SSLContext");
     g_sslCtxGetDefaultMethod =          GetMethod(env, true,  g_sslCtxClass, "getDefault", "()Ljavax/net/ssl/SSLContext;");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -88,7 +88,6 @@ extern jmethodID g_sigNumMethod;
 
 // javax/net/ssl/SSLParameters
 extern jclass    g_SSLParametersClass;
-extern jmethodID g_SSLParametersCtor;
 extern jmethodID g_SSLParametersGetProtocols;
 extern jmethodID g_SSLParametersSetApplicationProtocols;
 extern jmethodID g_SSLParametersSetServerNames;
@@ -417,6 +416,7 @@ extern jmethodID g_SSLEngineCloseOutbound;
 extern jmethodID g_SSLEngineGetApplicationProtocol;
 extern jmethodID g_SSLEngineGetHandshakeStatus;
 extern jmethodID g_SSLEngineGetSession;
+extern jmethodID g_SSLEngineGetSSLParameters;
 extern jmethodID g_SSLEngineGetSupportedProtocols;
 extern jmethodID g_SSLEngineSetEnabledProtocols;
 extern jmethodID g_SSLEngineSetSSLParameters;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -90,6 +90,7 @@ extern jmethodID g_sigNumMethod;
 extern jclass    g_SSLParametersClass;
 extern jmethodID g_SSLParametersCtor;
 extern jmethodID g_SSLParametersGetProtocols;
+extern jmethodID g_SSLParametersSetApplicationProtocols;
 extern jmethodID g_SSLParametersSetServerNames;
 
 // javax/net/ssl/SSLContext

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -411,17 +411,18 @@ extern jmethodID g_SNIHostNameCtor;
 
 // javax/net/ssl/SSLEngine
 extern jclass    g_SSLEngine;
-extern jmethodID g_SSLEngineGetApplicationProtocol;
-extern jmethodID g_SSLEngineSetUseClientMode;
-extern jmethodID g_SSLEngineGetSession;
 extern jmethodID g_SSLEngineBeginHandshake;
-extern jmethodID g_SSLEngineWrap;
-extern jmethodID g_SSLEngineUnwrap;
 extern jmethodID g_SSLEngineCloseOutbound;
+extern jmethodID g_SSLEngineGetApplicationProtocol;
 extern jmethodID g_SSLEngineGetHandshakeStatus;
+extern jmethodID g_SSLEngineGetSession;
 extern jmethodID g_SSLEngineGetSupportedProtocols;
 extern jmethodID g_SSLEngineSetEnabledProtocols;
 extern jmethodID g_SSLEngineSetSSLParameters;
+extern jmethodID g_SSLEngineSetUseClientMode;
+extern jmethodID g_SSLEngineSetWantClientAuth;
+extern jmethodID g_SSLEngineUnwrap;
+extern jmethodID g_SSLEngineWrap;
 
 // java/nio/ByteBuffer
 extern jclass    g_ByteBuffer;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.c
@@ -51,3 +51,8 @@ PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void)
     RELEASE_LOCALS(loc, env);
     return supported;
 }
+
+bool AndroidCryptoNative_SSLSupportsApplicationProtocolsConfiguration(void)
+{
+    return g_SSLParametersSetApplicationProtocols != NULL;
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ssl.h
@@ -10,3 +10,8 @@
 Get the supported protocols
 */
 PALEXPORT PAL_SslProtocol AndroidCryptoNative_SSLGetSupportedProtocols(void);
+
+/*
+Returns whether or not configuration of application protocols is supported
+*/
+PALEXPORT bool AndroidCryptoNative_SSLSupportsApplicationProtocolsConfiguration(void);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -761,6 +761,15 @@ cleanup:
     return ret;
 }
 
+void AndroidCryptoNative_SSLStreamRequestClientAuthentication(SSLStream* sslStream)
+{
+    assert(sslStream != NULL);
+    JNIEnv* env = GetJNIEnv();
+
+    // sslEngine.setWantClientAuth(true);
+    (*env)->CallVoidMethod(env, sslStream->sslEngine, g_SSLEngineSetWantClientAuth, true);
+}
+
 static jstring GetSslProtocolAsString(JNIEnv* env, PAL_SslProtocol protocol)
 {
     switch (protocol)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -471,7 +471,7 @@ exit:
     return ret;
 }
 
-int32_t AndroidCryptoNative_SSLStreamConfigureParameters(SSLStream* sslStream, char* targetHost)
+int32_t AndroidCryptoNative_SSLStreamSetTargetHost(SSLStream* sslStream, char* targetHost)
 {
     assert(sslStream != NULL);
     assert(targetHost != NULL);
@@ -492,10 +492,10 @@ int32_t AndroidCryptoNative_SSLStreamConfigureParameters(SSLStream* sslStream, c
     (*env)->CallBooleanMethod(env, loc[nameList], g_ArrayListAdd, loc[hostName]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
-    // SSLParameters params = new SSLParameters();
+    // SSLParameters params = sslEngine.getSSLParameters();
     // params.setServerNames(nameList);
     // sslEngine.setSSLParameters(params);
-    loc[params] = (*env)->NewObject(env, g_SSLParametersClass, g_SSLParametersCtor);
+    loc[params] = (*env)->CallObjectMethod(env, sslStream->sslEngine, g_SSLEngineGetSSLParameters);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, loc[params], g_SSLParametersSetServerNames, loc[nameList]);
     (*env)->CallVoidMethod(env, sslStream->sslEngine, g_SSLEngineSetSSLParameters, loc[params]);
@@ -818,10 +818,10 @@ int32_t AndroidCryptoNative_SSLStreamSetApplicationProtocols(SSLStream* sslStrea
         (*env)->DeleteLocalRef(env, protocol);
     }
 
-    // SSLParameters params = new SSLParameters();
+    // SSLParameters params = sslEngine.getSSLParameters();
     // params.setApplicationProtocols(protocols);
     // sslEngine.setSSLParameters(params);
-    loc[params] = (*env)->NewObject(env, g_SSLParametersClass, g_SSLParametersCtor);
+    loc[params] = (*env)->CallObjectMethod(env, sslStream->sslEngine, g_SSLEngineGetSSLParameters);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, loc[params], g_SSLParametersSetApplicationProtocols, loc[protocols]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -147,6 +147,11 @@ PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetPeerCertificates(SSLStream* ss
                                                                    int32_t* outLen);
 
 /*
+Configure the session to request client authentication
+*/
+PALEXPORT void AndroidCryptoNative_SSLStreamRequestClientAuthentication(SSLStream* sslStream);
+
+/*
 Set enabled protocols
   - protocols : array of protocols to enable
   - count     : number of elements in protocols

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -24,6 +24,8 @@ typedef struct SSLStream
     STREAM_WRITER streamWriter;
 } SSLStream;
 
+typedef struct ApplicationProtocolData_t ApplicationProtocolData;
+
 // Matches managed PAL_SSLStreamStatus enum
 enum
 {
@@ -150,6 +152,16 @@ PALEXPORT int32_t AndroidCryptoNative_SSLStreamGetPeerCertificates(SSLStream* ss
 Configure the session to request client authentication
 */
 PALEXPORT void AndroidCryptoNative_SSLStreamRequestClientAuthentication(SSLStream* sslStream);
+
+/*
+Set application protocols
+  - protocolData : array of application protocols to set
+  - count        : number of elements in protocolData
+Returns 1 on success, 0 otherwise
+*/
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamSetApplicationProtocols(SSLStream* sslStream,
+                                                                       ApplicationProtocolData* protocolData,
+                                                                       int32_t count);
 
 /*
 Set enabled protocols

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.h
@@ -68,12 +68,12 @@ PALEXPORT int32_t AndroidCryptoNative_SSLStreamInitialize(
     SSLStream* sslStream, bool isServer, STREAM_READER streamReader, STREAM_WRITER streamWriter, int32_t appBufferSize);
 
 /*
-Set configuration parameters
+Set target host
   - targetHost : SNI host name
 
 Returns 1 on success, 0 otherwise
 */
-PALEXPORT int32_t AndroidCryptoNative_SSLStreamConfigureParameters(SSLStream* sslStream, char* targetHost);
+PALEXPORT int32_t AndroidCryptoNative_SSLStreamSetTargetHost(SSLStream* sslStream, char* targetHost);
 
 /*
 Start or continue the TLS handshake

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -440,6 +440,9 @@
   <data name="net_ssl_app_protocol_invalid" xml:space="preserve">
     <value>The application protocol value is invalid.</value>
   </data>
+  <data name="net_ssl_app_protocol_config_notsupported" xml:space="preserve">
+    <value>Configuration of application protocols is not supported on this platform.</value>
+  </data>
   <data name="net_conflicting_options" xml:space="preserve">
     <value>The '{0}' option was already set in the SslStream constructor.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -440,9 +440,6 @@
   <data name="net_ssl_app_protocol_invalid" xml:space="preserve">
     <value>The application protocol value is invalid.</value>
   </data>
-  <data name="net_ssl_app_protocol_config_notsupported" xml:space="preserve">
-    <value>Configuration of application protocols is not supported on this platform.</value>
-  </data>
   <data name="net_conflicting_options" xml:space="preserve">
     <value>The '{0}' option was already set in the SslStream constructor.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -233,16 +233,6 @@ namespace System.Net
                 Interop.AndroidCrypto.SSLStreamSetEnabledProtocols(handle, s_orderedSslProtocols.AsSpan(minIndex, maxIndex - minIndex + 1));
             }
 
-            if (isServer && authOptions.RemoteCertRequired)
-            {
-                Interop.AndroidCrypto.SSLStreamRequestClientAuthentication(handle);
-            }
-
-            if (!isServer && !string.IsNullOrEmpty(authOptions.TargetHost))
-            {
-                Interop.AndroidCrypto.SSLStreamConfigureParameters(handle, authOptions.TargetHost);
-            }
-
             if (authOptions.ApplicationProtocols != null)
             {
                 if (!Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration())
@@ -251,6 +241,16 @@ namespace System.Net
                 }
 
                 Interop.AndroidCrypto.SSLStreamSetApplicationProtocols(handle, authOptions.ApplicationProtocols);
+            }
+
+            if (isServer && authOptions.RemoteCertRequired)
+            {
+                Interop.AndroidCrypto.SSLStreamRequestClientAuthentication(handle);
+            }
+
+            if (!isServer && !string.IsNullOrEmpty(authOptions.TargetHost))
+            {
+                Interop.AndroidCrypto.SSLStreamSetTargetHost(handle, authOptions.TargetHost);
             }
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -233,13 +233,9 @@ namespace System.Net
                 Interop.AndroidCrypto.SSLStreamSetEnabledProtocols(handle, s_orderedSslProtocols.AsSpan(minIndex, maxIndex - minIndex + 1));
             }
 
-            if (authOptions.ApplicationProtocols != null)
+            if (authOptions.ApplicationProtocols != null && Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration())
             {
-                if (!Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration())
-                {
-                    throw new PlatformNotSupportedException(SR.net_ssl_app_protocol_config_notsupported);
-                }
-
+                // Set application protocols if the platform supports it. Otherwise, we will silently ignore the option.
                 Interop.AndroidCrypto.SSLStreamSetApplicationProtocols(handle, authOptions.ApplicationProtocols);
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -213,9 +213,7 @@ namespace System.Net
 
             bool isServer = authOptions.IsServer;
 
-            if (authOptions.ApplicationProtocols != null
-                || authOptions.CipherSuitesPolicy != null
-                || (isServer && authOptions.RemoteCertRequired))
+            if (authOptions.ApplicationProtocols != null || authOptions.CipherSuitesPolicy != null)
             {
                 // TODO: [AndroidCrypto] Handle non-system-default options
                 throw new NotImplementedException(nameof(SafeDeleteSslContext));
@@ -233,6 +231,11 @@ namespace System.Net
 
                 (int minIndex, int maxIndex) = protocolsToEnable.ValidateContiguous(s_orderedSslProtocols);
                 Interop.AndroidCrypto.SSLStreamSetEnabledProtocols(handle, s_orderedSslProtocols.AsSpan(minIndex, maxIndex - minIndex + 1));
+            }
+
+            if (isServer && authOptions.RemoteCertRequired)
+            {
+                Interop.AndroidCrypto.SSLStreamRequestClientAuthentication(handle);
             }
 
             if (!isServer && !string.IsNullOrEmpty(authOptions.TargetHost))

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -213,7 +213,7 @@ namespace System.Net
 
             bool isServer = authOptions.IsServer;
 
-            if (authOptions.ApplicationProtocols != null || authOptions.CipherSuitesPolicy != null)
+            if (authOptions.CipherSuitesPolicy != null)
             {
                 // TODO: [AndroidCrypto] Handle non-system-default options
                 throw new NotImplementedException(nameof(SafeDeleteSslContext));
@@ -241,6 +241,16 @@ namespace System.Net
             if (!isServer && !string.IsNullOrEmpty(authOptions.TargetHost))
             {
                 Interop.AndroidCrypto.SSLStreamConfigureParameters(handle, authOptions.TargetHost);
+            }
+
+            if (authOptions.ApplicationProtocols != null)
+            {
+                if (!Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration())
+                {
+                    throw new PlatformNotSupportedException(SR.net_ssl_app_protocol_config_notsupported);
+                }
+
+                Interop.AndroidCrypto.SSLStreamSetApplicationProtocols(handle, authOptions.ApplicationProtocols);
             }
         }
     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -233,7 +233,14 @@ namespace System.Net.Security.Tests
             var args = string.Join(".", protocols.Select(p => ProtocolToString(p)));
             var name = testMethodName.Length > 63 ? testMethodName.Substring(0, 63) : testMethodName;
 
-            return $"{name}.{args}";
+            name = $"{name}.{args}";
+            if (PlatformDetection.IsAndroid)
+            {
+                // Android does not support underscores in host names
+                name = name.Replace("_", string.Empty);
+            }
+
+            return name;
         }
     }
 }


### PR DESCRIPTION
- Set `ApplicationProtocols` when supported by the platform
  - Throws PNSE if platform doesn't support configuration (< API level 29)
- Request client certificate when running in server mode and `RemoteCertRequired` is true
- Fix writing large content to stream
- Update test utilities to check for alpn support on Android

cc @jkoritzinsky @steveisok @AaronRobinsonMSFT @bartonjs @wfurt