### PR TITLE
Fix another hang on shutdown

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             ApplicationLifetime.StopApplication();
 
             // Don't block in process shutdown for CTRL+C/SIGINT since we can set e.Cancel to true
-            // we assume that application code will unwind once StopApplication signals the
+            // we assume that application code will unwind once StopApplication signals the token
             _shutdownBlock.Set();
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             e.Cancel = true;
             ApplicationLifetime.StopApplication();
+
+            // Don't block in process shutdown for CTRL+C/SIGINT since we can set e.Cancel to true
+            // we assume that application code will unwind once StopApplication signals the
+            _shutdownBlock.Set();
         }
 
         public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
- If SIGINT/Ctrl+C fires don't block shutdown waiting for dispose. This mechanism was intended to be a way to let application code unwind completely before exiting the process but we can cancel the the CancelKeyPress today, which means we don't need to wait for dispose to be called.
- This is a change in behavior but I can't figure out a case where ProcessExit would fire and you'd want it to wait on a dispose call *after* SIGINT/CTRL+C has fired.

Fixes https://github.com/dotnet/runtime/issues/51622

PS: Seems like we've disabled these tests with the intent to re-work them but haven't as yet? Also, this doesn't fix the case where process exit fires without CTRL+C/SIGINT so SIGTERM and CTRL_SHUTDOWN_EVENT will still hang 😢 