### PR TITLE
Optimize Span<T>.Fill implementation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Text;
 using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 using Internal.Runtime.CompilerServices;
@@ -280,53 +279,21 @@ namespace System
         /// <summary>
         /// Fills the contents of this span with the given value.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Fill(T value)
         {
             if (Unsafe.SizeOf<T>() == 1)
             {
-                uint length = (uint)_length;
-                if (length == 0)
-                    return;
-
-                T tmp = value; // Avoid taking address of the "value" argument. It would regress performance of the loop below.
-                Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _pointer.Value), Unsafe.As<T, byte>(ref tmp), length);
+                // Special-case single-byte types like byte / sbyte / bool.
+                // The runtime eventually calls memset, which can efficiently support large buffers.
+                // We don't need to check IsReferenceOrContainsReferences because no references
+                // can ever be stored in types this small.
+                Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _pointer.Value), Unsafe.As<T, byte>(ref value), (uint)_length);
             }
             else
             {
-                // Do all math as nuint to avoid unnecessary 64->32->64 bit integer truncations
-                nuint length = (uint)_length;
-                if (length == 0)
-                    return;
-
-                ref T r = ref _pointer.Value;
-
-                // TODO: Create block fill for value types of power of two sizes e.g. 2,4,8,16
-
-                nuint elementSize = (uint)Unsafe.SizeOf<T>();
-                nuint i = 0;
-                for (; i < (length & ~(nuint)7); i += 8)
-                {
-                    Unsafe.AddByteOffset<T>(ref r, (i + 0) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 1) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 2) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 3) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 4) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 5) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 6) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 7) * elementSize) = value;
-                }
-                if (i < (length & ~(nuint)3))
-                {
-                    Unsafe.AddByteOffset<T>(ref r, (i + 0) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 1) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 2) * elementSize) = value;
-                    Unsafe.AddByteOffset<T>(ref r, (i + 3) * elementSize) = value;
-                    i += 4;
-                }
-                for (; i < length; i++)
-                {
-                    Unsafe.AddByteOffset<T>(ref r, i * elementSize) = value;
-                }
+                // Call our optimized workhorse method for all other types.
+                SpanHelpers.Fill(ref _pointer.Value, (uint)_length, value);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -284,11 +284,18 @@ namespace System
         {
             if (Unsafe.SizeOf<T>() == 1)
             {
-                // Special-case single-byte types like byte / sbyte / bool.
-                // The runtime eventually calls memset, which can efficiently support large buffers.
-                // We don't need to check IsReferenceOrContainsReferences because no references
-                // can ever be stored in types this small.
-                Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _pointer.Value), Unsafe.As<T, byte>(ref value), (uint)_length);
+#if MONO
+                // Mono runtime's implementation of initblk performs a null check on the address.
+                // We'll perform a length check here to avoid passing a null address in the empty span case.
+                if (_length != 0)
+#endif
+                {
+                    // Special-case single-byte types like byte / sbyte / bool.
+                    // The runtime eventually calls memset, which can efficiently support large buffers.
+                    // We don't need to check IsReferenceOrContainsReferences because no references
+                    // can ever be stored in types this small.
+                    Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _pointer.Value), Unsafe.As<T, byte>(ref value), (uint)_length);
+                }
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -4,103 +4,119 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using Internal.Runtime.CompilerServices;
 
 namespace System
 {
     internal static partial class SpanHelpers // .T
     {
-        public static void Fill<T>(ref T refData, uint numElements, T value)
+        public static void Fill<T>(ref T refData, nuint numElements, T value)
         {
-            // n.b. If Fill is ever adapted to work for lengths beyond uint.MaxValue, double-check
-            // where it's used in the arithmetic operations below to ensure no integer overflow is possible.
+            // Early checks to see if it's even possible to vectorize - JIT will turn these checks into consts.
+            // - T cannot contain references (GC can't track references in vectors)
+            // - Vectorization must be hardware-accelerated
+            // - T's size must not exceed the vector's size and must be a whole power of 2
 
-            if (numElements == 0)
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>()) { goto CannotVectorize; }
+            if (!Vector.IsHardwareAccelerated) { goto CannotVectorize; }
+            if (Unsafe.SizeOf<T>() > Vector<byte>.Count) { goto CannotVectorize; }
+            if ((Unsafe.SizeOf<T>() & (Unsafe.SizeOf<T>() - 1)) != 0) { goto CannotVectorize; } // power of 2 check
+
+            if (numElements > (uint)(Vector<byte>.Count / Unsafe.SizeOf<T>()))
             {
-                return; // nothing to do
-            }
+                // We have enough data for at least one vectorized write.
 
-            if (typeof(T) != typeof(float) && typeof(T) != typeof(double) && !RuntimeHelpers.IsBitwiseEquatable<T>())
-            {
-                goto CannotVectorize; // it might not be valid to SIMD-spray this value into the backing span
-            }
-
-            if (Vector.IsHardwareAccelerated)
-            {
-                if (numElements < (uint)(Vector<byte>.Count / Unsafe.SizeOf<T>()))
-                {
-                    goto CannotVectorize; // not enough data for even a single run through the vectorized loop
-                }
-
+                T tmp = value; // Avoid taking address of the "value" argument. It would regress performance of the loops below.
                 Vector<byte> vector;
 
-                if (typeof(T) == typeof(float))
+                if (Unsafe.SizeOf<T>() == 1)
                 {
-                    vector = (Vector<byte>)(new Vector<float>((float)(object)value!));
+                    vector = new Vector<byte>(Unsafe.As<T, byte>(ref tmp));
                 }
-                else if (typeof(T) == typeof(double))
+                else if (Unsafe.SizeOf<T>() == 2)
                 {
-                    vector = (Vector<byte>)(new Vector<double>((double)(object)value!));
+                    vector = (Vector<byte>)(new Vector<ushort>(Unsafe.As<T, ushort>(ref tmp)));
                 }
-                else
+                else if (Unsafe.SizeOf<T>() == 4)
                 {
-                    T tmp = value; // Avoid taking address of the "value" argument. It would regress performance of the loops below.
-                    if (Unsafe.SizeOf<T>() == 1)
+                    // special-case float since it's already passed in a SIMD reg
+                    vector = (typeof(T) == typeof(float))
+                        ? (Vector<byte>)(new Vector<float>((float)(object)tmp!))
+                        : (Vector<byte>)(new Vector<uint>(Unsafe.As<T, uint>(ref tmp)));
+                }
+                else if (Unsafe.SizeOf<T>() == 8)
+                {
+                    // special-case double since it's already passed in a SIMD reg
+                    vector = (typeof(T) == typeof(double))
+                        ? (Vector<byte>)(new Vector<double>((double)(object)tmp!))
+                        : (Vector<byte>)(new Vector<ulong>(Unsafe.As<T, ulong>(ref tmp)));
+                }
+                else if (Unsafe.SizeOf<T>() == 16)
+                {
+                    Vector128<byte> vec128 = Unsafe.As<T, Vector128<byte>>(ref tmp);
+                    if (Vector<byte>.Count == 16)
                     {
-                        vector = new Vector<byte>(Unsafe.As<T, byte>(ref tmp));
+                        vector = vec128.AsVector();
                     }
-                    else if (Unsafe.SizeOf<T>() == 2)
+                    else if (Vector<byte>.Count == 32)
                     {
-                        vector = (Vector<byte>)(new Vector<ushort>(Unsafe.As<T, ushort>(ref tmp)));
-                    }
-                    else if (Unsafe.SizeOf<T>() == 4)
-                    {
-                        vector = (Vector<byte>)(new Vector<uint>(Unsafe.As<T, uint>(ref tmp)));
-                    }
-                    else if (Unsafe.SizeOf<T>() == 8)
-                    {
-                        vector = (Vector<byte>)(new Vector<ulong>(Unsafe.As<T, ulong>(ref tmp)));
+                        vector = Vector256.Create(vec128, vec128).AsVector();
                     }
                     else
                     {
-                        Debug.Fail("This should never happen. Did we miss special-casing a bitwise equatable type?");
+                        Debug.Fail("Vector<T> isn't 128 or 256 bits in size?");
                         goto CannotVectorize;
                     }
                 }
+                else if (Unsafe.SizeOf<T>() == 32)
+                {
+                    vector = Unsafe.As<T, Vector256<byte>>(ref tmp).AsVector();
+                }
+                else
+                {
+                    Debug.Fail("Vector<T> is greater than 256 bits in size?");
+                    goto CannotVectorize;
+                }
 
+                ref byte refDataAsBytes = ref Unsafe.As<T, byte>(ref refData);
                 nuint totalByteLength = numElements * (nuint)Unsafe.SizeOf<T>(); // get this calculation ready ahead of time
-                nuint stopLoopAtOffset = totalByteLength & (nuint)(-Vector<byte>.Count * 2);
+                nuint stopLoopAtOffset = totalByteLength & (nuint)(nint)(2 * (int)-Vector<byte>.Count); // intentional sign extension carries the negative bit
                 nuint offset = 0;
 
                 // Loop, writing 2 vectors at a time.
+                // Compare 'numElements' rather than 'stopLoopAtOffset' because we don't want a dependency
+                // on the very recently calculated 'stopLoopAtOffset' value.
 
-                if (numElements >= 2 * (uint)(Vector<byte>.Count / Unsafe.SizeOf<T>()))
+                if (numElements >= (uint)(2 * Vector<byte>.Count / Unsafe.SizeOf<T>()))
                 {
                     do
                     {
-                        Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref Unsafe.As<T, byte>(ref refData), offset), vector);
-                        Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref Unsafe.As<T, byte>(ref refData), offset + (uint)Vector<byte>.Count), vector);
-                        offset += 2 * (uint)Vector<byte>.Count;
+                        Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref refDataAsBytes, offset), vector);
+                        Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref refDataAsBytes, offset + (nuint)Vector<byte>.Count), vector);
+                        offset += (uint)(2 * Vector<byte>.Count);
                     } while (offset < stopLoopAtOffset);
                 }
 
-                // There are [ 0, 2 * sizeof(Vector) ) bytes remaining.
-                // If there are >= sizeof(Vector) bytes remaining, write one vector now.
+                // At this point, if any data remains to be written, it's strictly less than
+                // 2 * sizeof(Vector) bytes. The loop above had us write an even number of vectors.
+                // If the total byte length instead involves us writing an odd number of vectors, write
+                // one additional vector now. The bit check below tells us if we're in an "odd vector
+                // count" situation.
 
                 if ((totalByteLength & (nuint)Vector<byte>.Count) != 0)
                 {
-                    Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref Unsafe.As<T, byte>(ref refData), offset), vector);
+                    Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref refDataAsBytes, offset), vector);
                 }
 
-                // If there's any remaining space that won't fill a full vector, write a vector at
-                // the very end of the destination buffer. This will result in overwriting a previous
-                // entry, but that's ok since we're splatting the same value for all entries, so this
-                // won't result in data corruption.
+                // It's possible that some small buffer remains to be populated - something that won't
+                // fit an entire vector's worth of data. Instead of falling back to a loop, we'll write
+                // a vector at the very end of the buffer. This may involve overwriting previously
+                // populated data, which is fine since we're splatting the same value for all entries.
+                // There's no need to perform a length check here because we already performed this
+                // check before entering the vectorized code path.
 
-                if ((totalByteLength & (nuint)(Vector<byte>.Count - 1)) != 0)
-                {
-                    Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref Unsafe.As<T, byte>(ref refData), totalByteLength - (uint)Vector<byte>.Count), vector);
-                }
+                Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref refDataAsBytes, totalByteLength - (nuint)Vector<byte>.Count), vector);
 
                 // And we're done!
 
@@ -109,13 +125,17 @@ namespace System
 
         CannotVectorize:
 
+            // If we reached this point, we cannot vectorize this T, or there are too few
+            // elements for us to vectorize. Fall back to an unrolled loop.
+
+            nuint i = 0;
+
+            // Write 8 elements at a time
+
+            if (numElements >= 8)
             {
-                nuint i = 0;
-                nuint stopLoopAtOffset = numElements & ~(uint)7;
-
-                // Write 8 elements at a time
-
-                for (; i < stopLoopAtOffset; i += 8)
+                nuint stopLoopAtOffset = numElements & ~(nuint)7;
+                do
                 {
                     Unsafe.Add(ref refData, (nint)i + 0) = value;
                     Unsafe.Add(ref refData, (nint)i + 1) = value;
@@ -125,34 +145,34 @@ namespace System
                     Unsafe.Add(ref refData, (nint)i + 5) = value;
                     Unsafe.Add(ref refData, (nint)i + 6) = value;
                     Unsafe.Add(ref refData, (nint)i + 7) = value;
-                }
+                } while ((i += 8) < stopLoopAtOffset);
+            }
 
-                // Write next 4 elements if needed
+            // Write next 4 elements if needed
 
-                if ((numElements & 4) != 0)
-                {
-                    Unsafe.Add(ref refData, (nint)i + 0) = value;
-                    Unsafe.Add(ref refData, (nint)i + 1) = value;
-                    Unsafe.Add(ref refData, (nint)i + 2) = value;
-                    Unsafe.Add(ref refData, (nint)i + 3) = value;
-                    i += 4;
-                }
+            if ((numElements & 4) != 0)
+            {
+                Unsafe.Add(ref refData, (nint)i + 0) = value;
+                Unsafe.Add(ref refData, (nint)i + 1) = value;
+                Unsafe.Add(ref refData, (nint)i + 2) = value;
+                Unsafe.Add(ref refData, (nint)i + 3) = value;
+                i += 4;
+            }
 
-                // Write next 2 elements if needed
+            // Write next 2 elements if needed
 
-                if ((numElements & 2) != 0)
-                {
-                    Unsafe.Add(ref refData, (nint)i + 0) = value;
-                    Unsafe.Add(ref refData, (nint)i + 1) = value;
-                    i += 2;
-                }
+            if ((numElements & 2) != 0)
+            {
+                Unsafe.Add(ref refData, (nint)i + 0) = value;
+                Unsafe.Add(ref refData, (nint)i + 1) = value;
+                i += 2;
+            }
 
-                // Write final element if needed
+            // Write final element if needed
 
-                if ((numElements & 1) != 0)
-                {
-                    Unsafe.Add(ref refData, (nint)i) = value;
-                }
+            if ((numElements & 1) != 0)
+            {
+                Unsafe.Add(ref refData, (nint)i) = value;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -23,7 +23,7 @@ namespace System
             if (Unsafe.SizeOf<T>() > Vector<byte>.Count) { goto CannotVectorize; }
             if ((Unsafe.SizeOf<T>() & (Unsafe.SizeOf<T>() - 1)) != 0) { goto CannotVectorize; } // power of 2 check
 
-            if (numElements > (uint)(Vector<byte>.Count / Unsafe.SizeOf<T>()))
+            if (numElements >= (uint)(Vector<byte>.Count / Unsafe.SizeOf<T>()))
             {
                 // We have enough data for at least one vectorized write.
 


### PR DESCRIPTION
This optimizes `Span<T>.Fill` via three primary mechanisms:

- For _T = byte_, forwards directly to the _initblk_ (_memset_) implementation
- For _T = \<primitive\>_, uses a SIMD-optimized worker loop if feasible
- Removes requirement for caller to stack-spill the span argument before calling main worker API

The central SIMD loop doesn't attempt to perform any type of alignment optimization. We can consider adding this in the future if benchmarking shows this to be a worthwhile addition.

I also didn't investigate any other call sites throughout the runtime + libraries to see if they should be migrated from whatever existing code they might have to this `Span<T>.Fill` implementation. That can come as a future commit to this PR or as a future PR.

<details>
<summary>Benchmark code</summary>

```cs
[GenericTypeArguments(typeof(byte))]
[GenericTypeArguments(typeof(char))]
[GenericTypeArguments(typeof(int))]
[GenericTypeArguments(typeof(long))]
[GenericTypeArguments(typeof(float))]
[GenericTypeArguments(typeof(double))]
[GenericTypeArguments(typeof(decimal))]
[GenericTypeArguments(typeof(string))]
public class SpanFillRunner<T>
{
    private T[] _arr;

    private T _value;

    [Params(0, 3, 7, 15, 16, 24, 128, 512)]
    public int Size;

    [GlobalSetup]
    public void Setup()
    {
        _arr = new T[Size];

        _value = (T)((IConvertible)42).ToType(typeof(T), null);
    }

    [Benchmark]
    public void Fill()
    {
        var arr = _arr;
        _ = arr.Length; // prove not null
        arr.AsSpan().Fill(_value);
    }
}
```
</details>

### Benchmark results:

<details>
<summary>byte</summary>

(Note: The internal _memset_ routine uses nontemporal stores, which could explain the blazing fast runtime.)

| Method |        Job | Toolchain | Size |     Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |---------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** | **1.882 ns** | **0.0093 ns** | **0.0083 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 | 1.382 ns | 0.0320 ns | 0.0300 ns |  0.74 |    0.01 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** | **3.449 ns** | **0.0172 ns** | **0.0144 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 | 1.865 ns | 0.0445 ns | 0.0395 ns |  0.54 |    0.01 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** | **3.439 ns** | **0.0112 ns** | **0.0100 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 | 1.854 ns | 0.0195 ns | 0.0163 ns |  0.54 |    0.01 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** | **3.386 ns** | **0.0115 ns** | **0.0102 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 | 1.857 ns | 0.0219 ns | 0.0183 ns |  0.55 |    0.01 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** | **3.424 ns** | **0.0115 ns** | **0.0096 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 | 1.845 ns | 0.0181 ns | 0.0151 ns |  0.54 |    0.01 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** | **3.211 ns** | **0.0173 ns** | **0.0153 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 | 1.918 ns | 0.0093 ns | 0.0087 ns |  0.60 |    0.00 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** | **5.484 ns** | **0.0543 ns** | **0.0454 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 | 4.321 ns | 0.1117 ns | 0.1602 ns |  0.79 |    0.03 |
|        |            |           |      |          |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **7.521 ns** | **0.0423 ns** | **0.0395 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 | 6.451 ns | 0.0442 ns | 0.0345 ns |  0.86 |    0.01 |
</details>

<details>
<summary>char</summary>

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.880 ns** | **0.0569 ns** | **0.0532 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.355 ns | 0.0039 ns | 0.0036 ns |  0.72 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **3.436 ns** | **0.0137 ns** | **0.0128 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.511 ns | 0.0167 ns | 0.0131 ns |  0.73 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **4.199 ns** | **0.0524 ns** | **0.0490 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   2.300 ns | 0.0121 ns | 0.0113 ns |  0.55 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |   **5.261 ns** | **0.0325 ns** | **0.0304 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |   2.591 ns | 0.0353 ns | 0.0330 ns |  0.49 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |   **5.263 ns** | **0.0192 ns** | **0.0170 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |   2.516 ns | 0.0150 ns | 0.0140 ns |  0.48 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |   **6.809 ns** | **0.0126 ns** | **0.0106 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |   2.296 ns | 0.0105 ns | 0.0098 ns |  0.34 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **30.955 ns** | **0.1179 ns** | **0.1103 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |   3.300 ns | 0.0942 ns | 0.1723 ns |  0.10 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **130.535 ns** | **1.7414 ns** | **1.5437 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |   7.081 ns | 0.1504 ns | 0.1407 ns |  0.05 |    0.00 |
</details>

<details>
<summary>int</summary>

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.603 ns** | **0.0630 ns** | **0.1183 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.720 ns | 0.1739 ns | 0.5127 ns |  0.98 |    0.23 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **2.611 ns** | **0.0225 ns** | **0.0211 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.030 ns | 0.0258 ns | 0.0241 ns |  0.78 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **2.638 ns** | **0.0194 ns** | **0.0181 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   2.062 ns | 0.0059 ns | 0.0055 ns |  0.78 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |   **4.415 ns** | **0.0084 ns** | **0.0075 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |   1.614 ns | 0.0045 ns | 0.0042 ns |  0.37 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |   **5.104 ns** | **0.0169 ns** | **0.0149 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |   2.060 ns | 0.0046 ns | 0.0041 ns |  0.40 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |   **7.028 ns** | **0.0173 ns** | **0.0162 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |   1.815 ns | 0.0157 ns | 0.0147 ns |  0.26 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **29.413 ns** | **0.0861 ns** | **0.0805 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |   5.971 ns | 0.0835 ns | 0.1609 ns |  0.21 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **117.060 ns** | **0.8512 ns** | **0.7962 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |  17.274 ns | 0.0655 ns | 0.0512 ns |  0.15 |    0.00 |
</details>

<details>
<summary>long</summary>

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.367 ns** | **0.0170 ns** | **0.0159 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.151 ns | 0.0086 ns | 0.0080 ns |  0.84 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **2.940 ns** | **0.0849 ns** | **0.0977 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.055 ns | 0.0052 ns | 0.0044 ns |  0.69 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **2.635 ns** | **0.0131 ns** | **0.0122 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   1.598 ns | 0.0203 ns | 0.0189 ns |  0.61 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |   **4.427 ns** | **0.0123 ns** | **0.0115 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |   1.662 ns | 0.0103 ns | 0.0097 ns |  0.38 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |   **5.116 ns** | **0.0095 ns** | **0.0079 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |   2.526 ns | 0.0072 ns | 0.0067 ns |  0.49 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |   **6.957 ns** | **0.0298 ns** | **0.0279 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |   2.974 ns | 0.0103 ns | 0.0096 ns |  0.43 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **29.398 ns** | **0.0854 ns** | **0.0799 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |  13.634 ns | 0.0477 ns | 0.0423 ns |  0.46 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **116.306 ns** | **0.1551 ns** | **0.1295 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |  60.719 ns | 0.1973 ns | 0.1845 ns |  0.52 |    0.00 |
</details>

<details>
<summary>float</summary>

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.367 ns** | **0.0189 ns** | **0.0177 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.141 ns | 0.0078 ns | 0.0073 ns |  0.83 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **3.011 ns** | **0.0395 ns** | **0.0369 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.055 ns | 0.0073 ns | 0.0069 ns |  0.68 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **2.742 ns** | **0.0432 ns** | **0.0404 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   2.054 ns | 0.0233 ns | 0.0218 ns |  0.75 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |   **4.565 ns** | **0.1167 ns** | **0.1949 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |   1.590 ns | 0.0297 ns | 0.0264 ns |  0.34 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |   **4.693 ns** | **0.0448 ns** | **0.0419 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |   2.078 ns | 0.0031 ns | 0.0027 ns |  0.44 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |   **6.848 ns** | **0.0843 ns** | **0.0789 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |   1.815 ns | 0.0172 ns | 0.0161 ns |  0.27 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **29.045 ns** | **0.0866 ns** | **0.0810 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |   6.326 ns | 0.0459 ns | 0.0429 ns |  0.22 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **115.432 ns** | **0.4247 ns** | **0.3973 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |  32.200 ns | 0.1476 ns | 0.1381 ns |  0.28 |    0.00 |
</details>

<details>
<summary>double</summary>

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.358 ns** | **0.0233 ns** | **0.0207 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.131 ns | 0.0163 ns | 0.0153 ns |  0.83 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **2.956 ns** | **0.0491 ns** | **0.0459 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.024 ns | 0.0366 ns | 0.0342 ns |  0.68 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **2.931 ns** | **0.0346 ns** | **0.0323 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   1.625 ns | 0.0335 ns | 0.0314 ns |  0.55 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |   **4.455 ns** | **0.0533 ns** | **0.0499 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |   1.678 ns | 0.0621 ns | 0.0829 ns |  0.36 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |   **5.098 ns** | **0.0513 ns** | **0.0480 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |   2.508 ns | 0.0802 ns | 0.1150 ns |  0.51 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |   **6.853 ns** | **0.0835 ns** | **0.0781 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |   2.943 ns | 0.0378 ns | 0.0353 ns |  0.43 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **28.694 ns** | **0.2794 ns** | **0.2613 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |  13.549 ns | 0.0357 ns | 0.0298 ns |  0.47 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **115.105 ns** | **1.1767 ns** | **1.1007 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |  60.911 ns | 0.7672 ns | 0.7177 ns |  0.53 |    0.01 |
</details>

<details>
<summary>decimal</summary>

(This exercises non-SIMD code paths.)

| Method |        Job | Toolchain | Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |---------- |----- |-----------:|----------:|----------:|------:|--------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |   **1.387 ns** | **0.0146 ns** | **0.0136 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |   1.350 ns | 0.0227 ns | 0.0212 ns |  0.97 |    0.02 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |   **3.848 ns** | **0.0300 ns** | **0.0281 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |   2.878 ns | 0.0370 ns | 0.0346 ns |  0.75 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |   **5.386 ns** | **0.0591 ns** | **0.0553 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |   4.827 ns | 0.0740 ns | 0.0692 ns |  0.90 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |  **10.885 ns** | **0.0963 ns** | **0.0804 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |  10.343 ns | 0.0469 ns | 0.0391 ns |  0.95 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |  **11.545 ns** | **0.0925 ns** | **0.0866 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |  10.919 ns | 0.0234 ns | 0.0207 ns |  0.95 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |  **16.824 ns** | **0.0822 ns** | **0.0769 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |  16.434 ns | 0.0904 ns | 0.0846 ns |  0.98 |    0.01 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |  **87.277 ns** | **0.2652 ns** | **0.2480 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |  86.800 ns | 0.1626 ns | 0.1358 ns |  0.99 |    0.00 |
|        |            |           |      |            |           |           |       |         |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **347.978 ns** | **0.8310 ns** | **0.7773 ns** |  **1.00** |    **0.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 | 349.540 ns | 1.1889 ns | 1.1121 ns |  1.00 |    0.00 |
</details>

<details>
<summary>string</summary>

(This exercises non-SIMD code paths.)

| Method |        Job | Toolchain | Size |         Mean |     Error |    StdDev | Ratio |
|------- |----------- |---------- |----- |-------------:|----------:|----------:|------:|
|   **Fill** | **Job-NKOJQM** |      **main** |    **0** |     **9.361 ns** | **0.0327 ns** | **0.0306 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |    0 |    11.414 ns | 0.0994 ns | 0.0930 ns |  1.22 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |    **3** |    **22.621 ns** | **0.1303 ns** | **0.1088 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |    3 |    15.888 ns | 0.0810 ns | 0.0758 ns |  0.70 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |    **7** |    **37.180 ns** | **0.4089 ns** | **0.3825 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |    7 |    21.691 ns | 0.3115 ns | 0.2762 ns |  0.58 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |   **15** |    **62.400 ns** | **0.4737 ns** | **0.4431 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |   15 |    32.190 ns | 0.0847 ns | 0.0792 ns |  0.52 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |   **16** |    **66.787 ns** | **0.2268 ns** | **0.2121 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |   16 |    34.926 ns | 0.2742 ns | 0.2565 ns |  0.52 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |   **24** |    **97.488 ns** | **0.2009 ns** | **0.1781 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |   24 |    46.627 ns | 0.1166 ns | 0.1034 ns |  0.48 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |  **128** |   **448.163 ns** | **0.8712 ns** | **0.8149 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |  128 |   200.046 ns | 0.5331 ns | 0.4452 ns |  0.45 |
|        |            |           |      |              |           |           |       |
|   **Fill** | **Job-NKOJQM** |      **main** |  **512** | **1,744.556 ns** | **3.5163 ns** | **3.2891 ns** |  **1.00** |
|   Fill | Job-DYLJDS |  spanfill |  512 |   748.678 ns | 1.5795 ns | 1.4002 ns |  0.43 |
</details>

Resolves https://github.com/dotnet/runtime/issues/24806.
Resolves https://github.com/dotnet/runtime/issues/7049.

/cc @carlossanlop @jozkee