### PR TITLE
Disable iOS ARM validation

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -98,14 +98,17 @@ stages:
       - tvOS_arm64
       - iOS_x64
       - iOS_x86
-      - iOS_arm
-      - iOS_arm64
       - OSX_x64
       - Linux_x64
       - Linux_arm
       - Linux_arm64
       - Linux_musl_x64
       - Browser_wasm
+
+      # https://github.com/dotnet/runtime/pull/50940
+      # - iOS_arm
+      # - iOS_arm64
+
       # - Linux_musl_arm
       # - Linux_musl_arm64
       # - Windows_NT_x64 enable once coreclr.dll has a version header: https://github.com/dotnet/runtime/issues/37503

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -90,14 +90,6 @@ stages:
       buildConfig: release
       runtimeFlavor: mono
       platforms:
-      - Android_x64
-      - Android_x86
-      - Android_arm
-      - Android_arm64
-      - tvOS_x64
-      - tvOS_arm64
-      - iOS_x64
-      - iOS_x86
       - OSX_x64
       - Linux_x64
       - Linux_arm
@@ -106,6 +98,14 @@ stages:
       - Browser_wasm
 
       # https://github.com/dotnet/runtime/pull/50940
+      # - Android_x64
+      # - Android_x86
+      # - Android_arm
+      # - Android_arm64
+      # - tvOS_x64
+      # - tvOS_arm64
+      # - iOS_x64
+      # - iOS_x86
       # - iOS_arm
       # - iOS_arm64
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -263,13 +263,13 @@ jobs:
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     runtimeFlavor: mono
     platforms:
-    - Android_x86
-    - Android_arm64
-    - tvOS_x64
-    - iOS_x86
     - Linux_arm
 
     # https://github.com/dotnet/runtime/pull/50940
+    # - Android_x86
+    # - Android_arm64
+    # - tvOS_x64
+    # - iOS_x86
     # - iOS_arm64
     jobParameters:
       testGroup: innerloop
@@ -288,13 +288,13 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms:
-    - Android_x64
-    - Android_arm
-    - tvOS_arm64
-    - iOS_x64
     - Linux_musl_x64
 
     # https://github.com/dotnet/runtime/pull/50940
+    # - Android_x64
+    # - Android_arm
+    # - tvOS_arm64
+    # - iOS_x64
     # - iOS_arm
     jobParameters:
       testGroup: innerloop

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -266,9 +266,11 @@ jobs:
     - Android_x86
     - Android_arm64
     - tvOS_x64
-    - iOS_arm64
     - iOS_x86
     - Linux_arm
+
+    # https://github.com/dotnet/runtime/pull/50940
+    # - iOS_arm64
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -291,9 +291,11 @@ jobs:
     - Android_x64
     - Android_arm
     - tvOS_arm64
-    - iOS_arm
     - iOS_x64
     - Linux_musl_x64
+
+    # https://github.com/dotnet/runtime/pull/50940
+    # - iOS_arm
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -402,7 +402,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
         public async Task SslStream_ClientCertificate_SendsChain()
         {
@@ -434,7 +434,10 @@ namespace System.Net.Security.Tests
                 }
 
                 // Verify we can construct full chain
-                Assert.True(chain.ChainElements.Count > clientChain.Count, "chain cannot be built");
+                if (chain.ChainElements.Count < clientChain.Count)
+                {
+                    throw new SkipTestException($"chain cannot be built {chain.ChainElements.Count}");
+                }
             }
 
             var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost",  };


### PR DESCRIPTION
As discussed in https://github.com/dotnet/runtime/pull/50940

Also, backports test fix from https://github.com/dotnet/runtime/pull/48261