### PR TITLE
Don't have gtAuxiliaryJitType and gtOtherReg share a union

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1492,7 +1492,8 @@ AGAIN:
                     if ((op1->AsHWIntrinsic()->gtHWIntrinsicId != op2->AsHWIntrinsic()->gtHWIntrinsicId) ||
                         (op1->AsHWIntrinsic()->GetSimdBaseType() != op2->AsHWIntrinsic()->GetSimdBaseType()) ||
                         (op1->AsHWIntrinsic()->GetSimdSize() != op2->AsHWIntrinsic()->GetSimdSize()) ||
-                        (op1->AsHWIntrinsic()->GetAuxiliaryType() != op2->AsHWIntrinsic()->GetAuxiliaryType()))
+                        (op1->AsHWIntrinsic()->GetAuxiliaryType() != op2->AsHWIntrinsic()->GetAuxiliaryType()) ||
+                        (op1->AsHWIntrinsic()->GetOtherReg() != op2->AsHWIntrinsic()->GetOtherReg()))
                     {
                         return false;
                     }
@@ -2163,6 +2164,7 @@ AGAIN:
                     hash += tree->AsHWIntrinsic()->GetSimdBaseType();
                     hash += tree->AsHWIntrinsic()->GetSimdSize();
                     hash += tree->AsHWIntrinsic()->GetAuxiliaryType();
+                    hash += tree->AsHWIntrinsic()->GetOtherReg();
                     break;
 #endif // FEATURE_HW_INTRINSICS
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4849,8 +4849,8 @@ struct GenTreeJitIntrinsic : public GenTreeOp
 private:
     ClassLayout* m_layout;
 
-    unsigned char gtAuxiliaryJitType; // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by element))
-    regNumberSmall gtOtherReg;        // For intrinsics that return 2 registers
+    unsigned char  gtAuxiliaryJitType; // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by element))
+    regNumberSmall gtOtherReg;         // For intrinsics that return 2 registers
 
     unsigned char gtSimdBaseJitType; // SIMD vector base JIT type
     unsigned char gtSimdSize;        // SIMD vector size in bytes, use 0 for scalar intrinsics

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4849,11 +4849,8 @@ struct GenTreeJitIntrinsic : public GenTreeOp
 private:
     ClassLayout* m_layout;
 
-    union {
-        unsigned char gtAuxiliaryJitType; // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by
-                                          // element))
-        regNumberSmall gtOtherReg;        // For intrinsics that return 2 registers
-    };
+    unsigned char gtAuxiliaryJitType; // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by element))
+    regNumberSmall gtOtherReg;        // For intrinsics that return 2 registers
 
     unsigned char gtSimdBaseJitType; // SIMD vector base JIT type
     unsigned char gtSimdSize;        // SIMD vector size in bytes, use 0 for scalar intrinsics


### PR DESCRIPTION
This resolves the assert @AndyAyersMS  was seeing in https://github.com/dotnet/runtime/issues/47434#issuecomment-823726020.
Now that the JIT type is the underlying field, it is problematic to use `GetAuxilliaryType` in the hashing algorithm when `gtAuxiliaryJitType` and `gtOtherReg` were sharing memory.