### PR TITLE
Reduce unnecessary casting in SslStreamPal

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -54,16 +54,16 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificateContext, protocols, policy);
         }
 
-        internal static byte[]? GetNegotiatedApplicationProtocol(SafeDeleteContext? context)
+        internal static byte[]? GetNegotiatedApplicationProtocol(SafeDeleteSslContext? context)
         {
             if (context == null)
                 return null;
 
-            return Interop.AndroidCrypto.SSLStreamGetApplicationProtocol(((SafeDeleteSslContext)context).SslContext);
+            return Interop.AndroidCrypto.SSLStreamGetApplicationProtocol(context.SslContext);
         }
 
         public static SecurityStatusPal EncryptMessage(
-            SafeDeleteContext securityContext,
+            SafeDeleteSslContext securityContext,
             ReadOnlyMemory<byte> input,
             int headerSize,
             int trailerSize,
@@ -75,8 +75,7 @@ namespace System.Net.Security
 
             try
             {
-                SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
-                SafeSslHandle sslHandle = sslContext.SslContext;
+                SafeSslHandle sslHandle = securityContext.SslContext;
 
                 PAL_SSLStreamStatus ret = Interop.AndroidCrypto.SSLStreamWrite(sslHandle, input);
                 SecurityStatusPalErrorCode statusCode = ret switch
@@ -88,13 +87,13 @@ namespace System.Net.Security
                     _ => SecurityStatusPalErrorCode.InternalError
                 };
 
-                if (sslContext.BytesReadyForConnection <= output?.Length)
+                if (securityContext.BytesReadyForConnection <= output?.Length)
                 {
-                    resultSize = sslContext.ReadPendingWrites(output, 0, output.Length);
+                    resultSize = securityContext.ReadPendingWrites(output, 0, output.Length);
                 }
                 else
                 {
-                    output = sslContext.ReadPendingWrites()!;
+                    output = securityContext.ReadPendingWrites()!;
                     resultSize = output.Length;
                 }
 
@@ -107,17 +106,16 @@ namespace System.Net.Security
         }
 
         public static SecurityStatusPal DecryptMessage(
-            SafeDeleteContext securityContext,
+            SafeDeleteSslContext securityContext,
             byte[] buffer,
             ref int offset,
             ref int count)
         {
             try
             {
-                SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
-                SafeSslHandle sslHandle = sslContext.SslContext;
+                SafeSslHandle sslHandle = securityContext.SslContext;
 
-                sslContext.Write(buffer.AsSpan(offset, count));
+                securityContext.Write(buffer.AsSpan(offset, count));
 
                 PAL_SSLStreamStatus ret = Interop.AndroidCrypto.SSLStreamRead(sslHandle, buffer.AsSpan(offset, count), out int read);
                 if (ret == PAL_SSLStreamStatus.Error)
@@ -162,10 +160,10 @@ namespace System.Net.Security
         }
 
         public static void QueryContextConnectionInfo(
-            SafeDeleteContext securityContext,
+            SafeDeleteSslContext securityContext,
             out SslConnectionInfo connectionInfo)
         {
-            connectionInfo = new SslConnectionInfo(((SafeDeleteSslContext)securityContext).SslContext);
+            connectionInfo = new SslConnectionInfo(securityContext.SslContext);
         }
 
         private static SecurityStatusPal HandshakeInternal(
@@ -225,10 +223,9 @@ namespace System.Net.Security
 
         public static SecurityStatusPal ApplyShutdownToken(
             ref SafeFreeCredentials? credentialsHandle,
-            SafeDeleteContext securityContext)
+            SafeDeleteSslContext securityContext)
         {
-            SafeDeleteSslContext sslContext = ((SafeDeleteSslContext)securityContext);
-            SafeSslHandle sslHandle = sslContext.SslContext;
+            SafeSslHandle sslHandle = securityContext.SslContext;
 
 
             bool success = Interop.AndroidCrypto.SSLStreamShutdown(sslHandle);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -42,12 +42,12 @@ namespace System.Net.Security
             return new SafeFreeSslCredentials(certificateContext?.Certificate, protocols, policy);
         }
 
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
+        public static SecurityStatusPal EncryptMessage(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
             return EncryptDecryptHelper(securityContext, input, offset: 0, size: 0, encrypt: true, output: ref output, resultSize: out resultSize);
         }
 
-        public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)
+        public static SecurityStatusPal DecryptMessage(SafeDeleteSslContext securityContext, byte[] buffer, ref int offset, ref int count)
         {
             SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, false, ref buffer, out int resultSize);
             if (retVal.ErrorCode == SecurityStatusPalErrorCode.OK ||
@@ -58,7 +58,7 @@ namespace System.Net.Security
             return retVal;
         }
 
-        public static ChannelBinding? QueryContextChannelBinding(SafeDeleteContext securityContext, ChannelBindingKind attribute)
+        public static ChannelBinding? QueryContextChannelBinding(SafeDeleteSslContext securityContext, ChannelBindingKind attribute)
         {
             ChannelBinding? bindingHandle;
 
@@ -74,7 +74,7 @@ namespace System.Net.Security
             else
             {
                 bindingHandle = Interop.OpenSsl.QueryChannelBinding(
-                    ((SafeDeleteSslContext)securityContext).SslContext,
+                    securityContext.SslContext,
                     attribute);
             }
 
@@ -86,9 +86,9 @@ namespace System.Net.Security
             streamSizes = StreamSizes.Default;
         }
 
-        public static void QueryContextConnectionInfo(SafeDeleteContext securityContext, out SslConnectionInfo connectionInfo)
+        public static void QueryContextConnectionInfo(SafeDeleteSslContext securityContext, out SslConnectionInfo connectionInfo)
         {
-            connectionInfo = new SslConnectionInfo(((SafeDeleteSslContext)securityContext).SslContext);
+            connectionInfo = new SslConnectionInfo(securityContext.SslContext);
         }
 
         public static byte[] ConvertAlpnProtocolListToByteArray(List<SslApplicationProtocol> applicationProtocols)
@@ -111,13 +111,13 @@ namespace System.Net.Security
                     context = new SafeDeleteSslContext((credential as SafeFreeSslCredentials)!, sslAuthenticationOptions);
                 }
 
-                bool done = Interop.OpenSsl.DoSslHandshake(((SafeDeleteSslContext)context).SslContext, inputBuffer, out output, out outputSize);
+                bool done = Interop.OpenSsl.DoSslHandshake(context.SslContext, inputBuffer, out output, out outputSize);
 
                 // When the handshake is done, and the context is server, check if the alpnHandle target was set to null during ALPN.
                 // If it was, then that indicates ALPN failed, send failure.
                 // We have this workaround, as openssl supports terminating handshake only from version 1.1.0,
                 // whereas ALPN is supported from version 1.0.2.
-                SafeSslHandle sslContext = ((SafeDeleteSslContext)context).SslContext;
+                SafeSslHandle sslContext = context.SslContext;
                 if (done && sslAuthenticationOptions.IsServer && sslAuthenticationOptions.ApplicationProtocols != null && sslContext.AlpnHandle.IsAllocated && sslContext.AlpnHandle.Target == null)
                 {
                     return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, Interop.OpenSsl.CreateSslException(SR.net_alpn_failed));
@@ -142,21 +142,21 @@ namespace System.Net.Security
             }
         }
 
-        internal static byte[]? GetNegotiatedApplicationProtocol(SafeDeleteContext? context)
+        internal static byte[]? GetNegotiatedApplicationProtocol(SafeDeleteSslContext? context)
         {
             if (context == null)
                 return null;
 
-            return Interop.Ssl.SslGetAlpnSelected(((SafeDeleteSslContext)context).SslContext);
+            return Interop.Ssl.SslGetAlpnSelected(context.SslContext);
         }
 
-        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, ReadOnlyMemory<byte> input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
+        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteSslContext securityContext, ReadOnlyMemory<byte> input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
         {
             resultSize = 0;
             try
             {
                 Interop.Ssl.SslErrorCode errorCode = Interop.Ssl.SslErrorCode.SSL_ERROR_NONE;
-                SafeSslHandle scHandle = ((SafeDeleteSslContext)securityContext).SslContext;
+                SafeSslHandle scHandle = securityContext.SslContext;
 
                 if (encrypt)
                 {
@@ -194,10 +194,8 @@ namespace System.Net.Security
             return new SecurityStatusPal(SecurityStatusPalErrorCode.OK);
         }
 
-        public static SecurityStatusPal ApplyShutdownToken(ref SafeFreeCredentials? credentialsHandle, SafeDeleteContext securityContext)
+        public static SecurityStatusPal ApplyShutdownToken(ref SafeFreeCredentials? credentialsHandle, SafeDeleteSslContext sslContext)
         {
-            SafeDeleteSslContext sslContext = ((SafeDeleteSslContext)securityContext);
-
             // Unset the quiet shutdown option initially configured.
             Interop.Ssl.SslSetQuietShutdown(sslContext.SslContext, 0);
 


### PR DESCRIPTION
Can pass a more strongly typed sealed derived type in.