### PR TITLE
IAsyncEnumerable deserializer should tolerate custom queue converters

### DIFF
--- a/src/libraries/System.Text.Json/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Text.Json/src/ILLink/ILLink.Suppressions.xml
@@ -35,7 +35,7 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Text.Json.Serialization.Metadata.JsonTypeInfo.#ctor(System.Type,System.Text.Json.JsonSerializerOptions)</property>
+      <property name="Target">M:System.Text.Json.Serialization.Metadata.JsonTypeInfo.#ctor(System.Type,System.Text.Json.Serialization.JsonConverter,System.Type,System.Text.Json.JsonSerializerOptions)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
@@ -9,6 +9,10 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : Queue<TElement>
     {
+        /// <summary>Lazily initialized singleton for hardcoding by the IAsyncEnumerable streaming deserializer.</summary>
+        internal static QueueOfTConverter<TCollection, TElement> Instance = _instance ??= new();
+        private static QueueOfTConverter<TCollection, TElement>? _instance;
+
         protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Enqueue(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -220,7 +220,7 @@ namespace System.Text.Json
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 var bufferState = new ReadAsyncBufferState(options.DefaultBufferSize);
-                // hardcode the queue converter to avoid accidental use of custom converters
+                // Hardcode the queue converter to avoid accidental use of custom converters
                 JsonConverter converter = QueueOfTConverter<Queue<TValue>, TValue>.Instance;
                 JsonTypeInfo jsonTypeInfo = new JsonTypeInfo(typeof(Queue<TValue>), converter, typeof(Queue<TValue>), options);
                 ReadStack readStack = default;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
@@ -219,9 +220,11 @@ namespace System.Text.Json
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 var bufferState = new ReadAsyncBufferState(options.DefaultBufferSize);
+                // hardcode the queue converter to avoid accidental use of custom converters
+                JsonConverter converter = QueueOfTConverter<Queue<TValue>, TValue>.Instance;
+                JsonTypeInfo jsonTypeInfo = new JsonTypeInfo(typeof(Queue<TValue>), converter, typeof(Queue<TValue>), options);
                 ReadStack readStack = default;
-                readStack.Initialize(typeof(Queue<TValue>), options, supportContinuation: true);
-                JsonConverter converter = readStack.Current.JsonPropertyInfo!.ConverterBase;
+                readStack.Initialize(jsonTypeInfo, supportContinuation: true);
                 var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
                 try
@@ -229,8 +232,8 @@ namespace System.Text.Json
                     do
                     {
                         bufferState = await ReadFromStreamAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
-                        ContinueDeserialize<Queue<TValue>>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
-                        if (readStack.Current.ReturnValue is Queue<TValue> queue)
+                        Queue<TValue>? queue = ContinueDeserialize<Queue<TValue>>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
+                        if (queue is not null)
                         {
                             while (queue.Count > 0)
                             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -160,17 +160,24 @@ namespace System.Text.Json.Serialization.Metadata
             PropertyInfoForTypeInfo = null!;
         }
 
-        internal JsonTypeInfo(Type type, JsonSerializerOptions options)
+        internal JsonTypeInfo(Type type, JsonSerializerOptions options) :
+            this(
+                type,
+                GetConverter(
+                    type,
+                    parentClassType: null, // A TypeInfo never has a "parent" class.
+                    memberInfo: null, // A TypeInfo never has a "parent" property.
+                    out Type runtimeType,
+                    options),
+                runtimeType,
+                options)
+        {
+        }
+
+        internal JsonTypeInfo(Type type, JsonConverter converter, Type runtimeType, JsonSerializerOptions options)
         {
             Type = type;
             Options = options;
-
-            JsonConverter converter = GetConverter(
-                Type,
-                parentClassType: null, // A TypeInfo never has a "parent" class.
-                memberInfo: null, // A TypeInfo never has a "parent" property.
-                out Type runtimeType,
-                Options);
 
             JsonNumberHandling? typeNumberHandling = GetNumberHandlingForType(Type);
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests/CollectionTests.AsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests/CollectionTests.AsyncEnumerable.cs
@@ -304,7 +304,7 @@ namespace System.Text.Json.Tests.Serialization
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
-        private class Utf8MemoryStream : MemoryStream
+        public class Utf8MemoryStream : MemoryStream
         {
             public Utf8MemoryStream() : base()
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.DeserializeAsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.DeserializeAsyncEnumerable.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Utf8MemoryStream = System.Text.Json.Tests.Serialization.CollectionTests.Utf8MemoryStream;
 
 namespace System.Text.Json.Serialization.Tests
 {
@@ -74,9 +75,71 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static async Task DeserializeAsyncEnumerable_ShouldTolerateCustomQueueConverters()
+        {
+            const int expectedCount = 20;
+
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                Converters = { new DegenerateQueueConverterFactory() }
+            };
+
+            byte[] data = JsonSerializer.SerializeToUtf8Bytes(Enumerable.Repeat(Enumerable.Repeat(1,3), expectedCount));
+
+            using var stream = new MemoryStream(data);
+
+            int callbackCount = 0;
+            await foreach (Queue<int> nestedQueue in JsonSerializer.DeserializeAsyncEnumerable<Queue<int>>(stream, options))
+            {
+                Assert.Equal(1, nestedQueue.Count);
+                Assert.Equal(0, nestedQueue.Peek());
+                callbackCount++;
+            }
+
+            Assert.Equal(expectedCount, callbackCount);
+        }
+
+        private class DegenerateQueueConverterFactory : JsonConverterFactory
+        {
+            public override bool CanConvert(Type typeToConvert) => typeToConvert.IsGenericType && typeof(Queue<>) == typeToConvert.GetGenericTypeDefinition();
+            public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+            {
+                Type queueElement = typeToConvert.GetGenericArguments()[0];
+                Type converterType = typeof(DegenerateQueueConverter<>).MakeGenericType(queueElement);
+                return (JsonConverter)Activator.CreateInstance(converterType, nonPublic: true);
+            }
+
+            private class DegenerateQueueConverter<T> : JsonConverter<Queue<T>>
+            {
+                public override bool CanConvert(Type typeToConvert) => typeof(Queue<T>).IsAssignableFrom(typeToConvert);
+                public override Queue<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    while (reader.Read() && reader.TokenType != JsonTokenType.EndArray);
+                    var queue = new Queue<T>();
+                    queue.Enqueue(default);
+                    return queue;
+                }
+
+                public override void Write(Utf8JsonWriter writer, Queue<T> value, JsonSerializerOptions options) => throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
         public static void DeserializeAsyncEnumerable_NullStream_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("utf8Json", () => JsonSerializer.DeserializeAsyncEnumerable<int>(utf8Json: null));
+        }
+
+        [Theory]
+        [InlineData("42")]
+        [InlineData("\"\"")]
+        [InlineData("{}")]
+        public static async Task DeserializeAsyncEnumerable_NotARootLevelJsonArray_ThrowsJsonException(string json)
+        {
+            var utf8Json = new Utf8MemoryStream(json);
+            IAsyncEnumerable<int> asyncEnumerable = JsonSerializer.DeserializeAsyncEnumerable<int>(utf8Json);
+            var enumerator = asyncEnumerable.GetAsyncEnumerator();
+            await Assert.ThrowsAsync<JsonException>(async () => await enumerator.MoveNextAsync());
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.DeserializeAsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.DeserializeAsyncEnumerable.cs
@@ -136,9 +136,9 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("{}")]
         public static async Task DeserializeAsyncEnumerable_NotARootLevelJsonArray_ThrowsJsonException(string json)
         {
-            var utf8Json = new Utf8MemoryStream(json);
+            using var utf8Json = new Utf8MemoryStream(json);
             IAsyncEnumerable<int> asyncEnumerable = JsonSerializer.DeserializeAsyncEnumerable<int>(utf8Json);
-            var enumerator = asyncEnumerable.GetAsyncEnumerator();
+            await using IAsyncEnumerator<int> enumerator = asyncEnumerable.GetAsyncEnumerator();
             await Assert.ThrowsAsync<JsonException>(async () => await enumerator.MoveNextAsync());
         }
 


### PR DESCRIPTION
Makes the `DeserializeAsyncEnumerable` method more tolerant of scenaria where custom Queue converters are registered by users.