### PR TITLE
Refactor the platform support attribute generation in the build

### DIFF
--- a/eng/targetframeworksuffix.props
+++ b/eng/targetframeworksuffix.props
@@ -1,18 +1,21 @@
 <Project>
-  
+
   <PropertyGroup>
     <TargetPlatformSupported>true</TargetPlatformSupported>
     <TargetPlatformVersionSupported>true</TargetPlatformVersionSupported>
+
+    <!-- Value of 0.0 produces versionless SupportedOSPlatform attribute.
+         This is required for platforms not expected to have a version,
+         and we currently omit the version for all platforms. -->
+    <SupportedOSPlatformVersion>0.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkSuffix)' != '' and '$(TargetFrameworkSuffix)' != 'windows'">
     <TargetPlatformIdentifier>$(TargetFrameworkSuffix)</TargetPlatformIdentifier>
     <TargetPlatformVersion>1.0</TargetPlatformVersion>
     <TargetPlatformMoniker>$(TargetFrameworkSuffix),Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
-    <!-- Value of 0.0 produces versionless SupportedOSPlatform attribute, which is important for platforms not expected to have a version -->
-    <SupportedOSPlatformVersion>0.0</SupportedOSPlatformVersion>
   </PropertyGroup>
-  
+
   <Choose>
     <When Condition="'$(TargetFrameworkSuffix)' == 'windows'">
       <PropertyGroup>

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -25,13 +25,6 @@
     </AssemblyMetadata>
   </ItemGroup>
 
-  <!-- Adds SupportedOSPlatform attribute for Windows Specific libraries -->
-  <ItemGroup Condition="'$(IsWindowsSpecific)' == 'true' and '$(IsTestProject)' != 'true' and '$(IncludePlatformAttributes)' != 'false'">
-    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
-        <_Parameter1>windows</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(TargetsAnyOS)' == 'true' and !$(TargetFrameworks.Contains('$(TargetFramework)-Browser'))">
       <CrossPlatformAndHasNoBrowserTarget>true</CrossPlatformAndHasNoBrowserTarget>
   </PropertyGroup>
@@ -57,29 +50,37 @@
     <SupportedPlatform Condition="'$(TargetsUnix)' == 'true'" Include="Unix"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <_unsupportedOSPlatforms Include="$(UnsupportedOSPlatforms)" />
-    <_supportedOSPlatforms Include="$(SupportedOSPlatforms)" />
-  </ItemGroup>
-
   <!-- Adds UnsupportedOSPlatform and SupportedOSPlatform attributes to the assembly when:
-      * At least one <UnsupportedOSPlatforms /> or <SupportedOSPlatforms /> has been specified
       * This isn't a test project
       * This is a cross-platform target
       * The build isn't targeting .NET Framework
     -->
   <Target Name="AddOSPlatformAttributes" BeforeTargets="GenerateAssemblyInfo" AfterTargets="PrepareForBuild"
     Condition="'$(TargetsAnyOS)' == 'true' and '$(IsTestProject)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Defensively de-dupe the values -->
+    <ItemGroup>
+      <_unsupportedOSPlatforms Include="$(UnsupportedOSPlatforms)" />
+      <_supportedOSPlatforms Include="$(SupportedOSPlatforms)" />
+    </ItemGroup>
+
     <ItemGroup Condition="'@(_unsupportedOSPlatforms)' != ''">
+      <!-- Add the assembly attribute -->
       <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform">
         <_Parameter1>%(_unsupportedOSPlatforms.Identity)</_Parameter1>
       </AssemblyAttribute>
+
+      <!-- Ensure this platform is included in the platforms enabled for the CA1416 analyzer -->
+      <SupportedPlatform Include="%(_unsupportedOSPlatforms.Identity)" />
     </ItemGroup>
 
     <ItemGroup Condition="'@(_supportedOSPlatforms)' != ''">
+      <!-- Add the assembly attribute -->
       <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
         <_Parameter1>%(_supportedOSPlatforms.Identity)</_Parameter1>
       </AssemblyAttribute>
+
+      <!-- Ensure this platform is included in the platforms enabled for the CA1416 analyzer -->
+      <SupportedPlatform Include="%(_supportedOSPlatforms.Identity)" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -133,12 +133,12 @@
     <PropertyGroup>
       <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
       <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
-      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath> 
+      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
       <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
       <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
       <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
       <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
-      <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters>  
+      <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters>
       <GenAPIAdditionalParameters Condition="'%(ProjectReference.Identity)' == '$(CoreLibProject)'">$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
     </PropertyGroup>
   </Target>
@@ -232,7 +232,10 @@
   <!-- Adds System.Runtime.Versioning*Platform* annotation attributes to < .NET 5 builds -->
   <Choose>
     <When Condition="'$(IncludePlatformAttributes)' == 'false'" />
-    <When Condition="('$(IncludePlatformAttributes)' == 'true' or '$(IsWindowsSpecific)' == 'true') and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0')))">
+    <When Condition="('$(IncludePlatformAttributes)' == 'true' or '$(SupportedOSPlatforms)' != '' or '$(UnsupportedOSPlatforms)' != '') and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0')))">
+      <!-- If a project is downlevel from net5.0 but uses the platform support attributes, then we include the classes
+           in the project as internal. If a project has specified assembly-level SupportedOSPlatforms or UnsupportedOSPlatforms,
+           we can infer the need without having IncludePlatformAttributes set. -->
       <ItemGroup>
         <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\PlatformAttributes.cs" Link="System\Runtime\Versioning\PlatformAttributes.cs" />
       </ItemGroup>

--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides support for managing access and audit control lists for Microsoft.Win32.RegistryKey.
 
 Commonly Used Types:

--- a/src/libraries/Microsoft.Win32.Registry/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.Registry/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides support for accessing and modifying the Windows Registry.
 
 Commonly Used Types:

--- a/src/libraries/Microsoft.Win32.SystemEvents/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.SystemEvents/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides access to Windows system event notifications.
 
 Commonly Used Types:

--- a/src/libraries/System.Data.OleDb/Directory.Build.props
+++ b/src/libraries/System.Data.OleDb/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides a collection of classes for OLEDB.
 
 Commonly Used Types:

--- a/src/libraries/System.Diagnostics.EventLog/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.EventLog/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides the System.Diagnostics.EventLog class, which allows the applications to use the windows event log service.
 
 Commonly Used Types:

--- a/src/libraries/System.Diagnostics.EventLog/src/Messages/System.Diagnostics.EventLog.Messages.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/src/Messages/System.Diagnostics.EventLog.Messages.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Win32Resource>EventLogMessages.res</Win32Resource>
-    <IncludePlatformAttributes>false</IncludePlatformAttributes>
+    <!-- Override the parent Directory.Build.props -->
+    <SupportedOSPlatforms />
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides the System.Diagnostics.PerformanceCounter class, which allows access to Windows performance counters.
 
 Commonly Used Types:

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
@@ -6,7 +6,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides uniform access and manipulation of user, computer, and group security principals across the multiple principal stores: Active Directory Domain Services (AD DS), Active Directory Lightweight Directory Services (AD LDS), and Machine SAM (MSAM).</PackageDescription>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices/Directory.Build.props
@@ -6,7 +6,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides easy access to Active Directory Domain Services.
 
 Commonly Used Types:

--- a/src/libraries/System.IO.FileSystem.AccessControl/Directory.Build.props
+++ b/src/libraries/System.IO.FileSystem.AccessControl/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides types for managing access and audit control lists for files and directories.
 
 Commonly Used Types:

--- a/src/libraries/System.IO.Pipes.AccessControl/Directory.Build.props
+++ b/src/libraries/System.IO.Pipes.AccessControl/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides types for managing access and audit control lists for pipes.
 
 Commonly Used Types:

--- a/src/libraries/System.Management/Directory.Build.props
+++ b/src/libraries/System.Management/Directory.Build.props
@@ -6,7 +6,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides access to a rich set of management information and management events about the system, devices, and applications instrumented to the Windows Management Instrumentation (WMI) infrastructure.
 
 Commonly Used Types:

--- a/src/libraries/System.Net.Http.WinHttpHandler/Directory.Build.props
+++ b/src/libraries/System.Net.Http.WinHttpHandler/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides a message handler for HttpClient based on the WinHTTP interface of Windows. While similar to HttpClientHandler, it provides developers more granular control over the application's HTTP communication than the HttpClientHandler.
 
 Commonly Used Types:

--- a/src/libraries/System.Security.AccessControl/Directory.Build.props
+++ b/src/libraries/System.Security.AccessControl/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides base classes that enable managing access and audit control lists on securable objects.
 
 Commonly Used Types:

--- a/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides cryptographic algorithm implementations and key management with Windows Cryptographic Next Generation API (CNG).
 
 Commonly Used Types:

--- a/src/libraries/System.Security.Cryptography.ProtectedData/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides access to Windows Data Protection Api.
 
 Commonly Used Types:

--- a/src/libraries/System.Security.Principal.Windows/Directory.Build.props
+++ b/src/libraries/System.Security.Principal.Windows/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides classes for retrieving the current Windows user and for interacting with Windows users and groups.
 
 Commonly Used Types:

--- a/src/libraries/System.ServiceProcess.ServiceController/Directory.Build.props
+++ b/src/libraries/System.ServiceProcess.ServiceController/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides the System.ServiceProcess.ServiceContainer class, which allows you to connect to a running or stopped service, manipulate it, or get information about it.
 
 Commonly Used Types:

--- a/src/libraries/System.Speech/Directory.Build.props
+++ b/src/libraries/System.Speech/Directory.Build.props
@@ -6,7 +6,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides types to perform speech synthesis and speech recognition.
 
 Commonly Used Types

--- a/src/libraries/System.Threading.AccessControl/Directory.Build.props
+++ b/src/libraries/System.Threading.AccessControl/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides support for managing access and audit control lists for synchronization primitives.
 
 Commonly Used Types:

--- a/src/libraries/System.Threading.Overlapped/Directory.Build.props
+++ b/src/libraries/System.Threading.Overlapped/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Windows.Extensions/Directory.Build.props
+++ b/src/libraries/System.Windows.Extensions/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <PackageDescription>Provides miscellaneous Windows-specific types
 
 Commonly Used Types:


### PR DESCRIPTION
Refactor the `SupportedOSPlatform`/`UnsupportedOSPlatform` attribute generation in the build to make it more consistent with fewer moving parts.

With #49261, we resurrected the idea of having an MSBuild property for `<SupportedOSPlatforms>` which was entertained in #41209 but not merged. This is a follow-up PR that further utilizes that new property and simplifies the logic overall while improving consistency of the attributes across the configurations.

Here are some concepts important to note:

1. The SDK automatically produces `[SupportedOSPlatform]` attributes for recognized platforms, such as `net6.0-windows` and `net6.0-ios`
2. The SDK recognizes `<SupportedOSPlatformVersion>` as a property to override the version number it uses on the attributes, with `0.0` meaning to omit the version
3. The Platform Compatibility Analyzer (CA1416) consumes the `<SupportedPlatform>` item to get the list of platform names the build recognizes
    * The SDK includes a default set of platforms in that item
    * Newer platforms (such as `ios`) are not included by default
    * This item supports custom platform names too, such as `Solaris`
4. Some cross-platform builds (`net6.0`) need to have assembly-level `[SupportedOSPlatform]` and `[UnsupportedOSPlatform]` attributes to indicate library-wide support
    * The SDK does not have a mechanism for specifying those attributes via MSBuild properties/items
    * We have introduced our own `<SupportedOSPlatforms>` and `<UnsupportedOSPlatforms>` properties to achieve that
5. The `SupportedOSPlatformAttribute` and `UnsupportedOSPlatformAttribute` types were introduced in net5.0, but we have places where we annotate libraries/APIs with the attributes in `netstandard` builds
    * The CA1416 analyzer recognizes and supports the attributes being defined within a library as internal for downlevel support
    * We have an `<IncludePlatformAttributes>true</IncludePlatformAttributes>` property that can be specified to include those types (as internal) in the project

In this PR, the logic for our build is refactored to:

* Replace the `<IsWindowsSpecific>true</IsWindowsSpecific>` property that was introduced in #39265 with `<SupportedOSPlatforms>windows</SupportedOSPlatforms>`
* Always specify `<SupportedOSPlatformVersion>0.0</SupportedOSPlatformVersion>` to produce versionless attributes
    * This was previously not applied to Windows builds, resulting in the production of `Windows7.0` attributes
    * We had concluded for Windows that we should use the simple `windows` platform name without a version
    * Because of this mismatch, we had some that were `windows` and some that were `Windows7.0`; we even had some getting both
* For any platform specified in `<SupportedOSPlatforms>` or `<UnsupportedOSPlatforms>`, we now explicitly add the platform to `<SupportedPlatform>` to ensure it's a recognized platform name (for custom targets not recognized by the SDK)
* Infer the effect of `<IncludePlatformAttributes>true</IncludePlatformAttributes>` when any `<SupportedOSPlatform>` or <UnsupportedOSPlatform>` value exists and the target is downlevel from net5.0

Testing the refactor and evaluating our attribute production consistency was annoying, so I [crafted a utility](https://gist.github.com/jeffhandley/9600dd0b73e9562b58ed25ad32541a41#file-scanner-cs) that can scan the `artifacts` folder and build a report of all libraries' generated attributes. This utility looks in the generated `AssemblyInfo.cs` files for each library and reports on the `src` and `ref` builds' attributes for `SupportedOSPlatform` and `UnsupportedOSPlatform`. I produced a copy of that report from `main` before this PR and then produced a copy of that report from after PR's changes.

* [Report before this PR](https://gist.github.com/jeffhandley/c62da06f668d10ed004422d8c9e3e839/6ae3d83f8d7fc1db61c3efee2c4a9fac6a3be374#file-runtime-libraries-md)
* [Report after this PR](https://gist.github.com/jeffhandley/c62da06f668d10ed004422d8c9e3e839#file-runtime-libraries-md)
* [Report diff](https://gist.github.com/jeffhandley/c62da06f668d10ed004422d8c9e3e839/revisions#diff-835bd791c03e4a429831f9a247a84a2267447c0feea8f0b5a24ca97f98acdbfe)

The net effects are:

1. Several Windows-specific builds were getting `[SupportedOSPlatform("Windows7.0")]` produced; those are now `[SupportedOSPlatform("windows")]` to be consistent throughout
2. Several Windows-specific builds were getting both `"Windows7.0"` and `"windows"` produced; this is now reduced to just `"Windows"` (side effect of the above change)
3. Several .NET Framework targeted builds were getting the attributes produced, but we had not intended to produce them for .NET Framework builds; those are now removed
4. Some `netstandard` platform-specific builds were getting the attributes produced, but that wasn't intentional (only the cross-platform build was intended to have them)
    * If we allow platform-specific builds to get the attributes applied, it can lead to conflicts with the `[SupportedOSPlatform]` attribute applied by the SDK itself
    * For example, for a library that is unsupported on browser, the Windows-specific build would end up with `[SupportedOSPlatform("Windows")]` and `[UnsupportedOSPlatform("browser")]`, which is not desired. The result should just be `[UnsupportedOSPlatform("browser")]`
