### PR TITLE
ImmutableDictionary.AddRange: throw if any item has a null Key.

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -963,6 +963,7 @@ namespace System.Collections.Immutable
             var newRoot = origin.Root;
             foreach (var pair in items)
             {
+                Requires.NotNullAllowStructs(pair.Key, nameof(pair.Key));
                 int hashCode = origin.KeyComparer.GetHashCode(pair.Key);
                 HashBucket bucket = newRoot.GetValueOrDefault(hashCode);
                 OperationResult result;

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
@@ -48,6 +48,15 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void BuilderAddRangeThrowsWhenAddingNullKey()
+        {
+            var set = ImmutableDictionary<string, int>.Empty.Add("1", 1);
+            var builder = set.ToBuilder();
+            var items = new[] { new KeyValuePair<string, int>(null, 0) };
+            Assert.Throws<ArgumentNullException>(() => builder.AddRange(items));
+        }
+
+        [Fact]
         public void BuilderFromMap()
         {
             var set = ImmutableDictionary<int, string>.Empty.Add(1, "1");

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -25,6 +25,18 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void AddRangeShouldThrowOnNullKeyTest()
+        {
+            var items = new[] { new KeyValuePair<string, string>(null, "value") };
+
+            var map = Empty(StringComparer.Ordinal, StringComparer.Ordinal);
+            Assert.Throws<ArgumentNullException>(() => map.AddRange(items));
+
+            map = map.WithComparers(new BadHasher<string>());
+            Assert.Throws<ArgumentNullException>(() => map.AddRange(items));
+        }
+
+        [Fact]
         public void UnorderedChangeTest()
         {
             var map = Empty<string, string>(StringComparer.Ordinal)
@@ -57,6 +69,16 @@ namespace System.Collections.Immutable.Tests
                 .SetItem("A", 1);
             map = map.SetItem("a", 2);
             Assert.Equal("a", map.Keys.Single());
+        }
+
+        [Fact]
+        public void SetItemsThrowOnNullKey()
+        {
+            var map = Empty<string, int>().WithComparers(StringComparer.OrdinalIgnoreCase);
+            var items = new[] { new KeyValuePair<string, int>(null, 0) };
+            Assert.Throws<ArgumentNullException>(() => map.SetItems(items));
+            map = map.WithComparers(new BadHasher<string>());
+            Assert.Throws<ArgumentNullException>(() => map.SetItems(items));
         }
 
         /// <summary>


### PR DESCRIPTION
The behavior of AddRange(items) should be the same as
foreach(var item in items) Add(item); Add(item) throws if item.Key == null,
so AddRange should it as well.

Fix #50865.