### PR TITLE
Improve backport command

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,11 +8,39 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to')
     runs-on: ubuntu-20.04
     steps:
+    - name: Extract backport target branch
+      uses: actions/github-script@v3
+      id: target-branch-extractor
+      with:
+        result-encoding: string
+        script: |
+          if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
+
+          // extract the target branch name from the trigger phrase containing these characters: a-z, A-Z, digits, forward slash, dot, hyphen, underscore
+          const regex = /\/backport to ([a-zA-Z\d\/\.\-\_]+)/;
+          target_branch = regex.exec(context.payload.comment.body);
+          if (target_branch == null) throw "Error: No backport branch found in the trigger phrase.";
+
+          return target_branch[1];
+    - name: Post backport started comment to pull request
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const backport_start_body = `Started backporting to ${{ steps.target-branch-extractor.outputs.result }}: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          await github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: backport_start_body
+          });
     - name: Checkout repo
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Run backport
       uses: ./eng/actions/backport
       with:
+        target_branch: ${{ steps.target-branch-extractor.outputs.result }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
         pr_description_template: |
           Backport of #%source_pr_number% to %target_branch%

--- a/eng/actions/backport/action.yml
+++ b/eng/actions/backport/action.yml
@@ -1,6 +1,8 @@
 name: 'PR Backporter'
 description: 'Backports a pull request to a branch using the "/backport to <branch>" comment'
 inputs:
+  target_branch:
+    description: 'Backport target branch.'
   auth_token:
     description: 'The token used to authenticate to GitHub.'
   pr_title_template:


### PR DESCRIPTION
GitHub Actions started doing shallow checkouts so we often ran into the case where applying the patch would fail with an error due to the commit blobs not being available:

```
error: sha1 information is lacking or useless (eng/pipelines/common/xplat-setup.yml).
error: could not build fake ancestor
```

Fix this by always checking out the whole history. Since this makes checkout quite slow (~2mins), refactor the action so we post the "Started backporting" comment before doing the checkout so the user isn't confused why nothing happens.

/cc @safern this should fix the backport error you hit in https://github.com/dotnet/runtime/pull/51279#issuecomment-820095297