### PR TITLE
JIT: fix BasicBlock::isEmpty()

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -913,16 +913,27 @@ unsigned JitPtrKeyFuncs<BasicBlock>::GetHashCode(const BasicBlock* ptr)
     return ptr->bbNum;
 }
 
+//------------------------------------------------------------------------
+// isEmpty: check if block is empty or contains only ignorable statements
+//
+// Return Value:
+//    True if block is empty, or contains only PHI assignments,
+//    or contains zero or more PHI assignments followed by NOPs.
+//
 bool BasicBlock::isEmpty()
 {
     if (!IsLIR())
     {
-        for (Statement* stmt : Statements())
+        Statement* stmt = FirstNonPhiDef();
+
+        while (stmt != nullptr)
         {
-            if (!stmt->GetRootNode()->OperIs(GT_PHI, GT_NOP))
+            if (!stmt->GetRootNode()->OperIs(GT_NOP))
             {
                 return false;
             }
+
+            stmt = stmt->GetNextStmt();
         }
     }
     else


### PR DESCRIPTION
The detection of blocks with only PHI assignments was broken by #50806.
Fix by using existing helper to find the first non-PHI assignment.

Closes #51326.