### PR TITLE
Fix issue with Win32 resource placement

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -56,6 +56,7 @@ namespace ILCompiler.DependencyAnalysis
             //
             // ReadyToRun Nodes
             //
+            Win32ResourcesNode,
             CorHeaderNode,
             ReadyToRunHeaderNode,
             ReadyToRunAssemblyHeaderNode,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Win32ResourcesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Win32ResourcesNode.cs
@@ -23,7 +23,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override bool IsShareable => false;
 
-        public override int ClassCode => 315358339;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.Win32ResourcesNode;
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -834,6 +834,15 @@ namespace ILCompiler.PEWriter
                 SymbolTarget symbolTarget = _symbolMap[_win32ResourcesSymbol];
                 Section section = _sections[symbolTarget.SectionIndex];
                 Debug.Assert(section.RVAWhenPlaced != 0);
+
+                // Windows has a bug in its resource processing logic that occurs when 
+                // 1. A PE file is loaded as a data file
+                // 2. The resource data found in the resources has an RVA which has a magnitude greater than the size of the section which holds the resources
+                // 3. The offset of the start of the resource data from the start of the section is not zero.
+                //
+                // As it is impossible to effect condition 1 in the compiler, and changing condition 2 would require bloating the virtual size of the sections,
+                // instead require that the resource data is located at offset 0 within the section.
+                Debug.Assert(symbolTarget.Offset == 0);
                 directoriesBuilder.ResourceTable = new DirectoryEntry(section.RVAWhenPlaced + symbolTarget.Offset, _win32ResourcesSize);
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -842,6 +842,7 @@ namespace ILCompiler.PEWriter
                 //
                 // As it is impossible to effect condition 1 in the compiler, and changing condition 2 would require bloating the virtual size of the sections,
                 // instead require that the resource data is located at offset 0 within the section.
+                // We achieve that by sorting the Win32ResourcesNode as the first node.
                 Debug.Assert(symbolTarget.Offset == 0);
                 directoriesBuilder.ResourceTable = new DirectoryEntry(section.RVAWhenPlaced + symbolTarget.Offset, _win32ResourcesSize);
             }


### PR DESCRIPTION
Windows has a bug in its resource processing logic that occurs when
1. A PE file is loaded as a data file
2. The resource data found in the resources has an RVA which has a magnitude greater than the size of the section which holds the resources
3. The offset of the start of the resource data from the start of the section is not zero.

As it is impossible to effect condition 1 in the compiler, and changing condition 2 would require bloating the virtual size of the sections, instead require that the resource data is located at offset 0 within its section, by sorting the Win32ResourceNode to be the first node. (This issue caused issues while developing dotnet/aspnetcore#31778.)