### PR TITLE
HTTP/3: Fix variable length encoding

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 
         // public for internal use in aspnetcore
         public const uint OneByteLimit = (1U << 6) - 1;
-        public const uint TwoByteLimit = (1U << 16) - 1;
+        public const uint TwoByteLimit = (1U << 14) - 1;
         public const uint FourByteLimit = (1U << 30) - 1;
         public const long EightByteLimit = (1L << 62) - 1;
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/HeaderField.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/HeaderField.cs
@@ -5,6 +5,10 @@ namespace System.Net.Http.QPack
 {
     internal readonly struct HeaderField
     {
+        // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.3-1
+        // public for internal use in aspnetcore
+        public const int RfcOverhead = 32;
+
         public HeaderField(byte[] name, byte[] value)
         {
             Name = name;


### PR DESCRIPTION
I noticed two byte encoding is wrong. Usable bits is 14, not 16 - https://tools.ietf.org/html/draft-ietf-quic-transport-16#section-16

Also adds const field that aspnetcore will use to calculate header sizes.