### PR TITLE
Use Apple's CCRandomGenerateBytes in GetCryptographicallySecureRandomBytes

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_random.c
+++ b/src/libraries/Native/Unix/System.Native/pal_random.c
@@ -10,6 +10,9 @@
 #include <unistd.h>
 #include <time.h>
 #include <errno.h>
+#if defined(__APPLE__) && __APPLE__
+#include <CommonCrypto/CommonRandom.h>
+#endif
 
 #include "pal_config.h"
 #include "pal_random.h"
@@ -75,6 +78,17 @@ int32_t SystemNative_GetCryptographicallySecureRandomBytes(uint8_t* buffer, int3
             sMissingBrowserCrypto = true;
         else
             return 0;
+    }
+#elif defined(__APPLE__) && __APPLE__
+    CCRNGStatus status = CCRandomGenerateBytes(buffer, bufferLength);
+
+    if (status == kCCSuccess)
+    {
+        return 0;
+    }
+    else
+    {
+        return -1;
     }
 #else
 


### PR DESCRIPTION
The Apple API offers significant performance improvements (an order of magnitude) over reading from /dev/urandom.

Closes #50897

BenchmarkDotNet=v0.12.1.20210419-develop, OS=macOS Big Sur 11.2.3 (20D91) [Darwin 20.3.0]
Intel Core i7-8700B CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.100-preview.3.21202.5
  [Host]     : .NET 6.0.0 (6.0.21.20104), X64 RyuJIT
  Job-JBYKHU : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT
  Job-LIKOBM : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT


|  Method |        Job | Toolchain |      Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |----------- |---------- |----------:|---------:|---------:|------:|------:|------:|------:|----------:|
| NewGuid | Job-JBYKHU |    branch |  76.92 ns | 1.553 ns | 1.376 ns |  0.12 |     - |     - |     - |         - |
| NewGuid | Job-LIKOBM |      main @ ccc47f55554e2ae12e7ec9a07ea19bd4b49e910c | 615.33 ns | 9.879 ns | 9.241 ns |  1.00 |     - |     - |     - |         - |


Benchmark code is available at https://github.com/vcsjones/DotNetCryptoBenches/blob/610b5b2c9865e9fa27b7834ce0dcd0666d776e4d/src/RngBench.cs

/cc @GrabYourPitchforks @jkotas 
