### PR TITLE
Add DuplexStream and implement for NetworkStream and QuicStream

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -118,7 +118,7 @@ namespace System.Net.Test.Common
 
         public async Task ShutdownSendAsync()
         {
-            _stream.Shutdown();
+            await _stream.CompleteWritesAsync().ConfigureAwait(false);
             await _stream.ShutdownWriteCompleted().ConfigureAwait(false);
         }
 

--- a/src/libraries/Common/tests/Tests/System/IO/ConnectedStreamsTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/ConnectedStreamsTests.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
             Task.FromResult<StreamPair>(ConnectedStreams.CreateUnidirectional());
     }
 
-    public class BidirectionalConnectedStreamsTests : ConnectedStreamConformanceTests
+    public class BidirectionalConnectedStreamsTests : DuplexConnectedStreamConformanceTests
     {
         protected override int BufferedSize => StreamBuffer.DefaultMaxBufferSize;
         protected override bool FlushRequiredToWriteData => false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -152,7 +152,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        _stream.Shutdown();
+                        await _stream.CompleteWritesAsync(cancellationToken).ConfigureAwait(false);
                     }
                 }
 
@@ -372,7 +372,7 @@ namespace System.Net.Http
                 _sendBuffer.Discard(_sendBuffer.ActiveLength);
             }
 
-            _stream.Shutdown();
+            await _stream.CompleteWritesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask WriteRequestContentAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -78,7 +78,7 @@ namespace System.Net.Quic
         public long MaxBidirectionalStreams { get { throw null; } set { } }
         public long MaxUnidirectionalStreams { get { throw null; } set { } }
     }
-    public sealed partial class QuicStream : System.IO.Stream
+    public sealed partial class QuicStream : System.IO.DuplexStream
     {
         internal QuicStream() { }
         public override bool CanRead { get { throw null; } }
@@ -91,6 +91,8 @@ namespace System.Net.Quic
         public void AbortWrite(long errorCode) { }
         public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
         public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
+        public override void CompleteWrites() { }
+        public override System.Threading.Tasks.ValueTask CompleteWritesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected override void Dispose(bool disposing) { }
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(System.IAsyncResult asyncResult) { }
@@ -102,7 +104,6 @@ namespace System.Net.Quic
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
-        public void Shutdown() { }
         public System.Threading.Tasks.ValueTask ShutdownWriteCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -178,12 +178,19 @@ namespace System.Net.Quic.Implementations.Mock
             return default;
         }
 
-        internal override void Shutdown()
+        public override void CompleteWrites()
         {
             CheckDisposed();
-
-            // This seems to mean shutdown send, in particular, not both.
             WriteStreamBuffer?.EndWrite();
+        }
+
+        public override ValueTask CompleteWritesAsync(CancellationToken cancellationToken)
+        {
+            CheckDisposed();
+            if (cancellationToken.IsCancellationRequested) return ValueTask.FromCanceled(cancellationToken);
+
+            WriteStreamBuffer?.EndWrite();
+            return default;
         }
 
         private void CheckDisposed()
@@ -198,7 +205,7 @@ namespace System.Net.Quic.Implementations.Mock
         {
             if (!_disposed)
             {
-                Shutdown();
+                CompleteWrites();
 
                 _disposed = true;
             }
@@ -208,7 +215,7 @@ namespace System.Net.Quic.Implementations.Mock
         {
             if (!_disposed)
             {
-                Shutdown();
+                CompleteWrites();
 
                 _disposed = true;
             }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
@@ -39,11 +39,13 @@ namespace System.Net.Quic.Implementations
 
         internal abstract ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default);
 
-        internal abstract void Shutdown();
-
         internal abstract void Flush();
 
         internal abstract Task FlushAsync(CancellationToken cancellationToken);
+
+        public abstract void CompleteWrites();
+
+        public abstract ValueTask CompleteWritesAsync(CancellationToken cancellationToken);
 
         public abstract void Dispose();
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Quic
 {
-    public sealed class QuicStream : Stream
+    public sealed class QuicStream : DuplexStream
     {
         private readonly QuicStreamProvider _provider;
 
@@ -101,7 +101,9 @@ namespace System.Net.Quic
 
         public ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default) => _provider.ShutdownWriteCompleted(cancellationToken);
 
-        public void Shutdown() => _provider.Shutdown();
+        public override void CompleteWrites() => _provider.CompleteWrites();
+
+        public override ValueTask CompleteWritesAsync(CancellationToken cancellationToken = default) => _provider.CompleteWritesAsync(cancellationToken);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -125,7 +125,7 @@ namespace System.Net.Quic.Tests
                         }
                     }
 
-                    stream.Shutdown();
+                    await stream.CompleteWritesAsync();
                     await stream.ShutdownWriteCompleted();
                 },
                 async serverConnection =>
@@ -143,7 +143,7 @@ namespace System.Net.Quic.Tests
                     int expectedTotalBytes = writes.SelectMany(x => x).Sum();
                     Assert.Equal(expectedTotalBytes, totalBytes);
 
-                    stream.Shutdown();
+                    await stream.CompleteWritesAsync();
                     await stream.ShutdownWriteCompleted();
                 });
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -81,7 +81,7 @@ namespace System.Net.Quic.Tests
 
     }
 
-    public abstract class QuicStreamConformanceTests : ConnectedStreamConformanceTests
+    public abstract class QuicStreamConformanceTests : DuplexConnectedStreamConformanceTests
     {
         public SslServerAuthenticationOptions GetSslServerAuthenticationOptions()
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -450,7 +450,7 @@ namespace System.Net.Quic.Tests
                         sendBuffer = sendBuffer.Slice(chunk.Length);
                     }
 
-                    clientStream.Shutdown();
+                    await clientStream.CompleteWritesAsync();
                     await clientStream.ShutdownWriteCompleted();
                 },
                 async serverConnection =>

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -114,7 +114,7 @@ namespace System.Net.Sockets
         public int InterfaceIndex { get { throw null; } set { } }
         public System.Net.IPAddress? LocalAddress { get { throw null; } set { } }
     }
-    public partial class NetworkStream : System.IO.Stream
+    public partial class NetworkStream : System.IO.DuplexStream
     {
         public NetworkStream(System.Net.Sockets.Socket socket) { }
         public NetworkStream(System.Net.Sockets.Socket socket, bool ownsSocket) { }
@@ -135,6 +135,8 @@ namespace System.Net.Sockets
         public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
         public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
         public void Close(int timeout) { }
+        public override void CompleteWrites() { }
+        public override System.Threading.Tasks.ValueTask CompleteWritesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected override void Dispose(bool disposing) { }
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(System.IAsyncResult asyncResult) { }

--- a/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
@@ -330,4 +330,7 @@
   <data name="net_sockets_handle_already_used" xml:space="preserve">
     <value>Handle is already used by another Socket.</value>
   </data>
+  <data name="net_io_shutdownfailure" xml:space="preserve">
+    <value>Unable to complete writes on the transport connection: {0}.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -506,8 +506,6 @@ namespace System.Net.Sockets
 
         // ReadAsync - provide async read functionality.
         //
-        // This method provides async read functionality.
-        //
         // Input:
         //
         //     buffer            - Buffer to read into.
@@ -565,8 +563,6 @@ namespace System.Net.Sockets
         }
 
         // WriteAsync - provide async write functionality.
-        //
-        // This method provides async write functionality.
         //
         // Input:
         //

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class NetworkStreamTest : ConnectedStreamConformanceTests
+    public class NetworkStreamTest : DuplexConnectedStreamConformanceTests
     {
         protected override bool BlocksOnZeroByteReads => true;
         protected override bool CanTimeout => true;
@@ -547,7 +547,7 @@ namespace System.Net.Sockets.Tests
                     await Task.WhenAll(remoteTask, clientConnectTask);
 
                     using (TcpClient remote = remoteTask.Result)
-                    using (NetworkStream serverStream = new NetworkStream(remote.Client, serverAccess, ownsSocket:true))
+                    using (NetworkStream serverStream = new NetworkStream(remote.Client, serverAccess, ownsSocket: true))
                     using (NetworkStream clientStream = new NetworkStream(client.Client, clientAccess, ownsSocket: true))
                     {
                         await func(serverStream, clientStream);

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3721,4 +3721,7 @@
   <data name="NotSupported_MethodBodyReplacement" xml:space="preserve">
     <value>Method body replacement not supported in this runtime.</value>
   </data>
+  <data name="DuplexStream_InvalidReadOnWriteOnlyStream" xml:space="preserve">
+    <value>A DuplexStream's write-only stream does not support reading.</value>
+  </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -396,6 +396,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\BufferedStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DirectoryNotFoundException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\DuplexStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EncodingCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EndOfStreamException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileAccess.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DuplexStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DuplexStream.cs
@@ -1,0 +1,217 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>
+    /// <see cref="DuplexStream"/> is a <see cref="Stream"/> that has independent read and write streams.
+    /// </summary>
+    public abstract class DuplexStream : Stream
+    {
+        /// <summary>
+        /// Gets a write-only <see cref="Stream"/> for the <see cref="DuplexStream"/>.
+        /// When disposed, the <see cref="Stream"/> will call <see cref="CompleteWrites"/>.
+        /// </summary>
+        /// <returns>A new write-only instance of the <see cref="DuplexStream"/>.</returns>
+        public Stream GetWriteOnlyStream() =>
+            new WriteOnlyProxyStream(this);
+
+        /// <summary>
+        /// Flushes the <see cref="DuplexStream"/> and completes the write stream,
+        /// allowing a peer to observe end of stream. There must be no further writes
+        /// to this <see cref="DuplexStream"/>, but reads may continue.
+        /// </summary>
+        /// <remarks>
+        /// Successful completion of <see cref="CompleteWrites"/> does not indicate
+        /// that the peer has acknowledged the end of stream.
+        /// </remarks>
+        public abstract void CompleteWrites();
+
+        /// <summary>
+        /// Flushes the <see cref="DuplexStream"/> and completes the write stream,
+        /// allowing a peer to observe end of stream. There must be no further writes
+        /// to this <see cref="DuplexStream"/>, but reads may continue.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the operation.</param>
+        /// <returns>A <see cref="ValueTask"/> representing the asynchronous write completion.</returns>
+        /// <remarks>
+        /// Successful completion of <see cref="CompleteWritesAsync"/> does not indicate
+        /// that the peer has acknowledged the end of stream.
+        /// </remarks>
+        public abstract ValueTask CompleteWritesAsync(CancellationToken cancellationToken = default);
+
+        private sealed class WriteOnlyProxyStream : Stream
+        {
+            private readonly DuplexStream _stream;
+            private int _disposed;
+
+            public override bool CanRead => false;
+            public override bool CanSeek => _disposed == 0 ? _stream.CanSeek : false;
+            public override bool CanWrite => _disposed == 0 ? _stream.CanWrite : false;
+            public override bool CanTimeout => _disposed == 0 ? _stream.CanTimeout : false;
+
+            public override long Length => _stream.Length;
+
+            public override long Position
+            {
+                get
+                {
+                    ThrowIfDisposed();
+                    return _stream.Position;
+                }
+                set
+                {
+                    ThrowIfDisposed();
+                    _stream.Position = value;
+                }
+            }
+
+            public override int ReadTimeout
+            {
+                get => throw CreateNotSupportedException();
+                set => throw CreateNotSupportedException();
+            }
+
+            public override int WriteTimeout
+            {
+                get
+                {
+                    ThrowIfDisposed();
+                    return _stream.WriteTimeout;
+                }
+                set
+                {
+                    ThrowIfDisposed();
+                    _stream.WriteTimeout = value;
+                }
+            }
+
+            public WriteOnlyProxyStream(DuplexStream stream)
+            {
+                _stream = stream;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                    {
+                        _stream.CompleteWrites();
+                    }
+                }
+
+                base.Dispose(disposing);
+            }
+
+            public override async ValueTask DisposeAsync()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    await _stream.CompleteWritesAsync().ConfigureAwait(false);
+                }
+
+                await base.DisposeAsync().ConfigureAwait(false);
+            }
+
+            public override int ReadByte() =>
+                throw CreateNotSupportedException();
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                throw CreateNotSupportedException();
+
+            public override int Read(Span<byte> buffer) =>
+                throw CreateNotSupportedException();
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                throw CreateNotSupportedException();
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+                throw CreateNotSupportedException();
+
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+                TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
+
+            public override int EndRead(IAsyncResult asyncResult) =>
+                TaskToApm.End<int>(asyncResult);
+
+            public override void WriteByte(byte value)
+            {
+                ThrowIfDisposed();
+                _stream.WriteByte(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                ThrowIfDisposed();
+                _stream.Write(buffer, offset, count);
+            }
+
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                ThrowIfDisposed();
+                _stream.Write(buffer);
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                ThrowIfDisposed();
+                return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                ThrowIfDisposed();
+                return _stream.WriteAsync(buffer, cancellationToken);
+            }
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+                TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
+
+            public override void EndWrite(IAsyncResult asyncResult) =>
+                TaskToApm.End(asyncResult);
+
+            public override void Flush()
+            {
+                ThrowIfDisposed();
+                _stream.Flush();
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                ThrowIfDisposed();
+                return _stream.FlushAsync(cancellationToken);
+            }
+
+            public override void CopyTo(Stream destination, int bufferSize) =>
+                throw CreateNotSupportedException();
+
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
+                throw CreateNotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                ThrowIfDisposed();
+                return _stream.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                ThrowIfDisposed();
+                _stream.SetLength(value);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                if (_disposed != 0) ThrowException();
+                static void ThrowException() => throw new ObjectDisposedException(nameof(WriteOnlyProxyStream));
+            }
+
+            private Exception CreateNotSupportedException() =>
+                new NotSupportedException(SR.DuplexStream_InvalidReadOnWriteOnlyStream);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7194,6 +7194,12 @@ namespace System.IO
         public DirectoryNotFoundException(string? message) { }
         public DirectoryNotFoundException(string? message, System.Exception? innerException) { }
     }
+    public abstract partial class DuplexStream : System.IO.Stream
+    {
+        public System.IO.Stream GetWriteOnlyStream() { throw null; }
+        public abstract void CompleteWrites();
+        public abstract System.Threading.Tasks.ValueTask CompleteWritesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
     public partial class EndOfStreamException : System.IO.IOException
     {
         public EndOfStreamException() { }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="System\Diagnostics\StackTraceHiddenAttributeTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundExceptionTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundException.InteropTests.cs" />
+    <Compile Include="System\IO\DuplexStreamTests.cs" />
     <Compile Include="System\IO\EndOfStreamExceptionTests.cs" />
     <Compile Include="System\IO\Exceptions.HResults.cs" />
     <Compile Include="System\IO\FileLoadExceptionTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/IO/DuplexStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System/IO/DuplexStreamTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public static class DuplexStreamTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WriteOnlyProxyDispose_CompletesDuplexStream(bool isAsync)
+        {
+            var stream = new TestDuplexStream();
+            Stream writeOnlyStream = stream.GetWriteOnlyStream();
+
+            if (isAsync) await writeOnlyStream.DisposeAsync();
+            else writeOnlyStream.Dispose();
+
+            Assert.True(stream.CompleteWritesCount == 1, $"Disposing the write-only stream must call {nameof(TestDuplexStream.CompleteWrites)}.");
+
+            if (isAsync) await writeOnlyStream.DisposeAsync();
+            else writeOnlyStream.Dispose();
+
+            Assert.True(stream.CompleteWritesCount == 1, $"Disposing the write-only stream multiple times must not call {nameof(TestDuplexStream.CompleteWrites)} multiple times.");
+        }
+
+        [Fact]
+        public static async Task WriteOnlyProxy_IsWriteOnly()
+        {
+            Stream stream = new TestDuplexStream().GetWriteOnlyStream();
+
+            Assert.False(stream.CanRead);
+            Assert.ThrowsAny<NotSupportedException>(() => _ = stream.ReadTimeout);
+            Assert.ThrowsAny<NotSupportedException>(() => stream.ReadTimeout = 1);
+            Assert.ThrowsAny<NotSupportedException>(() => stream.Read(Array.Empty<byte>()));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(() => stream.ReadAsync(Array.Empty<byte>()).AsTask());
+            Assert.ThrowsAny<NotSupportedException>(() => stream.CopyTo(Stream.Null));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(() => stream.CopyToAsync(Stream.Null));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WriteOnlyProxy_UnusableAfterDispose(bool isAsync)
+        {
+            Stream stream = new TestDuplexStream().GetWriteOnlyStream();
+
+            if (isAsync) await stream.DisposeAsync();
+            else stream.Dispose();
+
+            Assert.False(stream.CanRead);
+            Assert.False(stream.CanSeek);
+            Assert.False(stream.CanWrite);
+            Assert.False(stream.CanTimeout);
+            Assert.ThrowsAny<ObjectDisposedException>(() => _ = stream.Position);
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.Position = 1);
+            Assert.ThrowsAny<ObjectDisposedException>(() => _ = stream.ReadTimeout);
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.ReadTimeout = 1);
+            Assert.ThrowsAny<ObjectDisposedException>(() => _ = stream.WriteTimeout);
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.WriteTimeout = 1);
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.Write(Array.Empty<byte>()));
+            await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => stream.WriteAsync(Array.Empty<byte>()).AsTask());
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.Flush());
+            await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => stream.FlushAsync());
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.Seek(0, SeekOrigin.Begin));
+            Assert.ThrowsAny<ObjectDisposedException>(() => stream.SetLength(0));
+        }
+
+        private sealed class TestDuplexStream : DuplexStream
+        {
+            public int CompleteWritesCount { get; private set; }
+
+            public override void CompleteWrites() =>
+                ++CompleteWritesCount;
+
+            public override ValueTask CompleteWritesAsync(CancellationToken cancellationToken = default)
+            {
+                ++CompleteWritesCount;
+                return default;
+            }
+
+            // note: throwing Exception rather than NotImplementedException differentiates between
+            // the write proxy throwing other exceptions versus incorrectly forwarding calls to its DuplexStream.
+
+            public override bool CanTimeout => throw new Exception();
+            public override bool CanRead => throw new Exception();
+            public override bool CanSeek => throw new Exception();
+            public override bool CanWrite => throw new Exception();
+            public override long Length => throw new Exception();
+            public override long Position { get => throw new Exception(); set => throw new Exception(); }
+            public override int ReadTimeout { get => throw new Exception(); set => throw new Exception(); }
+            public override int WriteTimeout { get => throw new Exception(); set => throw new Exception(); }
+
+            public override void Flush() => throw new Exception();
+            public override int Read(byte[] buffer, int offset, int count) => throw new Exception();
+            public override long Seek(long offset, SeekOrigin origin) => throw new Exception();
+            public override void SetLength(long value) => throw new Exception();
+            public override void Write(byte[] buffer, int offset, int count) => throw new Exception();
+            public override void CopyTo(Stream destination, int bufferSize) => throw new Exception();
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => throw new Exception();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #43290.

Adds `DuplexStream` for `NetworkStream` and `QuicStream`, and new conformance tests.

Adding issues #51431, #51432, and #51433 for filling out other `Stream` implementations.

@karelz please adjust labels if OCD kicks in :D