### PR TITLE
[mono] Add HAVE_PTHREAD_JIT_WRITE_PROTECT_NP to cmake config.h.in

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -580,6 +580,9 @@
 /* Define to 1 if you have the `pthread_get_stackaddr_np' function. */
 #cmakedefine HAVE_PTHREAD_GET_STACKADDR_NP 1
 
+/* Define to 1 if you have the `pthread_jit_write_protect_np' function. */
+#cmakedefine HAVE_PTHREAD_JIT_WRITE_PROTECT_NP 1
+
 /* Define to 1 if you have the declaration of `pthread_mutexattr_setprotocol',
    and to 0 if you don't. */
 #cmakedefine HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL 1

--- a/src/mono/cmake/configure.cmake
+++ b/src/mono/cmake/configure.cmake
@@ -86,13 +86,14 @@ set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_IN
 
 ac_check_funcs(
   pthread_getname_np pthread_setname_np pthread_cond_timedwait_relative_np pthread_kill
-  pthread_attr_setstacksize pthread_get_stackaddr_np pthread_jit_write_protect_np
+  pthread_attr_setstacksize pthread_get_stackaddr_np
 )
 
 check_symbol_exists(pthread_mutexattr_setprotocol "pthread.h" HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL)
 check_symbol_exists(CLOCK_MONOTONIC "time.h" HAVE_CLOCK_MONOTONIC)
 check_symbol_exists(CLOCK_MONOTONIC_COARSE "time.h" HAVE_CLOCK_MONOTONIC_COARSE)
 check_symbol_exists(sys_signame "signal.h" HAVE_SYSSIGNAME)
+check_symbol_exists(pthread_jit_write_protect_np "pthread.h" HAVE_PTHREAD_JIT_WRITE_PROTECT_NP)
 
 ac_check_type("struct sockaddr_in6" sockaddr_in6 "netinet/in.h")
 ac_check_type("struct timeval" timeval "sys/time.h;sys/types.h;utime.h")


### PR DESCRIPTION
Otherwise mono_codeman_enable_write is a no-op

Should fix jiting on macOS arm64

Fixes #49042 