### PR TITLE
Add metadata update handler to System.ComponentModel.TypeConverter

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -70,6 +70,7 @@
     <Compile Include="System\ComponentModel\MemberDescriptor.cs" />
     <Compile Include="System\ComponentModel\PropertyDescriptorCollection.cs" />
     <Compile Include="System\ComponentModel\ProvidePropertyAttribute.cs" />
+    <Compile Include="System\ComponentModel\ReflectionCachesUpdateHandler.cs" />
     <Compile Include="System\ComponentModel\ReflectEventDescriptor.cs" />
     <Compile Include="System\ComponentModel\ReflectPropertyDescriptor.cs" />
     <Compile Include="System\ComponentModel\ReflectTypeDescriptionProvider.cs" />
@@ -253,6 +254,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.Loader" />
     <Reference Include="System.Runtime.Serialization.Formatters" />
     <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -207,10 +207,10 @@ namespace System.ComponentModel
         /// <summary>Clear the global caches this maintains on top of reflection.</summary>
         internal static void ClearReflectionCaches()
         {
-            Volatile.Write(ref s_propertyCache, null);
-            Volatile.Write(ref s_eventCache, null);
-            Volatile.Write(ref s_attributeCache, null);
-            Volatile.Write(ref s_extendedPropertyCache, null);
+            s_propertyCache = null;
+            s_eventCache = null;
+            s_attributeCache = null;
+            s_extendedPropertyCache = null;
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -204,6 +204,15 @@ namespace System.ComponentModel
 
         private static Hashtable ExtendedPropertyCache => LazyInitializer.EnsureInitialized(ref s_extendedPropertyCache, () => new Hashtable());
 
+        /// <summary>Clear the global caches this maintains on top of reflection.</summary>
+        internal static void ClearReflectionCaches()
+        {
+            Volatile.Write(ref s_propertyCache, null);
+            Volatile.Write(ref s_eventCache, null);
+            Volatile.Write(ref s_attributeCache, null);
+            Volatile.Write(ref s_extendedPropertyCache, null);
+        }
+
         /// <summary>
         /// Adds an editor table for the given editor base type.
         /// Typically, editors are specified as metadata on an object. If no metadata for a

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectionCachesUpdateHandler.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectionCachesUpdateHandler.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System.ComponentModel;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+[assembly: MetadataUpdateHandler(typeof(ReflectionCachesUpdateHandler))]
+
+namespace System.ComponentModel
+{
+    internal static class ReflectionCachesUpdateHandler
+    {
+        public static void BeforeUpdate(Type[]? types)
+        {
+            // ReflectTypeDescriptionProvider maintains global caches on top of reflection.
+            // Clear those.
+            ReflectTypeDescriptionProvider.ClearReflectionCaches();
+
+            // Each type descriptor may also cache reflection-based state that it gathered
+            // from ReflectTypeDescriptionProvider.  Clear those as well.
+            if (types is not null)
+            {
+                foreach (Type type in types)
+                {
+                    TypeDescriptor.Refresh(type);
+                }
+            }
+            else
+            {
+                foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    TypeDescriptor.Refresh(assembly);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    [SimpleUpdateTest]
+    public class ReflectionCachesUpdateHandlerTests
+    {
+        [Fact]
+        public void ReflectionCachesUpdateHandler_CachesCleared()
+        {
+            AttributeCollection ac1 = TypeDescriptor.GetAttributes(typeof(ReflectionCachesUpdateHandlerTests));
+            AttributeCollection ac2 = TypeDescriptor.GetAttributes(typeof(ReflectionCachesUpdateHandlerTests));
+            Assert.Equal(ac1.Count, ac2.Count);
+            Assert.Equal(1, ac1.Count);
+            Assert.Same(ac1[0], ac2[0]);
+
+            MethodInfo beforeUpdate = typeof(TypeDescriptionProvider).Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler", throwOnError: true).GetMethod("BeforeUpdate");
+            Assert.NotNull(beforeUpdate);
+            beforeUpdate.Invoke(null, new object[] { null });
+
+            AttributeCollection ac3 = TypeDescriptor.GetAttributes(typeof(ReflectionCachesUpdateHandlerTests));
+            Assert.NotSame(ac1[0], ac3[0]);
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class SimpleUpdateTestAttribute : Attribute { }
+}

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Mocks\MockServiceProvider.cs" />
     <Compile Include="MultilineStringConverterTests.cs" />
     <Compile Include="NullableConverterTests.cs" />
+    <Compile Include="ReflectionCachesUpdateHandlerTests.cs" />
     <Compile Include="PropertyDescriptorCollectionTests.cs" />
     <Compile Include="PropertyDescriptorTests.cs" />
     <Compile Include="ProvidePropertyAttributeTests.cs" />


### PR DESCRIPTION
This is in support of hot reload, to be able to clear TypeConverter's reflection caches in response to types being patched. I'm not familiar with all the inner workings of TypeConverters, but this appears to be what's necessary to clear the reflection caches TypeConverter maintains; please let me know if I've missed something, or if this is problematic in other ways.

cc: @tommcdon, @pranavkm, @mikem8361