### PR TITLE
Large page testing

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -501,6 +501,9 @@ jobs:
         ${{ if in(parameters.testGroup, 'clrinterpreter') }}:
           scenarios:
           - clrinterpreter
+        ${{ if in(parameters.testGroup, 'gc-largepages') }}:
+          scenarios:
+          - gclargepages
 
     # Publish Logs
     - task: PublishPipelineArtifact@1

--- a/eng/pipelines/coreclr/gc-largepages.yml
+++ b/eng/pipelines/coreclr/gc-largepages.yml
@@ -1,0 +1,42 @@
+trigger: none
+
+# schedules:
+# - cron: "0 11 * * 2,4"
+#   displayName: Every Tuesday and Thursday at 3:00 AM (UTC-8:00)
+#   branches:
+#     include:
+#     - main
+#   always: true
+
+jobs:
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: release
+    platforms:
+    - windows_x64
+    jobParameters:
+      testGroup: gc-largepages
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: release
+    platforms:
+    - windows_x64
+    jobParameters:
+      testGroup: gc-largepages
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: release
+    platforms:
+    - windows_x64
+    helixQueueGroup: gc-largepages
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: gc-largepages
+      liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -116,9 +116,9 @@ jobs:
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'gc-largepages', 'libraries')) }}:
         - Windows.10.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'gc-largepages', 'libraries')) }}:
         - (Windows.Nano.1809.Amd64.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1809-helix-amd64-08e8e40-20200107182504
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -37,6 +37,10 @@
       COMPlus_EnableSSSE3;
       COMPlus_FeatureSIMD;
       COMPlus_ForceRelocs;
+      COMPlus_GCLargePages;
+      COMPlus_GCHeapHardLimitSOH;
+      COMPlus_GCHeapHardLimitLOH;
+      COMPlus_GCHeapHardLimitPOH;
       COMPlus_GCStress;
       COMPlus_HeapVerify;
       COMPlus_JITMinOpts;
@@ -155,6 +159,7 @@
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" />
     <TestEnvironment Include="dynamicpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
+    <TestEnvironment Include="gclargepages" GCLargePages="1" GCHeapHardLimitSOH="80000000" GCHeapHardLimitLOH="80000000" GCHeapHardLimitPOH="0" />
   </ItemGroup>
 
   <!-- We use target batching on the COMPlusVariable items to iterate over the all COMPlus_* environment variables


### PR DESCRIPTION
In 2019, we [introduced](https://github.com/dotnet/coreclr/pull/23251) the large page support in the GC. However, this feature is not regularly tested, and we found it broken (and [fixed](https://github.com/dotnet/runtime/pull/50665)) once in a while due to [careless changes](https://github.com/dotnet/runtime/pull/37166).

It is time for us to introduce automated testing to avoid future regression. 

**Status:** right now, we have the pipeline set up to build the product code, build the test code and run all the tests with the environment variables set. Unfortunately, there are some known failures, but those failures shouldn't block us from starting to test them regularly.

In order to avoid spinning cycles analyzing known failures, I turned the automatic scheduling off. The goal is to merge the change as is so that we can start to work to get the tests green. These tests will be run manually until we are done with fixing the tests (or excluding them due to compatibility reasons)