### PR TITLE
Simplify trimming non significant digits in JsonUtf8Writer

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -49,8 +49,8 @@ namespace System.Text.Json
             // YYYY-MM-DDThh:mm:ss.fffffffZ (JsonConstants.MaximumFormatDateTimeLength + 1)
             // YYYY-MM-DDThh:mm:ss.fffffff(+|-)hh:mm (JsonConstants.MaximumFormatDateTimeOffsetLength)
             Debug.Assert(buffer.Length == maxDateTimeLength ||
-            buffer.Length == maxDateTimeLength + 1 ||
-            buffer.Length == JsonConstants.MaximumFormatDateTimeOffsetLength);
+                buffer.Length == maxDateTimeLength + 1 ||
+                buffer.Length == JsonConstants.MaximumFormatDateTimeOffsetLength);
 
             // Find the last significant digit.
             int curIndex;
@@ -61,14 +61,16 @@ namespace System.Text.Json
                             if (buffer[maxDateTimeLength - 5] == '0')
                                 if (buffer[maxDateTimeLength - 6] == '0')
                                     if (buffer[maxDateTimeLength - 7] == '0')
+                                    {
                                         // All decimal places are 0 so we can delete the decimal point too.
                                         curIndex = maxDateTimeLength - 7 - 1;
-                                    else curIndex = maxDateTimeLength - 6;
-                                else curIndex = maxDateTimeLength - 5;
-                            else curIndex = maxDateTimeLength - 4;
-                        else curIndex = maxDateTimeLength - 3;
-                    else curIndex = maxDateTimeLength - 2;
-                else curIndex = maxDateTimeLength - 1;
+                                    }
+                                    else { curIndex = maxDateTimeLength - 6; }
+                                else { curIndex = maxDateTimeLength - 5; }
+                            else { curIndex = maxDateTimeLength - 4; }
+                        else { curIndex = maxDateTimeLength - 3; }
+                    else { curIndex = maxDateTimeLength - 2; }
+                else { curIndex = maxDateTimeLength - 1; }
             else
             {
                 // There is nothing to trim.


### PR DESCRIPTION
Found this while thinking about DateTime only.

<details>
<summary>Benchmark</summary>

```cs
        private static byte[] data;

        [Params(true, false)]
        public bool WithOffset;

        [Params(0, 3, 7)]
        public int SignificantDigits;

        [GlobalSetup]
        public void Setup()
        {
            string str = SignificantDigits switch
            {
                0 => "2019-04-24T14:50:17.0000000",
                3 => "2019-04-24T14:50:17.1230000",
                7 => "2019-04-24T14:50:17.1234567",
                _ => throw new Exception()
            };
            data = Encoding.UTF8.GetBytes(str + (WithOffset ? "+12:34" : ""));
        }

        [Benchmark]
        public void Unrolled() => TrimDateTimeOffset_Unrolled(data, out _);

        [Benchmark(Baseline = true)]
        public void Original() => TrimDateTimeOffset_Original(data, out _);
```
</details>

|   Method | WithOffset | SignificantDigits |      Mean |     Error |    StdDev | Ratio |
|--------- |----------- |------------------ |----------:|----------:|----------:|------:|
| Unrolled |      False |                 0 |  6.490 ns | 0.1511 ns | 0.1413 ns |  0.77 |
| Original |      False |                 0 |  8.448 ns | 0.0376 ns | 0.0333 ns |  1.00 |
|          |            |                   |           |           |           |       |
| Unrolled |      False |                 3 |  6.659 ns | 0.0242 ns | 0.0227 ns |  0.19 |
| Original |      False |                 3 | 34.686 ns | 0.0985 ns | 0.0873 ns |  1.00 |
|          |            |                   |           |           |           |       |
| Unrolled |      False |                 7 |  5.318 ns | 0.0303 ns | 0.0253 ns |  0.14 |
| Original |      False |                 7 | 37.438 ns | 0.1090 ns | 0.0966 ns |  1.00 |
|          |            |                   |           |           |           |       |
| Unrolled |       True |                 0 |  4.971 ns | 0.0953 ns | 0.0845 ns |  0.11 |
| Original |       True |                 0 | 43.909 ns | 0.1322 ns | 0.1236 ns |  1.00 |
|          |            |                   |           |           |           |       |
| Unrolled |       True |                 3 |  5.321 ns | 0.0203 ns | 0.0190 ns |  0.12 |
| Original |       True |                 3 | 43.836 ns | 0.1169 ns | 0.0976 ns |  1.00 |
|          |            |                   |           |           |           |       |
| Unrolled |       True |                 7 |  4.945 ns | 0.0288 ns | 0.0269 ns |  0.11 |
| Original |       True |                 7 | 44.322 ns | 0.1316 ns | 0.1167 ns |  1.00 |