### PR TITLE
[Android] Disable a socket address test

### DIFF
--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -98,7 +98,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Theory]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
-        [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.Browser, "Expected behavior is different on Linux or Browser")]
+        [SkipOnPlatform(TestPlatforms.Android | TestPlatforms.Linux | TestPlatforms.Browser, "Expected behavior is different on Android, Linux, or Browser")]
         public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
         {
             Assert.Throws<PlatformNotSupportedException>(() => new SocketAddress(family));


### PR DESCRIPTION
`SocketAddressTest.ToString_UnsupportedFamily_Throws` test fails on Android in case of `AddressFamily.Packet` and `AddressFamily.ControllerAreaNetwork` because it expects PNSE for both address family types but there is no any exception thrown. 

This change disables the mentioned test on Android due to different behavior. Also, I'm not sure whether the test has right name.

https://github.com/dotnet/runtime/issues/47911#issuecomment-812427991