### PR TITLE
Clean Installer test

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -191,11 +191,6 @@ namespace Microsoft.NET.HostModel.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
-
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Directory.Delete(dotnetSymlink);
-            }
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -72,10 +72,12 @@ namespace Microsoft.NET.HostModel.Tests
 
             // second symlink -> apphost
             string secondSymbolicLink = Path.Combine(testDir, secondSymlinkRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(secondSymbolicLink));
             CreateSymbolicLink(secondSymbolicLink, appExe);
 
             // first symlink -> second symlink
             string firstSymbolicLink = Path.Combine(testDir, firstSymlinkRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(firstSymbolicLink));
             CreateSymbolicLink(firstSymbolicLink, secondSymbolicLink);
 
             Command.Create(firstSymbolicLink)

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -69,8 +69,6 @@ namespace Microsoft.NET.HostModel.Tests
             
             var appExe = fixture.TestProject.AppExe;
             var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
-            Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(firstSymlinkRelativePath)));
-            Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(secondSymlinkRelativePath)));
 
             // second symlink -> apphost
             string secondSymbolicLink = Path.Combine(testDir, secondSymlinkRelativePath);
@@ -86,12 +84,6 @@ namespace Microsoft.NET.HostModel.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
-
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Directory.Delete(firstSymbolicLink);
-                Directory.Delete(secondSymbolicLink);
-            }
         }
 
         //[Theory]


### PR DESCRIPTION
CI is fails to use `stat` on created symlinks on Linux release builds .