### PR TITLE
FileStream rewrite: Caching the ValueTaskSource in AsyncWindowsFileStreamStrategy

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -119,10 +119,6 @@ namespace System.IO.Strategies
                     _strategy._fileHandle.ThreadPoolBinding!.FreeNativeOverlapped(_overlapped);
                     _overlapped = null;
                 }
-
-                // Ensure we're no longer set as the current ValueTaskSource (we may not have been to begin with).
-                // Only one operation at a time is eligible to use the preallocated overlapped
-                _strategy.TryToReuse(this);
             }
 
             private static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
@@ -193,6 +189,9 @@ namespace System.IO.Strategies
                     Debug.Assert(result == TaskSourceCodes.ResultSuccess, "Unknown result");
                     _source.SetResult((int)(packedResult & uint.MaxValue));
                 }
+
+                // The instance is ready to be reused
+                _strategy.TryToReuse(this);
             }
 
             private void Cancel(CancellationToken token)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -109,11 +109,6 @@ namespace System.IO.Strategies
 
             private static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
             {
-                // Extract the ValueTaskSource from the overlapped.  The state in the overlapped
-                // will either be a AsyncWindowsFileStreamStrategy (in the case where the preallocated overlapped was used),
-                // in which case the operation being completed is its _currentOverlappedOwner, or it'll
-                // be directly the ValueTaskSource that's completing (in the case where the preallocated
-                // overlapped was already in use by another operation).
                 ValueTaskSource valueTaskSource = (ValueTaskSource)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped)!;
                 Debug.Assert(valueTaskSource._overlapped == pOverlapped, "Overlaps don't match");
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -15,7 +15,7 @@ namespace System.IO.Strategies
         /// <summary>
         /// Type that helps reduce allocations for FileStream.ReadAsync and FileStream.WriteAsync.
         /// </summary>
-        private unsafe class ValueTaskSource : IValueTaskSource<int>, IValueTaskSource
+        private sealed unsafe class ValueTaskSource : IValueTaskSource<int>, IValueTaskSource
         {
             internal static readonly IOCompletionCallback s_ioCallback = IOCallback;
             private MemoryHandle _handle;
@@ -133,9 +133,7 @@ namespace System.IO.Strategies
                 // in which case the operation being completed is its _currentOverlappedOwner, or it'll
                 // be directly the ValueTaskSource that's completing (in the case where the preallocated
                 // overlapped was already in use by another operation).
-                object? state = ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
-                Debug.Assert(state is ValueTaskSource);
-                ValueTaskSource valueTaskSource = (ValueTaskSource)state;
+                ValueTaskSource valueTaskSource = (ValueTaskSource)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
                 Debug.Assert(valueTaskSource != null);
                 Debug.Assert(valueTaskSource._overlapped == pOverlapped, "Overlaps don't match");
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -33,13 +33,15 @@ namespace System.IO.Strategies
             {
                 _strategy = strategy;
                 _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, null);
+
+                _source = default;
+                _source.RunContinuationsAsynchronously = true;
             }
 
             internal NativeOverlapped* Configure(ReadOnlyMemory<byte> memory)
             {
                 _result = TaskSourceCodes.NoResult;
-                _source = default;
-                _source.RunContinuationsAsynchronously = true;
+                _source.Reset();
 
                 _handle = memory.Pin();
                 _overlapped = _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(_preallocatedOverlapped);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -61,6 +61,7 @@ namespace System.IO.Strategies
                 else
                 {
                     _handle = memory.Pin();
+                    Debug.Assert(_handle.Pointer != default);
                     _overlapped = _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(s_ioCallback, this, null);
                 }
 
@@ -111,7 +112,10 @@ namespace System.IO.Strategies
 
             internal void ReleaseNativeResource()
             {
-                _handle.Dispose();
+                if (_handle.Pointer != default)
+                {
+                    _handle.Dispose();
+                }
 
                 // Ensure that cancellation has been completed and cleaned up.
                 _cancellationRegistration.Dispose();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -20,7 +20,7 @@ namespace System.IO.Strategies
             internal static readonly IOCompletionCallback s_ioCallback = IOCallback;
             private MemoryHandle _handle;
             private readonly AsyncWindowsFileStreamStrategy _strategy;
-            internal PreAllocatedOverlapped? _preallocatedOverlapped;
+            internal readonly PreAllocatedOverlapped? _preallocatedOverlapped;
             private ManualResetValueTaskSourceCore<int> _source; // mutable struct; do not make this readonly
             private NativeOverlapped* _overlapped;
             private CancellationTokenRegistration _cancellationRegistration;
@@ -105,7 +105,7 @@ namespace System.IO.Strategies
                 }
             }
 
-            internal virtual void ReleaseNativeResource()
+            internal void ReleaseNativeResource()
             {
                 _handle.Dispose();
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.ValueTaskSource.cs
@@ -18,9 +18,9 @@ namespace System.IO.Strategies
         private unsafe class ValueTaskSource : IValueTaskSource<int>, IValueTaskSource
         {
             internal static readonly IOCompletionCallback s_ioCallback = IOCallback;
-
+            private MemoryHandle _handle;
             private readonly AsyncWindowsFileStreamStrategy _strategy;
-
+            internal PreAllocatedOverlapped? _preallocatedOverlapped;
             private ManualResetValueTaskSourceCore<int> _source; // mutable struct; do not make this readonly
             private NativeOverlapped* _overlapped;
             private CancellationTokenRegistration _cancellationRegistration;
@@ -29,37 +29,36 @@ namespace System.IO.Strategies
             private bool _cancellationHasBeenRegistered;
 #endif
 
-            public static ValueTaskSource Create(
-                AsyncWindowsFileStreamStrategy strategy,
-                PreAllocatedOverlapped? preallocatedOverlapped,
-                ReadOnlyMemory<byte> memory)
-            {
-                // If the memory passed in is the strategy's internal buffer, we can use the base AwaitableProvider,
-                // which has a PreAllocatedOverlapped with the memory already pinned.  Otherwise, we use the derived
-                // MemoryAwaitableProvider, which Retains the memory, which will result in less pinning in the case
-                // where the underlying memory is backed by pre-pinned buffers.
-                return preallocatedOverlapped != null &&
-                       MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> buffer) &&
-                       preallocatedOverlapped.IsUserObject(buffer.Array) ?
-                            new ValueTaskSource(strategy, preallocatedOverlapped, buffer.Array) :
-                            new MemoryValueTaskSource(strategy, memory);
-            }
 
-            protected ValueTaskSource(
-                AsyncWindowsFileStreamStrategy strategy,
-                PreAllocatedOverlapped? preallocatedOverlapped,
-                byte[]? bytes)
+            internal ValueTaskSource(AsyncWindowsFileStreamStrategy strategy, byte[]? internalBuffer)
             {
                 _strategy = strategy;
                 _result = TaskSourceCodes.NoResult;
-
                 _source = default;
                 _source.RunContinuationsAsynchronously = true;
 
-                _overlapped = bytes != null &&
-                              _strategy.CompareExchangeCurrentOverlappedOwner(this, null) == null ?
-                              _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(preallocatedOverlapped!) : // allocated when buffer was created, and buffer is non-null
-                              _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(s_ioCallback, this, bytes);
+                if (internalBuffer != null)
+                {
+                    _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, internalBuffer);
+                }
+            }
+
+            internal void Configure(ReadOnlyMemory<byte> memory)
+            {
+                // The array of preallocatedOverlapped is the same as the memory array when flushing in buffered mode,
+                // because the ReadOnlyMemory object passed to WriteAsync/ReadAsync is the internal buffer that we need
+                // to write to disk at the end
+                if (_preallocatedOverlapped != null &&
+                   MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> arrSegment) &&
+                   _preallocatedOverlapped.IsUserObject(arrSegment.Array))
+                {
+                    _overlapped = _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(_preallocatedOverlapped);
+                }
+                else
+                {
+                    _handle = memory.Pin();
+                    _overlapped = _strategy._fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(s_ioCallback, this, null);
+                }
 
                 Debug.Assert(_overlapped != null, "AllocateNativeOverlapped returned null");
             }
@@ -108,6 +107,8 @@ namespace System.IO.Strategies
 
             internal virtual void ReleaseNativeResource()
             {
+                _handle.Dispose();
+
                 // Ensure that cancellation has been completed and cleaned up.
                 _cancellationRegistration.Dispose();
 
@@ -120,25 +121,21 @@ namespace System.IO.Strategies
                     _overlapped = null;
                 }
 
-                // Ensure we're no longer set as the current AwaitableProvider (we may not have been to begin with).
+                // Ensure we're no longer set as the current ValueTaskSource (we may not have been to begin with).
                 // Only one operation at a time is eligible to use the preallocated overlapped
                 _strategy.CompareExchangeCurrentOverlappedOwner(null, this);
             }
 
             private static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
             {
-                // Extract the AwaitableProvider from the overlapped.  The state in the overlapped
+                // Extract the ValueTaskSource from the overlapped.  The state in the overlapped
                 // will either be a AsyncWindowsFileStreamStrategy (in the case where the preallocated overlapped was used),
                 // in which case the operation being completed is its _currentOverlappedOwner, or it'll
-                // be directly the AwaitableProvider that's completing (in the case where the preallocated
+                // be directly the ValueTaskSource that's completing (in the case where the preallocated
                 // overlapped was already in use by another operation).
                 object? state = ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
-                Debug.Assert(state is AsyncWindowsFileStreamStrategy or ValueTaskSource);
-                ValueTaskSource valueTaskSource = state switch
-                {
-                    AsyncWindowsFileStreamStrategy strategy => strategy._currentOverlappedOwner!, // must be owned
-                    _ => (ValueTaskSource)state
-                };
+                Debug.Assert(state is ValueTaskSource);
+                ValueTaskSource valueTaskSource = (ValueTaskSource)state;
                 Debug.Assert(valueTaskSource != null);
                 Debug.Assert(valueTaskSource._overlapped == pOverlapped, "Overlaps don't match");
 
@@ -222,29 +219,6 @@ namespace System.IO.Strategies
                         _source.SetException(e);
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Extends <see cref="ValueTaskSource"/> with to support disposing of a
-        /// <see cref="MemoryHandle"/> when the operation has completed.  This should only be used
-        /// when memory doesn't wrap a byte[].
-        /// </summary>
-        private sealed class MemoryValueTaskSource : ValueTaskSource
-        {
-            private MemoryHandle _handle; // mutable struct; do not make this readonly
-
-            // this type handles the pinning, so bytes are null
-            internal unsafe MemoryValueTaskSource(AsyncWindowsFileStreamStrategy strategy, ReadOnlyMemory<byte> memory)
-                : base(strategy, null, null) // this type handles the pinning, so null is passed for bytes to the base
-            {
-                _handle = memory.Pin();
-            }
-
-            internal override void ReleaseNativeResource()
-            {
-                _handle.Dispose();
-                base.ReleaseNativeResource();
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -198,6 +198,7 @@ namespace System.IO.Strategies
                     // Failure to do so looks like we are freeing a pending overlapped later.
                     intOverlapped->InternalLow = IntPtr.Zero;
                     valueTaskSource.ReleaseNativeResource();
+                    TryToReuse(valueTaskSource);
                     return new ValueTask<int>(0);
                 }
                 else if (errorCode != Interop.Errors.ERROR_IO_PENDING)
@@ -208,6 +209,7 @@ namespace System.IO.Strategies
                     }
 
                     valueTaskSource.ReleaseNativeResource();
+                    TryToReuse(valueTaskSource);
 
                     if (errorCode == Interop.Errors.ERROR_HANDLE_EOF)
                     {
@@ -301,6 +303,7 @@ namespace System.IO.Strategies
                     // Not an error, but EOF. AsyncFSCallback will NOT be called.
                     // Completing TCS and return cached task allowing the GC to collect TCS.
                     valueTaskSource.ReleaseNativeResource();
+                    TryToReuse(valueTaskSource);
                     return ValueTask.CompletedTask;
                 }
                 else if (errorCode != Interop.Errors.ERROR_IO_PENDING)
@@ -311,6 +314,7 @@ namespace System.IO.Strategies
                     }
 
                     valueTaskSource.ReleaseNativeResource();
+                    TryToReuse(valueTaskSource);
 
                     if (errorCode == Interop.Errors.ERROR_HANDLE_EOF)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -110,7 +110,7 @@ namespace System.IO.Strategies
             _reusableValueTaskSource = new ValueTaskSource(this, buffer);
         }
 
-        private void TryToReuse(ValueTaskSource source) => Interlocked.CompareExchange(ref _reusableValueTaskSource, null, source);
+        private void TryToReuse(ValueTaskSource source) => Interlocked.CompareExchange(ref _reusableValueTaskSource, source, null);
 
         public override int Read(byte[] buffer, int offset, int count)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -139,15 +139,10 @@ namespace System.IO.Strategies
             // - First time calling ReadAsync in buffered mode
             // - Second+ time calling ReadAsync, both buffered or unbuffered
             // - On buffered flush, when source memory is also the internal buffer
-            ValueTaskSource? valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null);
             // valueTaskSource is null when:
             // - First time calling ReadAsync in unbuffered mode
-            if (valueTaskSource == null)
-            {
-                valueTaskSource = new ValueTaskSource(this);
-            }
-            valueTaskSource.Configure(destination);
-            NativeOverlapped* intOverlapped = valueTaskSource.Overlapped;
+            ValueTaskSource valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
+            NativeOverlapped* intOverlapped = valueTaskSource.Configure(destination);
 
             // Calculate position in the file we should be at after the read is done
             long positionBefore = _filePosition;
@@ -265,15 +260,10 @@ namespace System.IO.Strategies
             // - First time calling WriteAsync in buffered mode
             // - Second+ time calling WriteAsync, both buffered or unbuffered
             // - On buffered flush, when source memory is also the internal buffer
-            ValueTaskSource? valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null);
             // valueTaskSource is null when:
             // - First time calling WriteAsync in unbuffered mode
-            if (valueTaskSource == null)
-            {
-                valueTaskSource = new ValueTaskSource(this);
-            }
-            valueTaskSource.Configure(source);
-            NativeOverlapped* intOverlapped = valueTaskSource.Overlapped;
+            ValueTaskSource valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
+            NativeOverlapped* intOverlapped = valueTaskSource.Configure(source);
 
             long positionBefore = _filePosition;
             if (CanSeek)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -104,6 +104,8 @@ namespace System.IO.Strategies
 
         private void TryToReuse(ValueTaskSource source)
         {
+            source._source.Reset();
+
             if (Interlocked.CompareExchange(ref _reusableValueTaskSource, source, null) is not null)
             {
                 source._preallocatedOverlapped.Dispose();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -1069,7 +1069,7 @@ namespace System.IO.Strategies
 
             void AllocateBuffer() // logic kept in a separate method to get EnsureBufferAllocated() inlined
             {
-                _buffer = GC.AllocateArray<byte>(_bufferSize,
+                _buffer = GC.AllocateUninitializedArray<byte>(_bufferSize,
                     pinned: true); // this allows us to avoid pinning when the buffer is used for the syscalls
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -604,7 +604,7 @@ namespace System.IO.Strategies
             }
             else
             {
-                Debug.Assert(_writePos == _bufferSize - 1);
+                Debug.Assert(_writePos <= _bufferSize);
                 FlushWrite();
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -462,7 +463,7 @@ namespace System.IO.Strategies
                 // If there was anything in the write buffer, clear it.
                 if (_writePos > 0)
                 {
-                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -474,7 +475,7 @@ namespace System.IO.Strategies
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
-                _readLen = await _strategy.ReadAsync(new Memory<byte>(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
+                _readLen = await _strategy.ReadAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
 
                 bytesFromBuffer = Math.Min(_readLen, buffer.Length);
                 _buffer.AsSpan(0, bytesFromBuffer).CopyTo(buffer.Span);
@@ -732,7 +733,7 @@ namespace System.IO.Strategies
                         }
                     }
 
-                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -833,7 +834,7 @@ namespace System.IO.Strategies
             {
                 if (_writePos > 0)
                 {
-                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                     Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
                     return;
@@ -887,13 +888,13 @@ namespace System.IO.Strategies
                 {
                     // If there's any read data in the buffer, write it all to the destination stream.
                     Debug.Assert(_writePos == 0, "Write buffer must be empty if there's data in the read buffer");
-                    await destination.WriteAsync(new ReadOnlyMemory<byte>(_buffer, _readPos, readBytes), cancellationToken).ConfigureAwait(false);
+                    await destination.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, _readPos, readBytes), cancellationToken).ConfigureAwait(false);
                     _readPos = _readLen = 0;
                 }
                 else if (_writePos > 0)
                 {
                     // If there's write data in the buffer, flush it back to the underlying stream, as does ReadAsync.
-                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -1068,7 +1069,8 @@ namespace System.IO.Strategies
 
             void AllocateBuffer() // logic kept in a separate method to get EnsureBufferAllocated() inlined
             {
-                _strategy.OnBufferAllocated(_buffer = new byte[_bufferSize]);
+                _buffer = GC.AllocateArray<byte>(_bufferSize,
+                    pinned: true); // this allows us to avoid pinning when the buffer is used for the syscalls
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -604,7 +604,7 @@ namespace System.IO.Strategies
             }
             else
             {
-                Debug.Assert(_writePos == _bufferSize);
+                Debug.Assert(_writePos == _bufferSize - 1);
                 FlushWrite();
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -604,6 +604,7 @@ namespace System.IO.Strategies
             }
             else
             {
+                Debug.Assert(_writePos == _bufferSize);
                 FlushWrite();
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
@@ -26,7 +26,5 @@ namespace System.IO.Strategies
         internal abstract void Flush(bool flushToDisk);
 
         internal abstract void DisposeInternal(bool disposing);
-
-        internal virtual void OnBufferAllocated(byte[] buffer) { }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50972
Fixes #25074

When `AsyncWindowsFileStreamStrategy` is wrapped by a `BufferedFileStreamStrategy`, we need to make sure the `ValueTaskSource` instance is cached to reduce the number of allocations when calling `ReadAsync` or `WriteAsync` multiple times in a row.

This PR is a continuation of https://github.com/dotnet/runtime/pull/50802, in which we switched from using `TaskCompletionSource` to `IValueTaskSource`.

Changes:
- Moved the `PreAllocatedOverlapped` instance inside `ValueTaskSource`, so the latter becomes its owner. This was done because we are only supposed to have an instance of a `PreAllocatedOverlapped` if the `ValueTaskSource` was created from `OnBufferedAllocated`, which is a method called only by `BufferedFileStreamStrategy` right before writing or reading.
- Removed `MemoryValueTaskSource` and moved the cases handled by it to `ValueTaskSource`.
- Created a method that refreshes the value of the `NativeOverlapped*`. This is done every time we call `ReadAsync`/`WriteAsync`, to make sure we are pinning the memory passed by the user.