### PR TITLE
Add and update `///` comments to help consumers of these APIs

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Runs an application and returns a Task that only completes when the token is triggered or shutdown is triggered.
+        /// Runs an application and returns a <see cref="Task"/> that only completes when the token is triggered or shutdown is triggered.
+        /// The <paramref name="host"/> instance is disposed of after running.
         /// </summary>
         /// <param name="host">The <see cref="IHost"/> to run.</param>
         /// <param name="token">The token to trigger shutdown.</param>
@@ -74,7 +75,6 @@ namespace Microsoft.Extensions.Hosting
                 {
                     host.Dispose();
                 }
-
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostEnvironment.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     {
         /// <summary>
         /// Gets or sets the name of the environment. The host automatically sets this property to the value of the
-        /// of the "environment" key as specified in configuration.
+        /// "environment" key as specified in configuration.
         /// </summary>
         string EnvironmentName { get; set; }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Extensions.Hosting
     public static class HostingHostBuilderExtensions
     {
         /// <summary>
-        /// Specify the environment to be used by the host.
+        /// Specify the environment to be used by the host. To avoid the environment being overwritten by a default
+        /// value, ensure this is called after defaults are configured.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <param name="environment">The environment to host the application in.</param>
@@ -31,13 +32,14 @@ namespace Microsoft.Extensions.Hosting
                 configBuilder.AddInMemoryCollection(new[]
                 {
                     new KeyValuePair<string, string>(HostDefaults.EnvironmentKey,
-                        environment  ?? throw new ArgumentNullException(nameof(environment)))
+                        environment ?? throw new ArgumentNullException(nameof(environment)))
                 });
             });
         }
 
         /// <summary>
-        /// Specify the content root directory to be used by the host.
+        /// Specify the content root directory to be used by the host. To avoid the content root directory being
+        /// overwritten by a default value, ensure this is called after defaults are configured.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <param name="contentRoot">Path to root directory of the application.</param>
@@ -164,7 +166,8 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Configures an existing <see cref="IHostBuilder"/> instance with pre-configured defaults.
+        /// Configures an existing <see cref="IHostBuilder"/> instance with pre-configured defaults. This will overwrite
+        /// previously configured values and is intended to be called before additional configuration calls.
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the <see cref="IHostBuilder"/>:

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -141,6 +141,48 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<AggregateException>(() => hostBuilder.Build());
         }
 
+        [Theory]
+        [InlineData("Beta-Testing"), InlineData("Another-Random-Env")]
+        public void UseEnvironmentIsOverwrittenByAdditionalCalls(string environment)
+        {
+            var expectedEnvironment = "SomeOtherEnvironment";
+            using var host = new HostBuilder()
+                .UseEnvironment(environment)
+                .ConfigureHostConfiguration(configBuilder =>
+                {
+                    configBuilder.AddInMemoryCollection(new[]
+                    {
+                        new KeyValuePair<string, string>(
+                            HostDefaults.EnvironmentKey, expectedEnvironment)
+                    });
+                })
+                .Build();
+
+            var hostEnv = host.Services.GetRequiredService<IHostEnvironment>();
+            Assert.Equal(expectedEnvironment, hostEnv.EnvironmentName);
+        }
+
+        [Theory]
+        [InlineData("Beta-Testing"), InlineData("Another-Random-Env")]
+        public void LastCallToUseEnvironmentWins(string environment)
+        {
+            var willBeOverwritten = "SomeOtherEnvironment";
+            using var host = new HostBuilder()
+                .ConfigureHostConfiguration(configBuilder =>
+                {
+                    configBuilder.AddInMemoryCollection(new[]
+                    {
+                        new KeyValuePair<string, string>(
+                            HostDefaults.EnvironmentKey, willBeOverwritten)
+                    });
+                })
+                .UseEnvironment(environment)
+                .Build();
+
+            var hostEnv = host.Services.GetRequiredService<IHostEnvironment>();
+            Assert.Equal(environment, hostEnv.EnvironmentName);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/48696")]

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                         new KeyValuePair<string, string>(
                             HostDefaults.EnvironmentKey, expectedEnvironment)
                     });
-                })
+                }) // This overwrites the call to UseEnvironment
                 .Build();
 
             var hostEnv = host.Services.GetRequiredService<IHostEnvironment>();
@@ -176,7 +176,8 @@ namespace Microsoft.Extensions.Hosting.Tests
                             HostDefaults.EnvironmentKey, willBeOverwritten)
                     });
                 })
-                .UseEnvironment(environment)
+                .UseEnvironment(Guid.NewGuid().ToString())
+                .UseEnvironment(environment) // Last one wins...
                 .Build();
 
             var hostEnv = host.Services.GetRequiredService<IHostEnvironment>();


### PR DESCRIPTION
- Added some `///` API comments to help consumers have a better understanding of the order of operations
- Added unit tests to affirm by-design aspect of `UseEnvironment` and order of operations
- Fixed redundancy in `///` comment on `IHostEnvironment.EnvironmentName` - "of the of the"
- Added comment about `host` instance being disposed of - I didn't realize this was done implicitly and believe this is helpful to consumers

Related to and closes #47050