### PR TITLE
Get the Current Crossgen2 Version in R2RDump logs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CompilerIdentifierNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CompilerIdentifierNode.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Text;
 using Internal.Text;
 using Internal.TypeSystem;
@@ -9,8 +10,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     internal class CompilerIdentifierNode : HeaderTableNode
     {
-        private static readonly string _compilerIdentifier = "CoreRT Ready-To-Run Compiler";
-
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
 
         public override int ClassCode => 230053202;
@@ -25,12 +24,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append("__ReadyToRunHeader_CompilerIdentifier");
         }
 
+        private string GetCompilerVersion()
+        {
+            return Assembly
+                   .GetExecutingAssembly()
+                   .GetCustomAttribute<AssemblyFileVersionAttribute>()
+                   .Version;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            string compilerIdentifier = $"Crossgen2 {GetCompilerVersion()}";
             builder.RequireInitialPointerAlignment();
             builder.AddSymbol(this);
-            builder.EmitBytes(Encoding.ASCII.GetBytes(_compilerIdentifier));
+            builder.EmitBytes(Encoding.ASCII.GetBytes(compilerIdentifier));
             return builder.ToObjectData();
         }
     }


### PR DESCRIPTION
This PR fixes issue #49231. When using *R2RDump*, the Compiler Identifier was shown as **CoreRT Ready-To-Run Compile**. This is no longer accurate since the current message should display the current version of Crossgen2. This PR removes this preset value and retrieves the current assembly version programmatically using the `Reflection` library, which in turn makes this component self-maintaining as well.

Here is a brief example of how it looks now:

```
Filename: C:\Git\runtime\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\framework-r2r.dll
OS: Windows
Machine: Amd64
ImageBase: 0x180000000

======================== R2R Header =========================

Signature: 0x00525452 (RTR)
RelativeVirtualAddress: 0x00001048
Size: 148 bytes
MajorVersion: 0x0005
MinorVersion: 0x0003
Flags: 0x00000008
  - READYTORUN_FLAG_NonSharedPInvokeStubs


======================= R2R Sections ========================

11 sections

_______________________________________________

Type:  CompilerIdentifier (100)
RelativeVirtualAddress: 0x00E6FFA0
Size: 24 bytes
Crossgen2 42.42.42.4242   // This used to say CoreRT Ready-To-Run Compile

_______________________________________________
```

We see that in this example, it's showing the Douglas Adams number as the version. This is expected in local tests but official builds should show the appropriate version number.
