### PR TITLE
Fix issues with version resilient hash

### DIFF
--- a/src/coreclr/vm/versionresilienthashcode.cpp
+++ b/src/coreclr/vm/versionresilienthashcode.cpp
@@ -164,6 +164,7 @@ public:
         {
             *data = *_pCode;
             _cbCode--;
+            _pCode++;
             return true;
         }
         return false;
@@ -175,6 +176,7 @@ public:
         {
             *data = *(uint16_t UNALIGNED*)_pCode;
             _cbCode -= 2;
+            _pCode += 2;
             return true;
         }
         return false;
@@ -186,6 +188,7 @@ public:
         {
             *data = *(uint32_t UNALIGNED*)_pCode;
             _cbCode -= 4;
+            _pCode += 4;
             return true;
         }
         return false;
@@ -237,7 +240,7 @@ bool AddVersionResilientHashCodeForInstruction(ILInstructionParser *parser, xxHa
     switch (opcodeFormat)
     {
         case InlineNone: // no inline args
-            return opcodeValue;
+            break;
 
         case ShortInlineI:
         case ShortInlineBrTarget:
@@ -355,7 +358,7 @@ bool GetVersionResilientILCodeHashCode(MethodDesc *pMD, int* hashCode, unsigned*
     {
         COR_ILMETHOD_DECODER header(pMD->GetILHeader(TRUE), pMD->GetMDImport(), NULL);
 
-        pILCode = header.GetCode();
+        pILCode = header.Code;
         cbILCode = header.GetCodeSize();
         maxStack = header.GetMaxStack();
         EHCount = header.EHCount();


### PR DESCRIPTION
I noticed that some methods under dynamic PGO did not have PGO data.
Tracked this down to the Tier0 jit being unable to allocate a PGO schema.
This in turn was caused by the IL hash computation failing.

So, this PR fixes issues in the IL hash:
* pass in the right pointer to the IL
* advance the pointer as we scan the IL
* don't bail out early for the InlineNone case