### PR TITLE
Fix SPMI handling of PGO schemas with class profiles

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -5529,7 +5529,7 @@ void MethodContext::dmpGetPgoInstrumentationResults(DWORDLONG key, const Agnosti
             printf(" %u-{Offset %016llX ILOffset %u Kind %u(0x%x) Count %u Other %u Data ",
                 i, pBuf[i].Offset, pBuf[i].ILOffset, pBuf[i].InstrumentationKind, pBuf[i].InstrumentationKind, pBuf[i].Count, pBuf[i].Other);
 
-            switch(pBuf[i].InstrumentationKind)
+            switch((ICorJitInfo::PgoInstrumentationKind)pBuf[i].InstrumentationKind)
             {
                 case ICorJitInfo::PgoInstrumentationKind::BasicBlockIntCount:
                     printf("B %u", *(unsigned*)(pInstrumentationData + pBuf[i].Offset));
@@ -5543,13 +5543,13 @@ void MethodContext::dmpGetPgoInstrumentationResults(DWORDLONG key, const Agnosti
                 case ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramTypeHandle:
                     for (unsigned int j = 0; j < pBuf[i].Count; j++)
                     {
-                        printf("[%u] %016llX ", j, *(uintptr_t*)(pInstrumentationData + pBuf[i].Offset + j * sizeof(uintptr_t)));
+                        printf("[%u] %016llX ", j, CastHandle(*(uintptr_t*)(pInstrumentationData + pBuf[i].Offset + j * sizeof(uintptr_t))));
                     }
                     break;
                 case ICorJitInfo::PgoInstrumentationKind::GetLikelyClass:
                     {
                         // (N)umber, (L)ikelihood, (C)lass
-                        printf("N %u L %u C %016llX", (unsigned)(pBuf[i].Other >> 8), (unsigned)(pBuf[i].Other && 0xFF), *(uintptr_t*)(pInstrumentationData + pBuf[i].Offset));
+                        printf("N %u L %u C %016llX", (unsigned)(pBuf[i].Other >> 8), (unsigned)(pBuf[i].Other && 0xFF), CastHandle(*(uintptr_t*)(pInstrumentationData + pBuf[i].Offset)));
                     }
                     break;
                 default:

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -5486,8 +5486,15 @@ void MethodContext::recGetPgoInstrumentationResults(CORINFO_METHOD_HANDLE ftnHnd
     size_t maxOffset = 0;
     for (UINT32 i = 0; i < (*pCountSchemaItems); i++)
     {
-        if (pInSchema[i].Offset > maxOffset)
-            maxOffset = pInSchema[i].Offset;
+        // Note >= here; for type histograms the count and handle schema entries have the same offset,
+        // but the handle schema (which comes second) has a larger count.
+        //
+        // The sizeof should really be target pointer size, so cross-bitness replay may not work here.
+        //
+        if (pInSchema[i].Offset >= maxOffset)
+        {
+            maxOffset = pInSchema[i].Offset + pInSchema[i].Count * sizeof(uintptr_t);
+        }
 
         agnosticSchema[i].Offset              = (DWORDLONG)pInSchema[i].Offset;
         agnosticSchema[i].InstrumentationKind = (DWORD)pInSchema[i].InstrumentationKind;
@@ -5498,11 +5505,8 @@ void MethodContext::recGetPgoInstrumentationResults(CORINFO_METHOD_HANDLE ftnHnd
     value.schema_index = GetPgoInstrumentationResults->AddBuffer((unsigned char*)agnosticSchema, sizeof(Agnostic_PgoInstrumentationSchema) * (*pCountSchemaItems));
     free(agnosticSchema);
 
-    // This isn't strictly accurate, but I think it'll do
-    size_t bufSize = maxOffset + 16;
-
-    value.data_index    = GetPgoInstrumentationResults->AddBuffer((unsigned char*)*pInstrumentationData, (unsigned)bufSize);
-    value.dataByteCount = (unsigned)bufSize;
+    value.data_index    = GetPgoInstrumentationResults->AddBuffer((unsigned char*)*pInstrumentationData, (unsigned)maxOffset);
+    value.dataByteCount = (unsigned)maxOffset;
     value.result        = (DWORD)result;
 
     GetPgoInstrumentationResults->Add(CastHandle(ftnHnd), value);
@@ -5517,14 +5521,46 @@ void MethodContext::dmpGetPgoInstrumentationResults(DWORDLONG key, const Agnosti
         Agnostic_PgoInstrumentationSchema* pBuf =
             (Agnostic_PgoInstrumentationSchema*)GetPgoInstrumentationResults->GetBuffer(value.schema_index);
 
+        BYTE* pInstrumentationData = (BYTE*)GetPgoInstrumentationResults->GetBuffer(value.data_index);
+
         printf("\n");
         for (DWORD i = 0; i < value.countSchemaItems; i++)
         {
-            printf(" %u-{Offset %016llX ILOffset %u Kind %u(0x%x) Count %u Other %u}\n",
+            printf(" %u-{Offset %016llX ILOffset %u Kind %u(0x%x) Count %u Other %u Data ",
                 i, pBuf[i].Offset, pBuf[i].ILOffset, pBuf[i].InstrumentationKind, pBuf[i].InstrumentationKind, pBuf[i].Count, pBuf[i].Other);
+
+            switch(pBuf[i].InstrumentationKind)
+            {
+                case ICorJitInfo::PgoInstrumentationKind::BasicBlockIntCount:
+                    printf("B %u", *(unsigned*)(pInstrumentationData + pBuf[i].Offset));
+                    break;
+                case ICorJitInfo::PgoInstrumentationKind::EdgeIntCount:
+                    printf("E %u", *(unsigned*)(pInstrumentationData + pBuf[i].Offset));
+                    break;
+                case ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramCount:
+                    printf("T %u", *(unsigned*)(pInstrumentationData + pBuf[i].Offset));
+                    break;
+                case ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramTypeHandle:
+                    for (unsigned int j = 0; j < pBuf[i].Count; j++)
+                    {
+                        printf("[%u] %016llX ", j, *(uintptr_t*)(pInstrumentationData + pBuf[i].Offset + j * sizeof(uintptr_t)));
+                    }
+                    break;
+                case ICorJitInfo::PgoInstrumentationKind::GetLikelyClass:
+                    {
+                        // (N)umber, (L)ikelihood, (C)lass
+                        printf("N %u L %u C %016llX", (unsigned)(pBuf[i].Other >> 8), (unsigned)(pBuf[i].Other && 0xFF), *(uintptr_t*)(pInstrumentationData + pBuf[i].Offset));
+                    }
+                    break;
+                default:
+                    printf("?");
+                    break;
+            }
+
+            printf("}\n");
         }
     }
-    printf("} data_index-%u [TODO, dump actual count data]", value.data_index);
+    printf("} data_index-%u", value.data_index);
 }
 HRESULT MethodContext::repGetPgoInstrumentationResults(CORINFO_METHOD_HANDLE ftnHnd,
                                                        ICorJitInfo::PgoInstrumentationSchema** pSchema,

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -60,8 +60,6 @@ LikelyClassHistogram::LikelyClassHistogram(uint32_t histogramCount, INT_PTR* his
     m_totalCount                   = 0;
     uint32_t unknownTypeHandleMask = 0;
 
-    JITDUMP("... histogram of %u entries at %p\n", entryCount, histogramEntries);
-
     for (unsigned k = 0; k < entryCount; k++)
     {
         if (histogramEntries[k] == 0)
@@ -72,8 +70,6 @@ LikelyClassHistogram::LikelyClassHistogram(uint32_t histogramCount, INT_PTR* his
         m_totalCount++;
 
         INT_PTR currentEntry = histogramEntries[k];
-
-        JITDUMP("[%u] : %p]\n", k, currentEntry);
 
         bool     found = false;
         unsigned h     = 0;
@@ -124,7 +120,6 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
         if ((schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::GetLikelyClass) &&
             (schema[i].Count == 1))
         {
-            JITDUMP("getLikelyClass: precomputed case\n");
             *pNumberOfClasses = (UINT32)schema[i].Other >> 8;
             *pLikelihood      = (UINT32)(schema[i].Other && 0xFF);
             INT_PTR result    = *(INT_PTR*)(pInstrumentationData + schema[i + 1].Offset);
@@ -138,7 +133,6 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
             (schema[i].Count == 1) && ((i + 1) < countSchemaItems) &&
             (schema[i + 1].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramTypeHandle))
         {
-            JITDUMP("getLikelyClass: building histogram...\n");
             // Form a histogram
             //
             LikelyClassHistogram h(*(uint32_t*)(pInstrumentationData + schema[i].Offset),

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -60,6 +60,8 @@ LikelyClassHistogram::LikelyClassHistogram(uint32_t histogramCount, INT_PTR* his
     m_totalCount                   = 0;
     uint32_t unknownTypeHandleMask = 0;
 
+    JITDUMP("... histogram of %u entries at %p\n", entryCount, histogramEntries);
+
     for (unsigned k = 0; k < entryCount; k++)
     {
         if (histogramEntries[k] == 0)
@@ -70,6 +72,8 @@ LikelyClassHistogram::LikelyClassHistogram(uint32_t histogramCount, INT_PTR* his
         m_totalCount++;
 
         INT_PTR currentEntry = histogramEntries[k];
+
+        JITDUMP("[%u] : %p]\n", k, currentEntry);
 
         bool     found = false;
         unsigned h     = 0;
@@ -120,6 +124,7 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
         if ((schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::GetLikelyClass) &&
             (schema[i].Count == 1))
         {
+            JITDUMP("getLikelyClass: precomputed case\n");
             *pNumberOfClasses = (UINT32)schema[i].Other >> 8;
             *pLikelihood      = (UINT32)(schema[i].Other && 0xFF);
             INT_PTR result    = *(INT_PTR*)(pInstrumentationData + schema[i + 1].Offset);
@@ -133,6 +138,7 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
             (schema[i].Count == 1) && ((i + 1) < countSchemaItems) &&
             (schema[i + 1].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramTypeHandle))
         {
+            JITDUMP("getLikelyClass: building histogram...\n");
             // Form a histogram
             //
             LikelyClassHistogram h(*(uint32_t*)(pInstrumentationData + schema[i].Offset),


### PR DESCRIPTION
SPMI wasn't capturing enough data for PGO schemas that had class profiles,
leading to replay failures.

Also, add a bit of logging to the new likely class computation, so we can
tell in a jit dump when we're using a live histogram vs a crosssgen summary
of a histogram.