### PR TITLE
Add stub definitions of inject debug resources targets to fix runtimeinfo build dependency issues.

### DIFF
--- a/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
@@ -243,6 +243,9 @@ if(CLR_CMAKE_TARGET_WIN32)
         add_custom_target(inject_debug_resources_singlefilehost ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/inject_debug_resources_singlefilehost.timestamp)
         add_dependencies(runtime inject_debug_resources_singlefilehost)
     endif()
+else()
+    add_custom_target(inject_debug_resources_coreclr DEPENDS coreclr)
+    add_custom_target(inject_debug_resources_singlefilehost DEPENDS singlefilehost)
 endif(CLR_CMAKE_TARGET_WIN32)
 
 # add the install targets


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/issues/51248

@vcsjones can you validate?