### PR TITLE
Avoid conv.i opcodes in hot paths in CoreLib

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -84,7 +84,7 @@ namespace System
         internal static unsafe void Memcpy(byte* dest, byte* src, int len)
         {
             Debug.Assert(len >= 0, "Negative length in memcpy!");
-            Memmove(ref *dest, ref *src, (uint)len);
+            Memmove(ref *dest, ref *src, (nuint)(uint)len /* force zero-extension */);
         }
 
         // Used by ilmarshalers.cpp
@@ -93,7 +93,7 @@ namespace System
             Debug.Assert((srcIndex >= 0) && (destIndex >= 0) && (len >= 0), "Index and length must be non-negative!");
             Debug.Assert(src.Length - srcIndex >= len, "not enough bytes in src");
 
-            Memmove(ref *(pDest + (uint)destIndex), ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), (nint)(uint)srcIndex), (uint)len);
+            Memmove(ref *(pDest + (uint)destIndex), ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), (nint)(uint)srcIndex /* force zero-extension */), (uint)len);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -84,7 +84,7 @@ namespace System
         internal static unsafe void Memcpy(byte* dest, byte* src, int len)
         {
             Debug.Assert(len >= 0, "Negative length in memcpy!");
-            Memmove(ref *dest, ref *src, (nuint)len);
+            Memmove(ref *dest, ref *src, (uint)len);
         }
 
         // Used by ilmarshalers.cpp
@@ -93,7 +93,7 @@ namespace System
             Debug.Assert((srcIndex >= 0) && (destIndex >= 0) && (len >= 0), "Index and length must be non-negative!");
             Debug.Assert(src.Length - srcIndex >= len, "not enough bytes in src");
 
-            Memmove(ref *(pDest + destIndex), ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), srcIndex), (nuint)len);
+            Memmove(ref *(pDest + (uint)destIndex), ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(src), (nint)(uint)srcIndex), (uint)len);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -31,7 +31,7 @@ namespace System
             if ((uint)start > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start), array.Length - start);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start /* force zero-extension */), array.Length - start);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System
             if ((uint)actualIndex > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)actualIndex), array.Length - actualIndex);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)actualIndex /* force zero-extension */), array.Length - actualIndex);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace System
                 ThrowHelper.ThrowArrayTypeMismatchException();
 
             (int start, int length) = range.GetOffsetAndLength(array.Length);
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start), length);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start /* force zero-extension */), length);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace System
             if ((uint)start > (uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
-            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start), text.Length - start);
+            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start /* force zero-extension */), text.Length - start);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #endif
 
-            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start), length);
+            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start /* force zero-extension */), length);
         }
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
@@ -1063,14 +1063,14 @@ namespace System
                 nuint size = (nuint)Unsafe.SizeOf<T>();
                 return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength))),
+                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength) /* force zero-extension */)),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
                     ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength)),
+                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength) /* force zero-extension */),
                     ref MemoryMarshal.GetReference(value),
                     valueLength);
         }
@@ -1088,14 +1088,14 @@ namespace System
                 nuint size = (nuint)Unsafe.SizeOf<T>();
                 return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength))),
+                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength) /* force zero-extension */)),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
                     ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength)),
+                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength) /* force zero-extension */),
                     ref MemoryMarshal.GetReference(value),
                     valueLength);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -31,7 +31,7 @@ namespace System
             if ((uint)start > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), start), array.Length - start);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start), array.Length - start);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System
             if ((uint)actualIndex > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), actualIndex), array.Length - actualIndex);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)actualIndex), array.Length - actualIndex);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace System
                 ThrowHelper.ThrowArrayTypeMismatchException();
 
             (int start, int length) = range.GetOffsetAndLength(array.Length);
-            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), start), length);
+            return new Span<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start), length);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace System
             if ((uint)start > (uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
-            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), start), text.Length - start);
+            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start), text.Length - start);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #endif
 
-            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), start), length);
+            return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start), length);
         }
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{T}"/> over the portion of the target string.</summary>
@@ -422,7 +422,7 @@ namespace System
                 SpanHelpers.SequenceEqual(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
-                    ((nuint)length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
+                    ((uint)length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return length == other.Length && SpanHelpers.SequenceEqual(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(other), length);
@@ -912,7 +912,7 @@ namespace System
                     SpanHelpers.SequenceEqual(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
-                        ((nuint)length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this API in such a case so we choose not to take the overhead of checking.
+                        ((uint)length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this API in such a case so we choose not to take the overhead of checking.
             }
 
             return length == other.Length && SpanHelpers.SequenceEqual(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(other), length);
@@ -954,7 +954,7 @@ namespace System
                         return SpanHelpers.SequenceEqual(
                             ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                             ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
-                            ((nuint)span.Length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this API in such a case so we choose not to take the overhead of checking.
+                            ((uint)span.Length) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this API in such a case so we choose not to take the overhead of checking.
                     }
 
                     // Otherwise, compare each element using EqualityComparer<T>.Default.Equals in a way that will enable it to devirtualize.
@@ -1024,7 +1024,7 @@ namespace System
                 SpanHelpers.SequenceEqual(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    ((nuint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
+                    ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(value), valueLength);
@@ -1044,7 +1044,7 @@ namespace System
                 SpanHelpers.SequenceEqual(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    ((nuint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
+                    ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(value), valueLength);
@@ -1063,14 +1063,14 @@ namespace System
                 nuint size = (nuint)Unsafe.SizeOf<T>();
                 return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), spanLength - valueLength)),
+                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength))),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    ((nuint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
+                    ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), spanLength - valueLength),
+                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength)),
                     ref MemoryMarshal.GetReference(value),
                     valueLength);
         }
@@ -1088,14 +1088,14 @@ namespace System
                 nuint size = (nuint)Unsafe.SizeOf<T>();
                 return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), spanLength - valueLength)),
+                    ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength))),
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    ((nuint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
+                    ((uint)valueLength) * size);  // If this multiplication overflows, the Span we got overflows the entire address range. There's no happy outcome for this api in such a case so we choose not to take the overhead of checking.
             }
 
             return valueLength <= spanLength &&
                 SpanHelpers.SequenceEqual(
-                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), spanLength - valueLength),
+                    ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)(spanLength - valueLength)),
                     ref MemoryMarshal.GetReference(value),
                     valueLength);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -76,7 +76,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start));
+            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start /* force zero-extension */));
             _length = length;
         }
 
@@ -134,7 +134,7 @@ namespace System
             {
                 if ((uint)index >= (uint)_length)
                     ThrowHelper.ThrowIndexOutOfRangeException();
-                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index);
+                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index /* force zero-extension */);
             }
         }
 
@@ -335,7 +335,7 @@ namespace System
             if ((uint)start > (uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), _length - start);
+            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start /* force zero-extension */), _length - start);
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), length);
+            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start /* force zero-extension */), length);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -76,7 +76,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), start));
+            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start));
             _length = length;
         }
 
@@ -134,7 +134,7 @@ namespace System
             {
                 if ((uint)index >= (uint)_length)
                     ThrowHelper.ThrowIndexOutOfRangeException();
-                return ref Unsafe.Add(ref _pointer.Value, index);
+                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index);
             }
         }
 
@@ -335,7 +335,7 @@ namespace System
             if ((uint)start > (uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, start), _length - start);
+            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), _length - start);
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
+            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), length);
         }
 
         /// <summary>
@@ -372,7 +372,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (uint)_length);
             return destination;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -82,7 +82,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start));
+            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start /* force zero-extension */));
             _length = length;
         }
 
@@ -140,7 +140,7 @@ namespace System
             {
                 if ((uint)index >= (uint)_length)
                     ThrowHelper.ThrowIndexOutOfRangeException();
-                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index);
+                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index /* force zero-extension */);
             }
         }
 
@@ -415,7 +415,7 @@ namespace System
             if ((uint)start > (uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), _length - start);
+            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start /* force zero-extension */), _length - start);
         }
 
         /// <summary>
@@ -443,7 +443,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), length);
+            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start /* force zero-extension */), length);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -82,7 +82,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), start));
+            _pointer = new ByReference<T>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start));
             _length = length;
         }
 
@@ -140,7 +140,7 @@ namespace System
             {
                 if ((uint)index >= (uint)_length)
                     ThrowHelper.ThrowIndexOutOfRangeException();
-                return ref Unsafe.Add(ref _pointer.Value, index);
+                return ref Unsafe.Add(ref _pointer.Value, (nint)(uint)index);
             }
         }
 
@@ -269,11 +269,11 @@ namespace System
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                SpanHelpers.ClearWithReferences(ref Unsafe.As<T, IntPtr>(ref _pointer.Value), (nuint)_length * (nuint)(Unsafe.SizeOf<T>() / sizeof(nuint)));
+                SpanHelpers.ClearWithReferences(ref Unsafe.As<T, IntPtr>(ref _pointer.Value), (uint)_length * (nuint)(Unsafe.SizeOf<T>() / sizeof(nuint)));
             }
             else
             {
-                SpanHelpers.ClearWithoutReferences(ref Unsafe.As<T, byte>(ref _pointer.Value), (nuint)_length * (nuint)Unsafe.SizeOf<T>());
+                SpanHelpers.ClearWithoutReferences(ref Unsafe.As<T, byte>(ref _pointer.Value), (uint)_length * (nuint)Unsafe.SizeOf<T>());
             }
         }
 
@@ -415,7 +415,7 @@ namespace System
             if ((uint)start > (uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, start), _length - start);
+            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), _length - start);
         }
 
         /// <summary>
@@ -443,7 +443,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
+            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, (nint)(uint)start), length);
         }
 
         /// <summary>
@@ -458,7 +458,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (uint)_length);
             return destination;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -42,7 +42,9 @@ namespace System
             Debug.Assert(countA >= 0 && countB >= 0);
             Debug.Assert(indexA + countA <= strA.Length && indexB + countB <= strB.Length);
 
-            return SpanHelpers.SequenceCompareTo(ref Unsafe.Add(ref strA.GetRawStringData(), (nint)(uint)indexA), countA, ref Unsafe.Add(ref strB.GetRawStringData(), (nint)(uint)indexB), countB);
+            return SpanHelpers.SequenceCompareTo(
+                ref Unsafe.Add(ref strA.GetRawStringData(), (nint)(uint)indexA /* force zero-extension */), countA,
+                ref Unsafe.Add(ref strB.GetRawStringData(), (nint)(uint)indexB /* force zero-extension */), countB);
         }
 
         internal static bool EqualsOrdinalIgnoreCase(string? strA, string? strB)

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -30,7 +30,7 @@ namespace System
             return SpanHelpers.SequenceEqual(
                     ref Unsafe.As<char, byte>(ref strA.GetRawStringData()),
                     ref Unsafe.As<char, byte>(ref strB.GetRawStringData()),
-                    ((nuint)strA.Length) * 2);
+                    ((uint)strA.Length) * sizeof(char));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -42,7 +42,7 @@ namespace System
             Debug.Assert(countA >= 0 && countB >= 0);
             Debug.Assert(indexA + countA <= strA.Length && indexB + countB <= strB.Length);
 
-            return SpanHelpers.SequenceCompareTo(ref Unsafe.Add(ref strA.GetRawStringData(), indexA), countA, ref Unsafe.Add(ref strB.GetRawStringData(), indexB), countB);
+            return SpanHelpers.SequenceCompareTo(ref Unsafe.Add(ref strA.GetRawStringData(), (nint)(uint)indexA), countA, ref Unsafe.Add(ref strB.GetRawStringData(), (nint)(uint)indexB), countB);
         }
 
         internal static bool EqualsOrdinalIgnoreCase(string? strA, string? strB)

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1747,7 +1747,7 @@ namespace System
             Buffer.Memmove(
                 elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
                 destination: ref result._firstChar,
-                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex));
+                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */));
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1747,7 +1747,7 @@ namespace System
             Buffer.Memmove(
                 elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
                 destination: ref result._firstChar,
-                source: ref Unsafe.Add(ref _firstChar, startIndex));
+                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex));
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -212,12 +212,12 @@ namespace System
 
         private static unsafe bool IsCharBitSet(uint* charMap, byte value)
         {
-            return (charMap[value & PROBABILISTICMAP_BLOCK_INDEX_MASK] & (1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT))) != 0;
+            return (charMap[(uint)value & PROBABILISTICMAP_BLOCK_INDEX_MASK] & (1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT))) != 0;
         }
 
         private static unsafe void SetCharBit(uint* charMap, byte value)
         {
-            charMap[value & PROBABILISTICMAP_BLOCK_INDEX_MASK] |= 1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
+            charMap[(uint)value & PROBABILISTICMAP_BLOCK_INDEX_MASK] |= 1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
         }
 
        /*

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -399,7 +399,7 @@ namespace System
             }
 #endif
 
-            slice = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex), count);
+            slice = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */), count);
             return true;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -399,7 +399,7 @@ namespace System
             }
 #endif
 
-            slice = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startIndex), count);
+            slice = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex), count);
             return true;
         }
 


### PR DESCRIPTION
We have several places in CoreLib where we sign-extend a non-negative 32-bit value to the native word size. Changing these to use zero-extensions is somewhat more efficient from a codegen perspective.

The methodology here was very simplistic: ildasm all of _System.Private.CoreLib.dll_ and look for calls to `conv.i`. If the method fit on my screen or was marked _aggressiveinlining_, I assume it's potentially on a hot path, so it's a candidate for fixing in this PR. I intentionally excluded methods that were large or complex or where trying to avoid the sign extension would seem not worth the tradeoff. For example, with this PR there are still lots of places in `string` and `Array` that perform sign-extension, but those extensions are performed within a larger unit of work and I didn't believe addressing them would provide any measurable benefit.

I also checked calls to `Unsafe.Add(..., int)`, rewriting them to use `Unsafe.Add(..., nint)` (via zero-extension) following approximately the same criteria as above. Though TBH these would be a little cleaner if we were to add an `Unsafe.Add(..., uint)` overload, but that seems out of scope for this.

Andy offline helped me run a diff tool against the binaries. Most of the improvements are expected. Some (like `Unsafe.Add`) seem like false positives, since I'm not changing that code. The regressions I believe might be due to more leaf methods now being eligible candidates for inlining, but that's just a guess.

```txt
Top file improvements (bytes):
        -630 : System.Private.CoreLib.dasm (-0.02% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions (bytes):
          57 (142.50% of base) : System.Private.CoreLib.dasm - Internal.Runtime.CompilerServices.Unsafe:Add(byref,long):byref (8 base, 17 diff methods)
          44 ( 2.56% of base) : System.Private.CoreLib.dasm - System.Buffers.Text.Utf8Parser:TryParseNumber(System.ReadOnlySpan`1[Byte],byref,byref,int,byref):bool
           8 ( 3.43% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
           4 ( 0.41% of base) : System.Private.CoreLib.dasm - System.Enum:InternalFlagsFormat(EnumInfo,long):System.String
           4 ( 0.84% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
           3 ( 0.86% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
           2 ( 1.44% of base) : System.Private.CoreLib.dasm - System.Exception:<ToString>g__Write|65_0(System.String,byref)

Top method improvements (bytes):
         -19 (-5.46% of base) : System.Private.CoreLib.dasm - Internal.Runtime.CompilerServices.Unsafe:Add(byref,int):byref (39 base, 37 diff methods)
         -16 (-1.66% of base) : System.Private.CoreLib.dasm - System.Globalization.CompareInfo:Compare(System.String,int,int,System.String,int,int,int):int:this
         -14 (-2.14% of base) : System.Private.CoreLib.dasm - System.String:MakeSeparatorList(System.ReadOnlySpan`1[Char],byref):this
         -11 (-2.47% of base) : System.Private.CoreLib.dasm - System.Text.Encoding:GetBytes(long,int,long,int):int:this
         -11 (-2.46% of base) : System.Private.CoreLib.dasm - System.Text.Encoding:GetChars(long,int,long,int):int:this
          -7 (-2.80% of base) : System.Private.CoreLib.dasm - System.Text.Encoding:GetByteCount(long,int):int:this
          -7 (-2.83% of base) : System.Private.CoreLib.dasm - System.Text.Encoding:GetCharCount(long,int):int:this
          -7 (-0.58% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:SymmetricExceptWithEnumerable(System.Collections.Generic.IEnumerable`1[__Canon]):this
          -6 (-4.80% of base) : System.Private.CoreLib.dasm - System.String:InitializeProbabilisticMap(long,System.ReadOnlySpan`1[Char])
          -6 (-1.27% of base) : System.Private.CoreLib.dasm - System.Globalization.CompareInfo:IsSuffix(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],int):bool:this
          -5 (-4.07% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[__Canon][System.__Canon]:ToArray():System.__Canon[]:this
          -5 (-4.07% of base) : System.Private.CoreLib.dasm - System.Span`1[__Canon][System.__Canon]:ToArray():System.__Canon[]:this
          -5 (-0.19% of base) : System.Private.CoreLib.dasm - System.Buffers.Text.Utf8Formatter:TryFormat(System.TimeSpan,System.Span`1[Byte],byref,System.Buffers.StandardFormat):bool
          -5 (-0.54% of base) : System.Private.CoreLib.dasm - System.Text.Encoding:GetBytesWithFallback(long,int,long,int,int,int,System.Text.EncoderNLS):int:this
          -5 (-0.75% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8:ToUtf16(System.ReadOnlySpan`1[Byte],System.Span`1[Char],byref,byref,bool,bool):int
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[TimeSpan][System.TimeSpan]:ToArray():System.TimeSpan[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[GCGenerationInfo][System.GCGenerationInfo]:ToArray():System.GCGenerationInfo[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.Span`1[Int16][System.Int16]:ToArray():System.Int16[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.Span`1[Int64][System.Int64]:ToArray():System.Int64[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Single][System.Single]:ToArray():System.Single[]:this

Top method regressions (percentages):
          57 (142.50% of base) : System.Private.CoreLib.dasm - Internal.Runtime.CompilerServices.Unsafe:Add(byref,long):byref (8 base, 17 diff methods)
           8 ( 3.43% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
          44 ( 2.56% of base) : System.Private.CoreLib.dasm - System.Buffers.Text.Utf8Parser:TryParseNumber(System.ReadOnlySpan`1[Byte],byref,byref,int,byref):bool
           2 ( 1.44% of base) : System.Private.CoreLib.dasm - System.Exception:<ToString>g__Write|65_0(System.String,byref)
           3 ( 0.86% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
           4 ( 0.84% of base) : System.Private.CoreLib.dasm - System.String:Concat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char]):System.String
           4 ( 0.41% of base) : System.Private.CoreLib.dasm - System.Enum:InternalFlagsFormat(EnumInfo,long):System.String

Top method improvements (percentages):
          -3 (-11.11% of base) : System.Private.CoreLib.dasm - System.String:IsCharBitSet(long,ubyte):bool
          -3 (-10.00% of base) : System.Private.CoreLib.dasm - System.String:SetCharBit(long,ubyte)
          -3 (-9.68% of base) : System.Private.CoreLib.dasm - System.Span`1[KeyValuePair`2][System.Collections.Generic.KeyValuePair`2[System.Int32,System.__Canon]]:Clear():this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[SByte][System.SByte]:ToArray():System.SByte[]:this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.Span`1[Byte][System.Byte]:ToArray():System.Byte[]:this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.Span`1[Boolean][System.Boolean]:ToArray():System.Boolean[]:this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Boolean][System.Boolean]:ToArray():System.Boolean[]:this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Byte][System.Byte]:ToArray():System.Byte[]:this
          -5 (-6.41% of base) : System.Private.CoreLib.dasm - System.Span`1[SByte][System.SByte]:ToArray():System.SByte[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.Span`1[Int16][System.Int16]:ToArray():System.Int16[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.Span`1[Char][System.Char]:ToArray():System.Char[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Char][System.Char]:ToArray():System.Char[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[UInt16][System.UInt16]:ToArray():System.UInt16[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Int16][System.Int16]:ToArray():System.Int16[]:this
          -5 (-6.17% of base) : System.Private.CoreLib.dasm - System.Span`1[UInt16][System.UInt16]:ToArray():System.UInt16[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[TimeSpan][System.TimeSpan]:ToArray():System.TimeSpan[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[GCGenerationInfo][System.GCGenerationInfo]:ToArray():System.GCGenerationInfo[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.Span`1[Int64][System.Int64]:ToArray():System.Int64[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Single][System.Single]:ToArray():System.Single[]:this
          -5 (-6.10% of base) : System.Private.CoreLib.dasm - System.ReadOnlySpan`1[Int32][System.Int32]:ToArray():System.Int32[]:this

372 total methods with Code Size differences (365 improved, 7 regressed), 28698 unchanged.
```