### PR TITLE
Update jit for new likely class records

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -5486,15 +5486,7 @@ void MethodContext::recGetPgoInstrumentationResults(CORINFO_METHOD_HANDLE ftnHnd
     size_t maxOffset = 0;
     for (UINT32 i = 0; i < (*pCountSchemaItems); i++)
     {
-        // Note >= here; for type histograms the count and handle schema entries have the same offset,
-        // but the handle schema (which comes second) has a larger count.
-        //
-        // The sizeof should really be target pointer size, so cross-bitness replay may not work here.
-        //
-        if (pInSchema[i].Offset >= maxOffset)
-        {
-            maxOffset = pInSchema[i].Offset + pInSchema[i].Count * sizeof(uintptr_t);
-        }
+        maxOffset = max(maxOffset, pInSchema[i].Offset + pInSchema[i].Count * sizeof(uintptr_t));
 
         agnosticSchema[i].Offset              = (DWORDLONG)pInSchema[i].Offset;
         agnosticSchema[i].InstrumentationKind = (DWORD)pInSchema[i].InstrumentationKind;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5887,7 +5887,7 @@ void Compiler::compCompileFinish()
                     break;
                 }
             }
-            assert(foundEntrypointBasicBlockCount);
+//            assert(foundEntrypointBasicBlockCount);
         }
 
         static bool headerPrinted = false;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5872,24 +5872,6 @@ void Compiler::compCompileFinish()
         // mdMethodDef __stdcall CEEInfo::getMethodDefFromMethod(CORINFO_METHOD_HANDLE hMethod)
         mdMethodDef currentMethodToken = info.compCompHnd->getMethodDefFromMethod(info.compMethodHnd);
 
-        unsigned profCallCount = 0;
-        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && fgHaveProfileData())
-        {
-            bool foundEntrypointBasicBlockCount = false;
-            for (UINT32 iSchema = 0; iSchema < fgPgoSchemaCount; iSchema++)
-            {
-                if ((fgPgoSchema[iSchema].InstrumentationKind ==
-                     ICorJitInfo::PgoInstrumentationKind::BasicBlockIntCount) &&
-                    (fgPgoSchema[iSchema].ILOffset == 0))
-                {
-                    foundEntrypointBasicBlockCount = true;
-                    profCallCount                  = *(uint32_t*)(fgPgoData + fgPgoSchema[iSchema].Offset);
-                    break;
-                }
-            }
-//            assert(foundEntrypointBasicBlockCount);
-        }
-
         static bool headerPrinted = false;
         if (!headerPrinted)
         {
@@ -5906,17 +5888,17 @@ void Compiler::compCompileFinish()
 
         if (fgHaveProfileData())
         {
-            if (profCallCount <= 9999)
+            if (fgCalledCount < 1000)
             {
-                printf("%4d | ", profCallCount);
+                printf("%4.0f | ", fgCalledCount);
             }
-            else if (profCallCount <= 999500)
+            else if (fgCalledCount < 1000000)
             {
-                printf("%3dK | ", (profCallCount + 500) / 1000);
+                printf("%3.0fK | ", fgCalledCount / 1000);
             }
             else
             {
-                printf("%3dM | ", (profCallCount + 500000) / 1000000);
+                printf("%3.0fM | ", fgCalledCount / 1000000);
             }
         }
         else

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1733,6 +1733,7 @@ PhaseStatus Compiler::fgIncorporateProfileData()
                 break;
 
             case ICorJitInfo::PgoInstrumentationKind::TypeHandleHistogramCount:
+            case ICorJitInfo::PgoInstrumentationKind::GetLikelyClass:
                 fgPgoClassProfiles++;
                 break;
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21313,7 +21313,7 @@ void Compiler::considerGuardedDevirtualization(
     const char* callKind = isInterface ? "interface" : "virtual";
 #endif
 
-    JITDUMP("Considering guarded devirtualization\n");
+    JITDUMP("Considering guarded devirtualization at IL offset %u (0x%x)\n", ilOffset, ilOffset);
 
     // We currently only get likely class guesses when there is PGO data
     // with class profiles.

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -121,7 +121,7 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
             (schema[i].Count == 1))
         {
             *pNumberOfClasses = (UINT32)schema[i].Other >> 8;
-            *pLikelihood      = (UINT32)(schema[i].Other && 0xFF);
+            *pLikelihood      = (UINT32)(schema[i].Other & 0xFF);
             INT_PTR result    = *(INT_PTR*)(pInstrumentationData + schema[i + 1].Offset);
             if (ICorJitInfo::IsUnknownTypeHandle(result))
                 return NULL;

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -122,7 +122,7 @@ extern "C" DLLEXPORT CORINFO_CLASS_HANDLE WINAPI getLikelyClass(ICorJitInfo::Pgo
         {
             *pNumberOfClasses = (UINT32)schema[i].Other >> 8;
             *pLikelihood      = (UINT32)(schema[i].Other & 0xFF);
-            INT_PTR result    = *(INT_PTR*)(pInstrumentationData + schema[i + 1].Offset);
+            INT_PTR result    = *(INT_PTR*)(pInstrumentationData + schema[i].Offset);
             if (ICorJitInfo::IsUnknownTypeHandle(result))
                 return NULL;
             else


### PR DESCRIPTION
Fix the jit to consume the new "LikelyClass" records seen from crossgen-processed PGO data.

