### PR TITLE
[release/5.0] backport card mark stealing fix to 5.0

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -30002,7 +30002,7 @@ bool gc_heap::find_next_chunk(card_marking_enumerator& card_mark_enumerator, hea
             dprintf (3, ("No more chunks on heap %d\n", heap_number));
             return false;
         }
-        card = card_of (chunk_low);
+        card = max(card, card_of(chunk_low));
         card_word_end = (card_of(align_on_card_word(chunk_high)) / card_word_width);
         dprintf (3, ("Moved to next chunk on heap %d: [%Ix,%Ix[", heap_number, (size_t)chunk_low, (size_t)chunk_high));
     }


### PR DESCRIPTION
Port [#51104](https://github.com/dotnet/runtime/pull/51104) to Release/5.0

when we have an object that straddles the 2mb boundary for card mark stealing, we could get into a very specific situation where we process the same card twice right after the 2mb boundary and mistakenly erase it. we fix this by avoid processing the same card twice. [#51104](https://github.com/dotnet/runtime/pull/51104) has the detailed description of how this can happen.

## Customer Impact

this causes an AV because GC would reclaim objects it shouldn't

## Testing

tested locally and the customer who hit this has already tested a private 5.0 build and verified it fixed their problem.

## Regression

no. this existed when we checked in the card mark stealing work in 5.0 (which means this only exists in 5.0). 