### PR TITLE
Add quotes around method.Name for crossgen2 replay instruction.

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -749,7 +749,7 @@ namespace ILCompiler
             var formatter = new CustomAttributeTypeNameFormatter((IAssemblyDesc)method.Context.SystemModule);
 
             sb.Append($"--singlemethodtypename \"{formatter.FormatName(method.OwningType, true)}\"");
-            sb.Append($" --singlemethodname {method.Name}");
+            sb.Append($" --singlemethodname \"{method.Name}\"");
             {
                 int curIndex = 0;
                 foreach (var searchMethod in method.OwningType.GetMethods())


### PR DESCRIPTION
In my case the repro was `Single method repro args:--singlemethodtypename "System.Runtime.Intrinsics.Vector256" --singlemethodname <Create>g__SoftwareFallback|43_0 --singlemethodindex 1` and VS did not like <Create>g__SoftwareFallback|43_0 on replay.