### PR TITLE
Only allow a single write to any fn_ptr during portable binding.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -139,6 +139,10 @@ void InitializeOpenSSLShim(void)
     // libcrypto.so.1.1.0/libssl.so.1.1.0
     const void* v1_0_sentinel = dlsym(libssl, "SSL_state");
 
+    // Only permit a single assignment here so that two assemblies both triggering the initializer doesn't cause a
+    // race where the fn_ptr is nullptr, then properly bound, then goes back to nullptr right before being used (then bound again).
+    void* tmp_ptr;
+
     // Get pointers to all the functions that are needed
 #define REQUIRED_FUNCTION(fn) \
     if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
@@ -150,11 +154,13 @@ void InitializeOpenSSLShim(void)
     fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn));
 
 #define FALLBACK_FUNCTION(fn) \
-    if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fn##_ptr = (TYPEOF(fn))local_##fn; }
+    if (!(tmp_ptr = dlsym(libssl, #fn))) { tmp_ptr = (void*)local_##fn; } \
+    fn##_ptr = (TYPEOF(fn))tmp_ptr;
 
 #define RENAMED_FUNCTION(fn,oldfn) \
-    fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn));\
-    if (!fn##_ptr && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #oldfn)))) { fprintf(stderr, "Cannot get required symbol " #oldfn " from libssl\n"); abort(); }
+    tmp_ptr = dlsym(libssl, #fn);\
+    if (!tmp_ptr && !(tmp_ptr = dlsym(libssl, #oldfn))) { fprintf(stderr, "Cannot get required symbol " #oldfn " from libssl\n"); abort(); } \
+    fn##_ptr = (TYPEOF(fn))tmp_ptr;
 
 #define LEGACY_FUNCTION(fn) \
     if (v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -90,7 +90,7 @@ static bool OpenLibrary()
     if (libssl == NULL)
     {
         // Debian 9 has dropped support for SSLv3 and so they have bumped their soname. Let's try it
-        // before trying the version 1.0.0 to make it less probable that some of our other dependencies 
+        // before trying the version 1.0.0 to make it less probable that some of our other dependencies
         // end up loading conflicting version of libssl.
         DlOpen(MAKELIB("1.0.2"));
     }
@@ -141,7 +141,7 @@ void InitializeOpenSSLShim(void)
 
     // Only permit a single assignment here so that two assemblies both triggering the initializer doesn't cause a
     // race where the fn_ptr is nullptr, then properly bound, then goes back to nullptr right before being used (then bound again).
-    void* tmp_ptr;
+    void* volatile tmp_ptr;
 
     // Get pointers to all the functions that are needed
 #define REQUIRED_FUNCTION(fn) \


### PR DESCRIPTION
Avoid a race condition where two assemblies each firing the CryptoInitializer cause a fn_ptr to transition back into a nullptr state.