### PR TITLE
Add --inputbubbleref option to crossgen2 in order to put only part of references into version bubble

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -16,6 +16,7 @@ namespace ILCompiler
         public string HelpText;
 
         public IReadOnlyList<string> InputFilePaths;
+        public IReadOnlyList<string> InputBubbleReferenceFilePaths;
         public IReadOnlyList<string> UnrootedInputFilePaths;
         public IReadOnlyList<string> ReferenceFilePaths;
         public IReadOnlyList<string> MibcFilePaths;
@@ -73,6 +74,7 @@ namespace ILCompiler
         public CommandLineOptions(string[] args)
         {
             InputFilePaths = Array.Empty<string>();
+            InputBubbleReferenceFilePaths = Array.Empty<string>();
             UnrootedInputFilePaths = Array.Empty<string>();
             ReferenceFilePaths = Array.Empty<string>();
             MibcFilePaths = Array.Empty<string>();
@@ -100,6 +102,7 @@ namespace ILCompiler
                 syntax.DefineOption("Os|optimize-space", ref OptimizeSpace, SR.OptimizeSpaceOption);
                 syntax.DefineOption("Ot|optimize-time", ref OptimizeTime, SR.OptimizeSpeedOption);
                 syntax.DefineOption("inputbubble", ref InputBubble, SR.InputBubbleOption);
+                syntax.DefineOptionList("inputbubbleref", ref InputBubbleReferenceFilePaths, SR.InputBubbleReferenceFiles);
                 syntax.DefineOption("composite", ref Composite, SR.CompositeBuildMode);
                 syntax.DefineOption("compile-no-methods", ref CompileNoMethods, SR.CompileNoMethodsOption);
                 syntax.DefineOption("out-near-input", ref OutNearInput, SR.OutNearInputOption);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -35,6 +35,8 @@ namespace ILCompiler
         private Dictionary<string, string> _allInputFilePaths = new Dictionary<string, string>();
         private List<ModuleDesc> _referenceableModules = new List<ModuleDesc>();
 
+        private Dictionary<string, string> _inputbubblereferenceFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         private CompilerTypeSystemContext _typeSystemContext;
         private ReadyToRunMethodLayoutAlgorithm _methodLayout;
         private ReadyToRunFileLayoutAlgorithm _fileLayout;
@@ -126,6 +128,9 @@ namespace ILCompiler
 
             foreach (var reference in _commandLineOptions.ReferenceFilePaths)
                 Helpers.AppendExpandedPaths(_referenceFilePaths, reference, false);
+
+            foreach (var reference in _commandLineOptions.InputBubbleReferenceFilePaths)
+              Helpers.AppendExpandedPaths(_inputbubblereferenceFilePaths, reference, false);
 
 
             int alignment = _commandLineOptions.CustomPESectionAlignment;
@@ -437,13 +442,27 @@ namespace ILCompiler
                     {
                         EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile);
                         _referenceableModules.Add(module);
-                        if (_commandLineOptions.InputBubble)
+                        if (_commandLineOptions.InputBubble && _inputbubblereferenceFilePaths.Count == 0)
                         {
                             // In large version bubble mode add reference paths to the compilation group
+                            // Consider bubble as large if no explicit bubble references were passed
                             versionBubbleModulesHash.Add(module);
                         }
                     }
                     catch { } // Ignore non-managed pe files
+                }
+
+                if (_commandLineOptions.InputBubble)
+                {
+                    foreach (var referenceFile in _inputbubblereferenceFilePaths.Values)
+                    {
+                        try
+                        {
+                            EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile);
+                            versionBubbleModulesHash.Add(module);
+                        }
+                        catch { } // Ignore non-managed pe files
+                    }
                 }
             }
 

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -219,6 +219,9 @@
   <data name="ReferenceFiles" xml:space="preserve">
     <value>Reference file(s) for compilation</value>
   </data>
+  <data name="InputBubbleReferenceFiles" xml:space="preserve">
+    <value>Input bubble reference file(s) to be added to bubble (any use of this option is unsupported!) </value>
+  </data>
   <data name="ResilientOption" xml:space="preserve">
     <value>Disable behavior where unexpected compilation failures cause overall compilation failure</value>
   </data>


### PR DESCRIPTION
The change allows to compile dll with bubble only for part of references. This is useful when all referenced dlls can't be included in version bubble. Behavior without `--inputbubbleref` remains unchanged.

For example, for crossgen2 compilation with:

### 1. default options
```sh
/home/z/Dev/runtime/overlay_x64/corerun /home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.dll -r:/home/z/Dev/runtime/overlay_x64/*.dll -r:/home/z/Dev/runtime/overlay_x64/crossgen2/*.dll -O --compilebubblegenerics --inputbubble --verbose --parallelism=1 -o:/home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.ni.dll /home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.dll
```

Methods from next dlls are shown in `--verbose` output as compiled into crossgen2.ni.dll:
```
crossgen2
ILCompiler.TypeSystem.ReadyToRun
S.P.CoreLib
System.Linq
```

### 2. Input bubble only for SPC.dll

```sh
/home/z/Dev/runtime/overlay_x64/corerun /home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.dll -r:/home/z/Dev/runtime/overlay_x64/*.dll -r:/home/z/Dev/runtime/overlay_x64/crossgen2/*.dll --inputbubbleref:/home/z/Dev/runtime/overlay_x64/System.Private.CoreLib.dll -O --compilebubblegenerics --inputbubble --verbose --parallelism=1 -o:/home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.ni.dll /home/z/Dev/runtime/overlay_x64/crossgen2/crossgen2.dll
```

Methods from next dlls are shown in `--verbose` output as compiled into crossgen2.ni.dll:
```
crossgen2
S.P.CoreLib
```

cc @alpencolt 