### PR TITLE
Fix Type.GetFields() after EnC/Hot reload update

### DIFF
--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -1709,6 +1709,26 @@ PTR_FieldDesc EncApproxFieldDescIterator::Next()
     return dac_cast<PTR_FieldDesc>(pFD);
 }
 
+// Returns the number of fields plus the number of add EnC fields
+int EncApproxFieldDescIterator::Count()
+{
+    int count = m_nonEnCIter.Count();
+
+    // If this module doesn't have any EnC data then there aren't any EnC fields
+    if (m_encClassData == NULL)
+    {
+        return count;
+    }
+
+    BOOL doInst = ( GetIteratorType() & (int)ApproxFieldDescIterator::INSTANCE_FIELDS);
+    BOOL doStatic = ( GetIteratorType() & (int)ApproxFieldDescIterator::STATIC_FIELDS);
+
+    int cNumAddedInst    =  doInst ? m_encClassData->GetAddedInstanceFields() : 0;
+    int cNumAddedStatics =  doStatic ? m_encClassData->GetAddedStaticFields() : 0;
+
+    return count + cNumAddedInst + cNumAddedStatics;
+}
+
 // Iterate through EnC added fields.
 // Returns NULL when done.
 PTR_EnCFieldDesc EncApproxFieldDescIterator::NextEnC()

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -330,13 +330,7 @@ HRESULT EditAndContinueModule::UpdateMethod(MethodDesc *pMethod)
     // to the Method's code must be to the call/jmp blob immediately in front of the
     // MethodDesc itself.  See MethodDesc::IsEnCMethod()
     //
-    pMethod->ResetCodeEntryPoint();
-
-    if (pMethod->HasNativeCodeSlot())
-    {
-        RelativePointer<TADDR> *pRelPtr = (RelativePointer<TADDR> *)pMethod->GetAddrOfNativeCodeSlot();
-        pRelPtr->SetValueMaybeNull(NULL);
-    }
+    pMethod->ResetCodeEntryPointForEnC();
 
     return S_OK;
 }

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -1706,6 +1706,15 @@ PTR_FieldDesc EncApproxFieldDescIterator::Next()
 // Returns the number of fields plus the number of add EnC fields
 int EncApproxFieldDescIterator::Count()
 {
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        FORBID_FAULT;
+        SUPPORTS_DAC;
+    }
+    CONTRACTL_END
+
     int count = m_nonEnCIter.Count();
 
     // If this module doesn't have any EnC data then there aren't any EnC fields

--- a/src/coreclr/vm/encee.h
+++ b/src/coreclr/vm/encee.h
@@ -415,7 +415,7 @@ public:
 
     PTR_FieldDesc Next() { WRAPPER_NO_CONTRACT; return m_nonEnCIter.Next(); }
 
-    int Count() { return m_nonEnCIter.Count(); }
+    int Count() { WRAPPER_NO_CONTRACT; return m_nonEnCIter.Count(); }
 #endif // EnC_SUPPORTED
 
     int GetIteratorType()

--- a/src/coreclr/vm/encee.h
+++ b/src/coreclr/vm/encee.h
@@ -407,12 +407,15 @@ public:
     // Get the next fieldDesc (either EnC or non-EnC)
     PTR_FieldDesc Next();
 
+    int Count();
 #else
     // Non-EnC version - simple wrapper
     EncApproxFieldDescIterator(MethodTable *pMT, int iteratorType, BOOL fixupEnC) :
       m_nonEnCIter( pMT, iteratorType ) {}
 
     PTR_FieldDesc Next() { WRAPPER_NO_CONTRACT; return m_nonEnCIter.Next(); }
+
+    int Count() { return m_nonEnCIter.Count(); }
 #endif // EnC_SUPPORTED
 
     int GetIteratorType()

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -5024,6 +5024,25 @@ void MethodDesc::ResetCodeEntryPoint()
     }
 }
 
+void MethodDesc::ResetCodeEntryPointForEnC()
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(!IsVersionable());
+    _ASSERTE(!IsVersionableWithPrecode());
+    _ASSERTE(!MayHaveEntryPointSlotsToBackpatch());
+
+    if (HasPrecode())
+    {
+        GetPrecode()->ResetTargetInterlocked();
+    }
+
+    if (HasNativeCodeSlot())
+    {
+        RelativePointer<TADDR> *pRelPtr = (RelativePointer<TADDR> *)GetAddrOfNativeCodeSlot();
+        pRelPtr->SetValueMaybeNull(NULL);
+    }
+}
+
 #endif // !CROSSGEN_COMPILE
 
 //*******************************************************************************

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1078,11 +1078,6 @@ public:
     inline WORD GetSlot()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-#ifndef DACCESS_COMPILE
-        // The DAC build uses this method to test for "sanity" of a MethodDesc, and
-        // doesn't need the assert.
-        _ASSERTE(! IsEnCAddedMethod() || !"Cannot get slot for method added via EnC");
-#endif // !DACCESS_COMPILE
 
         // Check if this MD is using the packed slot layout
         if (!RequiresFullSlotNumber())

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1411,6 +1411,7 @@ public:
     void TrySetInitialCodeEntryPointForVersionableMethod(PCODE entryPoint, bool mayHaveEntryPointSlotsToBackpatch);
     void SetCodeEntryPoint(PCODE entryPoint);
     void ResetCodeEntryPoint();
+    void ResetCodeEntryPointForEnC();
 
 #endif // !CROSSGEN_COMPILE
 

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -30,6 +30,7 @@
 #include "eventtrace.h"
 #include "invokeutil.h"
 #include "castcache.h"
+#include "encee.h"
 
 BOOL QCALLTYPE MdUtf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
 {

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -668,7 +668,7 @@ FCIMPL3(FC_BOOL_RET, RuntimeTypeHandle::GetFields, ReflectClassBaseObject *pType
     BOOL retVal = FALSE;
     HELPER_METHOD_FRAME_BEGIN_RET_1(refType);
     // <TODO>Check this approximation - we may be losing exact type information </TODO>
-    ApproxFieldDescIterator fdIterator(pMT, ApproxFieldDescIterator::ALL_FIELDS);
+    EncApproxFieldDescIterator fdIterator(pMT, ApproxFieldDescIterator::ALL_FIELDS, TRUE);
     INT32 count = (INT32)fdIterator.Count();
 
     if (count > *pCount)


### PR DESCRIPTION
Switch to the EncApproxFieldDescIterator in the GetFields() FCall.

Issue: #51517

Added MethodDesc::ResetCodeEntryPointForEnC() that reset the entry point without
the asserts that caused the problem.

Introduced in the fix for #50445.