### PR TITLE
Improve Lsra stats

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5181,7 +5181,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     codeGen->genGenerateCode(methodCodePtr, methodCodeSize);
 
 #if TRACK_LSRA_STATS
-    if ((JitConfig.DisplayLsraStats() == 2))
+    if (JitConfig.DisplayLsraStats() == 2)
     {
         m_pLinearScan->dumpLsraStatsCsv(jitstdout);
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5180,6 +5180,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Generate code
     codeGen->genGenerateCode(methodCodePtr, methodCodeSize);
 
+#if TRACK_LSRA_STATS
+    if ((JitConfig.DisplayLsraStats() == 2))
+    {
+        m_pLinearScan->dumpLsraStatsCsv(jitstdout);
+    }
+#endif // TRACK_LSRA_STATS
+
     // We're done -- set the active phase to the last phase
     // (which isn't really a phase)
     mostRecentlyActivePhase = PHASE_POST_EMIT;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1139,6 +1139,9 @@ public:
     virtual void doLinearScan()                                = 0;
     virtual void recordVarLocationsAtStartOfBB(BasicBlock* bb) = 0;
     virtual bool willEnregisterLocalVars() const               = 0;
+#if TRACK_LSRA_STATS
+    virtual void dumpLsraStatsCsv(FILE* file) = 0;
+#endif // TRACK_LSRA_STATS
 };
 
 LinearScanInterface* getLinearScanAllocator(Compiler* comp);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -25,7 +25,9 @@ CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)          // Make the disas
 CONFIG_INTEGER(JitDasmWithAddress, W("JitDasmWithAddress"), 0) // Print the process address next to each instruction of
                                                                // the disassembly
 CONFIG_INTEGER(DisplayLoopHoistStats, W("JitLoopHoistStats"), 0) // Display JIT loop hoisting statistics
-CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Linear Scan Register Allocator statistics
+CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0) // Display JIT Linear Scan Register Allocator statistics
+                                                       // if set to 1. If set to "2", display the stats in csv format.
+                                                       // Recommended to use with JitStdOutFile flag.
 CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console
 CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1)  // Whether absolute addr be encoded as PC-rel offset by
                                                              // RyuJIT where possible

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1299,10 +1299,6 @@ void LinearScan::doLinearScan()
     {
         dumpLsraStats(jitstdout);
     }
-    else if ((JitConfig.DisplayLsraStats() == 2))
-    {
-        dumpLsraStatsCsv(jitstdout);
-    }
 #endif // TRACK_LSRA_STATS
 
     DBEXEC(VERBOSE, TupleStyleDump(LSRA_DUMP_POST));
@@ -3392,10 +3388,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         // We must have at least one with the lowest spill cost.
         assert(lowestCostSpillSet != RBM_NONE);
         found = selector.applySelection(SPILL_COST, lowestCostSpillSet);
-        if (found)
-        {
-            INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_SPILL_COST, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_SPILL_COST, refPosition->bbNum));
     }
 
     // Apply the FAR_NEXT_REF heuristic.
@@ -3426,10 +3419,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         // We must have at least one with the lowest spill cost.
         assert(farthestSet != RBM_NONE);
         found = selector.applySelection(FAR_NEXT_REF, farthestSet);
-        if (found)
-        {
-            INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_FAR_NEXT_REF, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_FAR_NEXT_REF, refPosition->bbNum));
     }
 
     // Apply the PREV_REG_OPT heuristic.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -9460,7 +9460,7 @@ void LinearScan::dumpLsraStatsCsv(FILE* file)
         {
             fprintf(file, ",\"%s\"", LinearScan::getStatName(statIndex));
         }
-        fprintf(file, "\n");
+        fprintf(file, ",\"PerfScore\"\n");
     }
 
     // bbNum == 0
@@ -9488,7 +9488,7 @@ void LinearScan::dumpLsraStatsCsv(FILE* file)
     {
         fprintf(file, ",%u", sumStats[statIndex]);
     }
-    fprintf(file, "\n");
+    fprintf(file, ",%.2f\n", compiler->info.compPerfScore);
 }
 #endif // TRACK_LSRA_STATS
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3086,10 +3086,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     else if (!found)
     {
         found = selector.applySelection(FREE, freeCandidates);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_FREE, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_FREE, refPosition->bbNum));
     }
 
     // Apply the CONST_AVAILABLE (matching constant) heuristic. Only applies if we have freeCandidates.
@@ -3100,10 +3097,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         {
             matchingConstants = getMatchingConstants(selector.candidates, currentInterval, refPosition);
             found             = selector.applySelection(CONST_AVAILABLE, matchingConstants);
-            if (found)
-            {
-                INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_CONST_AVAILABLE, refPosition->bbNum));
-            }
+            INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_CONST_AVAILABLE, refPosition->bbNum));
         }
     }
 
@@ -3111,10 +3105,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     if (!found && (prevRegRec != nullptr) && (freeCandidates != RBM_NONE))
     {
         found = selector.applySelection(THIS_ASSIGNED, freeCandidates & preferences & prevRegBit);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_THIS_ASSIGNED, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_THIS_ASSIGNED, refPosition->bbNum));
     }
 
     // Compute the sets for COVERS, OWN_PREFERENCE, COVERS_RELATED, COVERS_FULL and UNASSIGNED together,
@@ -3192,10 +3183,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     if (!found)
     {
         found = selector.applySelection(COVERS, coversSet & preferenceSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_COVERS, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_COVERS, refPosition->bbNum));
     }
 
     // Apply the OWN_PREFERENCE heuristic.
@@ -3204,10 +3192,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     {
         assert((preferenceSet & freeCandidates) == preferenceSet);
         found = selector.applySelection(OWN_PREFERENCE, preferenceSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_OWN_PREFERENCE, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_OWN_PREFERENCE, refPosition->bbNum));
     }
 
     // Apply the COVERS_RELATED heuristic.
@@ -3215,40 +3200,28 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     {
         assert((coversRelatedSet & freeCandidates) == coversRelatedSet);
         found = selector.applySelection(COVERS_RELATED, coversRelatedSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_COVERS_RELATED, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_COVERS_RELATED, refPosition->bbNum));
     }
 
     // Apply the RELATED_PREFERENCE heuristic.
     if (!found)
     {
         found = selector.applySelection(RELATED_PREFERENCE, relatedPreferences & freeCandidates);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_RELATED_PREFERENCE, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_RELATED_PREFERENCE, refPosition->bbNum));
     }
 
     // Apply the CALLER_CALLEE heuristic.
     if (!found)
     {
         found = selector.applySelection(CALLER_CALLEE, callerCalleePrefs & freeCandidates);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_CALLER_CALLEE, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_CALLER_CALLEE, refPosition->bbNum));
     }
 
     // Apply the UNASSIGNED heuristic.
     if (!found)
     {
         found = selector.applySelection(UNASSIGNED, unassignedSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_UNASSIGNED, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_UNASSIGNED, refPosition->bbNum));
     }
 
     // Apply the COVERS_FULL heuristic.
@@ -3256,10 +3229,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     {
         assert((coversFullSet & freeCandidates) == coversFullSet);
         found = selector.applySelection(COVERS_FULL, coversFullSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_COVERS_FULL, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_COVERS_FULL, refPosition->bbNum));
     }
 
     // Apply the BEST_FIT heuristic. Only applies if we have freeCandidates.
@@ -3325,10 +3295,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         }
         assert(bestFitSet != RBM_NONE);
         found = selector.applySelection(BEST_FIT, bestFitSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_BEST_FIT, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_BEST_FIT, refPosition->bbNum));
     }
 
     // Apply the IS_PREV_REG heuristic. TODO: Check if Only applies if we have freeCandidates.
@@ -3336,10 +3303,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
     if ((prevRegRec != nullptr) && ((selector.score & COVERS_FULL) != 0))
     {
         found = selector.applySingleRegSelection(IS_PREV_REG, prevRegBit);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_IS_PREV_REG, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_IS_PREV_REG, refPosition->bbNum));
     }
 
     // Apply the REG_ORDER heuristic. Only applies if we have freeCandidates.
@@ -3364,10 +3328,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         }
         assert(lowestRegOrderBit != RBM_NONE);
         found = selector.applySingleRegSelection(REG_ORDER, lowestRegOrderBit);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_REG_ORDER, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_REG_ORDER, refPosition->bbNum));
     }
 
     // The set of registers with the lowest spill weight.
@@ -3433,7 +3394,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         found = selector.applySelection(SPILL_COST, lowestCostSpillSet);
         if (found)
         {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_SPILL_COST, refPosition->bbNum));
+            INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_SPILL_COST, refPosition->bbNum));
         }
     }
 
@@ -3467,7 +3428,7 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
         found = selector.applySelection(FAR_NEXT_REF, farthestSet);
         if (found)
         {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_FAR_NEXT_REF, refPosition->bbNum));
+            INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_FAR_NEXT_REF, refPosition->bbNum));
         }
     }
 
@@ -3547,20 +3508,14 @@ regNumber LinearScan::allocateReg(Interval* currentInterval, RefPosition* refPos
 #endif
         }
         found = selector.applySelection(PREV_REG_OPT, prevRegOptSet);
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_PREV_REG_OPT, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_PREV_REG_OPT, refPosition->bbNum));
     }
 
     // Apply the REG_NUM heuristic.
     if (!found)
     {
         found = selector.applySingleRegSelection(REG_NUM, genFindLowestBit(selector.candidates));
-        if (found)
-        {
-            INTRACK_STATS(updateLsraStat(LsraStat::REGSEL_REG_NUM, refPosition->bbNum));
-        }
+        INTRACK_STATS_IF(found, updateLsraStat(LsraStat::REGSEL_REG_NUM, refPosition->bbNum));
     }
 
     assert(found && isSingleRegister(selector.candidates));

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -9313,7 +9313,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
 const char* LinearScan::getStatName(unsigned stat)
 {
     LsraStat lsraStat = (LsraStat)stat;
-    assert (lsraStat != COUNT);
+    assert(lsraStat != COUNT);
 
     static const char* const lsraStatNames[] = {
 #define LSRA_STAT_DEF(stat, name) name,
@@ -9353,7 +9353,7 @@ void LinearScan::updateLsraStat(LsraStat stat, unsigned bbNum)
 //
 void LinearScan::dumpLsraStats(FILE* file)
 {
-    unsigned sumStats[LsraStat::COUNT] = {0};
+    unsigned             sumStats[LsraStat::COUNT] = {0};
     BasicBlock::weight_t wtdStats[LsraStat::COUNT] = {0};
 
     fprintf(file, "----------\n");
@@ -9388,8 +9388,8 @@ void LinearScan::dumpLsraStats(FILE* file)
     }
     fprintf(file, "Total Number of spill temps created: %d\n\n", numSpillTemps);
     fprintf(file, "----------\n");
-    bool addedBlockHeader   = false;
-    bool anyNonZeroStat = false;
+    bool addedBlockHeader = false;
+    bool anyNonZeroStat   = false;
 
     for (int statIndex = 0; statIndex < LsraStat::COUNT; statIndex++)
     {
@@ -9426,7 +9426,7 @@ void LinearScan::dumpLsraStats(FILE* file)
         }
 
         addedBlockHeader = false;
-        anyNonZeroStat = false;
+        anyNonZeroStat   = false;
         for (int statIndex = 0; statIndex < LsraStat::COUNT; statIndex++)
         {
             unsigned lsraStat = blockInfo[block->bbNum].stats[statIndex];
@@ -9463,7 +9463,7 @@ void LinearScan::dumpLsraStats(FILE* file)
         {
             fprintf(file, "----------\n");
         }
-        //TODO-review: I don't see a point of displaying Stats (SpillCount, etc.) if they are zero. Thoughts?
+        // TODO-review: I don't see a point of displaying Stats (SpillCount, etc.) if they are zero. Thoughts?
         if ((regSelectI < firstRegSelStat) || (sumStats[regSelectI] != 0))
         {
             // Print register selection stats

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -375,6 +375,16 @@ public:
     void ReturnNode(RefInfoListNode* listNode);
 };
 
+
+#if TRACK_LSRA_STATS
+enum LsraStat
+{
+#define LSRA_STAT_DEF(enum_name, enum_str) enum_name,
+#include "lsrastats.h"
+#undef LSRA_STAT_DEF
+};
+#endif // TRACK_LSRA_STATS
+
 struct LsraBlockInfo
 {
     // bbNum of the predecessor to use for the register location of live-in variables.
@@ -389,21 +399,7 @@ struct LsraBlockInfo
 
 #if TRACK_LSRA_STATS
     // Per block maintained LSRA statistics.
-
-    // Number of spills of local vars or tree temps in this basic block.
-    unsigned spillCount;
-
-    // Number of GT_COPY nodes inserted in this basic block while allocating regs.
-    // Note that GT_COPY nodes are also inserted as part of basic block boundary
-    // resolution, which are accounted against resolutionMovCount but not
-    // against copyRegCount.
-    unsigned copyRegCount;
-
-    // Number of resolution moves inserted in this basic block.
-    unsigned resolutionMovCount;
-
-    // Number of critical edges from this block that are split.
-    unsigned splitEdgeCount;
+    unsigned stats[LsraStat::COUNT];
 #endif // TRACK_LSRA_STATS
 };
 
@@ -1202,6 +1198,7 @@ private:
             regMaskTP newCandidates = candidates & selectionCandidate;
             if (newCandidates != RBM_NONE)
             {
+                score += selectionScore;
                 candidates = newCandidates;
                 return true;
             }
@@ -1360,14 +1357,11 @@ private:
 #endif // DEBUG
 
 #if TRACK_LSRA_STATS
-    enum LsraStat{
-        LSRA_STAT_SPILL, LSRA_STAT_COPY_REG, LSRA_STAT_RESOLUTION_MOV, LSRA_STAT_SPLIT_EDGE,
-    };
-
     unsigned regCandidateVarCount;
+    const char* getStatName(unsigned stat);
     void updateLsraStat(LsraStat stat, unsigned currentBBNum);
-
     void dumpLsraStats(FILE* file);
+    LsraStat firstRegSelStat = LsraStat::REGSEL_FREE;
 
 #define INTRACK_STATS(x) x
 #else // !TRACK_LSRA_STATS

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1366,8 +1366,15 @@ public:
     static const char* getStatName(unsigned stat);
 
 #define INTRACK_STATS(x) x
+#define INTRACK_STATS_IF(condition, work)                                                                              \
+    if (condition)                                                                                                     \
+    {                                                                                                                  \
+        work;                                                                                                          \
+    }
+
 #else // !TRACK_LSRA_STATS
 #define INTRACK_STATS(x)
+#define INTRACK_STATS_IF(condition, work)
 #endif // !TRACK_LSRA_STATS
 
 private:

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1359,10 +1359,10 @@ private:
     unsigned regCandidateVarCount;
     void updateLsraStat(LsraStat stat, unsigned currentBBNum);
     void dumpLsraStats(FILE* file);
-    void dumpLsraStatsCsv(FILE* file);
     LsraStat firstRegSelStat = LsraStat::REGSEL_FREE;
 
 public:
+    virtual void dumpLsraStatsCsv(FILE* file);
     static const char* getStatName(unsigned stat);
 
 #define INTRACK_STATS(x) x

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -375,7 +375,6 @@ public:
     void ReturnNode(RefInfoListNode* listNode);
 };
 
-
 #if TRACK_LSRA_STATS
 enum LsraStat
 {
@@ -1357,7 +1356,7 @@ private:
 #endif // DEBUG
 
 #if TRACK_LSRA_STATS
-    unsigned regCandidateVarCount;
+    unsigned    regCandidateVarCount;
     const char* getStatName(unsigned stat);
     void updateLsraStat(LsraStat stat, unsigned currentBBNum);
     void dumpLsraStats(FILE* file);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1356,20 +1356,23 @@ private:
 #endif // DEBUG
 
 #if TRACK_LSRA_STATS
-    unsigned    regCandidateVarCount;
-    const char* getStatName(unsigned stat);
+    unsigned regCandidateVarCount;
     void updateLsraStat(LsraStat stat, unsigned currentBBNum);
     void dumpLsraStats(FILE* file);
+    void dumpLsraStatsCsv(FILE* file);
     LsraStat firstRegSelStat = LsraStat::REGSEL_FREE;
+
+public:
+    static const char* getStatName(unsigned stat);
 
 #define INTRACK_STATS(x) x
 #else // !TRACK_LSRA_STATS
 #define INTRACK_STATS(x)
 #endif // !TRACK_LSRA_STATS
 
+private:
     Compiler* compiler;
 
-private:
     CompAllocator getAllocator(Compiler* comp)
     {
         return comp->getAllocator(CMK_LSRA);

--- a/src/coreclr/jit/lsrastats.h
+++ b/src/coreclr/jit/lsrastats.h
@@ -49,3 +49,5 @@ LSRA_STAT_DEF(REGSEL_REG_NUM,               "REG_NUM")
 LSRA_STAT_DEF(COUNT,                        "COUNT")
 
 #endif // TRACK_LSRA_STATS
+
+// clang-format on

--- a/src/coreclr/jit/lsrastats.h
+++ b/src/coreclr/jit/lsrastats.h
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// clang-format off
+
+/*****************************************************************************/
+/*****************************************************************************/
+#ifndef LSRA_STAT_DEF
+#error  Must define LSRA_STAT_DEF macro before including this file
+#endif
+
+#if TRACK_LSRA_STATS
+
+// Number of spills of local vars or tree temps in this basic block.
+LSRA_STAT_DEF(STAT_SPILL,                   "SpillCount")
+
+// Number of GT_COPY nodes inserted in this basic block while allocating regs.
+// Note that GT_COPY nodes are also inserted as part of basic block boundary
+// resolution, which are accounted against resolutionMovCount but not
+// against copyRegCount.
+LSRA_STAT_DEF(STAT_COPY_REG,                "CopyReg")
+
+// Number of resolution moves inserted in this basic block.
+LSRA_STAT_DEF(STAT_RESOLUTION_MOV,          "ResolutionMovs")
+
+// Number of critical edges from this block that are split.
+LSRA_STAT_DEF(STAT_SPLIT_EDGE,              "SplitEdges")
+
+// Register selection stats
+
+LSRA_STAT_DEF(REGSEL_FREE,                  "FREE")
+LSRA_STAT_DEF(REGSEL_CONST_AVAILABLE,       "CONST_AVAILABLE")
+LSRA_STAT_DEF(REGSEL_THIS_ASSIGNED,         "THIS_ASSIGNED")
+LSRA_STAT_DEF(REGSEL_COVERS,                "COVERS")
+LSRA_STAT_DEF(REGSEL_OWN_PREFERENCE,        "OWN_PREFERENCE")
+LSRA_STAT_DEF(REGSEL_COVERS_RELATED,        "COVERS_RELATED")
+LSRA_STAT_DEF(REGSEL_RELATED_PREFERENCE,    "RELATED_PREFERENCE")
+LSRA_STAT_DEF(REGSEL_CALLER_CALLEE,         "CALLER_CALLEE")
+LSRA_STAT_DEF(REGSEL_UNASSIGNED,            "UNASSIGNED")
+LSRA_STAT_DEF(REGSEL_COVERS_FULL,           "COVERS_FULL")
+LSRA_STAT_DEF(REGSEL_BEST_FIT,              "BEST_FIT")
+LSRA_STAT_DEF(REGSEL_IS_PREV_REG,           "IS_PREV_REG")
+LSRA_STAT_DEF(REGSEL_REG_ORDER,             "REG_ORDER")
+LSRA_STAT_DEF(REGSEL_SPILL_COST,            "SPILL_COST")
+LSRA_STAT_DEF(REGSEL_FAR_NEXT_REF,          "FAR_NEXT_REF")
+LSRA_STAT_DEF(REGSEL_PREV_REG_OPT,          "PREV_REG_OPT")
+LSRA_STAT_DEF(REGSEL_REG_NUM,               "REG_NUM")
+
+LSRA_STAT_DEF(COUNT,                        "COUNT")
+
+#endif // TRACK_LSRA_STATS


### PR DESCRIPTION
Improve Lsra stats to include register selection heuristics information. The sample output looks like this:

```cmd
----------
LSRA Stats : System.Runtime.CompilerServices.CastHelpers:LdelemaRef(System.Array,int,long):byref
----------
Total Tracked Vars:  5
Total Reg Cand Vars: 5
Total number of Intervals: 8
Total number of RefPositions: 39
Total Number of spill temps created: 0
..........
BB01 [  100.00]: COVERS = 2, RELATED_PREFERENCE = 1, BEST_FIT = 1, REG_ORDER = 2
..........
Total SpillCount : 0   Weighted: 0.000000
Total CopyReg : 0   Weighted: 0.000000
Total ResolutionMovs : 0   Weighted: 0.000000
Total SplitEdges : 0   Weighted: 0.000000
..........
Total COVERS [# 4] : 2   Weighted: 200.000000
Total RELATED_PREFERENCE [# 7] : 1   Weighted: 100.000000
Total BEST_FIT [#11] : 1   Weighted: 100.000000
Total REG_ORDER [#13] : 2   Weighted: 200.000000
```

I have also added a way to store the stats in csv form if we set `COMPlus_JitLsraStats=2`. With that, I can easily summarize graphically which heuristics is popular. Below is the data I gathered by running `MulMatrix` microbenchmark and all the register selection heuristics during that:

![image](https://user-images.githubusercontent.com/12488060/114793336-ffcb9f80-9d3e-11eb-9dea-6f4f3ca8a674.png)
