### PR TITLE
Fix silent fallback to Debug when building native libs

### DIFF
--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -52,10 +52,10 @@ echo.
 :: cmake requires forward slashes in paths
 set __cmakeRepoRoot=%__repoRoot:\=/%
 set __ExtraCmakeParams="-DCMAKE_REPO_ROOT=%__cmakeRepoRoot%"
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%"
 
 if /i "%__BuildArch%" == "wasm" (
     set __sourceDir=%~dp0\Unix
-    set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%"
 )
 
 if [%__outConfig%] == [] set __outConfig=%__TargetOS%-%__BuildArch%-%CMAKE_BUILD_TYPE%


### PR DESCRIPTION
* Currently the CMAKE_BUILD_TYPE is not being passed in when
  creating the native library intermediates.
* Before the change to Ninja for CMake generation (8c2158f9fe1)
  the default uninitialized cmake build type was set to Release so the
  bug was not visible.
* After the Ninja change, the default uninitialized cmake build type
  is set to Debug so it becomes more apparent.
* This improves performance of native libs like System.IO.Compression
  by a considerable amount as they are currently being built in Debug,
  even when the Release configuration is specified.