### PR TITLE
Backport #51237 to release/6.0-preview4

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -194,9 +194,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>355eff52bed00e7ca9d4a6d769ddbe2bbadbea47</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21215.2">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21217.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>1ed6f39a6e716b42fa5e478dcfd30a59f1c8f25e</Sha>
+      <Sha>0e2e95e9db92cd41f620f96dda84171cbf34fa6c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21214.1">
       <Uri>https://github.com/dotnet/xharness</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
-    <MicrosoftNETILLinkTasksVersion>6.0.100-preview.2.21215.2</MicrosoftNETILLinkTasksVersion>
+    <MicrosoftNETILLinkTasksVersion>6.0.100-preview.2.21217.1</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>6.0.0-preview.4.21212.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->

--- a/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -145,6 +145,7 @@ namespace System.Diagnostics.Tracing
         Send = 9,
         Receive = 240,
     }
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     public partial class EventSource : System.IDisposable
     {
         protected EventSource() { }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -51,12 +51,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2072</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Diagnostics.Tracing.EventSource.EnsureDescriptorsInitialized</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Internal.Runtime.InteropServices.ComActivator.ClassRegistrationScenarioForType(Internal.Runtime.InteropServices.ComActivationContext,System.Boolean)</property>


### PR DESCRIPTION
## Description 
This fixes the last trimming warning in HelloWorld. The last remaining trim warningis from EventSource – it’s warning about reflection on implementors. The first fix is just a backport of #51237 to add the appropriate annotation to preserve members on types inheriting from EventSource. The fix also requires the linker to understand how to keep types through inheritance, which we implemented shortly before the snap. A bug was found and fixed (https://github.com/mono/linker/pull/1972) in that feature just after the snap. That fix is the sole change in the new version of the linker included here.

 
## Customer Impact
There is an unactionable EventSource warning produced by almost all trimming on .NET 6.
 
## Regression?
- [ ] Yes
- [X] No
 
## Risk
- [ ] High
- [ ] Medium
- [X] Low

The change in runtime is just attributes. The change in the linker fixes a bug that would still exist without the fix.

## Verification
- [] Manual
- [X] Automated
 
## Packaging changes reviewed?
- [ ] Yes
- [] No
- [X ] N/A
