### PR TITLE
New pgo data

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,14 +117,14 @@
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>6.0.0-beta.21212.1</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>6.0.0-beta.21212.1</SystemWindowsExtensionsTestDataVersion>
     <!-- dotnet-optimization dependencies -->
-    <optimizationwindows_ntx64MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationwindows_ntx64MIBCRuntimeVersion>
-    <optimizationwindows_ntx86MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationwindows_ntx86MIBCRuntimeVersion>
-    <optimizationlinuxx64MIBCRuntimeVersion>99.99.99-master-20210317.2</optimizationlinuxx64MIBCRuntimeVersion>
+    <optimizationwindows_ntx64MIBCRuntimeVersion>99.99.99-master-20210415.12</optimizationwindows_ntx64MIBCRuntimeVersion>
+    <optimizationwindows_ntx86MIBCRuntimeVersion>99.99.99-master-20210415.12</optimizationwindows_ntx86MIBCRuntimeVersion>
+    <optimizationlinuxx64MIBCRuntimeVersion>99.99.99-master-20210415.12</optimizationlinuxx64MIBCRuntimeVersion>
     <optimizationwindows_ntx64IBCCoreFxVersion>99.99.99-master-20200806.6</optimizationwindows_ntx64IBCCoreFxVersion>
     <optimizationlinuxx64IBCCoreFxVersion>99.99.99-master-20200806.6</optimizationlinuxx64IBCCoreFxVersion>
     <optimizationwindows_ntx64IBCCoreCLRVersion>99.99.99-master-20200806.6</optimizationwindows_ntx64IBCCoreCLRVersion>
     <optimizationlinuxx64IBCCoreCLRVersion>99.99.99-master-20200806.6</optimizationlinuxx64IBCCoreCLRVersion>
-    <optimizationPGOCoreCLRVersion>99.99.99-master-20200806.6</optimizationPGOCoreCLRVersion>
+    <optimizationPGOCoreCLRVersion>99.99.99-master-20210415.12</optimizationPGOCoreCLRVersion>
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderNativeVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativeVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20253.1</SystemCommandLineVersion>

--- a/src/coreclr/.nuget/optdata/optdata.csproj
+++ b/src/coreclr/.nuget/optdata/optdata.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <OptimizationDataSupported Condition="'$(TargetOS)' == 'windows' And ('$(TargetArchitecture)' == 'x64' Or '$(TargetArchitecture)' == 'x86')">True</OptimizationDataSupported>
-    <OptimizationDataSupported Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">True</OptimizationDataSupported>
+    <OptimizationDataSupported Condition="'$(TargetOS)' == 'windows' And '$(TargetArchitecture)' == 'x64'">True</OptimizationDataSupported>
     <RuntimeIdentifiers>win7-x64;win7-x86;linux-x64</RuntimeIdentifiers>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <_TargetOSArchLowercase>$(TargetOS.ToLower())-$(TargetArchitecture.ToLower())</_TargetOSArchLowercase>

--- a/src/coreclr/.nuget/optdata/optdata.csproj
+++ b/src/coreclr/.nuget/optdata/optdata.csproj
@@ -3,7 +3,13 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <OptimizationDataSupported Condition="'$(TargetOS)' == 'windows' And '$(TargetArchitecture)' == 'x64'">True</OptimizationDataSupported>
+
+    <OptimizationDataSupported Condition="'$(TargetOS)' == 'windows' And ('$(TargetArchitecture)' == 'x64' Or '$(TargetArchitecture)' == 'x86')">True</OptimizationDataSupported>
+    <OptimizationDataSupported Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">True</OptimizationDataSupported>
+
+    <!-- At the moment, we are only generating data for Windows X64 in the most recent optimization data publishing platform. Use the old data for now -->
+    <oldOptimizationPGOCoreCLRVersion>99.99.99-master-20200806.6</oldOptimizationPGOCoreCLRVersion>
+    <optimizationPGOCoreCLRVersion Condition="'$(TargetOS)' != 'windows' or '$(TargetArchitecture)' != 'x64'">$(oldOptimizationPGOCoreCLRVersion)</optimizationPGOCoreCLRVersion>
     <RuntimeIdentifiers>win7-x64;win7-x86;linux-x64</RuntimeIdentifiers>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <_TargetOSArchLowercase>$(TargetOS.ToLower())-$(TargetArchitecture.ToLower())</_TargetOSArchLowercase>
@@ -11,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="optimization.PGO.CoreCLR"
+    <PackageReference Include="optimization.$(_TargetOSArchLowercase).PGO.CoreCLR"
       Version="$(optimizationPGOCoreCLRVersion)"
       Condition="'$(optimizationPGOCoreCLRVersion)'!='' And '$(OptimizationDataSupported)'!=''"
       GeneratePathProperty="true" />
@@ -33,10 +39,25 @@
     <Error Condition="'$(PgoDataPackagePathOutputFile)'==''" Text="PgoDataPackagePathOutputFile must be passed as a property." />
 
     <PropertyGroup>
-      <PgoPackagePath>$([MSBuild]::NormalizePath($(Pkgoptimization_PGO_CoreCLR),../../,optimization.$(_TargetOSArchLowercase).pgo.coreclr,$(optimizationPGOCoreCLRVersion)))</PgoPackagePath>
+      <PgoPackagePathProperty>Pkgoptimization_$(_TargetOSArchLowercase)_PGO_CoreCLR</PgoPackagePathProperty>
     </PropertyGroup>
 
-    <Error Condition="!Exists('$(PgoPackagePath)') And '$(OptimizationDataSupported)' == 'True'" Text="Unable to locate restored PGO package. Maybe the platform-specific package naming changed?" />
+    <!--
+      Use an item group for expansion of $($(PgoPackagePathProperty)) (an illegal MSBuild expression)
+      i.e. the prop value's value.
+    -->
+    <ItemGroup>
+      <PgoPackagePathPropertyItemList Include="$(PgoPackagePathProperty)" />
+      <PgoPackagePathPropertyItemList>
+        <PgoPackagePath>$(%(Identity))</PgoPackagePath>
+      </PgoPackagePathPropertyItemList>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PgoPackagePath>@(PgoPackagePathPropertyItemList->'%(PgoPackagePath)')</PgoPackagePath>
+    </PropertyGroup>
+
+    <Error Condition="!Exists('$(PgoPackagePath)') And '$(OptimizationDataSupported)' == 'True'" Text="Unable to locate restored PGO package at $(PgoPackagePath). Maybe the platform-specific package naming changed?" />
 
     <!-- Cleanup old version file -->
 


### PR DESCRIPTION
Enable new native pgo data for Windows X64 and update mibc data for all platforms.
- Leave existing pgo data in place for Linux X64 and Windows X86 as the pipeline for those is not yet in place
