### PR TITLE
OpenSSL3: Register legacy algorithms when needed

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LegacyAlgorithms.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LegacyAlgorithms.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        private static bool s_loadedLegacy;
+        private static object s_legacyLoadLock = new object();
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern void CryptoNative_RegisterLegacyAlgorithms();
+
+        internal static void RegisterLegacyAlgorithms()
+        {
+            if (!s_loadedLegacy)
+            {
+                lock (s_legacyLoadLock)
+                {
+                    if (!s_loadedLegacy)
+                    {
+                        CryptoNative_RegisterLegacyAlgorithms();
+                        s_loadedLegacy = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LegacyAlgorithms.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LegacyAlgorithms.cs
@@ -7,13 +7,13 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        private static bool s_loadedLegacy;
-        private static object s_legacyLoadLock = new object();
+        private static volatile bool s_loadedLegacy;
+        private static readonly object s_legacyLoadLock = new object();
 
         [DllImport(Libraries.CryptoNative)]
         private static extern void CryptoNative_RegisterLegacyAlgorithms();
 
-        internal static void RegisterLegacyAlgorithms()
+        internal static void EnsureLegacyAlgorithmsRegistered()
         {
             if (!s_loadedLegacy)
             {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/entrypoints.c
@@ -221,6 +221,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_PushX509StackField)
     DllImportEntry(CryptoNative_ReadX509AsDerFromBio)
     DllImportEntry(CryptoNative_RecursiveFreeX509Stack)
+    DllImportEntry(CryptoNative_RegisterLegacyAlgorithms)
     DllImportEntry(CryptoNative_RsaCreate)
     DllImportEntry(CryptoNative_RsaDecrypt)
     DllImportEntry(CryptoNative_RsaDestroy)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1121,6 +1121,16 @@ int64_t CryptoNative_OpenSslVersionNumber()
     return (int64_t)OpenSSL_version_num();
 }
 
+void CryptoNative_RegisterLegacyAlgorithms()
+{
+#if NEED_OPENSSL_3_0
+    if (API_EXISTS(OSSL_PROVIDER_try_load))
+    {
+        OSSL_PROVIDER_try_load(NULL, "legacy", 1);
+    }
+#endif
+}
+
 #ifdef NEED_OPENSSL_1_0
 // Lock used to make sure EnsureopenSslInitialized itself is thread safe
 static pthread_mutex_t g_initLock = PTHREAD_MUTEX_INITIALIZER;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -72,3 +72,5 @@ PALEXPORT int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, con
 PALEXPORT int32_t CryptoNative_EnsureOpenSslInitialized(void);
 
 PALEXPORT int64_t CryptoNative_OpenSslVersionNumber(void);
+
+PALEXPORT void CryptoNative_RegisterLegacyAlgorithms(void);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -41,6 +41,10 @@
 #define OPENSSL_VERSION_1_1_0_RTM 0x10100000L
 #define OPENSSL_VERSION_1_0_2_RTM 0x10002000L
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_3_0_RTM
+#include <openssl/provider.h>
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1_1_RTM
 #define HAVE_OPENSSL_SET_CIPHERSUITES 1
 #else
@@ -391,6 +395,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     RENAMED_FUNCTION(OPENSSL_sk_push, sk_push) \
     RENAMED_FUNCTION(OPENSSL_sk_value, sk_value) \
     FALLBACK_FUNCTION(OpenSSL_version_num) \
+    LIGHTUP_FUNCTION(OSSL_PROVIDER_try_load) \
     REQUIRED_FUNCTION(PEM_read_bio_PKCS7) \
     REQUIRED_FUNCTION(PEM_read_bio_X509) \
     REQUIRED_FUNCTION(PEM_read_bio_X509_AUX) \
@@ -820,6 +825,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OPENSSL_sk_push OPENSSL_sk_push_ptr
 #define OPENSSL_sk_value OPENSSL_sk_value_ptr
 #define OpenSSL_version_num OpenSSL_version_num_ptr
+#define OSSL_PROVIDER_try_load OSSL_PROVIDER_try_load_ptr
 #define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
 #define PEM_read_bio_X509 PEM_read_bio_X509_ptr
 #define PEM_read_bio_X509_AUX PEM_read_bio_X509_AUX_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/osslcompat_30.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/osslcompat_30.h
@@ -12,6 +12,9 @@
 #undef EVP_PKEY_CTX_set_rsa_pss_saltlen
 #undef EVP_PKEY_CTX_set_signature_md
 
+typedef struct ossl_provider_st OSSL_PROVIDER;
+typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
+
 void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
@@ -20,4 +23,5 @@ int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad_mode);
 int EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int saltlen);
 int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
+OSSL_PROVIDER* OSSL_PROVIDER_try_load(OSSL_LIB_CTX* , const char* name, int retain_fallbacks);
 X509* SSL_get1_peer_certificate(const SSL* ssl);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
@@ -32,13 +32,15 @@ namespace Internal.Cryptography
                     break;
                 case CipherMode.CFB:
 
-                    Debug.Assert(feedbackSize == 1, "TripleDES with CFB should have FeedbackSize set to 1");
+                    Debug.Assert(feedbackSize == 1, "DES with CFB should have FeedbackSize set to 1");
                     algorithm = Interop.Crypto.EvpDesCfb8();
 
                     break;
                 default:
                     throw new NotSupportedException();
             }
+
+            Interop.Crypto.RegisterLegacyAlgorithms();
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
@@ -40,7 +40,7 @@ namespace Internal.Cryptography
                     throw new NotSupportedException();
             }
 
-            Interop.Crypto.RegisterLegacyAlgorithms();
+            Interop.Crypto.EnsureLegacyAlgorithmsRegistered();
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Unix.cs
@@ -34,7 +34,7 @@ namespace Internal.Cryptography
                     throw new NotSupportedException();
             }
 
-            Interop.Crypto.RegisterLegacyAlgorithms();
+            Interop.Crypto.EnsureLegacyAlgorithmsRegistered();
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, effectiveKeyLength, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -471,7 +471,6 @@
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
@@ -567,6 +566,7 @@
     <Compile Include="System\Security\Cryptography\AesGcm.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(UseAndroidCrypto)' != 'true' and '$(UseAppleCrypto)' != 'true'">
+    <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaOpenSsl.cs"
              Link="Common\System\Security\Cryptography\ECDsaOpenSsl.cs" />
@@ -584,6 +584,8 @@
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Rsa.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Rsa.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.LegacyAlgorithms.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.LegacyAlgorithms.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs"
@@ -648,6 +650,7 @@
              Link="Common\System\Security\Cryptography\ECDsaAndroid.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSAAndroid.cs"
              Link="Common\System\Security\Cryptography\RSAAndroid.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.Android.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.Android.cs" />
     <Compile Include="System\Security\Cryptography\AesCcm.Android.cs" />
     <Compile Include="System\Security\Cryptography\AesGcm.Android.cs" />


### PR DESCRIPTION
OpenSSL 3.0 has moved RC2 and (1)DES (as well as other algorithms we don't support) into an outer ring
that requires explicit code or config opt-in to use.  Attempting to use the algorithms without this gesture
results in `Interop+Crypto+OpenSslCryptographicException : error:0308010C:digital envelope routines::unsupported`

The first time a process calls CreateEncryptor or CreateDecryptor on an instance of RC2(Implementation) or
DES(Implementation) when they are backed by OpenSSL we'll call into a shim function that is a no-op on 1.0/1.1,
and on 3.0 does an auxiliary load of the "legacy" module so that the algorithms work.

Another (easier?) option is to simply perform the gesture when spinning up OpenSSL, but this way we get to keep
the legacy module unloaded until such a time as someone actually tries to use it.

One last option is to simply fail unless the user/admin has explicitly marked the legacy provider as on by default, but
since the application has already made the gesture to ask for the algorithm that seems like unnecessary UX burden.

Contributes to #46526.