### PR TITLE
Skip forwarding entrypoint library name to Android application Main()

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -43,11 +43,6 @@ public class MonoRunner extends Instrumentation
     @Override
     public void onCreate(Bundle arguments) {
         if (arguments != null) {
-            String lib = arguments.getString("entryPointLibName");
-            if (lib != null) {
-                entryPointLibName = lib;
-            }
-
             ArrayList<String> argsList = new ArrayList<String>();
             for (String key : arguments.keySet()) {
                 if (key.startsWith("env:")) {
@@ -55,6 +50,8 @@ public class MonoRunner extends Instrumentation
                     String envValue = arguments.getString(key);
                     setEnv(envName, envValue);
                     Log.i("DOTNET", "env:" + envName + "=" + envValue);
+                } else if (key.equals("entrypoint:libname")) {
+                    entryPointLibName = arguments.getString(key);
                 } else {
                     String val = arguments.getString(key);
                     if (val != null) {
@@ -96,7 +93,7 @@ public class MonoRunner extends Instrumentation
         Looper.prepare();
 
         if (entryPointLibName == "") {
-            Log.e("DOTNET", "Missing entryPointLibName argument, pass '-e entryPointLibName <name.dll>' to adb to specify which program to run.");
+            Log.e("DOTNET", "Missing entrypoint argument, pass '-e entrypoint:libname <name.dll>' to adb to specify which program to run.");
             finish(1, null);
             return;
         }

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -362,7 +362,7 @@ else
 	HARNESS_RUNNER="xharness"
 fi
 
-$__Command $HARNESS_RUNNER android test --instrumentation="net.dot.MonoRunner" --package-name="net.dot.$__Category" --app="$__TestBinaryBase/$__Category.apk" --output-directory=`pwd` --arg=entryPointLibName=$(MsBuildProjectName).dll --expected-exit-code=100 -v
+$__Command $HARNESS_RUNNER android test --instrumentation="net.dot.MonoRunner" --package-name="net.dot.$__Category" --app="$__TestBinaryBase/$__Category.apk" --output-directory=`pwd` --arg=entrypoint:libname=$(MsBuildProjectName).dll --expected-exit-code=100 -v
 CLRTestExitCode=$?
 
 # Exist code of xharness is zero when tests finished successfully

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -328,7 +328,7 @@ IF NOT "%XHARNESS_CLI_PATH%"=="" (
   set HARNESS_RUNNER=xharness
 )
 
-%__Command% %HARNESS_RUNNER% android test --instrumentation="net.dot.MonoRunner" --package-name="net.dot.%__Category%" --app="%__TestBinaryBase%\%__Category%.apk" --output-directory="%25cd%25" --arg=entryPointLibName=$(MsBuildProjectName).dll --expected-exit-code=100 -v
+%__Command% %HARNESS_RUNNER% android test --instrumentation="net.dot.MonoRunner" --package-name="net.dot.%__Category%" --app="%__TestBinaryBase%\%__Category%.apk" --output-directory="%25cd%25" --arg=entrypoint:libname=$(MsBuildProjectName).dll --expected-exit-code=100 -v
 set CLRTestExitCode=!ERRORLEVEL!
 set CLRTestExpectedExitCode=0
     ]]></BatchCLRTestLaunchCmds>


### PR DESCRIPTION
Some of the Android runtime tests were recently broken because they got an "entryPointLibName=<test assembly name>" argument in their Main args.
This argument is normally used to run a specific test: https://github.com/dotnet/runtime/blob/dd63ea2e6a9cc6f2661b817d15e558fc6605fa17/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Program.cs#L24

After https://github.com/dotnet/runtime/commit/1a98ba0ec20550c9e1ece5fff555d683dec3252b we were passing the `entryPointLibName` down to the managed app args even though it's only supposed to be used to tell the runtime which assembly to run.