### PR TITLE
[Release/5.0] Update palinternal.h to fix compile on Alpine >= 3.13

### DIFF
--- a/src/coreclr/src/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/src/pal/src/include/pal/palinternal.h
@@ -170,6 +170,7 @@ function_name() to call the system's implementation
 #define memset DUMMY_memset
 #define memmove DUMMY_memmove
 #define memchr DUMMY_memchr
+#define atoll DUMMY_atoll
 #define strlen DUMMY_strlen
 #define stricmp DUMMY_stricmp
 #define strstr DUMMY_strstr
@@ -357,6 +358,7 @@ function_name() to call the system's implementation
 #undef memset
 #undef memmove
 #undef memchr
+#undef atoll
 #undef strlen
 #undef strnlen
 #undef wcsnlen


### PR DESCRIPTION
Port #45352 to Release/5.0
Fix compilation for Alpine Linux and some other platforms. Related: https://github.com/dotnet/runtime/issues/44988

## Customer Impact
Without this change, native part of the runtime in release/5.0 fails during compilation on Alpine >= 3.13.

## Testing
CoreCLR and libraries tests

## Risk
Low, it doesn't change anything functionally, it just ensures we don't introduce conflicting function prototype.

## Regression
No