### PR TITLE
Faster wasm runtime

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -72,7 +72,7 @@ ifeq ($(ENABLE_METADATA_UPDATE),true)
 endif
 
 EMCC_DEBUG_FLAGS =-g -Os -s ASSERTIONS=1 -DDEBUG=1
-EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2
+EMCC_RELEASE_FLAGS=-O3 --llvm-opts 3 -flto
 
 ifeq ($(NOSTRIP),)
 STRIP_CMD=&& $(EMSDK_PATH)/upstream/bin/wasm-opt --strip-dwarf $(NATIVE_BIN_DIR)/dotnet.wasm -o $(NATIVE_BIN_DIR)/dotnet.wasm
@@ -108,13 +108,13 @@ $(BUILDS_OBJ_DIR)/pinvoke-table.h: $(PINVOKE_TABLE) | $(BUILDS_OBJ_DIR)
 	if cmp -s $(PINVOKE_TABLE) $$@ ; then : ; else cp $(PINVOKE_TABLE) $$@ ; fi
 
 $(BUILDS_OBJ_DIR)/driver.o: runtime/driver.c | $(BUILDS_OBJ_DIR)
-	$(EMCC) $(EMCC_FLAGS) $(1) -Oz -DCORE_BINDINGS -I$(BUILDS_OBJ_DIR) -I$(MONO_INCLUDE_DIR) runtime/driver.c -c -o $$@
+	$(EMCC) $(EMCC_FLAGS) $(1) -O3 -flto -DCORE_BINDINGS -I$(BUILDS_OBJ_DIR) -I$(MONO_INCLUDE_DIR) runtime/driver.c -c -o $$@
 
 $(BUILDS_OBJ_DIR)/pinvoke.o: runtime/pinvoke.c runtime/pinvoke.h $(BUILDS_OBJ_DIR)/pinvoke-table.h | $(BUILDS_OBJ_DIR)
-	$(EMCC) $(EMCC_FLAGS) $(1) -Oz -DGEN_PINVOKE=1 -I$(BUILDS_OBJ_DIR) runtime/pinvoke.c -c -o $$@
+	$(EMCC) $(EMCC_FLAGS) $(1) -O3 -flto -DGEN_PINVOKE=1 -I$(BUILDS_OBJ_DIR) runtime/pinvoke.c -c -o $$@
 
 $(BUILDS_OBJ_DIR)/corebindings.o: runtime/corebindings.c | $(BUILDS_OBJ_DIR)
-	$(EMCC) $(EMCC_FLAGS) $(1) -Oz -I$(MONO_INCLUDE_DIR) runtime/corebindings.c -c -o $$@
+	$(EMCC) $(EMCC_FLAGS) $(1) -O3 -flto -I$(MONO_INCLUDE_DIR) runtime/corebindings.c -c -o $$@
 
 $(NATIVE_BIN_DIR)/src/emcc-flags.txt: | $(NATIVE_BIN_DIR)/src Makefile
 	echo "$(call escape_quote,$(EMCC_FLAGS)) $(1)" > $$@

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -72,7 +72,8 @@ ifeq ($(ENABLE_METADATA_UPDATE),true)
 endif
 
 EMCC_DEBUG_FLAGS =-g -Os -s ASSERTIONS=1 -DDEBUG=1
-EMCC_RELEASE_FLAGS=-O3 --llvm-opts 3 -flto
+EMCC_RELEASE_FLAGS=-O3 -flto --llvm-opts 3
+EMCC_CLOSURE_ARGS=--externs runtime/externs.js
 
 ifeq ($(NOSTRIP),)
 STRIP_CMD=&& $(EMSDK_PATH)/upstream/bin/wasm-opt --strip-dwarf $(NATIVE_BIN_DIR)/dotnet.wasm -o $(NATIVE_BIN_DIR)/dotnet.wasm

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -541,6 +541,7 @@ var BindingSupportLib = {
 						((typeof js_obj === "object" || typeof js_obj === "function") && typeof js_obj.then === "function")
 			}
 
+			var result;
 			switch (true) {
 				case js_obj === null:
 				case typeof js_obj === "undefined":
@@ -962,7 +963,7 @@ var BindingSupportLib = {
 
 				var conv = primitiveConverters.get (key);
 				if (!conv)
-					throw new Error ("Unknown parameter type " + type);
+					throw new Error ("Unknown parameter type " + key);
 
 				var localStep = Object.create (conv.steps[0]);
 				localStep.size = conv.size;
@@ -1300,7 +1301,7 @@ var BindingSupportLib = {
 			converter, buffer, resultRoot, exceptionRoot, argsRootBuffer, is_result_marshaled
 		) {
 			this._handle_exception_for_call (converter, buffer, resultRoot, exceptionRoot, argsRootBuffer);
-
+			var result;
 			if (is_result_marshaled)
 				result = this._unbox_mono_obj_root (resultRoot);
 			else
@@ -1443,7 +1444,7 @@ var BindingSupportLib = {
 				"return result;"
 			);
 
-			bodyJs = body.join ("\r\n");
+			var bodyJs = body.join ("\r\n");
 
 			if (friendly_name) {
 				var escapeRE = /[^A-Za-z0-9_]/g;
@@ -1699,7 +1700,6 @@ var BindingSupportLib = {
 
 		var js_args = BINDING.mono_wasm_parse_args(args);
 
-		var res;
 		try {
 			var m = obj [js_name];
 			if (typeof m === "undefined")
@@ -1731,7 +1731,6 @@ var BindingSupportLib = {
 			return BINDING.js_string_to_mono_string ("Invalid property name object '" + js_name + "'");
 		}
 
-		var res;
 		try {
 			var m = obj [js_name];
 			if (m === Object(m) && obj.__is_mono_proxied__)

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -43,7 +43,7 @@ EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exceptio
 	}
 	catch (e)
 	{
-		res = e.toString ();
+		var res = e.toString ();
 		setValue (is_exception, 1, "i32");
 		if (res === null || res === undefined)
 			res = "unknown exception";

--- a/src/mono/wasm/runtime/dotnet_support.js
+++ b/src/mono/wasm/runtime/dotnet_support.js
@@ -46,7 +46,7 @@ var DotNetSupportLib = {
 			var funcNameJsString = DOTNET.conv_string(functionName);
 			var argsJsonJsString = argsJson && DOTNET.conv_string (argsJson);
 
-			var dotNetExports = globaThis.DotNet;
+			var dotNetExports = globalThis.DotNet;
 			if (!dotNetExports) {
 				throw new Error('The Microsoft.JSInterop.js library is not loaded.');
 			}

--- a/src/mono/wasm/runtime/externs.js
+++ b/src/mono/wasm/runtime/externs.js
@@ -1,0 +1,4 @@
+// @externs
+ 
+var ___cxa_is_pointer_type = function(type) {};
+var ___cxa_can_catch = function(caughtType, thrownType, exceptionThrowBuf) {};

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -2268,7 +2268,7 @@ var MonoSupportLib = {
 
 			var manifest;
 			try {
-				manifestContent = Module.UTF8ArrayToString(data, 8, manifestSize);
+				var manifestContent = Module.UTF8ArrayToString(data, 8, manifestSize);
 				manifest = JSON.parse(manifestContent);
 				if (!(manifest instanceof Array))
 					return false;
@@ -2295,7 +2295,7 @@ var MonoSupportLib = {
 				Module['FS_createPath'](prefix, folder, true, true);
 			});
 
-			for (row of manifest) {
+			for (var row of manifest) {
 				var name = row[0];
 				var length = row[1];
 				var bytes = data.slice(0, length);

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -119,12 +119,13 @@
       <EmccFlags>--profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'UTF8ArrayToString', 'addFunction']" -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -emit-llvm -s FORCE_FILESYSTEM=1 -s USE_ZLIB=1</EmccFlags>
       <EmccFlags Condition="'$(WasmEnableES6)' == 'true'">$(EmccFlags) -s MODULARIZE=1 -s EXPORT_ES6=1</EmccFlags>
       <EmccConfigurationFlags Condition="'$(Configuration)' == 'Debug'">-g -Os -s ASSERTIONS=1 -DENABLE_NETCORE=1 -DDEBUG=1</EmccConfigurationFlags>
-      <EmccConfigurationFlags Condition="'$(Configuration)' == 'Release'">-Oz --llvm-opts 2 -DENABLE_NETCORE=1</EmccConfigurationFlags>
+      <EmccConfigurationFlags Condition="'$(Configuration)' == 'Release'">-O3 -flto --llvm-opts 3 -DENABLE_NETCORE=1</EmccConfigurationFlags>
       <StripCmd>&quot;$(EMSDK_PATH)/upstream/bin/wasm-opt&quot; --strip-dwarf &quot;$(NativeBinDir)/dotnet.wasm&quot; -o &quot;$(NativeBinDir)/dotnet.wasm&quot;</StripCmd>
       <WasmObjDir>$(ArtifactsObjDir)wasm</WasmObjDir>
       <WasmVersionFile>$(WasmObjDir)\emcc-version.txt</WasmVersionFile>
       <MonoIncludeDir>$(MonoArtifactsPath)include/mono-2.0</MonoIncludeDir>
       <SystemNativeDir>$(RepoRoot)src\libraries\Native\Unix\System.Native</SystemNativeDir>
+      <EmccClosureArgs>--externs runtime/externs.js</EmccClosureArgs>
     </PropertyGroup>
     <ItemGroup>
       <ICULibNativeFiles Include="$(ICULibDir)/libicuuc.a;
@@ -140,11 +141,11 @@
       <ICULibFiles Include="$(ICULibDir)/*.dat" />
     </ItemGroup>
 
-    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -Oz -I&quot;$(MonoIncludeDir)&quot; runtime/corebindings.c -c -o &quot;$(MonoObjDir)corebindings.o&quot;"
+    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -O3 -flto -I&quot;$(MonoIncludeDir)&quot; runtime/corebindings.c -c -o &quot;$(MonoObjDir)corebindings.o&quot;"
           EmSdkPath="$(EMSDK_PATH)"
           IgnoreStandardErrorWarningFormat="true" />
 
-    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -Oz -DCORE_BINDINGS -I&quot;$(MonoObjDir.TrimEnd('\/'))&quot; -I&quot;$(MonoIncludeDir)&quot; runtime/driver.c -c -o &quot;$(MonoObjDir)driver.o&quot;"
+    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -O3 -flto -DCORE_BINDINGS -I&quot;$(MonoObjDir.TrimEnd('\/'))&quot; -I&quot;$(MonoIncludeDir)&quot; runtime/driver.c -c -o &quot;$(MonoObjDir)driver.o&quot;"
           EmSdkPath="$(EMSDK_PATH)"
           IgnoreStandardErrorWarningFormat="true" />
 
@@ -152,12 +153,17 @@
           DestinationFolder="$(MonoObjDir)"
           SkipUnchangedFiles="true" />
 
-    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -Oz -DGEN_PINVOKE=1 -I&quot;$(MonoObjDir.TrimEnd('\/'))&quot; -I&quot;$(MonoIncludeDir)&quot; runtime/pinvoke.c -c -o &quot;$(MonoObjDir)pinvoke.o&quot;"
+    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -O3 -flto -DGEN_PINVOKE=1 -I&quot;$(MonoObjDir.TrimEnd('\/'))&quot; -I&quot;$(MonoIncludeDir)&quot; runtime/pinvoke.c -c -o &quot;$(MonoObjDir)pinvoke.o&quot;"
           EmSdkPath="$(EMSDK_PATH)"
           IgnoreStandardErrorWarningFormat="true" />
 
-    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) --js-library runtime/library_mono.js --js-library runtime/binding_support.js --js-library runtime/dotnet_support.js --js-library &quot;$(SystemNativeDir)\pal_random.js&quot; &quot;$(MonoObjDir)/driver.o&quot; &quot;$(MonoObjDir)/pinvoke.o&quot; &quot;$(MonoObjDir)/corebindings.o&quot; &quot;@(MonoLibFiles->'%(FullPath)', '&quot; &quot;')&quot; -o &quot;$(NativeBinDir)/dotnet.js&quot; &amp;&amp; $(StripCmd)"
+    <!--
+    Add &#45;&#45;closure 1 to enable ADVANCED_OPTIMIZATIONS for the closure complier which reduces the output JavaScript file significantly;
+    however the correct extern values need to be added to externs.js so names used outside aren't mangled.
+    -->
+    <RunWithEmSdkEnv Command="$(EmccCmd) $(EmccFlags) $(EmccConfigurationFlags) -O3 -flto --js-library runtime/library_mono.js --js-library runtime/binding_support.js --js-library runtime/dotnet_support.js --js-library &quot;$(SystemNativeDir)\pal_random.js&quot; &quot;$(MonoObjDir)/driver.o&quot; &quot;$(MonoObjDir)/pinvoke.o&quot; &quot;$(MonoObjDir)/corebindings.o&quot; &quot;@(MonoLibFiles->'%(FullPath)', '&quot; &quot;')&quot; -v -o &quot;$(NativeBinDir)/dotnet.js&quot; &amp;&amp; $(StripCmd)"
           EmSdkPath="$(EMSDK_PATH)"
+          ClosureArgs="$(EmccClosureArgs)"
           IgnoreStandardErrorWarningFormat="true" />
 
     <RunWithEmSdkEnv Command="$(EmccCmd) --version"

--- a/src/tasks/WasmAppBuilder/RunWithEmSdkEnv.cs
+++ b/src/tasks/WasmAppBuilder/RunWithEmSdkEnv.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -14,6 +15,8 @@ namespace Microsoft.WebAssembly.Build.Tasks
         [NotNull]
         [Required]
         public string? EmSdkPath { get; set; }
+
+        public string? ClosureArgs { get; set; }
 
         public override bool Execute()
         {
@@ -35,6 +38,11 @@ namespace Microsoft.WebAssembly.Build.Tasks
                     return false;
 
                 Command = $"bash -c 'source {envScriptPath} > /dev/null 2>&1 && {Command}'";
+            }
+
+            if (ClosureArgs != null)
+            {
+                Environment.SetEnvironmentVariable("EMCC_CLOSURE_ARGS", ClosureArgs);
             }
 
             var workingDir = string.IsNullOrEmpty(WorkingDirectory) ? Directory.GetCurrentDirectory() : WorkingDirectory;


### PR DESCRIPTION
* Compile the wasm using `-O3` rather than `-Oz` for a faster runtime
* Use Link Time Optimization `-flto` for extra optimizations
* Fix issues in JS and lay groundwork for closure compiler's `--closure 1` which can greatly reduce the size of the JS and more than make up for the increase in the wasm (see: https://github.com/dotnet/runtime/pull/51446)

File           | Branch | Uncompressed |     Brotli |
-------------- |-------:|-------------:|-----------:|
dotnet.wasm    |   main |     2,220 KB |     764 KB |
dotnet.wasm    |     PR |     2,338 KB |     771 KB |
 | | | |
**Net Change** |        |        +118 KB |     +7 KB |

[Optimizing Code | Link Times](https://emscripten.org/docs/optimizing/Optimizing-Code.html#link-times)

> Of course, for a final release build, it is usually worth linking with something like `-O3 --closure 1` for full optimizations.

[Trading off code size and performance](https://emscripten.org/docs/optimizing/Optimizing-Code.html#trading-off-code-size-and-performance)

> You may wish to build the less performance-sensitive source files in your project using -Os or -Oz and the remainder using -O2 (-Os and -Oz are similar to -O2, but reduce code size at the expense of performance. -Oz reduces code size more than -Os.)
>
> **Compiling with -Os or -Oz generally avoids inlining too.**

Inspired by [Is WebAssembly magic performance pixie dust?](https://surma.dev/things/js-to-asc/) where they were seeing a ore than x2 perf degradation from `-Os`:

> Another thing that the AssemblyScript folks pointed out to me is that the --optimize flag is equivalent to -O3s which aggressively optimizes for speed, but makes tradeoffs to reduce binary size. -O3 optimizes for speed and speed only. Having -O3s as a default is good in spirit — binary size matters on the web — but is it worth it? At least in this specific example the answer is no: -O3s ends up trading the laughable amount of ~30 bytes for a huge performance penalty

And its currently using `-Oz` which is even worse for performance than `-Os`