### PR TITLE
Switch over the runtime outerloop pipeline to use Crossgen2

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -147,7 +147,8 @@ jobs:
     jobParameters:
       testGroup: outerloop
       readyToRun: true
-      displayNameArgs: R2R
+      crossgen2: true
+      displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
 
 #


### PR DESCRIPTION
With this change, the only remaining pipelines using Crossgen1 are
"r2r.yml", "r2r-extra.yml" and "release-tests.yml". I haven't yet
identified the pipeline running the "release-tests.yml" script;
for the "r2r*.yml", these now remain the only pipelines exercising
Crossgen1. I don't think it makes sense to switch them over to
CG2 as we already have their CG2 counterparts; my expectation is
that, once CG1 is finally decommissioned, they will be just deleted.

Thanks

Tomas

/cc @dotnet/crossgen-contrib @dotnet/runtime-infrastructure  