### PR TITLE
Modify test OOMException01 and enable test OOMException01

### DIFF
--- a/src/tests/baseservices/exceptions/sharedexceptions/emptystacktrace/oomexception01.cs
+++ b/src/tests/baseservices/exceptions/sharedexceptions/emptystacktrace/oomexception01.cs
@@ -18,44 +18,55 @@ public class SharedExceptions
 
     public void RunTest()
     {
-        CreateAndThrow();        
+        CreateAndThrow();
     }
 
     public void CreateAndThrow()
     {
-    	string currStack;
-		
+        string currStack;
+
         try
         {
-        	throw new Exception();
+            throw new Exception();
         }
-	catch(Exception e)
-	{
-		currStack = e.StackTrace;
-	}
-	
+        catch(Exception e)
+        {
+            currStack = e.StackTrace;
+        }
+
         try
-        {            
+        {
             Guid[] g = new Guid[Int32.MaxValue];
         }
         catch(OutOfMemoryException e)
         {
             retVal = 100;
-			
-            Console.WriteLine("Caught OOM");     
 
-            if(e.StackTrace.ToString().Substring(0, e.StackTrace.Length - 8) != currStack.Substring(0, currStack.Length - 8))
-            {	
-            	Console.WriteLine("Actual Exception Stack Trace:");
+            Console.WriteLine("Caught OOM");
+
+            string oomStack = e.StackTrace;
+            string expectedStack = currStack;
+
+            if (oomStack.IndexOf(':') != -1)
+            {
+                oomStack = oomStack.Substring(0, oomStack.IndexOf(':') - 1);
+            }
+
+            if (expectedStack.IndexOf(':') != -1)
+            {
+                expectedStack = expectedStack.Substring(0, expectedStack.IndexOf(':') - 1);
+            }
+
+            if (oomStack != expectedStack)
+            {
+                Console.WriteLine("Actual Exception Stack Trace:");
                 Console.WriteLine(e.StackTrace);
                 Console.WriteLine();				
-            	Console.WriteLine("Expected Stack Trace:");
-		        Console.WriteLine(currStack.ToString());
+                Console.WriteLine("Expected Stack Trace:");
+                Console.WriteLine(currStack.ToString());
                 retVal = 50;
             }
         }
-            
     }
-
 }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2,9 +2,6 @@
 <Project DefaultTargets = "GetListOfTestCmds" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- All OS/Arch/Runtime excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/sharedexceptions/emptystacktrace/OOMException01/*">
-            <Issue>https://github.com/dotnet/runtime/issues/51209</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/DynamicMethodGCStress/DynamicMethodGCStress/*">
             <Issue>timeout</Issue>
         </ExcludeList>


### PR DESCRIPTION
TC fix for #51209
Enable disabled test from #51263

In order to avoid failure due to modification of #44013,
the TC has been modified so that the content after':' is not compared.