### PR TITLE
Remove unused Mac interop libraries

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -10,8 +10,6 @@ internal static partial class Interop
         internal const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork";
         internal const string libobjc = "/usr/lib/libobjc.dylib";
         internal const string libproc = "/usr/lib/libproc.dylib";
-        internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto.dylib";
-        internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel.dylib";
         internal const string Odbc32 = "libodbc.2.dylib";
         internal const string OpenLdap = "libldap.dylib";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";


### PR DESCRIPTION
`LibSystemCommonCrypto` and `LibSystemKernel` are unused by any code so I'm removing them as dead code.