### PR TITLE
Fix symbolic link tests

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -16,12 +16,6 @@ namespace Microsoft.NET.HostModel.Tests
     {
         private SharedTestState sharedTestState;
 
-        private void CreateSymbolicLink(string source, string target)
-        {
-            if (!SymbolicLinking.MakeSymbolicLink(source, target, out var errorString))
-                throw new Exception($"Failed to create symbolic link '{source}' targeting: '{target}': {errorString}");
-        }
-
         public AppHostUsedWithSymbolicLinks(AppHostUsedWithSymbolicLinks.SharedTestState fixture)
         {
             sharedTestState = fixture;
@@ -44,7 +38,7 @@ namespace Microsoft.NET.HostModel.Tests
             Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(symlinkRelativePath)));
             var symlinkFullPath = Path.Combine(testDir, symlinkRelativePath);
 
-            CreateSymbolicLink(symlinkFullPath, appExe);
+            using var symlink = new SymLink(symlinkFullPath, appExe);
             Command.Create(symlinkFullPath)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -66,21 +60,21 @@ namespace Microsoft.NET.HostModel.Tests
 
             var fixture = sharedTestState.StandaloneAppFixture_Published
                 .Copy();
-            
+
             var appExe = fixture.TestProject.AppExe;
             var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
 
             // second symlink -> apphost
-            string secondSymbolicLink = Path.Combine(testDir, secondSymlinkRelativePath);
-            Directory.CreateDirectory(Path.GetDirectoryName(secondSymbolicLink));
-            CreateSymbolicLink(secondSymbolicLink, appExe);
+            string symlink2Path = Path.Combine(testDir, secondSymlinkRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(symlink2Path));
+            using var symlink2 = new SymLink(symlink2Path, appExe);
 
             // first symlink -> second symlink
-            string firstSymbolicLink = Path.Combine(testDir, firstSymlinkRelativePath);
-            Directory.CreateDirectory(Path.GetDirectoryName(firstSymbolicLink));
-            CreateSymbolicLink(firstSymbolicLink, secondSymbolicLink);
+            string symlink1Path = Path.Combine(testDir, firstSymlinkRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(symlink1Path));
+            using var symlink1 = new SymLink(symlink1Path, symlink2Path);
 
-            Command.Create(firstSymbolicLink)
+            Command.Create(symlink1.SrcPath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -88,18 +82,14 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        //[Theory]
-        //[InlineData("a/b/SymlinkToFrameworkDependentApp")]
-        //[InlineData("a/SymlinkToFrameworkDependentApp")]
-        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
-            "CI failing to use stat on symbolic links on Linux (permission denied).")]
-        public void Run_framework_dependent_app_behind_symlink(/* string symlinkRelativePath */)
+        [Theory]
+        [InlineData("a/b/SymlinkToFrameworkDependentApp")]
+        [InlineData("a/SymlinkToFrameworkDependentApp")]
+        public void Run_framework_dependent_app_behind_symlink(string symlinkRelativePath)
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return;
-
-            string symlinkRelativePath = string.Empty;
 
             var fixture = sharedTestState.FrameworkDependentAppFixture_Published
                 .Copy();
@@ -108,10 +98,9 @@ namespace Microsoft.NET.HostModel.Tests
             var builtDotnet = fixture.BuiltDotnet.BinPath;
             var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
             Directory.CreateDirectory(Path.Combine(testDir, Path.GetDirectoryName(symlinkRelativePath)));
-            var symlinkFullPath = Path.Combine(testDir, symlinkRelativePath);
 
-            CreateSymbolicLink(symlinkFullPath, appExe);
-            Command.Create(symlinkFullPath)
+            using var symlink = new SymLink(Path.Combine(testDir, symlinkRelativePath), appExe);
+            Command.Create(symlink.SrcPath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable("DOTNET_ROOT", builtDotnet)
@@ -121,8 +110,7 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
-            "CI failing to use stat on symbolic links on Linux (permission denied).")]
+        [Fact]
         public void Run_framework_dependent_app_with_runtime_behind_symlink()
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.
@@ -137,9 +125,9 @@ namespace Microsoft.NET.HostModel.Tests
             var dotnetSymlink = Path.Combine(testDir, "dotnet");
             var dotnetDir = fixture.BuiltDotnet.BinPath;
 
-            CreateSymbolicLink(dotnetSymlink, dotnetDir);
+            using var symlink = new SymLink(dotnetSymlink, dotnetDir);
             Command.Create(appExe)
-                .EnvironmentVariable("DOTNET_ROOT", dotnetSymlink)
+                .EnvironmentVariable("DOTNET_ROOT", symlink.SrcPath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -162,7 +150,7 @@ namespace Microsoft.NET.HostModel.Tests
             var binDirNewPath = Path.Combine(Directory.GetParent(fixture.TestProject.Location).ToString(), "PutTheBinDirSomewhereElse");
             Directory.Move(binDir, binDirNewPath);
 
-            CreateSymbolicLink(binDir, binDirNewPath);
+            using var symlink = new SymLink(binDir, binDirNewPath);
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -186,8 +174,8 @@ namespace Microsoft.NET.HostModel.Tests
             var testDir = Directory.GetParent(fixture.TestProject.Location).ToString();
             var dotnetSymlink = Path.Combine(testDir, "dotnet");
 
-            CreateSymbolicLink(dotnetSymlink, dotnetExe);
-            Command.Create(dotnetSymlink, fixture.TestProject.AppDll)
+            using var symlink = new SymLink(dotnetSymlink, dotnetExe);
+            Command.Create(symlink.SrcPath, fixture.TestProject.AppDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -210,7 +198,7 @@ namespace Microsoft.NET.HostModel.Tests
             var binDirNewPath = Path.Combine(Directory.GetParent(fixture.TestProject.Location).ToString(), "PutTheBinDirSomewhereElse");
             Directory.Move(binDir, binDirNewPath);
 
-            CreateSymbolicLink(binDir, binDirNewPath);
+            using var symlink = new SymLink(binDir, binDirNewPath);
             dotnet.Exec(fixture.TestProject.AppDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -231,10 +219,10 @@ namespace Microsoft.NET.HostModel.Tests
 
             var dotnet = fixture.SdkDotnet;
             var binDir = fixture.TestProject.OutputDirectory;
-            var binDirNewPath = Path.Combine(Directory.GetParent(fixture.TestProject.Location).ToString(), "PutTheBinDirSomewhereElse"); 
+            var binDirNewPath = Path.Combine(Directory.GetParent(fixture.TestProject.Location).ToString(), "PutTheBinDirSomewhereElse");
             Directory.Move(binDir, binDirNewPath);
 
-            CreateSymbolicLink(binDir, binDirNewPath);
+            using var symlink = new SymLink(binDir, binDirNewPath);
             dotnet.Exec("run")
                 .WorkingDirectory(fixture.TestProject.Location)
                 .CaptureStdErr()
@@ -264,12 +252,12 @@ namespace Microsoft.NET.HostModel.Tests
             var firstSatelliteDir = Directory.GetDirectories(binDir).Single(dir => dir.Contains("kn-IN"));
             var firstSatelliteNewDir = Path.Combine(satellitesDir, "kn-IN");
             Directory.Move(firstSatelliteDir, firstSatelliteNewDir);
-            CreateSymbolicLink(firstSatelliteDir, firstSatelliteNewDir);
+            using var symlink1 = new SymLink(firstSatelliteDir, firstSatelliteNewDir);
 
             var secondSatelliteDir = Directory.GetDirectories(binDir).Single(dir => dir.Contains("ta-IN"));
             var secondSatelliteNewDir = Path.Combine(satellitesDir, "ta-IN");
             Directory.Move(secondSatelliteDir, secondSatelliteNewDir);
-            CreateSymbolicLink(secondSatelliteDir, secondSatelliteNewDir);
+            using var symlink2 = new SymLink(secondSatelliteDir, secondSatelliteNewDir);
 
             Command.Create(appExe)
                 .CaptureStdErr()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -82,14 +82,18 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        [Theory]
-        [InlineData("a/b/SymlinkToFrameworkDependentApp")]
-        [InlineData("a/SymlinkToFrameworkDependentApp")]
-        public void Run_framework_dependent_app_behind_symlink(string symlinkRelativePath)
+        //[Theory]
+        //[InlineData("a/b/SymlinkToFrameworkDependentApp")]
+        //[InlineData("a/SymlinkToFrameworkDependentApp")]
+        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
+            "CI failing to use stat on symbolic links on Linux (permission denied).")]
+        public void Run_framework_dependent_app_behind_symlink(/*string symlinkRelativePath*/)
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return;
+
+            var symlinkRelativePath = string.Empty;
 
             var fixture = sharedTestState.FrameworkDependentAppFixture_Published
                 .Copy();
@@ -110,7 +114,8 @@ namespace Microsoft.NET.HostModel.Tests
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        [Fact]
+        [Fact(Skip = "Currently failing in OSX with \"No such file or directory\" when running Command.Create. " +
+                     "CI failing to use stat on symbolic links on Linux (permission denied).")]
         public void Run_framework_dependent_app_with_runtime_behind_symlink()
         {
             // Creating symbolic links requires administrative privilege on Windows, so skip test.


### PR DESCRIPTION
Use IDisposable and `File.Delete` to ensure that symlinks get created
and cleaned up properly on all platforms. If all symlinks aren't
deleted, the later test cleanup phases have problems deleting them.

Fixes #51502