### PR TITLE
Replace some uses of Span.Fill with Span.Clear

### DIFF
--- a/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
@@ -209,7 +209,7 @@ namespace System.Net
                         _blocks.AsSpan().Slice((int)unusedInitialBlocks, (int)usedBlocks).CopyTo(_blocks);
 
                         // Null out the part of the array left over from the shift, so that we aren't holding references to those blocks.
-                        _blocks.AsSpan().Slice((int)usedBlocks, (int)unusedInitialBlocks).Fill(null);
+                        _blocks.AsSpan().Slice((int)usedBlocks, (int)unusedInitialBlocks).Clear();
                     }
 
                     uint shift = unusedInitialBlocks * BlockSize;

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
@@ -118,7 +118,7 @@ namespace System.Formats.Cbor
                 if (!keyEncodingRanges.Add(currentKey))
                 {
                     // reset writer state to right before the offending key write
-                    _buffer.AsSpan(currentKey.Offset, _offset).Fill(0);
+                    _buffer.AsSpan(currentKey.Offset, _offset).Clear();
                     _offset = currentKey.Offset;
 
                     throw new InvalidOperationException(SR.Format(SR.Cbor_ConformanceMode_ContainsDuplicateKeys, ConformanceMode));

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
@@ -260,7 +260,7 @@ namespace System.Formats.Cbor
             // clean up
             s_bufferPool.Return(tempBuffer);
             _currentIndefiniteLengthStringRanges.Clear();
-            buffer.Slice(_offset, initialOffset - _offset).Fill(0x0);
+            buffer.Slice(_offset, initialOffset - _offset).Clear();
         }
     }
 }


### PR DESCRIPTION
`Span<T>.Clear()` should generally be preferred to `Span<T>.Fill(default)`. In partial service of https://github.com/dotnet/runtime/issues/33813.