### PR TITLE
JIT: revise criteria for inline candidates with intrinsics or folding…

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1488,7 +1488,6 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                 break;
 
             case CEE_BOX:
-            {
                 // Look for evidence of type specialization patterns.
                 //
                 // box + br
@@ -1537,7 +1536,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                             break;
                     }
                 }
-            }
+                break;
 
             default:
                 break;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1509,6 +1509,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                             {
                                 compInlineResult->Note(InlineObservation::CALLEE_POSSIBLE_TYPE_FOLD);
                             }
+                            break;
 
                         case CEE_ISINST:
                             if (codeAddr + 1 + sizeof(mdToken) + 1 <= codeEndp)
@@ -1530,6 +1531,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                                         break;
                                 }
                             }
+                            break;
 
                         default:
                             break;

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -80,6 +80,7 @@ INLINE_OBSERVATION(HAS_PINNED_LOCALS,         bool,   "has pinned locals",      
 INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                           INFORMATION, CALLEE)
 INLINE_OBSERVATION(IL_CODE_SIZE,              int,    "number of bytes of IL",                INFORMATION, CALLEE)
+INLINE_OBSERVATION(INTRINSIC_CALL,            bool,   "intrinsic call",                       INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_CLASS_CTOR,             bool,   "class constructor",                    INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heuristics",         INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",          INFORMATION, CALLEE)
@@ -94,6 +95,7 @@ INLINE_OBSERVATION(OPCODE_NORMED,             int,    "next opcode in IL stream"
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",                  INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_BASIC_BLOCKS,    int,    "number of basic blocks",               INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",                     INFORMATION, CALLEE)
+INLINE_OBSERVATION(POSSIBLE_TYPE_FOLD,        bool,   "possible type fold branch",            INFORMATION, CALLEE)
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                        INFORMATION, CALLEE)
 INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",                   INFORMATION, CALLEE)
 

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -96,6 +96,8 @@ public:
         , m_ArgFeedsConstantTest(0)
         , m_ArgFeedsRangeCheck(0)
         , m_ConstantArgFeedsConstantTest(0)
+        , m_IntrinsicCalls(0)
+        , m_PossibleTypeFolds(0)
         , m_CalleeNativeSizeEstimate(0)
         , m_CallsiteNativeSizeEstimate(0)
         , m_IsForceInline(false)
@@ -164,6 +166,8 @@ protected:
     unsigned                m_ArgFeedsConstantTest;
     unsigned                m_ArgFeedsRangeCheck;
     unsigned                m_ConstantArgFeedsConstantTest;
+    unsigned                m_IntrinsicCalls;
+    unsigned                m_PossibleTypeFolds;
     int                     m_CalleeNativeSizeEstimate;
     int                     m_CallsiteNativeSizeEstimate;
     bool                    m_IsForceInline : 1;


### PR DESCRIPTION
… opportunities

Look for IL patterns in an inlinee that are indicative of type folding. Also track
when an inlinee has calls that are intrinsics.

Use this to boost the inlinee profitability estimate.

Also, allow an aggressive inline inline candidate method to go over the budget when
it contains type folding or intrinsics (and so the method may be simpler than it appears).
Remove the old criteria (top-level inline) which was harder to reason about.

Closes #43761.
Closes #41692.
Closes #51587.
Closes #47434.