### PR TITLE
Remove harvesting of System.Composition*

### DIFF
--- a/src/libraries/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.pkgproj
+++ b/src/libraries/System.Composition.AttributedModel/pkg/System.Composition.AttributedModel.pkgproj
@@ -4,8 +4,8 @@
     <ProjectReference Include="..\src\System.Composition.AttributedModel.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-
-    <HarvestIncludePaths Include="lib/netstandard1.0;lib/portable-net45+win8+wp8+wpa81" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Composition.Convention/pkg/System.Composition.Convention.pkgproj
+++ b/src/libraries/System.Composition.Convention/pkg/System.Composition.Convention.pkgproj
@@ -4,8 +4,8 @@
     <ProjectReference Include="..\src\System.Composition.Convention.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-
-    <HarvestIncludePaths Include="lib/netstandard1.0;lib/portable-net45+win8+wp8+wpa81" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Composition.Hosting/pkg/System.Composition.Hosting.pkgproj
+++ b/src/libraries/System.Composition.Hosting/pkg/System.Composition.Hosting.pkgproj
@@ -4,8 +4,8 @@
     <ProjectReference Include="..\src\System.Composition.Hosting.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-
-    <HarvestIncludePaths Include="lib/netstandard1.0;lib/portable-net45+win8+wp8+wpa81" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Composition.Runtime/pkg/System.Composition.Runtime.pkgproj
+++ b/src/libraries/System.Composition.Runtime/pkg/System.Composition.Runtime.pkgproj
@@ -4,8 +4,8 @@
     <ProjectReference Include="..\src\System.Composition.Runtime.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-
-    <HarvestIncludePaths Include="lib/netstandard1.0;lib/portable-net45+win8+wp8+wpa81" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Composition.TypedParts/pkg/System.Composition.TypedParts.pkgproj
+++ b/src/libraries/System.Composition.TypedParts/pkg/System.Composition.TypedParts.pkgproj
@@ -4,8 +4,8 @@
     <ProjectReference Include="..\src\System.Composition.TypedParts.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-
-    <HarvestIncludePaths Include="lib/netstandard1.0;lib/portable-net45+win8+wp8+wpa81" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
The netstandard1.0 and portable* configurations of the
System.Composition.* packages aren't built anymore. Instead
the already built matching binary from the latest available package
version is redistributed when packaging these libraries.

Dropping the netstandard1.0 asset and the portable* one as the
minimum supported set of platforms are ones that support netstandard2.0.
For .NET Framework, there's still a net461 configuration to avoid
binding redirect issues.

Contributes to #47530