### PR TITLE
Call TypeDescriptor.GetProperties before calling Refresh in ReflectionCachesUpdateHandler

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectionCachesUpdateHandler.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectionCachesUpdateHandler.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Metadata;
 
@@ -12,6 +13,7 @@ namespace System.ComponentModel
 {
     internal static class ReflectionCachesUpdateHandler
     {
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "The actual properties retrieved by GetProperties do not matter.")]
         public static void BeforeUpdate(Type[]? types)
         {
             // ReflectTypeDescriptionProvider maintains global caches on top of reflection.
@@ -31,6 +33,7 @@ namespace System.ComponentModel
             {
                 foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
+                    TypeDescriptor.GetProperties(assembly); // must call before calling Refresh
                     TypeDescriptor.Refresh(assembly);
                 }
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    [SimpleUpdateTest]
+    [Collection("NoParallelTests")]
     public class ReflectionCachesUpdateHandlerTests
     {
         [Fact]
@@ -26,7 +26,4 @@ namespace System.ComponentModel.Tests
             Assert.NotSame(ac1[0], ac3[0]);
         }
     }
-
-    [AttributeUsage(AttributeTargets.All)]
-    internal sealed class SimpleUpdateTestAttribute : Attribute { }
 }


### PR DESCRIPTION
Try to fix https://github.com/dotnet/runtime/issues/51588

According to the docs:
"Before you make a call to the Refresh method to clear the cache, you need to call the GetProperties method for the specific assembly to cache the information first."

Counterintuitive, but ok.

cc: @jeffhandley, @safern 