### PR TITLE
Fix test failure #51474

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -710,11 +710,12 @@ namespace Microsoft.Extensions.Hosting.Internal
             var wasStoppingCalled = false;
             lifetime.ApplicationStopping.Register(() =>
             {
-                otherTcs.SetResult(true);
                 wasStoppingCalled = true;
+                otherTcs.SetResult(true);
             });
 
-            await host.StartAsync();
+            // Ensure all completions have been signaled before continuing
+            await Task.WhenAll(host.StartAsync(), throwingTcs.Task, otherTcs.Task);
 
             Assert.True(wasStartedCalled);
             Assert.True(wasStoppingCalled);


### PR DESCRIPTION
There was a race condition, in which it was possible for the `await host.StartAsync()` to have returned before the test callbacks were invoked.

Fixes #51474