### PR TITLE
Add internal Array.Clear(Array), optimize some Array callers + codegen

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -355,7 +355,7 @@ namespace System
 
         void IList.Clear()
         {
-            Array.Clear(this, this.GetLowerBound(0), this.Length);
+            Array.Clear(this);
         }
 
         int IList.IndexOf(object? value)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
@@ -143,7 +143,7 @@ namespace System.Buffers
                 // Clear the array if the user requests
                 if (clearArray)
                 {
-                    Array.Clear(array, 0, array.Length);
+                    Array.Clear(array);
                 }
 
                 // Return the buffer to its bucket.  In the future, we might consider having Return return false

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -173,7 +173,7 @@ namespace System.Buffers
                 // Clear the array if the user requests.
                 if (clearArray)
                 {
-                    Array.Clear(array, 0, array.Length);
+                    Array.Clear(array);
                 }
 
                 // Check to see if the buffer is the correct size for this bucket
@@ -274,7 +274,7 @@ namespace System.Buffers
                     foreach (KeyValuePair<T[]?[], object?> tlsBuckets in s_allTlsBuckets)
                     {
                         T[]?[] buckets = tlsBuckets.Key;
-                        Array.Clear(buckets, 0, buckets.Length);
+                        Array.Clear(buckets);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -246,7 +246,7 @@ namespace System.Collections.Generic
                 Debug.Assert(_buckets != null, "_buckets should be non-null");
                 Debug.Assert(_entries != null, "_entries should be non-null");
 
-                Array.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_buckets);
 
                 _count = 0;
                 _freeList = -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -189,7 +189,7 @@ namespace System.Collections.Generic
                 Debug.Assert(_buckets != null, "_buckets should be non-null");
                 Debug.Assert(_entries != null, "_entries should be non-null");
 
-                Array.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_buckets);
                 _count = 0;
                 _freeList = -1;
                 _freeCount = 0;

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4655,18 +4655,41 @@ namespace System.Tests
                 return;
             }
 
+            short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
+            a[0, 1] = 42;
+            Array.Copy(a, 1, a, Int32.MaxValue, 2);
+            Assert.Equal(42, a[1, Int32.MaxValue - 2_000_000_000]);
+
+            Array.Clear(a, Int32.MaxValue - 1, 3);
+            Assert.Equal(0, a[1, Int32.MaxValue - 2_000_000_000]);
+        }
+
+        [OuterLoop] // Allocates large array
+        [ConditionalFact]
+        public static void Clear_LargeMultiDimensionalArray()
+        {
+            // If this test is run in a 32-bit process, the large allocation will fail.
+            if (IntPtr.Size != sizeof(long))
+            {
+                return;
+            }
+
+            short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
+            a[1, 1_999_999_999] = 0x1234;
+
+            ((IList)a).Clear();
+            Assert.Equal(0, a[1, 1_999_999_999]);
+        }
+
+        private static short[,] AllocateLargeMDArray(int dim0Length, int dim1Length)
+        {
             try
             {
-                short[,] a = new short[2, 2_000_000_000];
-                a[0, 1] = 42;
-                Array.Copy(a, 1, a, Int32.MaxValue, 2);
-                Assert.Equal(42, a[1, Int32.MaxValue - 2_000_000_000]);
-
-                Array.Clear(a, Int32.MaxValue - 1, 3);
-                Assert.Equal(0, a[1, Int32.MaxValue - 2_000_000_000]);
+                return new short[dim0Length, dim1Length];
             }
             catch (OutOfMemoryException)
             {
+                // not a fatal error - we'll just skip the test in this case
                 throw new SkipTestException("Unable to allocate enough memory");
             }
         }

--- a/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
@@ -62,6 +62,20 @@ namespace System
             get => Rank;
         }
 
+        internal static unsafe void Clear(Array array)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            ref byte ptr = ref array.GetRawSzArrayData();
+            nuint byteLength = array.NativeLength * (nuint)(uint)array.GetElementSize() /* force zero-extension */;
+
+            if (RuntimeHelpers.ObjectHasReferences(array))
+                SpanHelpers.ClearWithReferences(ref Unsafe.As<byte, IntPtr>(ref ptr), byteLength / (uint)sizeof(IntPtr));
+            else
+                SpanHelpers.ClearWithoutReferences(ref ptr, byteLength);
+        }
+
         public static unsafe void Clear(Array array, int index, int length)
         {
             if (array == null)


### PR DESCRIPTION
Optimized some calls to `Array.Clear`, including adding an internal _non-generic_ `Array.Clear(Array)` method for common use cases, plus redirecting some existing calls to `Array.Clear` or `Span<T>.Clear` (see https://github.com/dotnet/runtime/pull/51534) or `Span<T>.Fill`.

__This is marked as draft because I'm soliciting feedback on whether to pursue this.__ It introduces some complexity to the `RawArrayData` and `RawData` types (using _FieldOffset_) in order to knock down the codegen. Whether complicating the C# definitions of these types in order to save some bytes of codegen is worth it I'll leave up to smarter people. :)

The codegen for `Array.Clear(Array)` is pretty well optimized now:

```asm
00007ffa`321721a0 4883ec28             sub     rsp, 28h
00007ffa`321721a4 4885c9               test    rcx, rcx  ; arr != null check
00007ffa`321721a7 745d                 je      System_Private_CoreLib!System.Array.Clear(System.Array)+0xffffffff`a0fc77c6 (00007ffa`32172206)
00007ffa`321721a9 488b11               mov     rdx, qword ptr [rcx]  ; rdx := pMethodTable
00007ffa`321721ac 4c8bc2               mov     r8, rdx
00007ffa`321721af 410fb700             movzx   eax, word ptr [r8]  ; rax := MethodTable::ComponentSize
00007ffa`321721b3 480faf4108           imul    rax, qword ptr [rcx+8]  ; rax := TotalByteLength (ComponentSize * NumElements)
00007ffa`321721b8 8b5204               mov     edx, dword ptr [rdx+4]  ; rdx := MethodTable::BaseSize
00007ffa`321721bb 4883c108             add     rcx, 8  ; ideally would be rolled into line immediately below, but eh, whatever
00007ffa`321721bf 488d4c11f0           lea     rcx, [rcx+rdx-10h]  ; rcx := &Array.FirstElement
00007ffa`321721c4 41f70000000001       test    dword ptr [r8], 1000000h  ; <does the method table contain gc-tracked types?>
; <snip>
```

jit-diff output for CoreLib below. Not sure what's going on with some methods being deleted + reintroduced. Maybe something weird in my build environment? Codegen for methods which now call `Array.Clear(Array)` instead of `Array.Clear(Array, int, int)` is smaller, as expected. Methods like `Array.Copy` which now rely on the internal `NativeLength` property instead of `LongLength` also saw codegen reductions.

```txt
Top method regressions (bytes):
         260 (     ∞ of base) : System.Private.CoreLib.dasm - Array:<Sort>g__GenericSort|128_0(Array,Array,int,int) (0 base, 1 diff methods)
         151 (     ∞ of base) : System.Private.CoreLib.dasm - Array:<BinarySearch>g__GenericBinarySearch|82_0(Array,int,int,Object):int (0 base, 1 diff methods)
         151 (     ∞ of base) : System.Private.CoreLib.dasm - Array:<IndexOf>g__GenericIndexOf|107_0(Array,Object,int,int):int (0 base, 1 diff methods)
         151 (     ∞ of base) : System.Private.CoreLib.dasm - Array:<LastIndexOf>g__GenericLastIndexOf|113_0(Array,Object,int,int):int (0 base, 1 diff methods)
         120 (     ∞ of base) : System.Private.CoreLib.dasm - SpanHelpers:ClearWithReferences(byref,long) (0 base, 1 diff methods)
         117 (     ∞ of base) : System.Private.CoreLib.dasm - Array:Clear(Array) (0 base, 1 diff methods)
           5 (     ∞ of base) : System.Private.CoreLib.dasm - Array:get_NativeLength():long:this (0 base, 1 diff methods)
           1 (25.00% of base) : System.Private.CoreLib.dasm - Array:get_LongLength():long:this

Top method improvements (bytes):
        -260 (-100.00% of base) : System.Private.CoreLib.dasm - Array:<Sort>g__GenericSort|125_0(Array,Array,int,int) (1 base, 0 diff methods)
        -151 (-100.00% of base) : System.Private.CoreLib.dasm - Array:<BinarySearch>g__GenericBinarySearch|79_0(Array,int,int,Object):int (1 base, 0 diff methods)
        -151 (-100.00% of base) : System.Private.CoreLib.dasm - Array:<IndexOf>g__GenericIndexOf|104_0(Array,Object,int,int):int (1 base, 0 diff methods)
        -151 (-100.00% of base) : System.Private.CoreLib.dasm - Array:<LastIndexOf>g__GenericLastIndexOf|110_0(Array,Object,int,int):int (1 base, 0 diff methods)
         -62 (-29.81% of base) : System.Private.CoreLib.dasm - String:Ctor(ushort,int):String:this
         -22 (-2.41% of base) : System.Private.CoreLib.dasm - TlsOverPerCoreLockedStacksArrayPool`1:Return(ref,bool):this
         -13 (-6.02% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,int,Array,int,int)
         -10 (-1.34% of base) : System.Private.CoreLib.dasm - Buffer:BlockCopy(Array,int,Array,int,int)
          -9 (-1.01% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,int,Array,int,int,bool)
          -6 (-2.70% of base) : System.Private.CoreLib.dasm - Array:Clear(Array,int,int)
          -6 (-0.59% of base) : System.Private.CoreLib.dasm - TlsOverPerCoreLockedStacksArrayPool`1:Trim():bool:this
          -5 (-1.62% of base) : System.Private.CoreLib.dasm - ConfigurableArrayPool`1:Return(ref,bool):this
          -4 (-1.71% of base) : System.Private.CoreLib.dasm - Array:Copy(Array,Array,int)
          -2 (-1.72% of base) : System.Private.CoreLib.dasm - Array:UnsafeArrayAsSpan(Array,int,int):Span`1
          -2 (-1.13% of base) : System.Private.CoreLib.dasm - Buffer:ByteLength(Array):int
          -2 (-2.99% of base) : System.Private.CoreLib.dasm - Buffer:GetByte(Array,int):ubyte
          -2 (-2.82% of base) : System.Private.CoreLib.dasm - Buffer:SetByte(Array,int,ubyte)
```