### PR TITLE
Fix a build error when USE_REGIONS is turned on

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -40460,7 +40460,7 @@ HRESULT GCHeap::Initialize()
     size_t gc_region_size = (size_t)GCConfig::GetGCRegionsSize();
     if (!power_of_two_p(gc_region_size) || ((gc_region_size * nhp * 19) > gc_heap::regions_range))
     {
-        return E_INVALIDARG;
+        return E_OUTOFMEMORY;
     }
     gc_heap::min_segment_size_shr = index_of_highest_set_bit (gc_region_size);
 #else


### PR DESCRIPTION
I missed this occurrence of `E_INVALIDARG`. Not having sufficient reserved addresses for the initial regions should be considered running out of memory so we don't need an extra exit code for it.