### PR TITLE
Bump installer tests timeout to 90m

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -279,6 +279,7 @@ jobs:
       useContinueOnErrorDuringBuild: true
       enablePublisTestResults: true
       testResultsFormat: xunit
+      timeoutInMinutes: 90
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:


### PR DESCRIPTION
They timed out in https://dev.azure.com/dnceng/public/_build/results?buildId=1095082&view=logs&jobId=d900f740-c9a5-5bf8-c5f6-bf1e5b71239a&j=d900f740-c9a5-5bf8-c5f6-bf1e5b71239a&t=8d9f84ed-f820-5356-7f05-f798e3a00bae.