### PR TITLE
[Release/5.0] - Update Alpine ARM docker image

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -110,7 +110,7 @@ jobs:
       archType: arm
       platform: Linux_musl_arm
       container:
-        image: ubuntu-18.04-cross-arm-alpine-20200818211451-14441ae
+        image: ubuntu-16.04-cross-arm-alpine-20210409142327-044d5b9
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -51,9 +51,9 @@ jobs:
     # Temporarily disabled until packages for musl-arm32 is available
     #- ${{ if eq(parameters.platform, 'Linux_musl_arm') }}:
     #  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    #    - (Alpine.312.Arm32.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-arm32v7-20200908125213-5bece88
+    #    - (Alpine.313.Arm32.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-helix-arm32v7-20210414141857-1ea6b0a
     #  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    #    - (Alpine.312.Arm32)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-arm32v7-20200908125213-5bece88
+    #    - (Alpine.313.Arm32)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-helix-arm32v7-20210414141857-1ea6b0a
 
     # Linux musl arm64
     - ${{ if eq(parameters.platform, 'Linux_musl_arm64') }}:


### PR DESCRIPTION
Port #51099 to Release/5.0

The Alpine ARM docker image is used for cross compilation. There was a
breaking change in Alpine 3.13 - it uses a new MUSL that has 64 bit
time_t even on 32 bit platforms. Since the official support for Alpine
ARM was not announced yet, it was decided that we will support it only
on Alpine >= 3.13 instead of having to build and distribute two
different
versions of runtime.

This change updates the docker image used to build Alpine ARM runtime to
a new version that uses Alpine 3.13 rootfs. It is also using Ubuntu
16.04 instead of 18.04 as a host to unify it with the one we use to
build for Alpine ARM64.

## Customer Impact
This change is needed to switch cross compilation of Alpine ARM runtime to target Alpine 3.13 that will be our minimal supported version for ARM. 

## Testing
CoreCLR and libraries tests

## Risk
Low, we have not announced support of Alpine ARM yet and this change only touches infra to enable proper build / CI testing.

## Regression
No