### PR TITLE
Disable failing test `bigevent` for GCStress macOS arm64

### DIFF
--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -7,6 +7,8 @@
     <CLRTestPriority>0</CLRTestPriority>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133 -->
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/51133