### PR TITLE
Fix EventSource EnableEvents(LogAlways)

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventListenerEnable.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventListenerEnable.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Tracing;
+using Xunit;
+
+namespace BasicEventSourceTests
+{
+    public class TestEventListenerEnable
+    {
+        [Fact]
+        public void EnableEventsRespectsHigherEventLevel()
+        {
+            using var eventSource = new TestEventSource();
+            using var listener = new TestEventListener();
+
+            Assert.False(eventSource.IsEnabled());
+
+            listener.EnableEvents(eventSource, EventLevel.Critical);
+            Assert.True(eventSource.IsEnabled(EventLevel.Critical, EventKeywords.All));
+            Assert.False(eventSource.IsEnabled(EventLevel.Informational, EventKeywords.All));
+            Assert.False(eventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+
+            listener.EnableEvents(eventSource, EventLevel.Informational);
+            Assert.True(eventSource.IsEnabled(EventLevel.Critical, EventKeywords.All));
+            Assert.True(eventSource.IsEnabled(EventLevel.Informational, EventKeywords.All));
+            Assert.False(eventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+
+            listener.EnableEvents(eventSource, EventLevel.LogAlways);
+            Assert.True(eventSource.IsEnabled(EventLevel.Critical, EventKeywords.All));
+            Assert.True(eventSource.IsEnabled(EventLevel.Informational, EventKeywords.All));
+            Assert.True(eventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+        }
+
+        private sealed class TestEventListener : EventListener { }
+
+        private sealed class TestEventSource : EventSource { }
+    }
+}

--- a/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="BasicEventSourceTest\FuzzyTests.cs" />
     <Compile Include="BasicEventSourceTest\Harness\Listeners.cs" />
     <Compile Include="BasicEventSourceTest\TestEventCounter.cs" />
+    <Compile Include="BasicEventSourceTest\TestEventListenerEnable.cs" />
     <Compile Include="BasicEventSourceTest\TestFilter.cs" />
     <Compile Include="BasicEventSourceTest\TestNotSupported.cs" />
     <Compile Include="BasicEventSourceTest\TestShutdown.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2586,7 +2586,7 @@ namespace System.Diagnostics.Tracing
                         else
                         {
                             // Already enabled, make it the most verbose of the existing and new filter
-                            if (commandArgs.level > m_level)
+                            if (commandArgs.level == 0 || commandArgs.level > m_level)
                                 m_level = commandArgs.level;
                             if (commandArgs.matchAnyKeyword == 0)
                                 m_matchAnyKeyword = 0;


### PR DESCRIPTION
`EventLevel.LogAlways` has a value 0, but is the most verbose option, so it has to be special-cased before the `>` check.
That is done properly in the `IsEnabled` check, but not when updating the level https://github.com/dotnet/runtime/blob/19caa608b9d226d0041d5ed1c7b0d5911fb13d2b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L2305

Previously, an already-enabled `EventSource` would ignore an enable command with `EventLevel.LogAlways`.