### PR TITLE
change if order to improve FileStream perf for cases when both buffers are of the same size

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -649,18 +649,18 @@ namespace System.IO.Strategies
                 bool releaseTheLock = true;
                 try
                 {
-                    // hot path #1 if the write completely fits into the buffer, we can complete synchronously:
-                    if (_bufferSize - _writePos >= buffer.Length)
+                    // hot path #1: the write buffer is empty and buffering would not be beneficial
+                    if (_writePos == 0 && buffer.Length >= _bufferSize)
                     {
+                        return _strategy.WriteAsync(buffer, cancellationToken);
+                    }
+                    else if (_bufferSize - _writePos >= buffer.Length)
+                    {
+                        // hot path #2 if the write completely fits into the buffer, we can complete synchronously:
                         EnsureBufferAllocated();
                         buffer.Span.CopyTo(_buffer.AsSpan(_writePos));
                         _writePos += buffer.Length;
                         return default;
-                    }
-                    else if (_writePos == 0 && buffer.Length >= _bufferSize)
-                    {
-                        // hot path #2: the write buffer is empty and buffering would not be beneficial
-                        return _strategy.WriteAsync(buffer, cancellationToken);
                     }
 
                     releaseTheLock = false;


### PR DESCRIPTION
When nothing has been written to the buffer yet (`_writePos == 0`) and the size of the buffer passed to `WriteAsync` is the same as internal `FileStream` buffer, we should omit buffering logic and just call the actual strategy directly.

This is ofc an edge case, but since we already have a benchmark for it and it's relatively small change we should IMO change it.

See the `Allocated` column:

|     Method |           Toolchain |  fileSize | userBufferSize |      options |         Mean | Ratio |   Allocated |
|----------- |-------------------- |---------- |--------------- |------------- |-------------:|------:|------------:|
| WriteAsync |  \after\corerun.exe |   1048576 |           4096 |         None |   3,708.7 us |  1.00 |    29,321 B |
| WriteAsync | \before\corerun.exe |   1048576 |           4096 |         None |   3,719.5 us |  1.00 |    55,969 B |
|            |                     |           |                |              |              |       |             |
| WriteAsync |  \after\corerun.exe |   1048576 |           4096 | Asynchronous |   4,141.6 us |  0.98 |       913 B |
| WriteAsync | \before\corerun.exe |   1048576 |           4096 | Asynchronous |   4,238.3 us |  1.00 |    27,561 B |
|            |                     |           |                |              |              |       |             |
| WriteAsync |  \after\corerun.exe | 104857600 |           4096 |         None | 212,481.6 us |  0.86 | 2,867,896 B |
| WriteAsync | \before\corerun.exe | 104857600 |           4096 |         None | 246,750.4 us |  1.00 | 5,124,856 B |
|            |                     |           |                |              |              |       |             |
| WriteAsync |  \after\corerun.exe | 104857600 |           4096 | Asynchronous | 348,312.7 us |  0.98 |       960 B |
| WriteAsync | \before\corerun.exe | 104857600 |           4096 | Asynchronous | 355,626.4 us |  1.00 | 2,257,880 B |