### PR TITLE
[WIP] Remove unsigned executable entitlement

### DIFF
--- a/eng/pipelines/common/entitlements.plist
+++ b/eng/pipelines/common/entitlements.plist
@@ -4,8 +4,6 @@
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
       <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-      <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
       <true/>
     <key>com.apple.security.cs.disable-library-validation</key>


### PR DESCRIPTION
we should be able to now remove this particular entitlement: `allow-unsigned-executable-memory`. Fixes https://github.com/dotnet/runtime/issues/45677