### PR TITLE
Enable superpmi collection for libraries tests

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -41,6 +41,10 @@ jobs:
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
+      # libraries test build platforms
+      testBuildPlatforms:
+      - Linux_x64
+      - windows_x64
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -115,6 +119,28 @@ jobs:
       liveLibrariesBuildConfig: Release
       collectionType: pmi
       collectionName: tests
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: tests_libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -56,69 +56,69 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: tests
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: tests
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -142,45 +142,45 @@ jobs:
       collectionType: pmi
       collectionName: tests_libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen2
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen2
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
-#     # - Linux_arm
-#     # - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: run
-#       collectionName: benchmarks
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
+    # - Linux_arm
+    # - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: run
+      collectionName: benchmarks

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -56,69 +56,69 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: tests
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: tests
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -142,45 +142,45 @@ jobs:
       collectionType: pmi
       collectionName: tests_libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen2
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen2
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
-    # - Linux_arm
-    # - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: run
-      collectionName: benchmarks
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
+#     # - Linux_arm
+#     # - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: run
+#       collectionName: benchmarks

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -39,7 +39,6 @@ jobs:
     collectionType: $ {{ parameters.collectionType }}
     collectionName: ${{ parameters.collectionName }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
-    timeoutInminutes: ${{ parameters.timeoutInMinutes }}
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
@@ -49,6 +48,8 @@ jobs:
     # tests collection takes longer so increase timeout to 8 hours
     ${{ if or(eq(parameters.collectionName, 'tests'), eq(parameters.collectionName, 'tests_libraries')) }}:
       timeoutInMinutes: 480
+    ${{ if and(ne(parameters.collectionName, 'tests'), ne(parameters.collectionName, 'tests_libraries')) }}:
+      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     variables:
 

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -39,6 +39,7 @@ jobs:
     collectionType: $ {{ parameters.collectionType }}
     collectionName: ${{ parameters.collectionName }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+    timeoutInminutes: ${{ parameters.timeoutInMinutes }}
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
@@ -46,10 +47,8 @@ jobs:
       displayName: '${{ parameters.jobName }}'
 
     # tests collection takes longer so increase timeout to 8 hours
-    ${{ if eq(parameters.collectionName, 'tests') }}:
+    ${{ if or(eq(parameters.collectionName, 'tests'), eq(parameters.collectionName, 'libraries_tests')) }}:
       timeoutInMinutes: 480
-    ${{ if ne(parameters.collectionName, 'tests') }}:
-      timeoutInminutes: ${{ parameters.timeoutInMinutes }}
 
     variables:
 
@@ -101,6 +100,9 @@ jobs:
     - ${{ if eq(parameters.collectionName, 'tests') }}:
       - name: InputDirectory
         value: '$(managedTestArtifactRootFolderPath)'
+    - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:
+      - name: InputDirectory
+        value: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
     workspace:
       clean: all
     pool:

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -47,7 +47,7 @@ jobs:
       displayName: '${{ parameters.jobName }}'
 
     # tests collection takes longer so increase timeout to 8 hours
-    ${{ if or(eq(parameters.collectionName, 'tests'), eq(parameters.collectionName, 'libraries_tests')) }}:
+    ${{ if or(eq(parameters.collectionName, 'tests'), eq(parameters.collectionName, 'tests_libraries')) }}:
       timeoutInMinutes: 480
 
     variables:
@@ -100,7 +100,7 @@ jobs:
     - ${{ if eq(parameters.collectionName, 'tests') }}:
       - name: InputDirectory
         value: '$(managedTestArtifactRootFolderPath)'
-    - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:
+    - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
       - name: InputDirectory
         value: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
     workspace:

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.{1}', parameters.osGroup, archiveExtension) }}
+          artifactFileName: 'libraries_test_assets_${{ parameters.osGroup }}_x64_Release.$(archiveExtension)'
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: 'libraries_test_assets_${{ parameters.osGroup }}_x64_Release.$(archiveExtension)'
+          artifactFileName: 'libraries_test_assets_${{ parameters.osGroup }}_x64_Release$(archiveExtension)'
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.zip', parameters.osGroup) }}
+          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.{1}', parameters.osGroup, archiveExtension) }}
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -45,7 +45,6 @@ jobs:
     collectionType: ${{ parameters.collectionType }}
     collectionName: ${{ parameters.collectionName }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
-    librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
     # Test job depends on the corresponding build job
     dependsOn:
      - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
@@ -105,8 +104,8 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: '$(librariesTestsArtifactName).tar.gz'
-          artifactName: '$(librariesTestsArtifactName)'
+          artifactFileName: ${{ format('libraries_test_assets_{0}_{1}_{2}.tar.gz', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
+          artifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
           displayName: 'generic libraries test artifacts'
 
     # Create Core_Root

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -45,6 +45,7 @@ jobs:
     collectionType: ${{ parameters.collectionType }}
     collectionName: ${{ parameters.collectionName }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
+    librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
     # Test job depends on the corresponding build job
     dependsOn:
      - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
@@ -56,9 +57,7 @@ jobs:
      - ${{ if eq(parameters.collectionName, 'tests') }}:
         - '${{ parameters.runtimeType }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
 
-    variables: 
-      - ${{ parameters.variables }}
-      - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
+    variables: ${{ parameters.variables }}
 
     frameworks:
       - ${{ parameters.framework }}

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -114,6 +114,7 @@ jobs:
         archiveFilePatterns: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)/**/*.zip'
         destinationFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
         cleanDestinationFolder: true
+        overwriteExistingFiles: true
 
     # Create Core_Root
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(buildConfig) $(archType) generatelayoutonly $(librariesOverrideArg)

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -102,7 +102,7 @@ jobs:
           displayName: 'generic managed test artifacts'
 
     # Download and unzip libraries test artifacts
-    - ${{ if eq(parameters.collectionName, 'tests') }}:
+    - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -53,10 +53,12 @@ jobs:
        - ${{ format('coreclr_{0}_product_build_{1}{2}_x64_{3}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.buildConfig) }}
      - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
        - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
-     - ${{ if eq(parameters.collectionName, 'tests') }}:
+     - ${{ if (eq(parameters.collectionName, 'tests')) }}:
         - '${{ parameters.runtimeType }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
 
-    variables: ${{ parameters.variables }}
+    variables: 
+      - ${{ parameters.variables }}
+      - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
 
     frameworks:
       - ${{ parameters.framework }}
@@ -90,7 +92,7 @@ jobs:
           artifactName: 'CoreCLRProduct__${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_x64_$(buildConfig)'
           displayName: 'Coreclr product build (x64)'
 
-    # # Download and unzip managed test artifacts
+    # Download and unzip managed test artifacts
     - ${{ if eq(parameters.collectionName, 'tests') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
@@ -98,6 +100,15 @@ jobs:
           artifactFileName: '$(managedGenericTestArtifactName).tar.gz'
           artifactName: '$(managedGenericTestArtifactName)'
           displayName: 'generic managed test artifacts'
+
+    # Download and unzip libraries test artifacts
+    - ${{ if eq(parameters.collectionName, 'tests') }}:
+      - template: /eng/pipelines/common/download-artifact-step.yml
+        parameters:
+          unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
+          artifactFileName: '$(librariesTestsArtifactName).tar.gz'
+          artifactName: '$(librariesTestsArtifactName)'
+          displayName: 'generic libraries test artifacts'
 
     # Create Core_Root
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(buildConfig) $(archType) generatelayoutonly $(librariesOverrideArg)

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: '*.zip'
+          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.zip', parameters.osGroup) }}
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.zip', parameters.osGroup) }}
+          artifactFileName: '*.zip'
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,8 +104,8 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: ${{ format('libraries_test_assets_{0}_{1}_{2}.tar.gz', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
-          artifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
+          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.tar.gz', parameters.osGroup) }}
+          artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 
     # Create Core_Root

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -104,7 +104,7 @@ jobs:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
-          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.tar.gz', parameters.osGroup) }}
+          artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.zip', parameters.osGroup) }}
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
 

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -103,10 +103,17 @@ jobs:
     - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
-          unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
+          unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)'
           artifactFileName: ${{ format('libraries_test_assets_{0}_x64_Release.zip', parameters.osGroup) }}
           artifactName: ${{ format('libraries_test_assets_{0}_x64_Release', parameters.osGroup) }}
           displayName: 'generic libraries test artifacts'
+
+    - task: ExtractFiles@1
+      displayName: 'Unzip Tests.zip'
+      inputs:
+        archiveFilePatterns: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)/**/*.zip'
+        destinationFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
+        cleanDestinationFolder: true
 
     # Create Core_Root
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(buildConfig) $(archType) generatelayoutonly $(librariesOverrideArg)

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -53,7 +53,7 @@ jobs:
        - ${{ format('coreclr_{0}_product_build_{1}{2}_x64_{3}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.buildConfig) }}
      - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
        - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
-     - ${{ if (eq(parameters.collectionName, 'tests')) }}:
+     - ${{ if eq(parameters.collectionName, 'tests') }}:
         - '${{ parameters.runtimeType }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
 
     variables: 

--- a/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -539,6 +539,12 @@ int doParallelSuperPMI(CommandLine::Options& o)
                                       arrDiffMCListPath[i]);
         }
 
+        if (o.failureLimit > 0)
+        {
+            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -failureLimit %d",
+                                      o.failureLimit);
+        }
+
         bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -v ewmin %s", spmiArgs);
 
         SECURITY_ATTRIBUTES sa;

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,14 +43,12 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 87c47638-85a6-48b8-9847-e754ae107158 */
-    0x87c47638,
-    0x85a6,
-    0x48b8,
-    { 0x98, 0x47, 0xe7, 0x54, 0xae, 0x10, 0x71, 0x58 }
+constexpr GUID JITEEVersionIdentifier = { /* a1f5e9a1-ee44-42f9-9319-e2a2dbf8c5c9 */
+    0xa1f5e9a1,
+    0xee44,
+    0x42f9,
+    {0x93, 0x19, 0xe2, 0xa2, 0xdb, 0xf8, 0xc5, 0xc9}
 };
-
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,12 +43,14 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* a1f5e9a1-ee44-42f9-9319-e2a2dbf8c5c9 */
-    0xa1f5e9a1,
-    0xee44,
-    0x42f9,
-    {0x93, 0x19, 0xe2, 0xa2, 0xdb, 0xf8, 0xc5, 0xc9}
+constexpr GUID JITEEVersionIdentifier = { /* 87c47638-85a6-48b8-9847-e754ae107158 */
+    0x87c47638,
+    0x85a6,
+    0x48b8,
+    { 0x98, 0x47, 0xe7, 0x54, 0xae, 0x10, 0x71, 0x58 }
 };
+
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -308,7 +308,10 @@ def copy_directory(src_path, dst_path, verbose_output=True, match_func=lambda pa
                 if match_func(src_item):
                     if verbose_output:
                         print("> copy {0} => {1}".format(src_item, dst_item))
-                    shutil.copy2(src_item, dst_item)
+                    try:
+                        shutil.copy2(src_item, dst_item)
+                    except PermissionError as pe_error:
+                        print('Ignoring PermissionError: {0}'.format(pe_error))
                 else:
                     if verbose_output:
                         print("> skipping {0}".format(src_item))

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -498,7 +498,14 @@ def main(main_args):
             print('Adding exclusions for crossgen2')
             # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.
             exclude_files += [ "Microsoft.Build.dll" ]
-        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory, exclude_files)
+
+        if coreclr_args.collection_name == "tests_libraries":
+            # tests_libraries artifacts contains files from core_root folder. Exclude them.
+            core_root_dir = coreclr_args.core_root_directory
+            exclude_files += [item for item in os.listdir(core_root_dir)
+                              if isfile(join(core_root_dir, item)) and (item.endswith(".dll") or item.endswith(".exe"))]
+        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory,
+                        exclude_files)
 
     # Set variables
     print('Setting pipeline variables:')

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -304,13 +304,17 @@ def copy_directory(src_path, dst_path, verbose_output=True, match_func=lambda pa
         if os.path.isdir(src_item):
             copy_directory(src_item, dst_item, verbose_output, match_func)
         else:
-            if match_func(src_item):
+            try:
+                if match_func(src_item):
+                    if verbose_output:
+                        print("> copy {0} => {1}".format(src_item, dst_item))
+                    shutil.copy2(src_item, dst_item)
+                else:
+                    if verbose_output:
+                        print("> skipping {0}".format(src_item))
+            except UnicodeEncodeError:
                 if verbose_output:
-                    print("> copy {0} => {1}".format(src_item, dst_item))
-                shutil.copy2(src_item, dst_item)
-            else:
-                if verbose_output:
-                    print("> skipping {0}".format(src_item))
+                    print("> Got UnicodeEncodeError")
 
 
 def copy_files(src_path, dst_path, file_names):

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -478,7 +478,18 @@ def main(main_args):
 
             print("Inside make_readable")
             run_command(["ls", "-l", folder_name])
-            os.chmod(folder_name,
+            for file_path, dirs, files in walk(folder_name, topdown=True):
+                for d in dirs:
+                    os.chmod(os.path.join(file_path, d),
+                    # read+write+execute for owner
+                    (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR) |
+                    # read for group
+                    (stat.S_IRGRP) |
+                    # read for other
+                    (stat.S_IROTH))
+
+                for f in files:
+                    os.chmod(os.path.join(file_path, f),
                     # read+write+execute for owner
                     (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR) |
                     # read for group

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -333,7 +333,11 @@ def copy_files(src_path, dst_path, file_names):
         dst_directory = path.dirname(dst_path_of_file)
         if not os.path.exists(dst_directory):
             os.makedirs(dst_directory)
-        shutil.copy2(f, dst_path_of_file)
+        try:
+            shutil.copy2(f, dst_path_of_file)
+        except PermissionError as pe_error:
+            print('Ignoring PermissionError: {0}'.format(pe_error))
+
 
 
 def partition_files(src_directory, dst_directory, max_size, exclude_directories=[],

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -35,6 +35,7 @@
 
 import argparse
 import shutil
+import stat
 import subprocess
 import tempfile
 
@@ -465,6 +466,28 @@ def main(main_args):
     # references will be present in CORE_ROOT.
     if coreclr_args.collection_name == "tests_libraries":
         print('Copying {} -> {}'.format(coreclr_args.input_directory, superpmi_dst_directory))
+
+        def make_readable(folder_name):
+            """Make file executable by changing the permission
+
+            Args:
+                folder_name (string): folder to mark with 744
+            """
+            if is_windows:
+                return
+
+            print("Inside make_readable")
+            run_command(["ls", "-l", folder_name])
+            os.chmod(folder_name,
+                    # read+write+execute for owner
+                    (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR) |
+                    # read for group
+                    (stat.S_IRGRP) |
+                    # read for other
+                    (stat.S_IROTH))
+            run_command(["ls", "-l", folder_name])
+
+        make_readable(coreclr_args.input_directory)
         copy_directory(coreclr_args.input_directory, superpmi_dst_directory, match_func=acceptable_copy)
 
     # Workitem directories

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -177,13 +177,13 @@ def setup_args(args):
     return coreclr_args
 
 
-def get_files_sorted_by_size(src_directory, exclude_directories, skip_file_func):
+def get_files_sorted_by_size(src_directory, exclude_directories, exclude_files):
     """ For a given src_directory, returns all the .dll files sorted by size.
 
     Args:
         src_directory (string): Path of directory to enumerate.
         exclude_directories ([string]): Directory names to exclude.
-        skip_file_func ((string, string, [string])->bool): Skip file function
+        exclude_files ([string]): File names to exclude.
     """
 
     def sorter_by_size(pair):
@@ -201,10 +201,14 @@ def get_files_sorted_by_size(src_directory, exclude_directories, skip_file_func)
         # Credit: https://stackoverflow.com/a/19859907
         dirs[:] = [d for d in dirs if d not in exclude_directories]
         for name in files:
-            if skip_file_func(file_path, name):
+            if name in exclude_files:
                 continue
-
             curr_file_path = path.join(file_path, name)
+
+            if not isfile(curr_file_path):
+                continue
+            if not name.endswith(".dll") and not name.endswith(".exe"):
+                continue
 
             size = getsize(curr_file_path)
             filename_with_size.append((curr_file_path, size))
@@ -280,47 +284,6 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False):
     return command_stdout, command_stderr, return_code
 
 
-def skip_file(file_path, file_name, exclude_files):
-    """Filter the files
-
-    Args:
-        file_path (string): full directory path of the file
-        file_name (string): file name
-        exclude_files ([string]): File names to exclude.
-    """
-    if file_name in exclude_files:
-        return True
-
-    curr_file_path = path.join(file_path, file_name)
-
-    if not isfile(curr_file_path):
-        return True
-    if not file_name.endswith(".dll") and not file_name.endswith(".exe"):
-        return True
-
-    return False
-
-
-def skip_file_tests_libraries(file_path, file_name, exclude_files):
-    """Filter the files
-
-    Args:
-        file_path (string): full directory path of the file
-        file_name (string): file name
-        exclude_files ([string]): File names to exclude.
-    """
-    if file_name == "Microsoft.Build.dll":
-        return True
-
-    if skip_file(file_path, file_name, exclude_files):
-        return True
-
-    if not file_name.endswith(".Tests.dll"):
-        return True
-
-    return False
-
-
 def copy_directory(src_path, dst_path, verbose_output=True, match_func=lambda path: True):
     """Copies directory in 'src_path' to 'dst_path' maintaining the directory
     structure. https://docs.python.org/3.5/library/shutil.html#shutil.copytree can't
@@ -376,19 +339,20 @@ def copy_files(src_path, dst_path, file_names):
             print('Ignoring PermissionError: {0}'.format(pe_error))
 
 
-def partition_files(src_directory, dst_directory, max_size, skip_file_func, exclude_directories=[]):
+def partition_files(src_directory, dst_directory, max_size, exclude_directories=[],
+                    exclude_files=native_binaries_to_ignore):
     """ Copy bucketized files based on size to destination folder.
 
     Args:
         src_directory (string): Source folder containing files to be copied.
         dst_directory (string): Destination folder where files should be copied.
         max_size (int): Maximum partition size in bytes
-        skip_file_func ((string, string, [string])->bool): Skip file function
         exclude_directories ([string]): List of folder names to be excluded.
+        exclude_files ([string]): List of files names to be excluded.
     """
 
     print('Partitioning files from {0} to {1}'.format(src_directory, dst_directory))
-    sorted_by_size = get_files_sorted_by_size(src_directory, exclude_directories, skip_file_func)
+    sorted_by_size = get_files_sorted_by_size(src_directory, exclude_directories, exclude_files)
     partitions = first_fit(sorted_by_size, max_size)
 
     index = 0
@@ -483,11 +447,10 @@ def main(main_args):
         acceptable_copy = lambda path: any(path.endswith(extension) for extension in [".py", ".dll", ".exe", ".json"])
     else:
         # Need to accept files without any extension, which is how executable file's names look.
-        acceptable_copy = lambda path: (os.path.basename(path).find(".") == -1) or any(
-            path.endswith(extension) for extension in [".py", ".dll", ".so", ".json"])
+        acceptable_copy = lambda path: (os.path.basename(path).find(".") == -1) or any(path.endswith(extension) for extension in [".py", ".dll", ".so", ".json"])
 
     print('Copying {} -> {}'.format(coreclr_args.core_root_directory, superpmi_dst_directory))
-    # copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory, match_func=acceptable_copy)
+    copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory, match_func=acceptable_copy)
 
     # Copy common test files to CORE_ROOT
     if coreclr_args.collection_name == "tests_libraries":
@@ -562,12 +525,8 @@ def main(main_args):
             exclude_files += [item for item in os.listdir(core_root_dir)
                               if isfile(join(core_root_dir, item)) and (item.endswith(".dll") or item.endswith(".exe"))]
 
-            skip_file_func = lambda file_path, file_name: skip_file_tests_libraries(file_path, file_name, exclude_files)
-        else:
-            skip_file_func = lambda file_path, file_name: skip_file(file_path, file_name, exclude_files)
-
-        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, skip_file_func,
-                        exclude_directory)
+        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory,
+                        exclude_files)
 
     # Set variables
     print('Setting pipeline variables:')

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -459,20 +459,13 @@ def main(main_args):
     print('Copying {} -> {}'.format(coreclr_args.core_root_directory, superpmi_dst_directory))
     copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory, match_func=acceptable_copy)
 
-    # Copy common test files to CORE_ROOT
+    # Copy all the test files to CORE_ROOT
+    # The reason is there are lot of dependencies with *.Tests.dll and to ensure we do not get
+    # Reflection errors, just copy everything to CORE_ROOT so for all individual partitions, the
+    # references will be present in CORE_ROOT.
     if coreclr_args.collection_name == "tests_libraries":
-
-        def common_libs_tests_files_copy(path):
-            if not acceptable_copy(path):
-                return False
-
-            if path.endswith(".Tests.dll") and not path.endswith("Common.Tests.dll"):
-                return False
-
-            return True
-
-        print('Copying filtered {} -> {}'.format(coreclr_args.input_directory, superpmi_dst_directory))
-        copy_directory(coreclr_args.input_directory, superpmi_dst_directory, match_func=common_libs_tests_files_copy)
+        print('Copying {} -> {}'.format(coreclr_args.input_directory, superpmi_dst_directory))
+        copy_directory(coreclr_args.input_directory, superpmi_dst_directory, match_func=acceptable_copy)
 
     # Workitem directories
     workitem_directory = path.join(source_directory, "workitem")


### PR DESCRIPTION
- Add a new pipeline `tests_libraries` that does the collection for libraries tests.
- Introduce `-error_limit` in superpmi.py that gets passed as `-failureLimit` to `superpmi.exe`. I couldn't use the name `-failure_limit` because that gives "ambiguous option -f" by superpmi.py
- Pass `-failureLimit` to parallel superpmi 

Sample pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=1095734&view=results