### PR TITLE
Fix test 49826 to work after the refactoring in #50074

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_49826/test49826.cs
+++ b/src/tests/Regressions/coreclr/GitHub_49826/test49826.cs
@@ -11,6 +11,10 @@ class Program
     static int Main()
     {
         JsonSerializerOptions options = new JsonSerializerOptions();
+
+        // This is needed to internally call RootBuiltInConvertersAndTypeInfoCreator
+        JsonSerializer.Serialize("a-string");
+
         JsonConverter converter = options.GetConverter(typeof(DateTime));
         Console.WriteLine("Converter type: {0}", converter.GetType());
         return converter != null ? 100 : 1;


### PR DESCRIPTION
The change #50074 made rooting of built-in serializers lazier. By
analyzing the library code I have figured out that I can root the
default serializers by calling Serialize. This fixes the test
failure.

Thanks

Tomas