### PR TITLE
Simplify some CallConv logic

### DIFF
--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2536,9 +2536,12 @@ namespace
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(nlt != NULL);
 
+        // Handle case where the value is not in the defined enumeration.
+        if ((int)value == 0)
+            value = nltAnsi;
+
         switch( value )
         {
-        case (CorNativeLinkType)0:  // Not set
         case nltAnsi:
             *nlt = nltAnsi;
             break;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2529,6 +2529,37 @@ namespace
             return CallConvWinApiSentinel;
         }
     }
+
+    // Convert a CorNativeLinkType into an unambiguous usable value.
+    bool TryRemapLinkType(_In_ CorNativeLinkType value, _Out_ CorNativeLinkType* nlt)
+    {
+        LIMITED_METHOD_CONTRACT;
+        _ASSERTE(nlt != NULL);
+
+        switch( value )
+        {
+        case 0:         // Not set
+        case nltAnsi:
+            *nlt = nltAnsi;
+            break;
+        case nltUnicode:
+            *nlt = nltUnicode;
+            break;
+        case nltAuto:
+#ifdef TARGET_WINDOWS
+            *nlt = nltUnicode;
+#else
+            *nlt = nltAnsi; // We don't have a utf8 charset in metadata so ANSI == UTF-8 off-Windows
+#endif
+            break;
+        default:
+            return false;
+        }
+
+        // Validate we remapped to a usable value.
+        _ASSERTE(*nlt == nltAnsi || *nlt == nltUnicode);
+        return true;
+    }
 }
 
 void PInvokeStaticSigInfo::PreInit(Module* pModule, MethodTable * pMT)
@@ -2655,35 +2686,20 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(MethodDesc* pMD, ThrowOnError throwOn
         IfFailGo(ParseKnownCaNamedArgs(ca, namedArgs, lengthof(namedArgs)));
 
         callConv = (CorPinvokeMap)(args[0].val.u4 << 8);
-        CorNativeLinkType nlt = (CorNativeLinkType)0;
 
-        // XXX Tue 07/19/2005
-        // Keep in sync with the handling of CorPInvokeMap in
-        // PInvokeStaticSigInfo::DllImportInit.
-        switch( namedArgs[MDA_CharSet].val.u4 )
+        CorNativeLinkType nlt;
+        if (!TryRemapLinkType((CorNativeLinkType)namedArgs[MDA_CharSet].val.u4, &nlt))
         {
-        case 0:
-        case nltAnsi:
-            nlt = nltAnsi; break;
-        case nltUnicode:
-            nlt = nltUnicode; break;
-        case nltAuto:
-#ifdef TARGET_WINDOWS
-            nlt = nltUnicode;
-#else
-            nlt = nltAnsi; // We don't have a utf8 charset in metadata yet, but ANSI == UTF-8 off-Windows
-#endif
-        break;
-        default:
-            hr = E_FAIL; goto ErrExit;
+            hr = E_FAIL;
+            goto ErrExit;
         }
+
         SetCharSet ( nlt );
         SetBestFitMapping (namedArgs[MDA_BestFitMapping].val.u1);
         SetThrowOnUnmappableChar (namedArgs[MDA_ThrowOnUnmappableChar].val.u1);
         if (namedArgs[MDA_SetLastError].val.u1)
             SetLinkFlags ((CorNativeLinkFlags)(nlfLastError | GetLinkFlags()));
     }
-
 
 ErrExit:
     if (hr != S_OK)
@@ -2709,7 +2725,7 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(
     PreInit(pModule, NULL);
     m_sig = sig;
     SetIsStatic (!(MetaSig::GetCallingConvention(pModule, sig) & IMAGE_CEE_CS_CALLCONV_HASTHIS));
-    InitCallConv(CorInfoCallConvExtension::Managed, FALSE);
+    InitCallConv(CallConvWinApiSentinel, FALSE);
 
     ReportErrors();
 }
@@ -2749,7 +2765,7 @@ void PInvokeStaticSigInfo::DllImportInit(MethodDesc* pMD, LPCUTF8 *ppLibName, LP
             BestGuessNDirectDefaults(pMD);
 #endif
 
-        InitCallConv(CorInfoCallConvExtension::Managed, pMD->IsVarArg());
+        InitCallConv(CallConvWinApiSentinel, pMD->IsVarArg());
         return;
     }
 
@@ -2790,26 +2806,29 @@ void PInvokeStaticSigInfo::DllImportInit(MethodDesc* pMD, LPCUTF8 *ppLibName, LP
     if (mappingFlags & pmNoMangle)
         SetLinkFlags ((CorNativeLinkFlags)(GetLinkFlags() | nlfNoMangle));
 
-    // Keep in sync with the handling of CorNativeLinkType in
-    // PInvokeStaticSigInfo::PInvokeStaticSigInfo.
-
     // charset : CorPinvoke -> CorNativeLinkType
     CorPinvokeMap charSetMask = (CorPinvokeMap)(mappingFlags & (pmCharSetNotSpec | pmCharSetAnsi | pmCharSetUnicode | pmCharSetAuto));
-    if (charSetMask == pmCharSetNotSpec || charSetMask == pmCharSetAnsi)
+    CorNativeLinkType nlt = nltMaxValue; // Initialize to invalid value
+    switch (charSetMask)
     {
-        SetCharSet (nltAnsi);
+        case pmCharSetNotSpec:
+        case pmCharSetAnsi:
+            nlt = nltAnsi;
+            break;
+        case pmCharSetUnicode:
+            nlt = nltUnicode;
+            break;
+        case pmCharSetAuto:
+            nlt = nltAuto;
+            break;
+        default:
+            _ASSERTE("Unknown CharSet mask value");
+            break;
     }
-    else if (charSetMask == pmCharSetUnicode)
+
+    if (TryRemapLinkType(nlt, &nlt))
     {
-        SetCharSet (nltUnicode);
-    }
-    else if (charSetMask == pmCharSetAuto)
-    {
-#ifdef TARGET_WINDOWS
-        SetCharSet(nltUnicode);
-#else
-        SetCharSet(nltAnsi); // We don't have a utf8 charset in metadata yet, but ANSI == UTF-8 off-Windows
-#endif
+        SetCharSet(nlt);
     }
     else
     {
@@ -2966,19 +2985,16 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
 {
     STANDARD_VM_CONTRACT;
 
-    CorInfoCallConvExtension sigCallConv = CallConvWinApiSentinel;
-    bool suppressGCTransition;
+    CallConvBuilder builder;
     UINT errorResID;
-    HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetScopeHandle(m_pModule), m_sig.GetRawSig(), m_sig.GetRawSigLen(), &sigCallConv, &suppressGCTransition, &errorResID);
+    HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetScopeHandle(m_pModule), m_sig.GetRawSig(), m_sig.GetRawSigLen(), &builder, &errorResID);
     if (FAILED(hr))
     {
         // Set an error message specific to P/Invokes or UnmanagedFunction for bad format.
         SetError(hr == COR_E_BADIMAGEFORMAT ? IDS_EE_NDIRECT_BADNATL : errorResID);
     }
-    else if (hr == S_FALSE)
-    {
-        sigCallConv = CallConvWinApiSentinel;
-    }
+
+    CorInfoCallConvExtension sigCallConv = builder.GetCurrentCallConv();
 
     // Validate that either no specific calling convention is provided or that the signature calling convention
     // matches the DllImport calling convention.
@@ -5923,23 +5939,19 @@ PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)
         }
         else
         {
-            CorInfoCallConvExtension callConvMaybe;
+            CallConvBuilder builder;
             UINT errorResID;
-            bool suppressGCTransition = false;
-            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetScopeHandle(pVASigCookie->pModule), signature.GetRawSig(), signature.GetRawSigLen(), &callConvMaybe, &suppressGCTransition, &errorResID);
+            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetScopeHandle(pVASigCookie->pModule), signature.GetRawSig(), signature.GetRawSigLen(), &builder, &errorResID);
             if (FAILED(hr))
                 COMPlusThrowHR(hr, errorResID);
 
-            if (hr == S_OK)
-            {
-                unmgdCallConv = callConvMaybe;
-            }
-            else
+            unmgdCallConv = builder.GetCurrentCallConv();
+            if (unmgdCallConv == CallConvBuilder::UnsetValue)
             {
                 unmgdCallConv = MetaSig::GetDefaultUnmanagedCallingConvention();
             }
 
-            if (suppressGCTransition)
+            if (builder.IsCurrentCallConvModSet(CallConvBuilder::CALL_CONV_MOD_SUPPRESSGCTRANSITION))
             {
                 dwStubFlags |= NDIRECTSTUB_FL_SUPPRESSGCTRANSITION;
             }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2540,7 +2540,7 @@ namespace
         if ((int)value == 0)
             value = nltAnsi;
 
-        switch( value )
+        switch (value)
         {
         case nltAnsi:
             *nlt = nltAnsi;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2538,7 +2538,7 @@ namespace
 
         switch( value )
         {
-        case 0:         // Not set
+        case (CorNativeLinkType)0:  // Not set
         case nltAnsi:
             *nlt = nltAnsi;
             break;

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -640,17 +640,10 @@ bool TryGetCallingConventionFromUnmanagedCallersOnly(MethodDesc* pMD, CorInfoCal
             }
         }
 
-        CallConvBuilder::CallConvModifiers modifiers;
-        callConvBuilder.GetCurrentCallConv(callConvLocal, modifiers);
-
-        if (callConvLocal == CallConvBuilder::DefaultValue)
+        callConvLocal = callConvBuilder.GetCurrentCallConv();
+        if (callConvLocal == CallConvBuilder::UnsetValue)
         {
             callConvLocal = MetaSig::GetDefaultUnmanagedCallingConvention();
-        }
-
-        if (modifiers & CallConvBuilder::CALL_CONV_MOD_MEMBERFUNCTION)
-        {
-            callConvLocal = MetaSig::GetMemberFunctionUnmanagedCallingConventionVariant(callConvLocal);
         }
     }
     *pCallConv = callConvLocal;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9914,6 +9914,7 @@ namespace
                 callConvLocal = MetaSig::GetDefaultUnmanagedCallingConvention();
             }
 
+            *pSuppressGCTransition = builder.IsCurrentCallConvModSet(CallConvBuilder::CALL_CONV_MOD_SUPPRESSGCTRANSITION);
             return callConvLocal;
         }
         case IMAGE_CEE_CS_CALLCONV_NATIVEVARARG:

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9901,21 +9901,20 @@ namespace
             return CorInfoCallConvExtension::Fastcall;
         case IMAGE_CEE_CS_CALLCONV_UNMANAGED:
         {
-            CorInfoCallConvExtension callConvMaybe;
+            CallConvBuilder builder;
             UINT errorResID;
-            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(mod, pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
+            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(mod, pSig, cbSig, &builder, &errorResID);
 
             if (FAILED(hr))
                 COMPlusThrowHR(hr, errorResID);
 
-            if (hr == S_OK)
+            CorInfoCallConvExtension callConvLocal = builder.GetCurrentCallConv();
+            if (callConvLocal == CallConvBuilder::UnsetValue)
             {
-                return callConvMaybe;
+                callConvLocal = MetaSig::GetDefaultUnmanagedCallingConvention();
             }
-            else
-            {
-                return MetaSig::GetDefaultUnmanagedCallingConvention();
-            }
+
+            return callConvLocal;
         }
         case IMAGE_CEE_CS_CALLCONV_NATIVEVARARG:
             return CorInfoCallConvExtension::C;

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -506,6 +506,53 @@ private:
     TokenPairList *m_pNext;
 };  // class TokenPairList
 
+// Attempts to parse the provided calling convention names to construct a
+// calling convention with known modifiers.
+//
+// The Add* functions return false if the type is known but cannot be applied.
+// Otherwise, they return true.
+class CallConvBuilder final
+{
+public:
+    enum CallConvModifiers
+    {
+        CALL_CONV_MOD_NONE = 0,
+        CALL_CONV_MOD_SUPPRESSGCTRANSITION = 0x1,
+        CALL_CONV_MOD_MEMBERFUNCTION = 0x2
+    };
+
+    struct State
+    {
+        CorInfoCallConvExtension CallConvBase;
+        CallConvModifiers CallConvModifiers;
+    };
+
+private:
+    State _state;
+
+public:
+    // The initial "unset" base calling convention.
+    static const CorInfoCallConvExtension UnsetValue;
+
+    CallConvBuilder();
+
+    // Add a fully qualified type name to the calling convention computation.
+    bool AddFullyQualifiedTypeName(
+        _In_ size_t typeLength,
+        _In_z_ LPCSTR typeName);
+
+    // Add a simple type name to the calling convention computation.
+    bool AddTypeName(
+        _In_ size_t typeLength,
+        _In_z_ LPCSTR typeName);
+
+    // Get the currently computed calling convention values.
+    CorInfoCallConvExtension GetCurrentCallConv() const;
+
+    // Check if the modifier is set on the computed calling convention.
+    bool IsCurrentCallConvModSet(_In_ CallConvModifiers mod) const;
+};
+
 //---------------------------------------------------------------------------------------
 //
 class MetaSig
@@ -794,8 +841,7 @@ class MetaSig
             _In_ CORINFO_MODULE_HANDLE pModule,
             _In_ PCCOR_SIGNATURE pSig,
             _In_ ULONG cSig,
-            _Out_ CorInfoCallConvExtension *callConvOut,
-            _Out_ bool* suppressGCTransitionOut,
+            _Inout_ CallConvBuilder *builder,
             _Out_ UINT *errorResID);
 
         static CorInfoCallConvExtension GetDefaultUnmanagedCallingConvention()
@@ -805,24 +851,6 @@ class MetaSig
 #else // TARGET_UNIX
             return CorInfoCallConvExtension::Stdcall;
 #endif // !TARGET_UNIX
-        }
-
-        static CorInfoCallConvExtension GetMemberFunctionUnmanagedCallingConventionVariant(CorInfoCallConvExtension baseCallConv)
-        {
-            switch (baseCallConv)
-            {
-            case CorInfoCallConvExtension::C:
-                return CorInfoCallConvExtension::CMemberFunction;
-            case CorInfoCallConvExtension::Stdcall:
-                return CorInfoCallConvExtension::StdcallMemberFunction;
-            case CorInfoCallConvExtension::Fastcall:
-                return CorInfoCallConvExtension::FastcallMemberFunction;
-            case CorInfoCallConvExtension::Thiscall:
-                return CorInfoCallConvExtension::Thiscall;
-            default:
-                _ASSERTE("Calling convention is not an unmanaged base calling convention.");
-                return baseCallConv;
-            }
         }
 
         //------------------------------------------------------------------
@@ -1183,52 +1211,6 @@ public:
         BYTE            m_flags;
         BYTE            m_CallConv;
 };  // class MetaSig
-
-// Attempts to parse the provided calling convention names to construct a
-// calling convention with known modifiers.
-//
-// The Add* functions return false if the type is known but cannot be applied.
-// Otherwise, they return true.
-class CallConvBuilder final
-{
-public:
-    enum CallConvModifiers
-    {
-        CALL_CONV_MOD_NONE = 0,
-        CALL_CONV_MOD_SUPPRESSGCTRANSITION = 0x1,
-        CALL_CONV_MOD_MEMBERFUNCTION = 0x2
-    };
-
-    struct State
-    {
-        CorInfoCallConvExtension CallConvBase;
-        CallConvModifiers CallConvModifiers;
-    };
-
-private:
-    State _state;
-
-public:
-    // The initial "unset" base calling convention.
-    static const CorInfoCallConvExtension DefaultValue;
-
-    CallConvBuilder();
-
-    // Add a fully qualified type name to the calling convention computation.
-    bool AddFullyQualifiedTypeName(
-        _In_ size_t typeLength,
-        _In_z_ LPCSTR typeName);
-
-    // Add a simple type name to the calling convention computation.
-    bool AddTypeName(
-        _In_ size_t typeLength,
-        _In_z_ LPCSTR typeName);
-
-    // Get the currently computed calling convention values.
-    void GetCurrentCallConv(
-        _Out_ CorInfoCallConvExtension &baseCallConv,
-        _Out_ CallConvModifiers &modsCallConv);
-};
 
 BOOL IsTypeRefOrDef(LPCSTR szClassName, Module *pModule, mdToken token);
 

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -546,7 +546,7 @@ public:
         _In_ size_t typeLength,
         _In_z_ LPCSTR typeName);
 
-    // Get the currently computed calling convention values.
+    // Get the currently computed calling convention value.
     CorInfoCallConvExtension GetCurrentCallConv() const;
 
     // Check if the modifier is set on the computed calling convention.

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -831,8 +831,7 @@ class MetaSig
         // Gets the unmanaged calling convention by reading any modopts.
         //
         // Returns:
-        //   S_OK - Calling convention was read from modopt
-        //   S_FALSE - Calling convention was not read from modopt
+        //   S_OK - No errors
         //   COR_E_BADIMAGEFORMAT - Signature had an invalid format
         //   COR_E_INVALIDPROGRAM - Program is considered invalid (more
         //                          than one calling convention specified)


### PR DESCRIPTION
Reuse the CallConvBuilder class in more places.
Unify CharSet logic for UnmanagedFunctionPointer and DllImport.

/cc @jkoritzinsky @elinor-fung 