### PR TITLE
Remove harvesting of Microsoft.Win32.Registry*

### DIFF
--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
@@ -5,11 +5,17 @@
       <SupportedFramework>net461;uap10.0.16299;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
+  <!-- Remove TFMs that aren't supported by the package intentionally anymore. -->
+  <Target Name="_RemoveSupportedFramework"
+          BeforeTargets="ValidateLibraryPackage">
+    <ItemGroup>
+      <SupportedFramework Remove="netcoreapp1.0" />
+      <SupportedFramework Remove="netcoreapp1.1" />
+      <SupportedFramework Remove="netcore50" />
+      <SupportedFramework Remove="uap10.0" />
+      <SupportedFramework Remove="net46" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
+++ b/src/libraries/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
@@ -5,11 +5,17 @@
       <SupportedFramework>net461;uap10.0.16299;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
+  <!-- Remove TFMs that aren't supported by the package intentionally anymore. -->
+  <Target Name="_RemoveSupportedFramework"
+          BeforeTargets="ValidateLibraryPackage">
+    <ItemGroup>
+      <SupportedFramework Remove="netcoreapp1.0" />
+      <SupportedFramework Remove="netcoreapp1.1" />
+      <SupportedFramework Remove="netcore50" />
+      <SupportedFramework Remove="uap10.0" />
+      <SupportedFramework Remove="net46" />
+    </ItemGroup>
+  </Target>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
The net46 and netstandard1.3 configuration of Microsoft.Win32.Registry
and Microsoft.Win32.Registry.AccessControl isn't built anymore. Instead
the already built matching binary from the latest available package
version is redistributed when packaging these libraries.

Dropping the netstandard1.3 asset and the net46 one as the
minimum supported set of platforms are ones that support netstandard2.0.
For .NET Framework, there's still a net461 configuration to avoid
binding redirect issues.

Contributes to #47530