### PR TITLE
Work around OpenSSL 3.0 ciphers not restoring original IV on reset.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -280,6 +280,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     LEGACY_FUNCTION(EVP_CIPHER_CTX_cleanup) \
     REQUIRED_FUNCTION(EVP_CIPHER_CTX_ctrl) \
     FALLBACK_FUNCTION(EVP_CIPHER_CTX_free) \
+    LIGHTUP_FUNCTION(EVP_CIPHER_CTX_get_original_iv) \
     LEGACY_FUNCTION(EVP_CIPHER_CTX_init) \
     FALLBACK_FUNCTION(EVP_CIPHER_CTX_new) \
     FALLBACK_FUNCTION(EVP_CIPHER_CTX_reset) \
@@ -709,6 +710,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_cleanup_ptr
 #define EVP_CIPHER_CTX_ctrl EVP_CIPHER_CTX_ctrl_ptr
 #define EVP_CIPHER_CTX_free EVP_CIPHER_CTX_free_ptr
+#define EVP_CIPHER_CTX_get_original_iv EVP_CIPHER_CTX_get_original_iv_ptr
 #define EVP_CIPHER_CTX_init EVP_CIPHER_CTX_init_ptr
 #define EVP_CIPHER_CTX_new EVP_CIPHER_CTX_new_ptr
 #define EVP_CIPHER_CTX_reset EVP_CIPHER_CTX_reset_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/osslcompat_30.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/osslcompat_30.h
@@ -15,6 +15,7 @@
 void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
+int EVP_CIPHER_CTX_get_original_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len);
 int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int bits);
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad_mode);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -126,8 +126,26 @@ int32_t CryptoNative_EvpCipherReset(EVP_CIPHER_CTX* ctx)
     //
     // But since we have a different object returned for CreateEncryptor
     // and CreateDecryptor we don't need to worry about that.
+    uint8_t* iv = NULL;
 
-    return EVP_CipherInit_ex(ctx, NULL, NULL, NULL, NULL, KEEP_CURRENT_DIRECTION);
+#ifdef NEED_OPENSSL_3_0
+    // OpenSSL 3.0 alpha 13 does not properly reset the IV. Work around that by
+    // asking for the original IV, and giving it back.
+    uint8_t tmpIV[EVP_MAX_IV_LENGTH];
+
+    // If we're direct against 3.0, or we're portable and found 3.0
+    if (API_EXISTS(EVP_CIPHER_CTX_get_original_iv))
+    {
+        if (EVP_CIPHER_CTX_get_original_iv(ctx, tmpIV, sizeof(tmpIV)) != 1)
+        {
+            return 0;
+        }
+
+        iv = tmpIV;
+    }
+#endif
+
+    return EVP_CipherInit_ex(ctx, NULL, NULL, NULL, iv, KEEP_CURRENT_DIRECTION);
 }
 
 int32_t CryptoNative_EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)


### PR DESCRIPTION
We can remove this workaround if/when OSSL3 plays nicely here.

The only thing it really costs us is some awkard #ifs, since it's pretty much the same as the code they'll have inside.

Contributes to #46526 