### PR TITLE
Update the docker images that are used in ci.

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -38,7 +38,7 @@ jobs:
       targetRid: linux-arm
       platform: Linux_arm
       container:
-        image: ubuntu-16.04-cross-20200413125008-09ec757
+        image: ubuntu-16.04-cross-20210409142327-044d5b9
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -64,7 +64,7 @@ jobs:
       targetRid: linux-arm64
       platform: Linux_arm64
       container:
-        image: ubuntu-16.04-cross-arm64-20201022204150-b2c2436
+        image: ubuntu-16.04-cross-arm64-20210409142327-b2c2436
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -91,7 +91,7 @@ jobs:
       targetRid: linux-musl-x64
       platform: Linux_musl_x64
       container:
-        image: alpine-3.9-WithNode-20200602002639-0fc54a3
+        image: alpine-3.9-WithNode-20200908125247-0fc54a3
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -116,7 +116,7 @@ jobs:
       targetRid: linux-musl-arm
       platform: Linux_musl_arm
       container:
-        image: ubuntu-18.04-cross-arm-alpine-20200818211451-14441ae
+        image: ubuntu-18.04-cross-arm-alpine-20210409142425-044d5b9
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -143,7 +143,7 @@ jobs:
       targetRid: linux-musl-arm64
       platform: Linux_musl_arm64
       container:
-        image: ubuntu-16.04-cross-arm64-alpine-20200413125008-406629a
+        image: ubuntu-16.04-cross-arm64-alpine-20210409142327-b2c2436
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -169,7 +169,7 @@ jobs:
       targetRid: linux-x64
       platform: Linux_x64
       container:
-        image: centos-7-20201227183837-5fe0e50
+        image: centos-7-20210408124440-5d87b80
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -260,7 +260,7 @@ jobs:
       targetRid: freebsd-x64
       platform: FreeBSD_x64
       container:
-        image: ubuntu-18.04-cross-freebsd-11-20200407092345-a84b0d2
+        image: ubuntu-18.04-cross-freebsd-11-20210409142425-f13d79e
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -285,7 +285,7 @@ jobs:
       targetRid: android-x64
       platform: Android_x64
       container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
+        image: ubuntu-18.04-android-20210409142425-0ece9b3
         registry: mcr
       jobParameters:
         runtimeFlavor: mono
@@ -309,7 +309,7 @@ jobs:
       targetRid: android-x86
       platform: Android_x86
       container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
+        image: ubuntu-18.04-android-20210409142425-0ece9b3
         registry: mcr
       jobParameters:
         runtimeFlavor: mono
@@ -333,7 +333,7 @@ jobs:
       targetRid: android-arm
       platform: Android_arm
       container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
+        image: ubuntu-18.04-android-20210409142425-0ece9b3
         registry: mcr
       jobParameters:
         runtimeFlavor: mono
@@ -357,7 +357,7 @@ jobs:
       targetRid: android-arm64
       platform: Android_arm64
       container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
+        image: ubuntu-18.04-android-20210409142425-0ece9b3
         registry: mcr
       jobParameters:
         runtimeFlavor: mono


### PR DESCRIPTION
The versions were taken from https://github.com/dotnet/versions/blob/master/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json, I need the update to get results of https://github.com/dotnet/arcade/pull/7197

PTAL @dotnet/runtime-infrastructure 


Thanks to @jkoritzinsky and @janvorli for their help.