### PR TITLE
Add MCS jitflags support for the new GetLikelyClass PGO record type

### DIFF
--- a/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
@@ -29,7 +29,8 @@ int verbJitFlags::DoWork(const char* nameOfInput)
         //
         bool hasEdgeProfile = false;
         bool hasClassProfile = false;
-        if (mc->hasPgoData(hasEdgeProfile, hasClassProfile))
+        bool hasLikelyClass = false;
+        if (mc->hasPgoData(hasEdgeProfile, hasClassProfile, hasLikelyClass))
         {
             rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_PGO);
 
@@ -41,6 +42,11 @@ int verbJitFlags::DoWork(const char* nameOfInput)
             if (hasClassProfile)
             {
                 rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
+            }
+
+            if (hasLikelyClass)
+            {
+                rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_LIKELY_CLASS);
             }
         }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -6784,7 +6784,7 @@ int MethodContext::dumpMD5HashToBuffer(BYTE* pBuffer, int bufLen, char* hash, in
     return m_hash.HashBuffer(pBuffer, bufLen, hash, hashLen);
 }
 
-bool MethodContext::hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile)
+bool MethodContext::hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile, bool& hasLikelyClass)
 {
     hasEdgeProfile = false;
     hasClassProfile = false;
@@ -6808,8 +6808,9 @@ bool MethodContext::hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile)
             {
                 hasEdgeProfile |= (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::EdgeIntCount);
                 hasClassProfile |= (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramCount);
+                hasLikelyClass |= (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::GetLikelyClass);
 
-                if (hasEdgeProfile && hasClassProfile)
+                if (hasEdgeProfile && hasClassProfile && hasLikelyClass)
                 {
                     break;
                 }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -49,7 +49,8 @@ enum EXTRA_JIT_FLAGS
 {
     HAS_PGO = 63,
     HAS_EDGE_PROFILE = 62,
-    HAS_CLASS_PROFILE = 61
+    HAS_CLASS_PROFILE = 61,
+    HAS_LIKELY_CLASS = 60
 };
 
 // Asserts to catch changes in corjit flags definitions.
@@ -57,6 +58,7 @@ enum EXTRA_JIT_FLAGS
 static_assert((int)EXTRA_JIT_FLAGS::HAS_PGO == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED36, "Jit Flags Mismatch");
 static_assert((int)EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED35, "Jit Flags Mismatch");
 static_assert((int)EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED34, "Jit Flags Mismatch");
+static_assert((int)EXTRA_JIT_FLAGS::HAS_LIKELY_CLASS == (int)CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_UNUSED33, "Jit Flags Mismatch");
 
 class MethodContext
 {
@@ -97,7 +99,7 @@ public:
     int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
     int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
 
-    bool hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile);
+    bool hasPgoData(bool& hasEdgeProfile, bool& hasClassProfile, bool& hasLikelyClass);
 
     void recGlobalContext(const MethodContext& other);
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -284,6 +284,7 @@ std::string SpmiDumpHelper::DumpJitFlags(unsigned long long flags)
     AddFlagNumeric(HAS_PGO, EXTRA_JIT_FLAGS::HAS_PGO);
     AddFlagNumeric(HAS_EDGE_PROFILE, EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE);
     AddFlagNumeric(HAS_CLASS_PROFILE, EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
+    AddFlagNumeric(HAS_LIKELY_CLASS, EXTRA_JIT_FLAGS::HAS_LIKELY_CLASS);
 
 #undef AddFlag
 #undef AddFlagNumeric


### PR DESCRIPTION
Records of this type are created when class profile histograms in dynamic PGO
data are summarized by the static PGO tooling.

These records can appear in both prejit and jit schemas when the static PGO data is
passed back to the jit.