### PR TITLE
Include the filename in the config file load errors

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Configuration
         private void Load(bool reload)
         {
             IFileInfo file = Source.FileProvider?.GetFileInfo(Source.Path);
-            if (file is null or { Exists: false })
+            if (file == null || !file.Exists)
             {
                 if (Source.Optional || reload) // Always optional on reload
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration
         private void HandleException(ExceptionDispatchInfo info)
         {
             bool ignoreException = false;
-            if (Source.OnLoadException is not null)
+            if (Source.OnLoadException != null)
             {
                 var exceptionContext = new FileLoadExceptionContext
                 {

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -91,18 +91,18 @@ namespace Microsoft.Extensions.Configuration
                     return fileInfo.CreateReadStream();
                 }
 
+                using Stream stream = OpenRead(file);
                 try
                 {
-                    using Stream stream = OpenRead(file);
                     Load(stream);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
                     if (reload)
                     {
                         Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     }
-                    var exception = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), e);
+                    var exception = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
                     HandleException(ExceptionDispatchInfo.Capture(exception));
                 }
             }
@@ -113,6 +113,8 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>
         /// Loads the contents of the file at <see cref="Path"/>.
         /// </summary>
+        /// <exception cref="DirectoryNotFoundException">If Optional is <c>false</c> on the source and part of a file or
+        /// or directory cannot be found at the specified Path.</exception>
         /// <exception cref="FileNotFoundException">If Optional is <c>false</c> on the source and a
         /// file does not exist at specified Path.</exception>
         /// <exception cref="InvalidDataException">Wrapping any exception thrown by the concrete implementation of the

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Error_ExpectedPhysicalPath" xml:space="preserve">
-    <value>The expected physical path was '{0}'.</value>
+    <value> The expected physical path was '{0}'.</value>
   </data>
   <data name="Error_FileNotFound" xml:space="preserve">
     <value>The configuration file '{0}' was not found and is not optional.</value>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/Resources/Strings.resx
@@ -123,4 +123,7 @@
   <data name="Error_FileNotFound" xml:space="preserve">
     <value>The configuration file '{0}' was not found and is not optional.</value>
   </data>
+  <data name="Error_FailedToLoad" xml:space="preserve">
+    <value>Failed to load configuration from file '{0}'.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Configuration.Test;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 
@@ -34,14 +32,50 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
             Assert.Empty(changeToken.Callbacks);
         }
 
+        [Theory]
+        [InlineData(@"C:\path\to\configuration.txt")]
+        [InlineData(@"/path/to/configuration.txt")]
+        public void ProviderThrowsInvalidDataExceptionWhenLoadFails(string physicalPath)
+        {
+            var fileProviderMock = new Mock<IFileProvider>();
+            fileProviderMock.Setup(fp => fp.Watch(It.IsAny<string>())).Returns(new ConfigurationRootTest.ChangeToken());
+            fileProviderMock.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(new FileInfoImpl(physicalPath));
+
+            var source = new FileConfigurationSourceImpl
+            {
+                FileProvider = fileProviderMock.Object,
+                ReloadOnChange = true,
+            };
+            var provider = new FileConfigurationProviderImpl(source);
+
+            var exception = Assert.Throws<InvalidDataException>(() => provider.Load());
+            Assert.Contains($"'{physicalPath}'", exception.Message);
+            Assert.IsType<DirectoryNotFoundException>(exception.InnerException);
+            Assert.Contains("Could not find a part of the path", exception.InnerException.Message);
+        }
+
+        public class FileInfoImpl : IFileInfo
+        {
+            public FileInfoImpl(string physicalPath) => PhysicalPath = physicalPath;
+            public Stream CreateReadStream() => new MemoryStream();
+            public bool Exists => true;
+            public bool IsDirectory => false;
+            public DateTimeOffset LastModified => default;
+            public long Length => default;
+            public string Name => default;
+            public string PhysicalPath { get; }
+        }
+
         public class FileConfigurationProviderImpl : FileConfigurationProvider
         {
             public FileConfigurationProviderImpl(FileConfigurationSource source)
                 : base(source)
-            { }
+            {
+            }
 
             public override void Load(Stream stream)
-            { }
+            {
+            }
         }
 
         public class FileConfigurationSourceImpl : FileConfigurationSource

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -70,12 +70,10 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
         {
             public FileConfigurationProviderImpl(FileConfigurationSource source)
                 : base(source)
-            {
-            }
+            { }
 
             public override void Load(Stream stream)
-            {
-            }
+            { }
         }
 
         public class FileConfigurationSourceImpl : FileConfigurationSource

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationExtensionsTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Configuration.Ini.Test
  
             // Act and Assert
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddIniFile(path).Build());
-            Assert.StartsWith($"The configuration file '{path}' was not found and is not optional. The physical path is '", ex.Message);
+            Assert.StartsWith($"The configuration file '{path}' was not found and is not optional. The expected physical path was '", ex.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
@@ -234,7 +234,7 @@ DefaultConnection=TestConnectionString
             var exception = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddIniFile("NotExistingConfig.ini").Build());
 
             // Assert
-            Assert.StartsWith($"The configuration file 'NotExistingConfig.ini' was not found and is not optional. The physical path is '", exception.Message);
+            Assert.StartsWith($"The configuration file 'NotExistingConfig.ini' was not found and is not optional. The expected physical path was '", exception.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationExtensionsTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.Json
 
             // Act and Assert
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddJsonFile(path).Build());
-            Assert.StartsWith($"The configuration file '{path}' was not found and is not optional. The physical path is '", ex.Message);
+            Assert.StartsWith($"The configuration file '{path}' was not found and is not optional. The expected physical path was '", ex.Message);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.Configuration
             var exception = Assert.Throws<FileNotFoundException>(() => config.Build());
 
             // Assert
-            Assert.StartsWith($"The configuration file 'NotExistingConfig.json' was not found and is not optional. The physical path is '", exception.Message);
+            Assert.StartsWith($"The configuration file 'NotExistingConfig.json' was not found and is not optional. The expected physical path was '", exception.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationExtensionsTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
 using Xunit;
 
@@ -17,7 +16,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
             // Arrange
             // Act and Assert
             var ex = Assert.Throws<FileNotFoundException>(() => config.Build());
-            Assert.StartsWith($"The configuration file 'NotExistingConfig.xml' was not found and is not optional. The physical path is '", ex.Message);
+            Assert.StartsWith($"The configuration file 'NotExistingConfig.xml' was not found and is not optional. The expected physical path was '", ex.Message);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -692,7 +692,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         public void XmlConfiguration_Throws_On_Missing_Configuration_File()
         {
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddXmlFile("NotExistingConfig.xml", optional: false).Build());
-            Assert.StartsWith($"The configuration file 'NotExistingConfig.xml' was not found and is not optional. The physical path is '", ex.Message);
+            Assert.StartsWith($"The configuration file 'NotExistingConfig.xml' was not found and is not optional. The expected physical path was '", ex.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -381,7 +381,7 @@ CommonKey3:CommonKey4=IniValue6";
                     .SetFileLoadExceptionHandler(jsonLoadError)
                     .Build();
             }
-            catch (Exception e)
+            catch (InvalidDataException e)
             {
                 Assert.Equal(e, jsonError);
             }
@@ -409,7 +409,7 @@ CommonKey3:CommonKey4=IniValue6";
                     .SetFileLoadExceptionHandler(loadError)
                     .Build();
             }
-            catch (Exception e)
+            catch (InvalidDataException e)
             {
                 Assert.Equal(e, error);
             }
@@ -438,10 +438,11 @@ IniKey1=IniValue2");
                     .SetFileLoadExceptionHandler(loadError)
                     .Build();
             }
-            catch (FormatException e)
+            catch (InvalidDataException e)
             {
                 Assert.Equal(e, error);
             }
+
             Assert.NotNull(provider);
         }
 
@@ -831,8 +832,8 @@ IniKey1=IniValue2");
             }";
             _fileSystem.WriteFile(_jsonFile, json);
 
-            var exception = Assert.Throws<FormatException>(() => CreateBuilder().AddJsonFile(_jsonFile).Build());
-            Assert.Contains("Could not parse the JSON file.", exception.Message);
+            var exception = Assert.Throws<InvalidDataException>(() => CreateBuilder().AddJsonFile(_jsonFile).Build());
+            Assert.Contains("Could not parse the JSON file.", exception.InnerException.Message);
         }
 
         [Fact]


### PR DESCRIPTION
- Simplify `source` null check in `FileConfigurationProvider`
- Add error messages to _Resources/Strings.resx_
- Wrap load error with `InvalidDataException` and ensure it's captured/handled
- Add and update unit tests to cover new logic
- Added unit tests for:
  - `InvalidDataException`
  - `FileNotFoundException`
  - `DirectoryNotFoundException`
- Adjusted existing unit tests

Fixes #36007