### PR TITLE
Backport API docs for System.Buffers

### DIFF
--- a/src/libraries/System.Buffers/src/System.Buffers.csproj
+++ b/src/libraries/System.Buffers/src/System.Buffers.csproj
@@ -5,6 +5,7 @@
     <ExcludeResourcesImport>true</ExcludeResourcesImport>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Action.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Action.cs
@@ -35,7 +35,17 @@ namespace System
 
 namespace System.Buffers
 {
+    /// <summary>Encapsulates a method that receives a span of objects of type <typeparamref name="T" /> and a state object of type <typeparamref name="TArg" />.</summary>
+    /// <typeparam name="T">The type of the objects in the span.</typeparam>
+    /// <typeparam name="TArg">The type of the object that represents the state.</typeparam>
+    /// <param name="span">A span of objects of type <typeparamref name="T" />.</param>
+    /// <param name="arg">A state object of type <typeparamref name="TArg" />.</param>
     public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
+    /// <summary>Encapsulates a method that receives a read-only span of objects of type <typeparamref name="T" /> and a state object of type <typeparamref name="TArg" />.</summary>
+    /// <typeparam name="T">The type of the objects in the read-only span.</typeparam>
+    /// <typeparam name="TArg">The type of the object that represents the state.</typeparam>
+    /// <param name="span">A read-only span of objects of type <typeparamref name="T" />.</param>
+    /// <param name="arg">A state object of type <typeparamref name="TArg" />.</param>
     public delegate void ReadOnlySpanAction<T, in TArg>(ReadOnlySpan<T> span, TArg arg);
 
     internal delegate TResult SpanFunc<TSpan, in T1, in T2, in T3, out TResult>(Span<TSpan> span, T1 arg1, T2 arg2, T3 arg3);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
@@ -3,99 +3,43 @@
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// Provides a resource pool that enables reusing instances of arrays.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Renting and returning buffers with an <see cref="ArrayPool{T}"/> can increase performance
-    /// in situations where arrays are created and destroyed frequently, resulting in significant
-    /// memory pressure on the garbage collector.
-    /// </para>
-    /// <para>
-    /// This class is thread-safe.  All members may be used by multiple threads concurrently.
-    /// </para>
-    /// </remarks>
+    /// <summary>Provides a resource pool that enables reusing instances of type T[].</summary>
+    /// <typeparam name="T">The type of the objects that are in the resource pool.</typeparam>
+    /// <remarks>Using the <see cref="System.Buffers.ArrayPool{T}" /> class to rent and return buffers (using the <see cref="System.Buffers.ArrayPool{T}.Rent" /> and <see cref="System.Buffers.ArrayPool{T}.Return" /> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.</remarks>
     public abstract class ArrayPool<T>
     {
         // Store the shared ArrayPool in a field of its derived sealed type so the Jit can "see" the exact type
         // when the Shared property is inlined which will allow it to devirtualize calls made on it.
         private static readonly TlsOverPerCoreLockedStacksArrayPool<T> s_shared = new TlsOverPerCoreLockedStacksArrayPool<T>();
 
-        /// <summary>
-        /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// The shared pool provides a default implementation of <see cref="ArrayPool{T}"/>
-        /// that's intended for general applicability.  It maintains arrays of multiple sizes, and
-        /// may hand back a larger array than was actually requested, but will never hand back a smaller
-        /// array than was requested. Renting a buffer from it with <see cref="Rent"/> will result in an
-        /// existing buffer being taken from the pool if an appropriate buffer is available or in a new
-        /// buffer being allocated if one is not available.
-        /// byte[] and char[] are the most commonly pooled array types. For these we use a special pool type
-        /// optimized for very fast access speeds, at the expense of more memory consumption.
-        /// The shared pool instance is created lazily on first access.
-        /// </remarks>
+        /// <summary>Gets a shared <see cref="System.Buffers.ArrayPool{T}" /> instance.</summary>
+        /// <value>A shared <see cref="System.Buffers.ArrayPool{T}" /> instance.</value>
+        /// <remarks>The shared pool provides a default implementation of the <see cref="System.Buffers.ArrayPool{T}" /> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but it will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <see cref="System.Buffers.ArrayPool{T}.Rent" /> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.</remarks>
         public static ArrayPool<T> Shared => s_shared;
 
-        /// <summary>
-        /// Creates a new <see cref="ArrayPool{T}"/> instance using default configuration options.
-        /// </summary>
-        /// <returns>A new <see cref="ArrayPool{T}"/> instance.</returns>
+        /// <summary>Creates a new instance of the <see cref="System.Buffers.ArrayPool{T}" /> class.</summary>
+        /// <returns>A new instance of the <see cref="System.Buffers.ArrayPool{T}" /> class.</returns>
         public static ArrayPool<T> Create() => new ConfigurableArrayPool<T>();
 
-        /// <summary>
-        /// Creates a new <see cref="ArrayPool{T}"/> instance using custom configuration options.
-        /// </summary>
-        /// <param name="maxArrayLength">The maximum length of array instances that may be stored in the pool.</param>
-        /// <param name="maxArraysPerBucket">
-        /// The maximum number of array instances that may be stored in each bucket in the pool.  The pool
-        /// groups arrays of similar lengths into buckets for faster access.
-        /// </param>
-        /// <returns>A new <see cref="ArrayPool{T}"/> instance with the specified configuration options.</returns>
-        /// <remarks>
-        /// The created pool will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/>
-        /// in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
-        /// </remarks>
+        /// <summary>Creates a new instance of the <see cref="System.Buffers.ArrayPool{T}" /> class using the specified configuration.</summary>
+        /// <param name="maxArrayLength">The maximum length of an array instance that may be stored in the pool.</param>
+        /// <param name="maxArraysPerBucket">The maximum number of array instances that may be stored in each bucket in the pool. The pool groups arrays of similar lengths into buckets for faster access.</param>
+        /// <returns>A new instance of the <see cref="System.Buffers.ArrayPool{T}" /> class with the specified configuration.</returns>
+        /// <remarks>The instance of the <see cref="System.Buffers.ArrayPool{T}" /> class created by this method will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket" /> in each bucket, and with those arrays not exceeding <paramref name="maxArrayLength" /> in length.</remarks>
         public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket) =>
             new ConfigurableArrayPool<T>(maxArrayLength, maxArraysPerBucket);
 
-        /// <summary>
-        /// Retrieves a buffer that is at least the requested length.
-        /// </summary>
-        /// <param name="minimumLength">The minimum length of the array needed.</param>
-        /// <returns>
-        /// An array that is at least <paramref name="minimumLength"/> in length.
-        /// </returns>
-        /// <remarks>
-        /// This buffer is loaned to the caller and should be returned to the same pool via
-        /// <see cref="Return"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.
-        /// It is not a fatal error to not return a rented buffer, but failure to do so may lead to
-        /// decreased application performance, as the pool may need to create a new buffer to replace
-        /// the one lost.
-        /// </remarks>
+        /// <summary>Retrieves a buffer that is at least the requested length.</summary>
+        /// <param name="minimumLength">The minimum length of the array.</param>
+        /// <returns>An array of type T that is at least <paramref name="minimumLength" /> in length.</returns>
+        /// <remarks>This buffer is loaned to the caller and should be returned to the same pool using the <see cref="System.Buffers.ArrayPool{T}.Return" /> method, so that it can be reused in subsequent calls to the <see cref="System.Buffers.ArrayPool{T}.Rent" /> method. Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.
+        /// The array returned by this method may not be zero-initialized.</remarks>
         public abstract T[] Rent(int minimumLength);
 
-        /// <summary>
-        /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same
-        /// <see cref="ArrayPool{T}"/> instance.
-        /// </summary>
-        /// <param name="array">
-        /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
-        /// </param>
-        /// <param name="clearArray">
-        /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
-        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/>
-        /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
-        /// the array's contents are left unchanged.
-        /// </param>
-        /// <remarks>
-        /// Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer
-        /// and must not use it. The reference returned from a given call to <see cref="Rent"/> must only be
-        /// returned via <see cref="Return"/> once.  The default <see cref="ArrayPool{T}"/>
-        /// may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
-        /// if it's determined that the pool already has enough buffers stored.
-        /// </remarks>
+        /// <summary>Returns an array to the pool that was previously obtained using the <see cref="System.Buffers.ArrayPool{T}.Rent(int)" /> method on the same <see cref="System.Buffers.ArrayPool{T}" /> instance.</summary>
+        /// <param name="array">A buffer to return to the pool that was previously obtained using the <see cref="System.Buffers.ArrayPool{T}.Rent(int)" /> method.</param>
+        /// <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="clearArray" /> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="System.Buffers.ArrayPool{T}.Return(T[],bool)" /> method will clear the <paramref name="array" /> of its contents so that a subsequent caller using the <see cref="System.Buffers.ArrayPool{T}.Rent(int)" /> method will not see the content of the previous caller. If <paramref name="clearArray" /> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
+        /// <remarks>Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer and must not use it. The reference returned from a given call to the <see cref="System.Buffers.ArrayPool{T}.Rent" /> method must only be returned using the <see cref="System.Buffers.ArrayPool{T}.Return" /> method once. The default <see cref="System.Buffers.ArrayPool{T}" /> may hold onto the returned buffer in order to rent it again, or it may release the returned buffer if it's determined that the pool already has enough buffers stored.</remarks>
         public abstract void Return(T[] array, bool clearArray = false);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
@@ -3,7 +3,7 @@
 
 namespace System.Buffers
 {
-    /// <summary>Provides a resource pool that enables reusing instances of type T[].</summary>
+    /// <summary>Provides a resource pool that enables reusing array instances of <typeparamref name="T" />.</summary>
     /// <typeparam name="T">The type of the objects that are in the resource pool.</typeparam>
     /// <remarks>Using the <see cref="System.Buffers.ArrayPool{T}" /> class to rent and return buffers (using the <see cref="System.Buffers.ArrayPool{T}.Rent" /> and <see cref="System.Buffers.ArrayPool{T}.Return" /> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.</remarks>
     public abstract class ArrayPool<T>
@@ -31,7 +31,7 @@ namespace System.Buffers
 
         /// <summary>Retrieves a buffer that is at least the requested length.</summary>
         /// <param name="minimumLength">The minimum length of the array.</param>
-        /// <returns>An array of type T that is at least <paramref name="minimumLength" /> in length.</returns>
+        /// <returns>An array of type <typeparamref name="T" /> that is at least <paramref name="minimumLength" /> in length.</returns>
         /// <remarks>This buffer is loaned to the caller and should be returned to the same pool using the <see cref="System.Buffers.ArrayPool{T}.Return" /> method, so that it can be reused in subsequent calls to the <see cref="System.Buffers.ArrayPool{T}.Rent" /> method. Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.
         /// The array returned by this method may not be zero-initialized.</remarks>
         public abstract T[] Rent(int minimumLength);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/IMemoryOwner.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/IMemoryOwner.cs
@@ -8,10 +8,12 @@ namespace System.Buffers
     /// <typeparam name="T">The type of elements to store in memory.</typeparam>
     /// <remarks>The <see cref="IMemoryOwner{T}" /> interface is used to define the owner responsible for the lifetime management of a <see cref="System.Memory{T}" /> buffer. An instance of the <see cref="IMemoryOwner{T}" /> interface is returned by the <see cref="System.Buffers.MemoryPool{T}.Rent" /> method.
     /// While a buffer can have multiple consumers, it can only have a single owner at any given time. The owner can:
-    /// - Create the buffer either directly or by calling a factory method.
-    /// - Transfer ownership to another consumer. In this case, the previous owner should no longer use the buffer.
-    /// - Destroy the buffer when it is no longer in use.
-    /// Because the <see cref="IMemoryOwner{T}" /> object implements the <see cref="System.IDisposable" /> interface, you should call its <see cref="System.IDisposable.Dispose" /> method only after the memory buffer is no longer needed and you have destroyed it. You should *not* dispose of the <see cref="IMemoryOwner{T}" /> object while a reference to its memory is available. This means that the type in which <see cref="IMemoryOwner{T}" /> is declared should not have a <see cref="object.Finalize" /> method.</remarks>
+    /// <list type="bullet">
+    ///   <item>Create the buffer either directly or by calling a factory method.</item>
+    ///   <item>Transfer ownership to another consumer. In this case, the previous owner should no longer use the buffer.</item>
+    ///   <item>Destroy the buffer when it is no longer in use.</item>
+    /// </list>
+    /// Because the <see cref="IMemoryOwner{T}" /> object implements the <see cref="System.IDisposable" /> interface, you should call its <see cref="System.IDisposable.Dispose" /> method only after the memory buffer is no longer needed and you have destroyed it. You should not dispose of the <see cref="IMemoryOwner{T}" /> object while a reference to its memory is available. This means that the type in which <see cref="IMemoryOwner{T}" /> is declared should not have a <see cref="object.Finalize" /> method.</remarks>
     public interface IMemoryOwner<T> : IDisposable
 #pragma warning restore CS1574
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/IMemoryOwner.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/IMemoryOwner.cs
@@ -3,14 +3,20 @@
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// Owner of Memory<typeparamref name="T"/> that is responsible for disposing the underlying memory appropriately.
-    /// </summary>
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved (System.Buffers.MemoryPool{T}.Rent)
+    /// <summary>Identifies the owner of a block of memory who is responsible for disposing of the underlying memory appropriately.</summary>
+    /// <typeparam name="T">The type of elements to store in memory.</typeparam>
+    /// <remarks>The <see cref="IMemoryOwner{T}" /> interface is used to define the owner responsible for the lifetime management of a <see cref="System.Memory{T}" /> buffer. An instance of the <see cref="IMemoryOwner{T}" /> interface is returned by the <see cref="System.Buffers.MemoryPool{T}.Rent" /> method.
+    /// While a buffer can have multiple consumers, it can only have a single owner at any given time. The owner can:
+    /// - Create the buffer either directly or by calling a factory method.
+    /// - Transfer ownership to another consumer. In this case, the previous owner should no longer use the buffer.
+    /// - Destroy the buffer when it is no longer in use.
+    /// Because the <see cref="IMemoryOwner{T}" /> object implements the <see cref="System.IDisposable" /> interface, you should call its <see cref="System.IDisposable.Dispose" /> method only after the memory buffer is no longer needed and you have destroyed it. You should *not* dispose of the <see cref="IMemoryOwner{T}" /> object while a reference to its memory is available. This means that the type in which <see cref="IMemoryOwner{T}" /> is declared should not have a <see cref="object.Finalize" /> method.</remarks>
     public interface IMemoryOwner<T> : IDisposable
+#pragma warning restore CS1574
     {
-        /// <summary>
-        /// Returns a Memory<typeparamref name="T"/>.
-        /// </summary>
+        /// <summary>Gets the memory belonging to this owner.</summary>
+        /// <value>The memory belonging to this owner.</value>
         Memory<T> Memory { get; }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/IPinnable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/IPinnable.cs
@@ -3,22 +3,19 @@
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// Provides a mechanism for pinning and unpinning objects to prevent the GC from moving them.
-    /// </summary>
+    /// <summary>Provides a mechanism for pinning and unpinning objects to prevent the garbage collector from moving them.</summary>
+    /// <remarks>The <see cref="System.Buffers.MemoryManager{T}" /> class implements the <see cref="IPinnable" /> interface.</remarks>
     public interface IPinnable
     {
-        /// <summary>
-        /// Call this method to indicate that the IPinnable object can not be moved by the garbage collector.
-        /// The address of the pinned object can be taken.
-        /// <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="MemoryHandle"/> points to.</param>
-        /// </summary>
+        /// <summary>Pins a block of memory.</summary>
+        /// <param name="elementIndex">The offset to the element within the memory buffer to which the returned <see cref="System.Buffers.MemoryHandle" /> points.</param>
+        /// <returns>A handle to the block of memory.</returns>
+        /// <remarks>A developer can access an object that implements the <see cref="System.Buffers.IPinnable" /> interface without pinning it only through managed APIs. Pinning is required for access by unmanaged APIs.
+        /// Call this method to indicate that the <see cref="System.Buffers.IPinnable" /> object cannot be moved by the garbage collector so that the address of the pinned object can be used.</remarks>
         MemoryHandle Pin(int elementIndex);
 
-        /// <summary>
-        /// Call this method to indicate that the IPinnable object no longer needs to be pinned.
-        /// The garbage collector is free to move the object now.
-        /// </summary>
+        /// <summary>Frees a block of pinned memory.</summary>
+        /// <remarks>Call this method to indicate that the <see cref="System.Buffers.IPinnable" /> object no longer needs to be pinned, and that the garbage collector can now move the object.</remarks>
         void Unpin();
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryHandle.cs
@@ -7,10 +7,12 @@ namespace System.Buffers
 {
     /// <summary>Provides a memory handle for a block of memory.</summary>
     /// <remarks>A <see cref="MemoryHandle" /> instance represents a handle to a pinned block of memory. It is returned by the following methods:
-    /// - <see cref="System.Buffers.IPinnable.Pin" />.
-    /// - <see cref="System.Memory{T}.Pin" />
-    /// - <see cref="System.ReadOnlyMemory{T}.Pin" />.
-    /// - <see cref="System.Buffers.MemoryManager{T}.Pin" /></remarks>
+    /// <list type="bullet">
+    ///   <item><see cref="System.Buffers.IPinnable.Pin" /></item>
+    ///   <item><see cref="System.Memory{T}.Pin" /></item>
+    ///   <item><see cref="System.ReadOnlyMemory{T}.Pin" /></item>
+    ///   <item><see cref="System.Buffers.MemoryManager{T}.Pin" /></item>
+    /// </list></remarks>
     public unsafe struct MemoryHandle : IDisposable
     {
         private void* _pointer;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryHandle.cs
@@ -5,21 +5,22 @@ using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// A handle for the memory.
-    /// </summary>
+    /// <summary>Provides a memory handle for a block of memory.</summary>
+    /// <remarks>A <see cref="MemoryHandle" /> instance represents a handle to a pinned block of memory. It is returned by the following methods:
+    /// - <see cref="System.Buffers.IPinnable.Pin" />.
+    /// - <see cref="System.Memory{T}.Pin" />
+    /// - <see cref="System.ReadOnlyMemory{T}.Pin" />.
+    /// - <see cref="System.Buffers.MemoryManager{T}.Pin" /></remarks>
     public unsafe struct MemoryHandle : IDisposable
     {
         private void* _pointer;
         private GCHandle _handle;
         private IPinnable? _pinnable;
 
-        /// <summary>
-        /// Creates a new memory handle for the memory.
-        /// </summary>
-        /// <param name="pointer">pointer to memory</param>
-        /// <param name="pinnable">reference to manually managed object, or default if there is no memory manager</param>
-        /// <param name="handle">handle used to pin array buffers</param>
+        /// <summary>Creates a new memory handle for the block of memory.</summary>
+        /// <param name="pointer">A pointer to memory.</param>
+        /// <param name="handle">A handle used to pin array buffers.</param>
+        /// <param name="pinnable">A reference to a manually managed object, or <see langword="default" /> if there is no memory manager.</param>
         [CLSCompliant(false)]
         public MemoryHandle(void* pointer, GCHandle handle = default, IPinnable? pinnable = default)
         {
@@ -28,15 +29,13 @@ namespace System.Buffers
             _pinnable = pinnable;
         }
 
-        /// <summary>
-        /// Returns the pointer to memory, where the memory is assumed to be pinned and hence the address won't change.
-        /// </summary>
+        /// <summary>Returns a pointer to the memory block.</summary>
+        /// <value>A pointer to the memory block.</value>
+        /// <remarks>The memory is assumed to be pinned so that its address won't change.</remarks>
         [CLSCompliant(false)]
         public void* Pointer => _pointer;
 
-        /// <summary>
-        /// Frees the pinned handle and releases IPinnable.
-        /// </summary>
+        /// <summary>Frees the pinned handle and releases the <see cref="System.Buffers.IPinnable" /> instance.</summary>
         public void Dispose()
         {
             if (_handle.IsAllocated)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/MemoryManager.cs
@@ -5,69 +5,64 @@ using System.Runtime.CompilerServices;
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// Manager of <see cref="System.Memory{T}"/> that provides the implementation.
-    /// </summary>
+    /// <summary>An abstract base class that is used to replace the implementation of <see cref="System.Memory{T}" />.</summary>
+    /// <typeparam name="T">The type of items in the memory buffer managed by this memory manager.</typeparam>
+    /// <remarks>The <see cref="MemoryManager{T}" /> class is used to extend the knowledge of types that <see cref="System.Memory{T}" /> is able to represent. For example, you can derive from <see cref="MemoryManager{T}" /> to allow <see cref="System.Memory{T}" /> to be backed by a <see cref="System.Runtime.InteropServices.SafeHandle" />.
+    /// <format type="text/markdown"><![CDATA[
+    /// > [!NOTE]
+    /// > The `MemoryManager<T>` class is intended for advanced scenarios. Most developers do not need to use it.
+    /// ]]></format></remarks>
     public abstract class MemoryManager<T> : IMemoryOwner<T>, IPinnable
     {
-        /// <summary>
-        /// Returns a <see cref="System.Memory{T}"/>.
-        /// </summary>
+        /// <summary>Gets the memory block handled by this <see cref="System.Buffers.MemoryManager{T}" />.</summary>
+        /// <value>The memory block handled by this <see cref="System.Buffers.MemoryManager{T}" />.</value>
         public virtual Memory<T> Memory => new Memory<T>(this, GetSpan().Length);
 
-        /// <summary>
-        /// Returns a span wrapping the underlying memory.
-        /// </summary>
+        /// <summary>Returns a memory span that wraps the underlying memory buffer.</summary>
+        /// <returns>A memory span that wraps the underlying memory buffer.</returns>
         public abstract Span<T> GetSpan();
 
-        /// <summary>
-        /// Returns a handle to the memory that has been pinned and hence its address can be taken.
-        /// </summary>
-        /// <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="MemoryHandle"/> points to. (default = 0)</param>
+        /// <summary>Returns a handle to the memory that has been pinned and whose address can be taken.</summary>
+        /// <param name="elementIndex">The offset to the element in the memory buffer at which the returned <see cref="System.Buffers.MemoryHandle" /> points.</param>
+        /// <returns>A handle to the memory that has been pinned.</returns>
         public abstract MemoryHandle Pin(int elementIndex = 0);
 
-        /// <summary>
-        /// Lets the garbage collector know that the object is free to be moved now.
-        /// </summary>
+        /// <summary>Unpins pinned memory so that the garbage collector is free to move it.</summary>
         public abstract void Unpin();
 
-        /// <summary>
-        /// Returns a <see cref="System.Memory{T}"/> for the current <see cref="MemoryManager{T}"/>.
-        /// </summary>
-        /// <param name="length">The element count in the memory, starting at offset 0.</param>
+        /// <summary>Returns a memory buffer consisting of a specified number of elements from the memory managed by the current memory manager.</summary>
+        /// <param name="length">The number of elements in the memory buffer, starting at offset 0.</param>
+        /// <returns>A memory buffer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Memory<T> CreateMemory(int length) => new Memory<T>(this, length);
 
-        /// <summary>
-        /// Returns a <see cref="System.Memory{T}"/> for the current <see cref="MemoryManager{T}"/>.
-        /// </summary>
-        /// <param name="start">The offset to the element which the returned memory starts at.</param>
-        /// <param name="length">The element count in the memory, starting at element offset <paramref name="start"/>.</param>
+        /// <summary>Returns a memory buffer consisting of a specified number of elements starting at a specified offset from the memory managed by the current memory manager.</summary>
+        /// <param name="start">The offset to the element at which the returned memory buffer starts.</param>
+        /// <param name="length">The number of elements to include in the returned memory buffer.</param>
+        /// <returns>A memory buffer that consists of <paramref name="length" /> elements starting at offset <paramref name="start" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Memory<T> CreateMemory(int start, int length) => new Memory<T>(this, start, length);
 
-        /// <summary>
-        /// Returns an array segment.
-        /// <remarks>Returns the default array segment if not overriden.</remarks>
-        /// </summary>
+        /// <summary>Returns an array segment.</summary>
+        /// <param name="segment">The array segment to write to.</param>
+        /// <returns><see langword="true" /> if the method succeeded in retrieving the array segment; otherwise, <see langword="false" />.</returns>
+        /// <remarks>If this method is not overridden, it returns the default array segment.</remarks>
         protected internal virtual bool TryGetArray(out ArraySegment<T> segment)
         {
             segment = default;
             return false;
         }
 
-        /// <summary>
-        /// Implements IDisposable.
-        /// </summary>
+        /// <summary>Releases all resources used by the memory manager.</summary>
+        /// <remarks>This method provides the memory manager's <see cref="System.IDisposable.Dispose" /> implementation.</remarks>
         void IDisposable.Dispose()
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Clean up of any leftover managed and unmanaged resources.
-        /// </summary>
+        /// <summary>Releases all resources used by the current memory manager.</summary>
+        /// <param name="disposing"><see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
         protected abstract void Dispose(bool disposing);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/OperationStatus.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/OperationStatus.cs
@@ -3,31 +3,16 @@
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// This enum defines the various potential status that can be returned from Span-based operations
-    /// that support processing of input contained in multiple discontiguous buffers.
-    /// </summary>
+    /// <summary>Defines the values that can be returned from span-based operations that support processing of input contained in multiple discontiguous buffers.</summary>
     public enum OperationStatus
     {
-        /// <summary>
-        /// The entire input buffer has been processed and the operation is complete.
-        /// </summary>
+        /// <summary>The entire input buffer has been processed and the operation is complete.</summary>
         Done,
-        /// <summary>
-        /// The input is partially processed, up to what could fit into the destination buffer.
-        /// The caller can enlarge the destination buffer, slice the buffers appropriately, and retry.
-        /// </summary>
+        /// <summary>The input is partially processed, up to what could fit into the destination buffer. The caller can enlarge the destination buffer, slice the buffers appropriately, and retry.</summary>
         DestinationTooSmall,
-        /// <summary>
-        /// The input is partially processed, up to the last valid chunk of the input that could be consumed.
-        /// The caller can stitch the remaining unprocessed input with more data, slice the buffers appropriately, and retry.
-        /// </summary>
+        /// <summary>The input is partially processed, up to the last valid chunk of the input that could be consumed. The caller can stitch the remaining unprocessed input with more data, slice the buffers appropriately, and retry.</summary>
         NeedMoreData,
-        /// <summary>
-        /// The input contained invalid bytes which could not be processed. If the input is partially processed,
-        /// the destination contains the partial result. This guarantees that no additional data appended to the input
-        /// will make the invalid sequence valid.
-        /// </summary>
+        /// <summary>The input contained invalid bytes which could not be processed. If the input is partially processed, the destination contains the partial result. This guarantees that no additional data appended to the input will make the invalid sequence valid.</summary>
         InvalidData,
     }
 }


### PR DESCRIPTION
Fixes #48967, backporting the API docs for `System.Buffers`. This port utilizes changes to the DocsPortingTool from a couple of open PRs so that generic APIs are handled properly.

* https://github.com/carlossanlop/DocsPortingTool/pull/72
* https://github.com/eiriktsarpalis/DocsPortingTool/pull/1