### PR TITLE
.vsconfig update for .NET 4.8

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -30,6 +30,7 @@
     "Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools",
     "Microsoft.Net.Component.4.7.TargetingPack",
     "Microsoft.Net.ComponentGroup.4.7.DeveloperTools",
+    "Microsoft.Net.Component.4.8.TargetingPack",
     "Microsoft.VisualStudio.Component.VC.CoreIde",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",


### PR DESCRIPTION
.vsconfig was missing the missing
the .NET 4.8 Targetting pack option.

Fix #51455