### PR TITLE
Remove FileStream long pinning, and simplify synchronization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -31,7 +31,7 @@ namespace System.IO.Strategies
             ValueTask result = base.DisposeAsync();
             Debug.Assert(result.IsCompleted, "the method must be sync, as it performs no flushing");
 
-            Interlocked.Exchange(ref _reusableValueTaskSource, null)?._preallocatedOverlapped.Dispose();
+            Interlocked.Exchange(ref _reusableValueTaskSource, null)?.Dispose();
 
             return result;
         }
@@ -42,7 +42,7 @@ namespace System.IO.Strategies
             // before _preallocatedOverlapped is disposed
             base.Dispose(disposing);
 
-            Interlocked.Exchange(ref _reusableValueTaskSource, null)?._preallocatedOverlapped.Dispose();
+            Interlocked.Exchange(ref _reusableValueTaskSource, null)?.Dispose();
         }
 
         protected override void OnInitFromHandle(SafeFileHandle handle)
@@ -133,111 +133,75 @@ namespace System.IO.Strategies
                 ThrowHelper.ThrowNotSupportedException_UnreadableStream();
             }
 
-            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
-
-            // valueTaskSource is not null when:
-            // - First time calling ReadAsync in buffered mode
-            // - Second+ time calling ReadAsync, both buffered or unbuffered
-            // - On buffered flush, when source memory is also the internal buffer
-            // valueTaskSource is null when:
-            // - First time calling ReadAsync in unbuffered mode
-            ValueTaskSource valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
-            NativeOverlapped* intOverlapped = valueTaskSource.Configure(destination);
-
-            // Calculate position in the file we should be at after the read is done
-            long positionBefore = _filePosition;
-            if (CanSeek)
+            // Rent the reusable ValueTaskSource, or create a new one to use if we couldn't get one (which
+            // should only happen on first use or if the FileStream is being used concurrently).
+            ValueTaskSource vts = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
+            try
             {
-                long len = Length;
+                NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(destination);
+                Debug.Assert(vts._memoryHandle.Pointer != null);
 
-                if (positionBefore + destination.Length > len)
+                // Calculate position in the file we should be at after the read is done
+                long positionBefore = _filePosition;
+                if (CanSeek)
                 {
-                    if (positionBefore <= len)
+                    long len = Length;
+
+                    if (positionBefore + destination.Length > len)
                     {
-                        destination = destination.Slice(0, (int)(len - positionBefore));
+                        destination = positionBefore <= len ?
+                            destination.Slice(0, (int)(len - positionBefore)) :
+                            default;
                     }
-                    else
-                    {
-                        destination = default;
-                    }
+
+                    // Now set the position to read from in the NativeOverlapped struct
+                    // For pipes, we should leave the offset fields set to 0.
+                    nativeOverlapped->OffsetLow = unchecked((int)positionBefore);
+                    nativeOverlapped->OffsetHigh = (int)(positionBefore >> 32);
+
+                    // When using overlapped IO, the OS is not supposed to
+                    // touch the file pointer location at all.  We will adjust it
+                    // ourselves, but only in memory. This isn't threadsafe.
+                    _filePosition += destination.Length;
                 }
 
-                // Now set the position to read from in the NativeOverlapped struct
-                // For pipes, we should leave the offset fields set to 0.
-                intOverlapped->OffsetLow = unchecked((int)positionBefore);
-                intOverlapped->OffsetHigh = (int)(positionBefore >> 32);
-
-                // When using overlapped IO, the OS is not supposed to
-                // touch the file pointer location at all.  We will adjust it
-                // ourselves, but only in memory. This isn't threadsafe.
-                _filePosition += destination.Length;
-            }
-
-            // queue an async ReadFile operation and pass in a packed overlapped
-            int r = FileStreamHelpers.ReadFileNative(_fileHandle, destination.Span, false, intOverlapped, out int errorCode);
-
-            // ReadFile, the OS version, will return 0 on failure.  But
-            // my ReadFileNative wrapper returns -1.  My wrapper will return
-            // the following:
-            // On error, r==-1.
-            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
-            // on async requests that completed sequentially, r==0
-            // You will NEVER RELIABLY be able to get the number of bytes
-            // read back from this call when using overlapped structures!  You must
-            // not pass in a non-null lpNumBytesRead to ReadFile when using
-            // overlapped structures!  This is by design NT behavior.
-            if (r == -1)
-            {
-                // For pipes, when they hit EOF, they will come here.
-                if (errorCode == Interop.Errors.ERROR_BROKEN_PIPE)
+                // Queue an async ReadFile operation.
+                if (Interop.Kernel32.ReadFile(_fileHandle, (byte*)vts._memoryHandle.Pointer, destination.Length, IntPtr.Zero, nativeOverlapped) == 0)
                 {
-                    // Not an error, but EOF.  AsyncFSCallback will NOT be
-                    // called.  Call the user callback here.
-
-                    // We clear the overlapped status bit for this special case.
-                    // Failure to do so looks like we are freeing a pending overlapped later.
-                    intOverlapped->InternalLow = IntPtr.Zero;
-                    valueTaskSource.ReleaseNativeResource();
-                    TryToReuse(valueTaskSource);
-                    return new ValueTask<int>(0);
-                }
-                else if (errorCode != Interop.Errors.ERROR_IO_PENDING)
-                {
-                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    // The operation failed, or it's pending.
+                    int errorCode = FileStreamHelpers.GetLastWin32ErrorAndDisposeHandleIfInvalid(_fileHandle);
+                    switch (errorCode)
                     {
-                        _filePosition = positionBefore;
-                    }
+                        case Interop.Errors.ERROR_IO_PENDING:
+                            // Common case: IO was initiated, completion will be handled by callback.
+                            // Register for cancellation now that the operation has been initiated.
+                            vts.RegisterForCancellation(cancellationToken);
+                            break;
 
-                    valueTaskSource.ReleaseNativeResource();
-                    TryToReuse(valueTaskSource);
+                        case Interop.Errors.ERROR_BROKEN_PIPE:
+                            // EOF on a pipe. Callback will not be called.
+                            // We clear the overlapped status bit for this special case (failure
+                            // to do so looks like we are freeing a pending overlapped later).
+                            nativeOverlapped->InternalLow = IntPtr.Zero;
+                            vts.Dispose();
+                            return ValueTask.FromResult(0);
 
-                    if (errorCode == Interop.Errors.ERROR_HANDLE_EOF)
-                    {
-                        ThrowHelper.ThrowEndOfFileException();
+                        default:
+                            // Error. Callback will not be called.
+                            vts.Dispose();
+                            return ValueTask.FromException<int>(HandleIOError(positionBefore, errorCode));
                     }
-                    else
-                    {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                    }
-                }
-                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
-                {
-                    // Only once the IO is pending do we register for cancellation
-                    valueTaskSource.RegisterForCancellation(cancellationToken);
                 }
             }
-            else
+            catch
             {
-                // Due to a workaround for a race condition in NT's ReadFile &
-                // WriteFile routines, we will always be returning 0 from ReadFileNative
-                // when we do async IO instead of the number of bytes read,
-                // irregardless of whether the operation completed
-                // synchronously or asynchronously.  We absolutely must not
-                // set asyncResult._numBytes here, since will never have correct
-                // results.
+                vts.Dispose();
+                throw;
             }
 
-            return new ValueTask<int>(valueTaskSource, valueTaskSource.Version);
+            // Completion handled by callback.
+            vts.FinishedScheduling();
+            return new ValueTask<int>(vts, vts.Version);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -256,93 +220,72 @@ namespace System.IO.Strategies
                 ThrowHelper.ThrowNotSupportedException_UnwritableStream();
             }
 
-            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
-
-            // valueTaskSource is not null when:
-            // - First time calling WriteAsync in buffered mode
-            // - Second+ time calling WriteAsync, both buffered or unbuffered
-            // - On buffered flush, when source memory is also the internal buffer
-            // valueTaskSource is null when:
-            // - First time calling WriteAsync in unbuffered mode
-            ValueTaskSource valueTaskSource = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
-            NativeOverlapped* intOverlapped = valueTaskSource.Configure(source);
-
-            long positionBefore = _filePosition;
-            if (CanSeek)
+            // Rent the reusable ValueTaskSource, or create a new one to use if we couldn't get one (which
+            // should only happen on first use or if the FileStream is being used concurrently).
+            ValueTaskSource vts = Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
+            try
             {
-                // Now set the position to read from in the NativeOverlapped struct
-                // For pipes, we should leave the offset fields set to 0.
-                intOverlapped->OffsetLow = (int)positionBefore;
-                intOverlapped->OffsetHigh = (int)(positionBefore >> 32);
+                NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(source);
+                Debug.Assert(vts._memoryHandle.Pointer != null);
 
-                // When using overlapped IO, the OS is not supposed to
-                // touch the file pointer location at all.  We will adjust it
-                // ourselves, but only in memory.  This isn't threadsafe.
-                _filePosition += source.Length;
-                UpdateLengthOnChangePosition();
-            }
-
-            // queue an async WriteFile operation and pass in a packed overlapped
-            int r = FileStreamHelpers.WriteFileNative(_fileHandle, source.Span, false, intOverlapped, out int errorCode);
-
-            // WriteFile, the OS version, will return 0 on failure.  But
-            // my WriteFileNative wrapper returns -1.  My wrapper will return
-            // the following:
-            // On error, r==-1.
-            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
-            // On async requests that completed sequentially, r==0
-            // You will NEVER RELIABLY be able to get the number of bytes
-            // written back from this call when using overlapped IO!  You must
-            // not pass in a non-null lpNumBytesWritten to WriteFile when using
-            // overlapped structures!  This is ByDesign NT behavior.
-            if (r == -1)
-            {
-                // For pipes, when they are closed on the other side, they will come here.
-                if (errorCode == Interop.Errors.ERROR_NO_DATA)
+                long positionBefore = _filePosition;
+                if (CanSeek)
                 {
-                    // Not an error, but EOF. AsyncFSCallback will NOT be called.
-                    // Completing TCS and return cached task allowing the GC to collect TCS.
-                    valueTaskSource.ReleaseNativeResource();
-                    TryToReuse(valueTaskSource);
-                    return ValueTask.CompletedTask;
+                    // Now set the position to read from in the NativeOverlapped struct
+                    // For pipes, we should leave the offset fields set to 0.
+                    nativeOverlapped->OffsetLow = (int)positionBefore;
+                    nativeOverlapped->OffsetHigh = (int)(positionBefore >> 32);
+
+                    // When using overlapped IO, the OS is not supposed to
+                    // touch the file pointer location at all.  We will adjust it
+                    // ourselves, but only in memory.  This isn't threadsafe.
+                    _filePosition += source.Length;
+                    UpdateLengthOnChangePosition();
                 }
-                else if (errorCode != Interop.Errors.ERROR_IO_PENDING)
+
+                // Queue an async WriteFile operation.
+                if (Interop.Kernel32.WriteFile(_fileHandle, (byte*)vts._memoryHandle.Pointer, source.Length, IntPtr.Zero, nativeOverlapped) == 0)
                 {
-                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    // The operation failed, or it's pending.
+                    int errorCode = FileStreamHelpers.GetLastWin32ErrorAndDisposeHandleIfInvalid(_fileHandle);
+                    if (errorCode == Interop.Errors.ERROR_IO_PENDING)
                     {
-                        _filePosition = positionBefore;
-                    }
-
-                    valueTaskSource.ReleaseNativeResource();
-                    TryToReuse(valueTaskSource);
-
-                    if (errorCode == Interop.Errors.ERROR_HANDLE_EOF)
-                    {
-                        ThrowHelper.ThrowEndOfFileException();
+                        // Common case: IO was initiated, completion will be handled by callback.
+                        // Register for cancellation now that the operation has been initiated.
+                        vts.RegisterForCancellation(cancellationToken);
                     }
                     else
                     {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                        // Error. Callback will not be invoked.
+                        vts.Dispose();
+                        return errorCode == Interop.Errors.ERROR_NO_DATA ? // EOF on a pipe. IO callback will not be called.
+                            ValueTask.CompletedTask :
+                            ValueTask.FromException(HandleIOError(positionBefore, errorCode));
                     }
                 }
-                else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
-                {
-                    // Only once the IO is pending do we register for cancellation
-                    valueTaskSource.RegisterForCancellation(cancellationToken);
-                }
             }
-            else
+            catch
             {
-                // Due to a workaround for a race condition in NT's ReadFile &
-                // WriteFile routines, we will always be returning 0 from WriteFileNative
-                // when we do async IO instead of the number of bytes written,
-                // irregardless of whether the operation completed
-                // synchronously or asynchronously.  We absolutely must not
-                // set asyncResult._numBytes here, since will never have correct
-                // results.
+                vts.Dispose();
+                throw;
             }
 
-            return new ValueTask(valueTaskSource, valueTaskSource.Version);
+            // Completion handled by callback.
+            vts.FinishedScheduling();
+            return new ValueTask(vts, vts.Version);
+        }
+
+        private Exception HandleIOError(long positionBefore, int errorCode)
+        {
+            if (!_fileHandle.IsClosed && CanSeek)
+            {
+                // Update Position... it could be anywhere.
+                _filePosition = positionBefore;
+            }
+
+            return errorCode == Interop.Errors.ERROR_HANDLE_EOF ?
+                ThrowHelper.CreateEndOfFileException() :
+                Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask; // no buffering = nothing to flush

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -216,7 +217,7 @@ namespace System.IO.Strategies
                 }
 
                 EnsureBufferAllocated();
-                n = _strategy.Read(_buffer!, 0, _bufferSize);
+                n = _strategy.Read(_buffer, 0, _bufferSize);
 
                 if (n == 0)
                 {
@@ -232,7 +233,7 @@ namespace System.IO.Strategies
             {
                 n = destination.Length;
             }
-            new ReadOnlySpan<byte>(_buffer!, _readPos, n).CopyTo(destination);
+            new ReadOnlySpan<byte>(_buffer, _readPos, n).CopyTo(destination);
             _readPos += n;
 
             // We may have read less than the number of bytes the user asked
@@ -291,7 +292,7 @@ namespace System.IO.Strategies
             }
 
             EnsureBufferAllocated();
-            _readLen = _strategy.Read(_buffer!, 0, _bufferSize);
+            _readLen = _strategy.Read(_buffer, 0, _bufferSize);
             _readPos = 0;
 
             if (_readLen == 0)
@@ -299,7 +300,7 @@ namespace System.IO.Strategies
                 return -1;
             }
 
-            return _buffer![_readPos++];
+            return _buffer[_readPos++];
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -463,7 +464,7 @@ namespace System.IO.Strategies
                 // If there was anything in the write buffer, clear it.
                 if (_writePos > 0)
                 {
-                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -475,7 +476,7 @@ namespace System.IO.Strategies
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
-                _readLen = await _strategy.ReadAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
+                _readLen = await _strategy.ReadAsync(new Memory<byte>(_buffer), cancellationToken).ConfigureAwait(false);
 
                 bytesFromBuffer = Math.Min(_readLen, buffer.Length);
                 _buffer.AsSpan(0, bytesFromBuffer).CopyTo(buffer.Span);
@@ -578,7 +579,7 @@ namespace System.IO.Strategies
 
             // Copy remaining bytes into buffer, to write at a later date.
             EnsureBufferAllocated();
-            source.CopyTo(_buffer!.AsSpan(_writePos));
+            source.CopyTo(_buffer.AsSpan(_writePos));
             _writePos = source.Length;
         }
 
@@ -721,19 +722,19 @@ namespace System.IO.Strategies
                     {
                         if (spaceLeft >= source.Length)
                         {
-                            source.Span.CopyTo(_buffer!.AsSpan(_writePos));
+                            source.Span.CopyTo(_buffer.AsSpan(_writePos));
                             _writePos += source.Length;
                             return;
                         }
                         else
                         {
-                            source.Span.Slice(0, spaceLeft).CopyTo(_buffer!.AsSpan(_writePos));
+                            source.Span.Slice(0, spaceLeft).CopyTo(_buffer.AsSpan(_writePos));
                             _writePos += spaceLeft;
                             source = source.Slice(spaceLeft);
                         }
                     }
 
-                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -751,7 +752,7 @@ namespace System.IO.Strategies
 
                 // Copy remaining bytes into buffer, to write at a later date.
                 EnsureBufferAllocated();
-                source.Span.CopyTo(_buffer!.AsSpan(_writePos));
+                source.Span.CopyTo(_buffer.AsSpan(_writePos));
                 _writePos = source.Length;
             }
             finally
@@ -834,7 +835,7 @@ namespace System.IO.Strategies
             {
                 if (_writePos > 0)
                 {
-                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                     Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
                     return;
@@ -888,13 +889,13 @@ namespace System.IO.Strategies
                 {
                     // If there's any read data in the buffer, write it all to the destination stream.
                     Debug.Assert(_writePos == 0, "Write buffer must be empty if there's data in the read buffer");
-                    await destination.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, _readPos, readBytes), cancellationToken).ConfigureAwait(false);
+                    await destination.WriteAsync(new ReadOnlyMemory<byte>(_buffer, _readPos, readBytes), cancellationToken).ConfigureAwait(false);
                     _readPos = _readLen = 0;
                 }
                 else if (_writePos > 0)
                 {
                     // If there's write data in the buffer, flush it back to the underlying stream, as does ReadAsync.
-                    await _strategy.WriteAsync(MemoryMarshal.CreateFromPinnedArray(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
+                    await _strategy.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, _writePos), cancellationToken).ConfigureAwait(false);
                     _writePos = 0;
                 }
 
@@ -1059,19 +1060,21 @@ namespace System.IO.Strategies
             }
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void EnsureBufferAllocated()
         {
-            // BufferedFileStreamStrategy is not intended for multi-threaded use, so no worries about the get/set race on _buffer.
-            if (_buffer == null)
+            if (_buffer is null)
             {
                 AllocateBuffer();
             }
+        }
 
-            void AllocateBuffer() // logic kept in a separate method to get EnsureBufferAllocated() inlined
-            {
-                _buffer = GC.AllocateUninitializedArray<byte>(_bufferSize,
-                    pinned: true); // this allows us to avoid pinning when the buffer is used for the syscalls
-            }
+        // TODO https://github.com/dotnet/roslyn/issues/47896: should be local function in EnsureBufferAllocated above.
+        [MemberNotNull(nameof(_buffer))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AllocateBuffer()
+        {
+            Interlocked.CompareExchange(ref _buffer, GC.AllocateUninitializedArray<byte>(_bufferSize), null);
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -476,7 +476,7 @@ namespace System.IO.Strategies
 
                 // Ok. We can fill the buffer:
                 EnsureBufferAllocated();
-                _readLen = await _strategy.ReadAsync(new Memory<byte>(_buffer), cancellationToken).ConfigureAwait(false);
+                _readLen = await _strategy.ReadAsync(new Memory<byte>(_buffer, 0, _bufferSize), cancellationToken).ConfigureAwait(false);
 
                 bytesFromBuffer = Math.Min(_readLen, buffer.Length);
                 _buffer.AsSpan(0, bytesFromBuffer).CopyTo(buffer.Span);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -227,7 +227,7 @@ namespace System.IO.Strategies
             return ret;
         }
 
-        private static int GetLastWin32ErrorAndDisposeHandleIfInvalid(SafeFileHandle handle)
+        internal static int GetLastWin32ErrorAndDisposeHandleIfInvalid(SafeFileHandle handle)
         {
             int errorCode = Marshal.GetLastWin32Error();
 
@@ -340,7 +340,6 @@ namespace System.IO.Strategies
             }
         }
 
-        // __ConsoleStream also uses this code.
         internal static unsafe int ReadFileNative(SafeFileHandle handle, Span<byte> bytes, bool syncUsingOverlapped, NativeOverlapped* overlapped, out int errorCode)
         {
             Debug.Assert(handle != null, "handle != null");

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -270,8 +270,11 @@ namespace System
         [DoesNotReturn]
         internal static void ThrowEndOfFileException()
         {
-            throw new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
+            throw CreateEndOfFileException();
         }
+
+        internal static Exception CreateEndOfFileException() =>
+            new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
 
         [DoesNotReturn]
         internal static void ThrowInvalidOperationException()


### PR DESCRIPTION
This PR has two changes for FileStream...

The first is to remove the permanent pinning performed by BufferedFileStreamStrategy.  Previously, on Windows when FileStream would allocate its buffer, it would also pin it as part of creating a PreallocatedOverlapped.  Recent changes removed the PreallocatedOverlapped wrapping of the buffer, and replaced it with a buffer from the pinned-object heap.  But POH allocations are considered to be gen2, which can then have a negative app-wide impact if lots of FileStreams are created and thrown away quickly.  Instead, this PR just removes that pinning entirely.  BufferedFileStreamStrategy's buffer, like any other buffer, will just be pinned for the duration of each individual read/write async operation, using Memory.Pin.  I do not see any degradation in the benchmarks as a result.  cc: @jkotas

The second change is to significantly simplify how the async completion is handled. There's currently a complicated set of interlocked operations that transition the promise through multiple stages, to account for the possibility of race conditions between various operations.  We can instead get rid of all of that, and just use an event to handle the rare case where additional configuration of an async operation after that async operation was just initiated (e.g. registering for cancellation) doesn't race with concurrent completion of that same operation.

@adamsitnik, I don't see regressions from these changes, but the benchmarks also appear to be quite noisy, at least on my machine.   If you could give them a go, that'd be helpful.  Thanks.