### PR TITLE
[wasm] Add build tests for no-op rebuilds

### DIFF
--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -268,7 +268,8 @@ namespace Wasm.Build.Tests
                                   bool? dotnetWasmFromRuntimePack = null,
                                   bool hasIcudt = true,
                                   bool useCache = true,
-                                  bool expectSuccess = true)
+                                  bool expectSuccess = true,
+                                  bool createProject = true)
         {
             if (useCache && _buildContext.TryGetBuildFor(buildArgs, out BuildProduct? product))
             {
@@ -282,12 +283,20 @@ namespace Wasm.Build.Tests
                 return (_projectDir, "FIXME");
             }
 
-            InitPaths(id);
-            InitProjectDir(_projectDir);
-            initProject?.Invoke();
+            if (createProject)
+            {
+                InitPaths(id);
+                InitProjectDir(_projectDir);
+                initProject?.Invoke();
 
-            File.WriteAllText(Path.Combine(_projectDir, $"{buildArgs.ProjectName}.csproj"), buildArgs.ProjectFileContents);
-            File.Copy(Path.Combine(AppContext.BaseDirectory, "runtime-test.js"), Path.Combine(_projectDir, "runtime-test.js"));
+                File.WriteAllText(Path.Combine(_projectDir, $"{buildArgs.ProjectName}.csproj"), buildArgs.ProjectFileContents);
+                File.Copy(Path.Combine(AppContext.BaseDirectory, "runtime-test.js"), Path.Combine(_projectDir, "runtime-test.js"));
+            }
+            else if (_projectDir is null)
+            {
+                throw new Exception("_projectDir should be set, to use createProject=false");
+            }
+
 
             StringBuilder sb = new();
             sb.Append("publish");

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/RebuildTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/RebuildTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace Wasm.Build.Tests
+{
+    public class RebuildTests : BuildTestBase
+    {
+        public RebuildTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
+            : base(output, buildContext)
+        {
+        }
+
+        [Theory]
+        [BuildAndRun(host: RunHost.V8, aot: false, parameters: false)]
+        [BuildAndRun(host: RunHost.V8, aot: false, parameters: true)]
+        [BuildAndRun(host: RunHost.V8, aot: true,  parameters: false)]
+        public void NoOpRebuild(BuildArgs buildArgs, bool nativeRelink, RunHost host, string id)
+        {
+            string projectName = $"rebuild_{buildArgs.Config}_{buildArgs.AOT}";
+            bool dotnetWasmFromRuntimePack = !nativeRelink && !buildArgs.AOT;
+
+            buildArgs = buildArgs with { ProjectName = projectName };
+            buildArgs = GetBuildArgsWith(buildArgs, $"<WasmBuildNative>{(nativeRelink ? "true" : "false")}</WasmBuildNative>");
+
+            BuildProject(buildArgs,
+                        initProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                        dotnetWasmFromRuntimePack: dotnetWasmFromRuntimePack,
+                        id: id,
+                        createProject: true);
+
+            Run();
+
+            if (!_buildContext.TryGetBuildFor(buildArgs, out BuildProduct? product))
+                Assert.True(false, $"Test bug: could not get the build product in the cache");
+
+            File.Move(product!.LogFile, Path.ChangeExtension(product.LogFile!, ".first.binlog"));
+
+            _testOutput.WriteLine($"{Environment.NewLine}Rebuilding with no changes ..{Environment.NewLine}");
+
+            // no-op Rebuild
+            BuildProject(buildArgs,
+                        () => {},
+                        dotnetWasmFromRuntimePack: dotnetWasmFromRuntimePack,
+                        id: id,
+                        createProject: false,
+                        useCache: false);
+
+            Run();
+
+            void Run() => RunAndTestWasmApp(
+                                buildArgs, buildDir: _projectDir, expectedExitCode: 42,
+                                test: output => {},
+                                host: host, id: id);
+        }
+    }
+}


### PR DESCRIPTION
.. this will catch problems like https://github.com/dotnet/runtime/pull/51703
which caused rebuild errors:

```
   1>wasm-ld : error : duplicate symbol: mono_aot_module_System_Runtime_info [/Users/radical/dev/r3/src/mono/sample/wasm/console/Wasm.Console.Sample.csproj]
         >>> defined in /Users/radical/dev/r3/artifacts/obj/mono/Wasm.Console.Sample/wasm/Release/browser-wasm/wasm/System.Runtime.dll.bc
         >>> defined in /Users/radical/dev/r3/artifacts/obj/mono/Wasm.Console.Sample/wasm/Release/browser-wasm/wasm/System.Runtime.dll.bc
```