### PR TITLE
Stop harvesting old frameworks in some libraries

### DIFF
--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;uap10.0.16299;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
@@ -5,17 +5,8 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
-
-    <!-- 
-      Suppress NETStandard.Library collpasing as it add more dependencies then needed in some 
-      scenarios like .NET Framework which adds an unecessary amount of package dependencies to download 
-    -->
-    <SuppressMetaPackage Include="NETStandard.Library" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.Pipelines/pkg/System.IO.Pipelines.pkgproj
+++ b/src/libraries/System.IO.Pipelines/pkg/System.IO.Pipelines.pkgproj
@@ -10,13 +10,15 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Pipelines.csproj" />
-    <HarvestIncludePaths Include="lib/netstandard1.3" />
 
     <!-- Even though this library is inbox we want to treat it as out
          of box in the package so that we can continue to evolve it. -->
     <ValidatePackageSuppression Include="TreatAsOutOfBox">
       <Value>.NETCoreApp</Value>
     </ValidatePackageSuppression>
+
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -1,19 +1,11 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\System.Net.Http.WinHttpHandler.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
-    </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Http.WinHttpHandler.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
-    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/runtime/issues/27470 -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
+++ b/src/libraries/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
@@ -16,8 +16,10 @@
     <ValidatePackageSuppression Include="TreatAsOutOfBox">
       <Value>UAP</Value>
     </ValidatePackageSuppression>
-
-    <HarvestIncludePaths Include="ref/netcore50;lib/netcore50;ref/portable-net45+win8;lib/portable-net45+win8" />
   </ItemGroup>
+  <!-- TODO: Re-enable support check after the 6.0 version of the package is released. -->
+  <PropertyGroup>
+    <SkipSupportCheck>true</SkipSupportCheck>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
+++ b/src/libraries/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
@@ -17,9 +17,6 @@
       <Value>UAP</Value>
     </ValidatePackageSuppression>
   </ItemGroup>
-  <!-- TODO: Re-enable support check after the 6.0 version of the package is released. -->
-  <PropertyGroup>
-    <SkipSupportCheck>true</SkipSupportCheck>
-  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -5,8 +5,11 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.AccessControl.csproj" />
-    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
-    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
+    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/netstandard1.3">
+      <SupportedFramework>netcore50</SupportedFramework>
+    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
@@ -5,10 +5,8 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ServiceProcess.ServiceController.csproj" />
-    <HarvestIncludePaths Include="ref/netstandard1.4">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.5;lib/netstandard1.4" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Text.Encodings.Web/pkg/System.Text.Encodings.Web.pkgproj
+++ b/src/libraries/System.Text.Encodings.Web/pkg/System.Text.Encodings.Web.pkgproj
@@ -1,13 +1,9 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\System.Text.Encodings.Web.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
-    </ProjectReference>
     <ProjectReference Include="..\src\System.Text.Encodings.Web.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <HarvestIncludePaths Include="lib/netstandard1.0" />
     <!-- Since UAP and .NETCoreApp are package based we still want to enable
      OOBing libraries that happen to overlap with their framework package.
      This avoids us having to lock the API in our NuGet packages just 
@@ -16,11 +12,8 @@
     <ValidatePackageSuppression Include="TreatAsOutOfBox">
       <Value>.NETCoreApp;UAP</Value>
     </ValidatePackageSuppression>
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore45;netcore451;netcore50;uap10.0;net45;net451;net46;wp8;wpa81" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
-    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/runtime/issues/27470 -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
+++ b/src/libraries/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;uap10.0.16299;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;net46;netcore50;uap10.0" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -4907,10 +4907,7 @@
       "BaselineVersion": "6.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
-        "portable46-net451+win81": "4.0.0.0",
-        "portable45-net45+win8": "4.0.0.0",
-        "uap10.0.16299": "4.0.3.0",
-        "win8": "4.0.0.0"
+        "uap10.0.16299": "4.0.3.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",


### PR DESCRIPTION
The removed configurations (few netstandard1.x, portable*, netcore50, net46)
of the touched packages aren't built anymore. Instead
the already built matching binaries from the latest available packages
are redistributed when packaging these libraries.

Dropping these assets as the minimum supported set of platforms are ones
that support netstandard2.0. For .NET Framework, there's still a net461
configuration present to avoid binding redirect issues.

Contributes to #47530