### PR TITLE
Add support for ifdefs when generating link descriptor

### DIFF
--- a/src/coreclr/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
+++ b/src/coreclr/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
@@ -11,6 +11,8 @@
     <_CortypeFilePath Condition=" '$(_CortypeFilePath)' == '' ">$(MSBuildThisFileDirectory)..\inc\cortypeinfo.h</_CortypeFilePath>
     <_RexcepFilePath Condition=" '$(_RexcepFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\rexcep.h</_RexcepFilePath>
     <_ILLinkDescriptorsIntermediatePath>$(IntermediateOutputPath)ILLink.Descriptors.Combined.xml</_ILLinkDescriptorsIntermediatePath>
+    <_DefineConstants>$(DefineConstants)</_DefineConstants>
+    <_DefineConstants Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">$(DefineConstants);_DEBUG</_DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,6 +39,7 @@
                                            CortypeFilePath="$(_CortypeFilePath)"
                                            RexcepFilePath="$(_RexcepFilePath)"
                                            ILLinkTrimXmlFilePath="$(_ILLinkDescriptorsIntermediatePath)"
+                                           DefineConstants="$(_DefineConstants)"
                                            RuntimeRootDescriptorFilePath="$(_ILLinkRuntimeRootDescriptorFilePath)" />
   </Target>
 

--- a/src/coreclr/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
+++ b/src/coreclr/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
@@ -11,8 +11,8 @@
     <_CortypeFilePath Condition=" '$(_CortypeFilePath)' == '' ">$(MSBuildThisFileDirectory)..\inc\cortypeinfo.h</_CortypeFilePath>
     <_RexcepFilePath Condition=" '$(_RexcepFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\rexcep.h</_RexcepFilePath>
     <_ILLinkDescriptorsIntermediatePath>$(IntermediateOutputPath)ILLink.Descriptors.Combined.xml</_ILLinkDescriptorsIntermediatePath>
-    <_DefineConstants>$(DefineConstants)</_DefineConstants>
-    <_DefineConstants Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">$(DefineConstants);_DEBUG</_DefineConstants>
+    <_DefineConstants>$(DefineConstants);FOR_ILLINK</_DefineConstants>
+    <_DefineConstants Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">$(_DefineConstants);_DEBUG</_DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -54,6 +54,7 @@
         <DefineConstants Condition="'$(FeatureTypeEquivalence)' == 'true'">$(DefineConstants);FEATURE_TYPEEQUIVALENCE</DefineConstants>
         <DefineConstants Condition="'$(FeatureBasicFreeze)' == 'true'">$(DefineConstants);FEATURE_BASICFREEZE</DefineConstants>
         <DefineConstants Condition="'$(FeaturePortableShuffleThunks)' == 'true'">$(DefineConstants);FEATURE_PORTABLE_SHUFFLE_THUNKS</DefineConstants>
+        <DefineConstants Condition="'$(FeatureICastable)' == 'true'">$(DefineConstants);FEATURE_ICASTABLE</DefineConstants>
 
         <DefineConstants Condition="'$(ProfilingSupportedBuild)' == 'true'">$(DefineConstants);PROFILING_SUPPORTED</DefineConstants>
         <DefineConstants Condition="'$(FeatureProfAttach)' == 'true'">$(DefineConstants);FEATURE_PROFAPI_ATTACH_DETACH</DefineConstants>


### PR DESCRIPTION
Simply passes the defines to the custom task. Had to add one feature define which was missing.

This is the dotnet/runtime part of the fix for https://github.com/mono/linker/issues/1973.