### PR TITLE
Lazy init of ThreadWaitInfo in Thread.Mono.cs to prevent crash on external attached threads.

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -138,9 +138,8 @@ namespace System.Threading
                 return 7;
             }
         }
-
 #if TARGET_UNIX || TARGET_BROWSER
-        internal WaitSubsystem.ThreadWaitInfo WaitInfo => _waitInfo;
+        internal WaitSubsystem.ThreadWaitInfo WaitInfo => EnsureWaitInfo();
 #endif
 
         public ThreadPriority Priority
@@ -206,15 +205,15 @@ namespace System.Threading
         {
             InitInternal(this);
 #if TARGET_UNIX || TARGET_BROWSER
-            _waitInfo = new WaitSubsystem.ThreadWaitInfo(this);
+            EnsureWaitInfo();
 #endif
         }
 
 #if TARGET_UNIX || TARGET_BROWSER
-        private void EnsureWaitInfo()
+        [MemberNotNull(nameof(_waitInfo))]
+        private WaitSubsystem.ThreadWaitInfo EnsureWaitInfo()
         {
-            if (_waitInfo == null)
-                _waitInfo = new WaitSubsystem.ThreadWaitInfo(this);
+            return LazyInitializer.EnsureInitialized(ref _waitInfo, () => new WaitSubsystem.ThreadWaitInfo(this));
         }
 #endif
 

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -139,7 +139,7 @@ namespace System.Threading
             }
         }
 #if TARGET_UNIX || TARGET_BROWSER
-        internal WaitSubsystem.ThreadWaitInfo WaitInfo => EnsureWaitInfo();
+        internal WaitSubsystem.ThreadWaitInfo WaitInfo => Volatile.Read(ref _waitInfo) ?? AllocateWaitInfo();
 #endif
 
         public ThreadPriority Priority
@@ -206,11 +206,6 @@ namespace System.Threading
         }
 
 #if TARGET_UNIX || TARGET_BROWSER
-        private WaitSubsystem.ThreadWaitInfo EnsureWaitInfo()
-        {
-            return Volatile.Read(ref _waitInfo) ?? AllocateWaitInfo();
-        }
-
         private WaitSubsystem.ThreadWaitInfo AllocateWaitInfo()
         {
             var value = new WaitSubsystem.ThreadWaitInfo(this);
@@ -323,9 +318,6 @@ namespace System.Threading
         private static Thread InitializeCurrentThread()
         {
             var current = GetCurrentThread();
-#if TARGET_UNIX || TARGET_BROWSER
-            current.EnsureWaitInfo();
-#endif
             t_currentThread = current;
             return t_currentThread;
         }


### PR DESCRIPTION
Commit https://github.com/dotnet/runtime/commit/457f58cd30082c9de0be9ca62e64fa179c37dab3 added a new managed object into Mono's managed thread object, _waitInfo.

This new object was initialized in Thread managed constructor, problem with that is for all threads that gets their thread object created in native code, create_thread_object, that code did the same thing as constructor before commit, since managed 
constructor called down into native code calling the same native method as create_thread_object meaning a thread object created from managed or native would be initialized identical.

After above commit this is no longer true, meaning that all managed thread objects created in native code (like attached external threads) won't get _waitInfo initialized and that leads to a crash when OnThreadExiting gets called from Finalizer thread.

Fix is to make sure _waitInfo get initialize regardless of thread object gets created from managed or native code.

This fix implements a lazy init as part of property access, I tested a native version of the fix, calling back into managed to init managed parts of thread when thread gets created in native, but turns out that such a fix gets a little complicated, since some of the threads are created early when it's not possible to run managed code, so that in turn needed additional changes into the init order, that in turn has bigger impact and could cause other unwanted side effects.

Fixing it in managed using lazy/on demand init is simpler/cleaner approach but might come with a small performance hit for callers of WaitInfo property (will add volatile read and conditional branch), but looking at callers of the property, they appear in functions with rather high "cost", like Sleep, NewMutex, Wait, SignalAndWait, Interrupt and RelinquishOwnership.

//CC @CoffeeFlux