### PR TITLE
Some small follow up to #50450

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14490,7 +14490,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         if (tree->gtOverflow() &&
                             ((op1->TypeIs(TYP_DOUBLE) && CheckedOps::CastFromDoubleOverflows(d1, tree->CastToType())) ||
                              (op1->TypeIs(TYP_FLOAT) &&
-                              CheckedOps::CastFromDoubleOverflows(forceCastToFloat(d1), tree->CastToType()))))
+                              CheckedOps::CastFromFloatOverflows(forceCastToFloat(d1), tree->CastToType()))))
                         {
                             return tree;
                         }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1042,7 +1042,7 @@
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/value_numbering_checked_casts_of_constants/*">
-            <Issue>Test not yet merged, issue will be created if the PR is to be approved</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/51323</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
             <Issue>Mono does not define out of range fp to int conversions</Issue>


### PR DESCRIPTION
- Added a link to the issue to `issues.targets`
- Switched to using `CastFromFloatOverflows` instead of `CastFromDoubleOverflows` in `gtFoldExprConst`. I have apparently missed this one in #50450 (they should be functionally equivalent, but the former doesn't require one to think about why is that the case).