### PR TITLE
Cbor docs - Fix SA1121: Use built-in type alias

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
@@ -21,7 +21,7 @@ namespace System.Formats.Cbor
         /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
         /// <remarks>
         /// Map contents are consumed as if they were arrays twice the length of the map's declared size.
-        /// For instance, a map of size 1 containing a key of type <see cref="System.Int32" /> with a value of type <see cref="System.String" />
+        /// For instance, a map of size 1 containing a key of type <see cref="int" /> with a value of type <see cref="string" />
         /// must be consumed by successive calls to <see cref="ReadInt32" /> and <see cref="ReadTextString" />.
         /// It is up to the caller to keep track of whether the next value is a key or a value.
         /// Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
@@ -26,7 +26,7 @@ namespace System.Formats.Cbor
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
         /// the <see cref="ConvertIndefiniteLengthEncodings" /> flag is enabled.
         /// Map contents are written as if arrays twice the length of the map's declared size.
-        /// For instance, a map of size 1 containing a key of type <see cref="System.Int32" /> with a value of type string must be written
+        /// For instance, a map of size 1 containing a key of type <see cref="int" /> with a value of type string must be written
         /// by successive calls to <see cref="WriteInt32(int)" /> and <see cref="WriteTextString(System.ReadOnlySpan{char})" />.
         /// It is up to the caller to keep track of whether the next call is a key or a value.
         /// Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of any type,


### PR DESCRIPTION
Warning caused by xml docs crefs: https://github.com/dotnet/runtime/pull/49506

```
src\libraries\System.Formats.Cbor\src\System\Formats\Cbor\Writer\CborWriter.Map.cs(29,79): error SA1121: (NETCORE_ENGINEERING_TELEMETRY=Build) Use built-in type alias
```

Fixes https://github.com/dotnet/runtime/issues/51518