### PR TITLE
Increase SslStream FrameOverhead estimation for newer TLS protocols

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -37,7 +37,9 @@ namespace System.Net.Security
         private object _handshakeLock => _sslAuthenticationOptions!;
         private volatile TaskCompletionSource<bool>? _handshakeWaiter;
 
-        private const int FrameOverhead = 32;
+        // FrameOverhead = 5 byte header + HMAC trailer + padding (if block cipher)
+        // HMAC: 32 bytes for SHA-256 or 20 bytes for SHA-1 or 16 bytes for the MD5
+        private const int FrameOverhead = 64;
         private const int ReadBufferSize = 4096 * 4 + FrameOverhead;         // We read in 16K chunks + headers.
         private const int InitialHandshakeBufferSize = 4096 + FrameOverhead; // try to fit at least 4K ServerCertificate
         private ArrayBuffer _handshakeBuffer;


### PR DESCRIPTION
From https://github.com/dotnet/runtime/pull/51060#issuecomment-820562242


Before

![image](https://user-images.githubusercontent.com/1142958/114289996-0b377600-9a74-11eb-9831-408e7632ca35.png)

After

![image](https://user-images.githubusercontent.com/1142958/114290010-1e4a4600-9a74-11eb-9c3e-2b62905adb57.png)


Resolves #51076