### PR TITLE
Optimize UTF-16 validation code

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -60,7 +60,7 @@ namespace System.Text.Unicode
 
             long tempUtf8CodeUnitCountAdjustment = 0;
             int tempScalarCountAdjustment = 0;
-            char* pEndOfInputBuffer = &pInputBuffer[(uint)inputLength];
+            char* pEndOfInputBuffer = pInputBuffer + (uint)inputLength;
 
             // Per https://github.com/dotnet/runtime/issues/41699, temporarily disabling
             // ARM64-intrinsicified code paths. ARM64 platforms may still use the vectorized

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -60,6 +60,7 @@ namespace System.Text.Unicode
 
             long tempUtf8CodeUnitCountAdjustment = 0;
             int tempScalarCountAdjustment = 0;
+            char* pEndOfInputBuffer = &pInputBuffer[(uint)inputLength];
 
             // Per https://github.com/dotnet/runtime/issues/41699, temporarily disabling
             // ARM64-intrinsicified code paths. ARM64 platforms may still use the vectorized
@@ -69,14 +70,16 @@ namespace System.Text.Unicode
             {
                 if (inputLength >= Vector128<ushort>.Count)
                 {
-                    Vector128<ushort> vector0080 = Vector128.Create((ushort)0x80);
-                    Vector128<ushort> vectorA800 = Vector128.Create((ushort)0xA800);
-                    Vector128<short> vector8800 = Vector128.Create(unchecked((short)0x8800));
-                    Vector128<ushort> vectorZero = Vector128<ushort>.Zero;
+                    Vector128<ushort> vector0080 = Vector128.Create((ushort)0x0080);
+                    Vector128<ushort> vector7800 = Vector128.Create((ushort)0x7800);
+                    Vector128<ushort> vectorA000 = Vector128.Create((ushort)0xA000);
 
                     Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
                         Vector128.Create(0x80402010_08040201).AsByte() :
                         Vector128.Create(0x01020408_10204080).AsByte();
+
+                    char* pHighestAddressWhereCanReadOneVector = pEndOfInputBuffer - Vector128<ushort>.Count;
+                    Debug.Assert(pHighestAddressWhereCanReadOneVector >= pInputBuffer);
 
                     do
                     {
@@ -90,6 +93,7 @@ namespace System.Text.Unicode
                             utf16Data = Sse2.LoadVector128((ushort*)pInputBuffer); // unaligned
                         }
 
+                        pInputBuffer += Vector128<ushort>.Count; // eagerly bump this now in preparation for next loop, will adjust later if necessary
                         Vector128<ushort> charIsNonAscii;
 
                         if (AdvSimd.Arm64.IsSupported)
@@ -133,14 +137,20 @@ namespace System.Text.Unicode
                         Vector128<ushort> charIsThreeByteUtf8Encoded;
                         uint mask;
 
+                        // Since 3-byte elements have a value >= 0x0800, we'll perform a saturating add of 0x7800 in order to
+                        // get all 3-byte elements to have their 0x8000 bits set. A saturating add will not set the 0x8000
+                        // bit for 1-byte or 2-byte elements. 2-byte and 3-byte elements MAY have their 0x0080 bits set,
+                        // but this is not required, and the 0x0080 bits (see 'charIsNonAscii' above) will be explicitly
+                        // set for such elements anyway by the immediately following OR instruction.
+
                         if (AdvSimd.IsSupported)
                         {
-                            charIsThreeByteUtf8Encoded = AdvSimd.Subtract(vectorZero, AdvSimd.ShiftRightLogical(utf16Data, 11));
+                            charIsThreeByteUtf8Encoded = AdvSimd.AddSaturate(utf16Data, vector7800);
                             mask = GetNonAsciiBytes(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte(), bitMask128);
                         }
                         else
                         {
-                            charIsThreeByteUtf8Encoded = Sse2.Subtract(vectorZero, Sse2.ShiftRightLogical(utf16Data, 11));
+                            charIsThreeByteUtf8Encoded = Sse2.AddSaturate(utf16Data, vector7800);
                             mask = (uint)Sse2.MoveMask(Sse2.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte());
                         }
 
@@ -168,24 +178,43 @@ namespace System.Text.Unicode
                         // unpaired surrogates in our data. (Unpaired surrogates would invalidate
                         // our computed result and we'd have to throw it away.)
 
-                        uint popcnt = (uint)BitOperations.PopCount(mask);
+                        nuint popcnt = (uint)BitOperations.PopCount(mask); // on x64, perform zero-extension for free
 
                         // Surrogates need to be special-cased for two reasons: (a) we need
                         // to account for the fact that we over-counted in the addition above;
                         // and (b) they require separate validation.
+                        //
+                        // Since surrogate code points are [D800..DFFF], adding {A000} to each element moves surrogate
+                        // code points to [7800..7FFF], which allows performing a single signed comparison.
                         if (AdvSimd.Arm64.IsSupported)
                         {
-                            utf16Data = AdvSimd.Add(utf16Data, vectorA800);
-                            mask = GetNonAsciiBytes(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte(), bitMask128);
+                            mask = GetNonAsciiBytes(AdvSimd.CompareLessThan(AdvSimd.Add(utf16Data, vectorA000).AsInt16(), vector7800.AsInt16()).AsByte(), bitMask128);
                         }
                         else
                         {
-                            utf16Data = Sse2.Add(utf16Data, vectorA800);
-                            mask = (uint)Sse2.MoveMask(Sse2.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte());
+                            mask = (uint)Sse2.MoveMask(Sse2.CompareLessThan(Sse2.Add(utf16Data, vectorA000).AsInt16(), vector7800.AsInt16()).AsByte());
                         }
 
-                        if (mask != 0)
+                    FinishIteration:
+
+                        // Note: mask bits are set when the corresponding element is NOT a surrogate.
+                        // We'll invert this before entering the "validate surrogate pairs" logic below.
+
+                        if (mask == 0xFFFF)
                         {
+                            // Put this logic up top since it's predicted-taken (surrogate pairs are uncommon).
+                            // Either we saw no surrogates or we already handled them below.
+
+                            tempUtf8CodeUnitCountAdjustment += (long)popcnt;
+                            if (pInputBuffer > pHighestAddressWhereCanReadOneVector)
+                            {
+                                goto NonVectorizedLoop; // can no longer read a vector's worth of data
+                            }
+                        }
+                        else
+                        {
+                            mask = ~mask;
+
                             // There's at least one UTF-16 surrogate code unit present.
                             // Since we performed a pmovmskb operation on the result of a 16-bit pcmpgtw,
                             // the resulting bits of 'mask' will occur in pairs:
@@ -194,10 +223,8 @@ namespace System.Text.Unicode
                             //
                             // A UTF-16 high/low surrogate code unit has the bit pattern [ 11011q## ######## ],
                             // where # is any bit; q = 0 represents a high surrogate, and q = 1 represents
-                            // a low surrogate. Since we added 0xA800 in the vectorized operation above,
-                            // our surrogate pairs will now have the bit pattern [ 10000q## ######## ].
-                            // If we logical right-shift each word by 3, we'll end up with the bit pattern
-                            // [ 00010000 q####### ], which means that we can immediately use pmovmskb to
+                            // a low surrogate. Right-shifting each surrogate char by 3 bits, we end up with
+                            // [ 00011011 q####### ], which means that we can immediately use pmovmskb to
                             // determine whether a given char was a high or a low surrogate.
                             //
                             // Therefore the resulting bits of 'mask2' will occur in pairs:
@@ -244,7 +271,7 @@ namespace System.Text.Unicode
                             highSurrogatesMask <<= 2;
                             if ((ushort)highSurrogatesMask != lowSurrogatesMask)
                             {
-                                goto NonVectorizedLoop; // error: mismatched surrogate pair; break out of vectorized logic
+                                break; // error: mismatched surrogate pair; break out of vectorized logic
                             }
 
                             if (highSurrogatesMask > ushort.MaxValue)
@@ -254,8 +281,7 @@ namespace System.Text.Unicode
 
                                 highSurrogatesMask = (ushort)highSurrogatesMask; // don't allow stray high surrogate to be consumed by popcnt
                                 popcnt -= 2; // the '0xC000_0000' bits in the original mask are shifted out and discarded, so account for that here
-                                pInputBuffer--;
-                                inputLength++;
+                                pInputBuffer--; // don't consume this char (pointer has already been bumped at start of loop)
                             }
 
                             // If we're 64-bit, we can perform the zero-extension of the surrogate pairs count for
@@ -286,12 +312,16 @@ namespace System.Text.Unicode
                                 // Take the hit of the 64-bit extension now.
                                 tempUtf8CodeUnitCountAdjustment -= 2 * (uint)surrogatePairsCountNuint;
                             }
-                        }
 
-                        tempUtf8CodeUnitCountAdjustment += popcnt;
-                        pInputBuffer += Vector128<ushort>.Count;
-                        inputLength -= Vector128<ushort>.Count;
-                    } while (inputLength >= Vector128<ushort>.Count);
+                            mask = 0xFFFF; // mark "no surrogates require processing"
+                            goto FinishIteration; // jump backward to continue the main loop
+                        }
+                    } while (true);
+
+                    // If we reached this point, we saw truly invalid data within the loop.
+                    // Need to undo the eager "bump pInputBuffer" adjustment that took place at start of loop.
+
+                    pInputBuffer -= Vector128<ushort>.Count;
                 }
             }
             else if (Vector.IsHardwareAccelerated)
@@ -302,6 +332,9 @@ namespace System.Text.Unicode
                     Vector<ushort> vector0400 = new Vector<ushort>(0x0400);
                     Vector<ushort> vector0800 = new Vector<ushort>(0x0800);
                     Vector<ushort> vectorD800 = new Vector<ushort>(0xD800);
+
+                    char* pHighestAddressWhereCanReadOneVector = pEndOfInputBuffer - Vector<ushort>.Count;
+                    Debug.Assert(pHighestAddressWhereCanReadOneVector >= pInputBuffer);
 
                     do
                     {
@@ -387,7 +420,6 @@ namespace System.Text.Unicode
                                 // We'll adjust our counters so that we don't consider this char consumed.
 
                                 pInputBuffer--;
-                                inputLength++;
                                 popcnt32 -= 2;
                             }
 
@@ -408,8 +440,7 @@ namespace System.Text.Unicode
 
                         tempUtf8CodeUnitCountAdjustment += popcnt32;
                         pInputBuffer += Vector<ushort>.Count;
-                        inputLength -= Vector<ushort>.Count;
-                    } while (inputLength >= Vector<ushort>.Count);
+                    } while (pInputBuffer <= pHighestAddressWhereCanReadOneVector);
                 }
             }
 
@@ -419,7 +450,7 @@ namespace System.Text.Unicode
             // from vectorization, or we saw invalid UTF-16 data in the vectorized code paths and need to
             // drain remaining valid chars before we report failure.
 
-            for (; inputLength > 0; pInputBuffer++, inputLength--)
+            for (; pInputBuffer < pEndOfInputBuffer; pInputBuffer++)
             {
                 uint thisChar = pInputBuffer[0];
                 if (thisChar <= 0x7F)
@@ -444,7 +475,7 @@ namespace System.Text.Unicode
 
                 tempUtf8CodeUnitCountAdjustment -= 2;
 
-                if (inputLength == 1)
+                if ((nuint)pEndOfInputBuffer - (nuint)pInputBuffer < sizeof(uint))
                 {
                     goto Error; // input buffer too small to read a surrogate pair
                 }
@@ -459,7 +490,6 @@ namespace System.Text.Unicode
                 tempUtf8CodeUnitCountAdjustment += 2; // 2 UTF-16 code units -> 4 UTF-8 code units
 
                 pInputBuffer++; // consumed one extra char
-                inputLength--;
             }
 
         Error:


### PR DESCRIPTION
This improves the performance of `Utf8Encoding.GetByteCount(string)` and similar APIs. There are three main optimizations:

1. Reorder the loop logic slightly to keep common paths (no surrogate pairs) together.
2. Reduce the total number of SIMD operations that take place within the main loop.
3. Simplify bookkeeping by bumping just the _pInputBuffer_ pointer without also toggling _inputLength_ within the hot loop.

Additionally, on x64, this reduces the total number of XMM registers used from 7 to 6, which means that the JIT can use only volatile registers (xmm0 - xmm5) throughout the method. This saves a little bit of space in the method prolog + epilog where we previously needed to save + restore xmm6.

__Benchmark results__, using the Project Gutenberg corpus (see also [perf repo sample texts](https://github.com/dotnet/performance/tree/main/src/benchmarks/micro/libraries/Common)):

|       Method |        Job |    Toolchain |      Corpus |      Mean |     Error |    StdDev | Ratio |
|------------- |----------- |------------- |------------ |----------:|----------:|----------:|------:|
| **GetByteCount** | **Job-OJQKGR** |         **main** |    **11-0.txt** | **19.889 μs** | **0.0923 μs** | **0.0771 μs** |  **1.00** |
| GetByteCount | Job-DHGKIB | utf16trans_b |    11-0.txt | 14.748 μs | 0.1517 μs | 0.1419 μs |  0.74 |
|              |            |              |             |           |           |           |       |
| **GetByteCount** | **Job-OJQKGR** |         **main** |      **11.txt** |  **4.977 μs** | **0.0580 μs** | **0.0514 μs** |  **1.00** |
| GetByteCount | Job-DHGKIB | utf16trans_b |      11.txt |  3.849 μs | 0.0276 μs | 0.0230 μs |  0.77 |
|              |            |              |             |           |           |           |       |
| **GetByteCount** | **Job-OJQKGR** |         **main** | **25249-0.txt** | **11.221 μs** | **0.0389 μs** | **0.0345 μs** |  **1.00** |
| GetByteCount | Job-DHGKIB | utf16trans_b | 25249-0.txt |  6.858 μs | 0.0340 μs | 0.0266 μs |  0.61 |
|              |            |              |             |           |           |           |       |
| **GetByteCount** | **Job-OJQKGR** |         **main** | **30774-0.txt** |  **9.593 μs** | **0.0535 μs** | **0.0417 μs** |  **1.00** |
| GetByteCount | Job-DHGKIB | utf16trans_b | 30774-0.txt |  5.788 μs | 0.0231 μs | 0.0216 μs |  0.60 |
|              |            |              |             |           |           |           |       |
| **GetByteCount** | **Job-OJQKGR** |         **main** | **39251-0.txt** | **12.239 μs** | **0.1219 μs** | **0.0952 μs** |  **1.00** |
| GetByteCount | Job-DHGKIB | utf16trans_b | 39251-0.txt |  7.387 μs | 0.0253 μs | 0.0224 μs |  0.60 |

Here's the method hot loop, annotated:

```asm
; Do we even have enough data to warrant vectorization?
00007ff9`fca57068 83ff08           cmp     edi, 8
00007ff9`fca5706b 0f8c0c010000     jl      <dont_vectorize>

; Setup: load frequently used consts into XMM registers
00007ff9`fca57071 c5f9100527010000 vmovupd xmm0, xmmword ptr [System_Private_CoreLib!System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar(Char*,  Int32,  Int64 ByRef,  Int32 ByRef)+0x180 (00007ff9`fca571a0)]
00007ff9`fca57079 c5f9100d2f010000 vmovupd xmm1, xmmword ptr [System_Private_CoreLib!System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar(Char*,  Int32,  Int64 ByRef,  Int32 ByRef)+0x190 (00007ff9`fca571b0)]
00007ff9`fca57081 c5f9101537010000 vmovupd xmm2, xmmword ptr [System_Private_CoreLib!System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar(Char*,  Int32,  Int64 ByRef,  Int32 ByRef)+0x1a0 (00007ff9`fca571c0)]
00007ff9`fca57089 4c8d41f0         lea     r8, [rcx-10h]

; Main loop: read 128 bits and check for valid UTF-16 while also performing UTF-8 / UTF-32 analysis over the text
00007ff9`fca5708d c5fa6f1e         vmovdqu xmm3, xmmword ptr [rsi]
00007ff9`fca57091 4883c610         add     rsi, 10h
00007ff9`fca57095 c4e2613ae0       vpminuw xmm4, xmm3, xmm0 ; process 2-byte chars
00007ff9`fca5709a c5e1dde9         vpaddusw xmm5, xmm3, xmm1 ; process 3-byte chars
00007ff9`fca5709e c5d9ebe5         vpor    xmm4, xmm4, xmm5
00007ff9`fca570a2 c579d7cc         vpmovmskb r9d, xmm4
00007ff9`fca570a6 f3450fb8c9       popcnt  r9d, r9d ; weird: JIT doesn't try to account for popcnt false dependency here?
00007ff9`fca570ab c5e1fde2         vpaddw  xmm4, xmm3, xmm2 ; look for surrogates
00007ff9`fca570af c5f165e4         vpcmpgtw xmm4, xmm1, xmm4
00007ff9`fca570b3 c579d7d4         vpmovmskb r10d, xmm4
00007ff9`fca570b7 4181faffff0000   cmp     r10d, 0FFFFh ; were any surrogates found?
00007ff9`fca570be 750d             jne     <surrogate_chars_found> ; perform some extra validation outside the hot loop
00007ff9`fca570c0 4903c1           add     rax, r9
00007ff9`fca570c3 493bf0           cmp     rsi, r8
00007ff9`fca570c6 76c5             jbe     System_Private_CoreLib!System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar(Char*,  Int32,  Int64 ByRef,  Int32 ByRef)+0x6d (00007ff9`fca5708d) ; start of loop

; Running out of data - go down non-vectorized code
00007ff9`fca570c8 e9b0000000       jmp     <dont_vectorize>
```