### PR TITLE
Fix issue #51468

### DIFF
--- a/src/native/eventpipe/ep-block.c
+++ b/src/native/eventpipe/ep-block.c
@@ -690,7 +690,7 @@ ep_event_block_base_write_event (
 	instance_timestamp = ep_event_instance_get_timestamp (event_instance);
 	if (event_block_base->min_timestamp > instance_timestamp)
 		event_block_base->min_timestamp = instance_timestamp;
-	if (event_block_base->max_timestamp > instance_timestamp)
+	if (event_block_base->max_timestamp < instance_timestamp)
 		event_block_base->max_timestamp = instance_timestamp;
 
 	block->write_pointer = write_pointer;


### PR DESCRIPTION
Fix of the bug with invalid max_timestamp produced for EventPipe block header in .NET 6 previews 