### PR TITLE
[debugger] Fix problem when debugging using interpreter after remove domain from StackFrameInfo

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -2183,6 +2183,7 @@ get_last_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 		/* Store the context/lmf for the frame above the last frame */
 		memcpy (&data->ctx, ctx, sizeof (MonoContext));
 		data->lmf = info->lmf;
+		data->domain = mono_get_root_domain ();
 		return TRUE;
 	}
 }


### PR DESCRIPTION
Fix debugger problem when debugging interpreter after remove domain from StackFrameInfo.
Fixed by @lambdageek :)