### PR TITLE
Fix disposal of MetadataProvider on failure to read Embedded PDB

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
@@ -68,7 +68,6 @@ namespace System.Reflection.PortableExecutable
             }
         }
 
-
         // internal for testing
         internal static unsafe ImmutableArray<byte> DecodeEmbeddedPortablePdbDebugDirectoryData(AbstractMemoryBlock block)
         {
@@ -147,7 +146,7 @@ namespace System.Reflection.PortableExecutable
             }
             finally
             {
-                if (candidate == null)
+                if (provider == null)
                 {
                     candidate?.Dispose();
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50682