### PR TITLE
[custom_attrs] Fix incorrect refactoring

### DIFF
--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -1982,9 +1982,8 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 
 	/* FIXME: metadata-update */
 	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
-	int rows = table_info_get_rows (ca);
-	if (method_index == rows) {
-		param_last = rows + 1;
+	if (method_index == table_info_get_rows (ca)) {
+		param_last = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;
 	} else {
 		param_last = mono_metadata_decode_row_col (ca, method_index, MONO_METHOD_PARAMLIST);
 	}


### PR DESCRIPTION
In
https://github.com/dotnet/runtime/pull/49738/files#diff-9bd9d0e46241d07dc62110246c89c9f056333eff4b0b089551780a625c871d0dL1982

When the code changed from acessing ca->rows directly, to using
table_info_get_rows, the "then" branch here was changed incorrectly.

The old code was

```c
if (method_index == ca->rows) {
		ca = &image->tables [MONO_TABLE_PARAM];
		param_last = ca->rows + 1;
```

So `param_last` should be set to one past the last row of
MONO_TABLE_PARAM, not one past the number of rows in MONO_TABLE_METHOD (ca)