### PR TITLE
Update msquic revision in docs after certificate work.

### DIFF
--- a/src/libraries/System.Net.Quic/readme.md
+++ b/src/libraries/System.Net.Quic/readme.md
@@ -1,15 +1,13 @@
 # MsQuic
 
 `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), Microsoft, cross-platform, native implementation of the [QUIC](https://datatracker.ietf.org/wg/quic/about/) protocol.
-Currently, `System.Net.Quic` depends on [**msquic@cc104e836a5d4a5e0d324bc08b42136d2acac997**](https://github.com/microsoft/msquic/commit/cc104e836a5d4a5e0d324bc08b42136d2acac997) revision.
+Currently, `System.Net.Quic` depends on [**msquic@7b31e149a9d1ed7a6850e8253ba3d0af707150e5**](https://github.com/microsoft/msquic/commit/7b31e149a9d1ed7a6850e8253ba3d0af707150e5) revision.
 
 ## Usage
 
 ### Build MsQuic
 
 [MsQuic build docs](https://github.com/microsoft/msquic/blob/main/docs/BUILD.md)
-
-> **Note**: At the moment, we're using stub_tls option to bypass OpenSSL/SChannel, since work with certificates is not fully figured out.
 
 #### Linux
 Prerequisites:

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTestBase.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Quic.Tests
 {
-    // TODO: why do we hawe 2 base clase with some duplicated methods?
+    // TODO: why do we have 2 base classes with some duplicated methods?
     public class MsQuicTestBase
     {
         public SslServerAuthenticationOptions GetSslServerAuthenticationOptions()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -204,6 +204,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public async Task CloseAsync_ByServer_AcceptThrows()
         {
             await RunClientServer(


### PR DESCRIPTION
Follow up for: https://github.com/dotnet/runtime/pull/50613

I updated the readme.md to reflect that we don't use STUB_TLS anymore and set the revision to the current main.

No code change, only docs.

cc: @wfurt 