### PR TITLE
ComWrappers fixes from NET 5 memory leak

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -4133,7 +4133,8 @@ BOOL ClrDataAccess::DACIsComWrappersCCW(CLRDATA_ADDRESS ccwPtr)
         return FALSE;
     }
 
-    return qiAddress == GetEEFuncEntryPoint(ManagedObjectWrapper_QueryInterface);
+    return (qiAddress == GetEEFuncEntryPoint(ManagedObjectWrapper_QueryInterface)
+        || qiAddress == GetEEFuncEntryPoint(TrackerTarget_QueryInterface));
 }
 
 TADDR ClrDataAccess::DACGetManagedObjectWrapperFromCCW(CLRDATA_ADDRESS ccwPtr)

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -630,6 +630,7 @@ typedef struct _DacGlobals
 #endif
 #ifdef FEATURE_COMWRAPPERS
     ULONG fn__ManagedObjectWrapper_QueryInterface;
+    ULONG fn__TrackerTarget_QueryInterface;
 #endif
 
     // Vtable pointer values for all classes that must

--- a/src/coreclr/interop/comwrappers.cpp
+++ b/src/coreclr/interop/comwrappers.cpp
@@ -3,6 +3,7 @@
 
 #include "comwrappers.hpp"
 #include <interoplibimports.h>
+#include <corerror.h>
 
 #include <new> // placement new
 
@@ -187,7 +188,7 @@ HRESULT STDMETHODCALLTYPE ManagedObjectWrapper_QueryInterface(
     /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
 {
     ManagedObjectWrapper* wrapper = ABI::ToManagedObjectWrapper(disp);
-    return wrapper->QueryInterface(riid, ppvObject);
+    return wrapper->QueryInterface(disp, riid, ppvObject);
 }
 
 namespace
@@ -235,6 +236,11 @@ namespace
     constexpr ULONG GetComCount(_In_ ULONGLONG c)
     {
         return static_cast<ULONG>(c & ComRefCountMask);
+    }
+
+    constexpr bool IsMarkedToDestroy(_In_ ULONGLONG c)
+    {
+        return (c & DestroySentinel) != 0;
     }
 
     ULONG STDMETHODCALLTYPE TrackerTarget_AddRefFromReferenceTracker(_In_ ABI::ComInterfaceDispatch* disp)
@@ -457,9 +463,14 @@ ManagedObjectWrapper::ManagedObjectWrapper(
     , _userDefined{ userDefined }
     , _dispatches{ dispatches }
     , _flags{ flags }
+    , _refTrackerDispatch{ nullptr }
 {
     bool wasSet = TrySetObjectHandle(objectHandle);
     _ASSERTE(wasSet);
+
+    // Retain the dispatch entry for the IReferenceTrackerTarget so we
+    // can branch quickly during a QI from that interface.
+    _refTrackerDispatch = (const ABI::ComInterfaceDispatch*)AsRuntimeDefined(__uuidof(IReferenceTrackerTarget));
 }
 
 ManagedObjectWrapper::~ManagedObjectWrapper()
@@ -541,6 +552,11 @@ bool ManagedObjectWrapper::IsRooted() const
     return rooted;
 }
 
+bool ManagedObjectWrapper::IsMarkedToDestroy() const
+{
+    return ::IsMarkedToDestroy(_refCount);
+}
+
 ULONG ManagedObjectWrapper::AddRefFromReferenceTracker()
 {
     LONGLONG prev;
@@ -573,10 +589,7 @@ ULONG ManagedObjectWrapper::ReleaseFromReferenceTracker()
     // If we observe the destroy sentinel, then this release
     // must destroy the wrapper.
     if (refCount == DestroySentinel)
-    {
-        _ASSERTE(!IsSet(CreateComInterfaceFlagsEx::IsPegged));
         Destroy(this);
-    }
 
     return GetTrackerCount(refCount);
 }
@@ -594,11 +607,36 @@ HRESULT ManagedObjectWrapper::Unpeg()
 }
 
 HRESULT ManagedObjectWrapper::QueryInterface(
+    _In_ const ABI::ComInterfaceDispatch* dispatch,
     /* [in] */ REFIID riid,
     /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
 {
     if (ppvObject == nullptr)
         return E_POINTER;
+
+    // Check if this is a QI from an IReferenceTrackerTarget.
+    ComHolder<ManagedObjectWrapper> releaseMaybe;
+    if (dispatch == _refTrackerDispatch)
+    {
+        // AddRef to keep the managed object alive.
+        // AddRef is "safe" at this point because if it is a MOW with outstanding
+        // Reference Tracker reference, we know for sure the MOW is not claimed yet
+        // but the managed object could be.
+        AddRef();
+
+        // We are taking an extra AddRef() that now must be released.
+        releaseMaybe.Attach(this);
+
+        // For MOWs that have outstanding Reference Tracker reference, they could be either:
+        //  1. Marked to Destroy - in this case it is unsafe to touch wrapper.
+        //  2. Object Handle target has been NULLed out by GC.
+        if (IsMarkedToDestroy() || !InteropLibImports::HasValidTarget(Target))
+        {
+            // It is unsafe to proceed with a QueryInterface call. The MOW has been
+            // marked destroyed or the associated managed object has been collected.
+            return COR_E_ACCESSING_CCW;
+        }
+    }
 
     // Find target interface
     *ppvObject = AsRuntimeDefined(riid);
@@ -652,13 +690,11 @@ HRESULT ManagedObjectWrapper::QueryInterface(
 
 ULONG ManagedObjectWrapper::AddRef(void)
 {
-    _ASSERTE((_refCount & DestroySentinel) == 0);
     return GetComCount(::InterlockedIncrement64(&_refCount));
 }
 
 ULONG ManagedObjectWrapper::Release(void)
 {
-    _ASSERTE((_refCount & DestroySentinel) == 0);
     if (GetComCount(_refCount) == 0)
     {
         _ASSERTE(!"Over release of MOW - COM");

--- a/src/coreclr/interop/comwrappers.hpp
+++ b/src/coreclr/interop/comwrappers.hpp
@@ -49,7 +49,6 @@ private:
     ABI::ComInterfaceDispatch* _dispatches;
 
     Volatile<CreateComInterfaceFlagsEx> _flags;
-    const ABI::ComInterfaceDispatch* _refTrackerDispatch;
 
 public: // static
     // Get the implementation for IUnknown.
@@ -115,7 +114,6 @@ public: // IReferenceTrackerTarget
 
 public: // Lifetime
     HRESULT QueryInterface(
-        _In_ const ABI::ComInterfaceDispatch* dispatch,
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR * __RPC_FAR * ppvObject);
     ULONG AddRef(void);

--- a/src/coreclr/interop/comwrappers.hpp
+++ b/src/coreclr/interop/comwrappers.hpp
@@ -49,6 +49,7 @@ private:
     ABI::ComInterfaceDispatch* _dispatches;
 
     Volatile<CreateComInterfaceFlagsEx> _flags;
+    const ABI::ComInterfaceDispatch* _refTrackerDispatch;
 
 public: // static
     // Get the implementation for IUnknown.
@@ -103,6 +104,9 @@ public:
     // Indicate if the wrapper should be considered a GC root.
     bool IsRooted() const;
 
+    // Check if the wrapper has been marked to be destroyed.
+    bool IsMarkedToDestroy() const;
+
 public: // IReferenceTrackerTarget
     ULONG AddRefFromReferenceTracker();
     ULONG ReleaseFromReferenceTracker();
@@ -111,6 +115,7 @@ public: // IReferenceTrackerTarget
 
 public: // Lifetime
     HRESULT QueryInterface(
+        _In_ const ABI::ComInterfaceDispatch* dispatch,
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR * __RPC_FAR * ppvObject);
     ULONG AddRef(void);

--- a/src/coreclr/interop/inc/interoplibimports.h
+++ b/src/coreclr/interop/inc/interoplibimports.h
@@ -44,6 +44,9 @@ namespace InteropLibImports
     // Delete Object instance handle.
     void DeleteObjectInstanceHandle(_In_ InteropLib::OBJECTHANDLE handle) noexcept;
 
+    // Check if Object instance handle still points at an Object.
+    bool HasValidTarget(_In_ InteropLib::OBJECTHANDLE handle) noexcept;
+
     // Get the current global pegging state.
     bool GetGlobalPeggingState() noexcept;
 

--- a/src/coreclr/interop/trackerobjectmanager.cpp
+++ b/src/coreclr/interop/trackerobjectmanager.cpp
@@ -176,8 +176,8 @@ namespace
 
             ManagedObjectWrapper* mow = ManagedObjectWrapper::MapFromIUnknown(target);
 
-            // Not a target we implemented.
-            if (mow == nullptr)
+            // Not a target we implemented or wrapper is marked to be destroyed.
+            if (mow == nullptr || mow->IsMarkedToDestroy())
                 return S_OK;
 
             // Notify the runtime a reference path was found.
@@ -331,16 +331,16 @@ HRESULT TrackerObjectManager::BeginReferenceTracking(_In_ RuntimeCallContext* cx
 
     s_HasTrackingStarted = TRUE;
 
-    // From this point, the tracker runtime decides whether a target
-    // should be pegged or not as the global pegging flag is now off.
-    InteropLibImports::SetGlobalPeggingState(false);
-
     // Let the tracker runtime know we are about to walk external objects so that
     // they can lock their reference cache. Note that the tracker runtime doesn't need to
     // unpeg all external objects at this point and they can do the pegging/unpegging.
     // in FindTrackerTargetsCompleted.
     _ASSERTE(s_TrackerManager != nullptr);
     RETURN_IF_FAILED(s_TrackerManager->ReferenceTrackingStarted());
+
+    // From this point, the tracker runtime decides whether a target
+    // should be pegged or not as the global pegging flag is now off.
+    InteropLibImports::SetGlobalPeggingState(false);
 
     // Time to walk the external objects
     RETURN_IF_FAILED(WalkExternalTrackerObjects(cxt));

--- a/src/coreclr/vm/interoplibinterface.cpp
+++ b/src/coreclr/vm/interoplibinterface.cpp
@@ -1018,6 +1018,29 @@ namespace InteropLibImports
         DestroyHandleCommon(static_cast<::OBJECTHANDLE>(handle), InstanceHandleType);
     }
 
+    bool HasValidTarget(_In_ InteropLib::OBJECTHANDLE handle) noexcept
+    {
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+            MODE_ANY;
+            PRECONDITION(handle != NULL);
+        }
+        CONTRACTL_END;
+
+        bool isValid = false;
+        ::OBJECTHANDLE objectHandle = static_cast<::OBJECTHANDLE>(handle);
+
+        {
+            // Switch to cooperative mode so the handle can be safely inspected.
+            GCX_COOP_THREAD_EXISTS(GET_THREAD());
+            isValid = ObjectFromHandle(objectHandle) != NULL;
+        }
+
+        return isValid;
+    }
+
     bool GetGlobalPeggingState() noexcept
     {
         CONTRACTL

--- a/src/coreclr/vm/interoplibinterface.cpp
+++ b/src/coreclr/vm/interoplibinterface.cpp
@@ -693,6 +693,8 @@ namespace
         ::ZeroMemory(&gc, sizeof(gc));
         GCPROTECT_BEGIN(gc);
 
+        STRESS_LOG4(LF_INTEROP, LL_INFO1000, "Get or Create EOC: (Identity: 0x%p) (Flags: %x) (Maybe: 0x%p) (ID: %lld)\n", identity, flags, OBJECTREFToObject(wrapperMaybe), wrapperId);
+
         gc.implRef = impl;
         gc.wrapperMaybeRef = wrapperMaybe;
 
@@ -724,6 +726,8 @@ namespace
                 }
             }
         }
+
+        STRESS_LOG2(LF_INTEROP, LL_INFO1000, "EOC: 0x%p or Handle: 0x%p\n", extObjCxt, handle);
 
         if (extObjCxt != NULL)
         {
@@ -794,6 +798,8 @@ namespace
                     extObjCxt = cache->FindOrAdd(cacheKey, resultHolder.GetContext());
                 }
 
+                STRESS_LOG2(LF_INTEROP, LL_INFO100, "EOC cache insert: 0x%p == 0x%p\n", extObjCxt, resultHolder.GetContext());
+
                 // If the returned context matches the new context it means the
                 // new context was inserted or a unique instance was requested.
                 if (extObjCxt == resultHolder.GetContext())
@@ -836,6 +842,8 @@ namespace
                 _ASSERTE(extObjCxt->IsActive());
             }
         }
+
+        STRESS_LOG3(LF_INTEROP, LL_INFO1000, "EOC: 0x%p, 0x%p => 0x%p\n", extObjCxt, identity, OBJECTREFToObject(gc.objRefMaybe));
 
         GCPROTECT_END();
 

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -83,12 +83,11 @@ namespace ComWrappersTests
             // Trigger the GC multiple times and then
             // wait for all finalizers since that is where
             // most of the cleanup occurs.
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
+            for (int i = 0; i < 5; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
         }
 
         static void ValidateComInterfaceCreation()
@@ -443,6 +442,56 @@ namespace ComWrappersTests
             ForceGC();
         }
 
+        static void ValidateQueryInterfaceAfterManagedObjectCollected()
+        {
+            Console.WriteLine($"Running {nameof(ValidateQueryInterfaceAfterManagedObjectCollected)}...");
+
+            var cw = new TestComWrappers();
+
+            {
+                // Activate the Reference Tracker system in the .NET runtime by consuming an IReferenceTracker instance.
+                IntPtr trackerObjRaw = MockReferenceTrackerRuntime.CreateTrackerObject();
+                var trackerObj = (ITrackerObjectWrapper)cw.GetOrCreateObjectForComInstance(trackerObjRaw, CreateObjectFlags.TrackerObject);
+                Marshal.Release(trackerObjRaw);
+            }
+
+            IntPtr refTrackerTarget;
+
+            {
+                // Create a native wrapper over a managed object.
+                IntPtr testWrapper = CreateWrapper(cw);
+
+                refTrackerTarget = MockReferenceTrackerRuntime.TrackerTarget_AddRefFromReferenceTrackerAndReturn(testWrapper);
+
+                // Ownership has been transferred to the IReferenceTrackerTarget instance.
+                // The COM reference count should be 0 and indicates to the GC the managed object
+                // can be collected.
+                int count = Marshal.Release(testWrapper);
+                Assert.AreEqual(0, count);
+            }
+
+            ForceGC();
+
+            // Calling QueryInterface on an IReferenceTrackerTarget instance is permitted if
+            // when wrapper lifetime has been extended. However, the QueryInterface may fail
+            // if the associated managed object was collected. The failure here is an important
+            // part of the contract for a Reference Tracker runtime.
+            var iid = typeof(ITest).GUID;
+            IntPtr iTestComObject;
+            int hr = Marshal.QueryInterface(refTrackerTarget, ref iid, out iTestComObject);
+
+            const int COR_E_ACCESSING_CCW = unchecked((int)0x80131544);
+            Assert.AreEqual(COR_E_ACCESSING_CCW, hr);
+
+            // Release the IReferenceTrackerTarget instance.
+            MockReferenceTrackerRuntime.TrackerTarget_ReleaseFromReferenceTracker(refTrackerTarget);
+
+            static IntPtr CreateWrapper(TestComWrappers cw)
+            {
+                return cw.GetOrCreateComInterfaceForObject(new Test(), CreateComInterfaceFlags.TrackerSupport);
+            }
+        }
+
         unsafe class Derived : ITrackerObjectWrapper
         {
             public Derived(ComWrappers cw, bool aggregateRefTracker)
@@ -519,6 +568,7 @@ namespace ComWrappersTests
                 ValidateIUnknownImpls();
                 ValidateBadComWrapperImpl();
                 ValidateRuntimeTrackerScenario();
+                ValidateQueryInterfaceAfterManagedObjectCollected();
                 ValidateAggregationWithComObject();
                 ValidateAggregationWithReferenceTrackerObject();
             }

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -155,7 +155,7 @@ namespace ComWrappersTests.Common
         extern public static IntPtr TrackerTarget_AddRefFromReferenceTrackerAndReturn(IntPtr ptr);
 
         [DllImport(nameof(MockReferenceTrackerRuntime))]
-        extern public static void TrackerTarget_ReleaseFromReferenceTracker(IntPtr ptr);
+        extern public static int TrackerTarget_ReleaseFromReferenceTracker(IntPtr ptr);
     }
 
     [Guid("42951130-245C-485E-B60B-4ED4254256F8")]

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -150,6 +150,12 @@ namespace ComWrappersTests.Common
 
         [DllImport(nameof(MockReferenceTrackerRuntime))]
         extern public static int Trigger_NotifyEndOfReferenceTrackingOnThread();
+
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern public static IntPtr TrackerTarget_AddRefFromReferenceTrackerAndReturn(IntPtr ptr);
+
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern public static void TrackerTarget_ReleaseFromReferenceTracker(IntPtr ptr);
     }
 
     [Guid("42951130-245C-485E-B60B-4ED4254256F8")]

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -204,6 +204,13 @@ namespace
             {
                 assert(c != nullptr && id != nullptr);
 
+                ComSmartPtr<API::IReferenceTrackerTarget> mowMaybe;
+                if (S_OK == c->QueryInterface(&mowMaybe))
+                {
+                    (void)mowMaybe->AddRefFromReferenceTracker();
+                    c = mowMaybe.p;
+                }
+
                 try
                 {
                     *id = _elementId;
@@ -216,10 +223,6 @@ namespace
                 {
                     return E_OUTOFMEMORY;
                 }
-
-                ComSmartPtr<API::IReferenceTrackerTarget> mowMaybe;
-                if (S_OK == c->QueryInterface(&mowMaybe))
-                    (void)mowMaybe->AddRefFromReferenceTracker();
 
                 return S_OK;
             }

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -546,10 +546,10 @@ extern "C" DLL_EXPORT void* STDMETHODCALLTYPE TrackerTarget_AddRefFromReferenceT
     return nullptr;
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE TrackerTarget_ReleaseFromReferenceTracker(API::IReferenceTrackerTarget *target)
+extern "C" DLL_EXPORT LONG STDMETHODCALLTYPE TrackerTarget_ReleaseFromReferenceTracker(API::IReferenceTrackerTarget *target)
 {
     assert(target != nullptr);
-    (void)target->ReleaseFromReferenceTracker();
+    return (LONG)target->ReleaseFromReferenceTracker();
 }
 
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE UpdateTestObjectAsIUnknown(IUnknown *obj, int i, IUnknown **out)

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -528,6 +528,30 @@ extern "C" DLL_EXPORT int STDMETHODCALLTYPE Trigger_NotifyEndOfReferenceTracking
     return TrackerRuntimeManager.NotifyEndOfReferenceTrackingOnThread();
 }
 
+extern "C" DLL_EXPORT void* STDMETHODCALLTYPE TrackerTarget_AddRefFromReferenceTrackerAndReturn(IUnknown *obj)
+{
+    assert(obj != nullptr);
+
+    API::IReferenceTrackerTarget* targetMaybe;
+    if (S_OK == obj->QueryInterface(&targetMaybe))
+    {
+        (void)targetMaybe->AddRefFromReferenceTracker();
+        (void)targetMaybe->Release();
+
+        // The IReferenceTrackerTarget instance is returned even after calling Release since
+        // the Reference Tracker count is now extending the lifetime of the object.
+        return targetMaybe;
+    }
+
+    return nullptr;
+}
+
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE TrackerTarget_ReleaseFromReferenceTracker(API::IReferenceTrackerTarget *target)
+{
+    assert(target != nullptr);
+    (void)target->ReleaseFromReferenceTracker();
+}
+
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE UpdateTestObjectAsIUnknown(IUnknown *obj, int i, IUnknown **out)
 {
     if (obj == nullptr)


### PR DESCRIPTION
This is a port and update of the fix for .NET 5 servicing https://github.com/dotnet/runtime/pull/51421.

The first commit is an exact port of the changes being pushed in .NET 5.

Subsequent commits represent optimizations and testing for additional scenarios in .NET 6.

/cc @jkoritzinsky @elinor-fung @davidwrighton 