### PR TITLE
Improve some of our recent obsoletions

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -66,6 +66,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0015`__ | DisablePrivateReflectionAttribute has no effect in .NET 6.0+ applications. |
 |  __`SYSLIB0016`__ | Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations. |
 |  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
+|  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
 
 ## Analyzer Warnings
 

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -36,7 +36,7 @@ The acceptance criteria for adding an obsoletion includes:
 * Register the `SYSLIB0###` URL in `aka.ms`
     * The vanity name will be `dotnet-warnings/syslib0###`
     * Ensure the link's group owner matches the group owner of `dotnet-warnings/syslib0001`
-    * Connect with `@jeffhandley`, `@levib`, or `@gewarren` with any questions
+    * Connect with `@jeffhandley`, `@GrabYourPitchforks`, or `@gewarren` with any questions
 
 An example obsoletion PR that can be referenced where each of the above criteria was met is:
 

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -65,6 +65,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0013`__ | Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead. |
 |  __`SYSLIB0015`__ | DisablePrivateReflectionAttribute has no effect in .NET 6.0+ applications. |
 |  __`SYSLIB0016`__ | Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations. |
+|  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -62,5 +62,8 @@ namespace System
 
         internal const string RuntimeEnvironmentMessage = "RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.";
         internal const string RuntimeEnvironmentDiagId = "SYSLIB0019";
+
+        internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";
+        internal const string JsonSerializerOptionsIgnoreNullValuesDiagId = "SYSLIB0020";
     }
 }

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -59,5 +59,8 @@ namespace System
 
         internal const string GetContextInfoMessage = "Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations.";
         internal const string GetContextInfoDiagId = "SYSLIB0016";
+
+        internal const string RuntimeEnvironmentMessage = "RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.";
+        internal const string RuntimeEnvironmentDiagId = "SYSLIB0019";
     }
 }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -7,10 +7,6 @@
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <!-- We conditionally apply net5.0+ obsoletions -->
-  <PropertyGroup Condition="!($(TargetFramework.StartsWith('netcoreapp')) or $(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4')))">
-    <DefineConstants>$(DefineConstants);NET50_OBSOLETIONS</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\CoreRtBridge.cs" />
     <Compile Include="System\Reflection\DefaultBinder.cs" />
@@ -164,7 +160,7 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
-  
+
   <!-- Application tfms (.NETCoreApp, .NETFramework) need to use the same or higher version of .NETStandard's dependencies. -->
   <Choose>
     <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
@@ -41,11 +41,11 @@ namespace System.Reflection.TypeLoading
 
         // Location and codebase
         public abstract override string Location { get; }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeBaseMessage, DiagnosticId = Obsoletions.CodeBaseDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public sealed override string CodeBase => throw new NotSupportedException(SR.NotSupported_AssemblyCodeBase);
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeBaseMessage, DiagnosticId = Obsoletions.CodeBaseDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public sealed override string EscapedCodeBase => throw new NotSupportedException(SR.NotSupported_AssemblyCodeBase);
@@ -151,7 +151,7 @@ namespace System.Reflection.TypeLoading
 
         // Miscellaneous properties
         public sealed override bool ReflectionOnly => true;
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete("The Global Assembly Cache is not supported.", DiagnosticId = "SYSLIB0005", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public sealed override bool GlobalAssemblyCache => false;

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -794,13 +794,13 @@ namespace System.Runtime.InteropServices
     }
     public static partial class RuntimeEnvironment
     {
-        [System.ObsoleteAttribute("SystemConfigurationFile is no longer supported.")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static string SystemConfigurationFile { get { throw null; } }
         public static bool FromGlobalAccessCache(System.Reflection.Assembly a) { throw null; }
         public static string GetRuntimeDirectory() { throw null; }
-        [System.ObsoleteAttribute("GetRuntimeInterfaceAsIntPtr(Guid, Guid) is no longer supported.")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.IntPtr GetRuntimeInterfaceAsIntPtr(System.Guid clsid, System.Guid riid) { throw null; }
-        [System.ObsoleteAttribute("GetRuntimeInterfaceAsObject(Guid, Guid) is no longer supported.")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static object GetRuntimeInterfaceAsObject(System.Guid clsid, System.Guid riid) { throw null; }
         public static string GetSystemVersion() { throw null; }
     }

--- a/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -46,6 +46,7 @@
     <Compile Include="System\Runtime\InteropServices\TypeLibVarFlags.cs" />
     <Compile Include="System\Runtime\InteropServices\TypeLibVersionAttribute.cs" />
     <Compile Include="System\Security\SecureStringMarshal.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.InteropServices
 {
     public static class RuntimeEnvironment
     {
-        [Obsolete("SystemConfigurationFile is no longer supported.")]
+        [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static string SystemConfigurationFile => throw new PlatformNotSupportedException();
 
         public static bool FromGlobalAccessCache(Assembly a) => false;
@@ -23,10 +23,10 @@ namespace System.Runtime.InteropServices
             return Path.GetDirectoryName(runtimeDirectory) + Path.DirectorySeparatorChar;
         }
 
-        [Obsolete("GetRuntimeInterfaceAsIntPtr(Guid, Guid) is no longer supported.")]
+        [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static IntPtr GetRuntimeInterfaceAsIntPtr(Guid clsid, Guid riid) => throw new PlatformNotSupportedException();
 
-        [Obsolete("GetRuntimeInterfaceAsObject(Guid, Guid) is no longer supported.")]
+        [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static object GetRuntimeInterfaceAsObject(Guid clsid, Guid riid) => throw new PlatformNotSupportedException();
 
         public static string GetSystemVersion() => typeof(object).Assembly.ImageRuntimeVersion;

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
@@ -20,29 +20,25 @@ namespace System.Runtime.InteropServices
             Assert.NotEmpty(RuntimeEnvironment.GetSystemVersion());
         }
 
+#pragma warning disable SYSLIB0019 // RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.
         [Fact]
         public void SystemConfigurationFile_Get_ThrowsPlatformNotSupportedException()
         {
-#pragma warning disable 618 // SystemConfigurationFile is marked as Obsolete
             Assert.Throws<PlatformNotSupportedException>(() => RuntimeEnvironment.SystemConfigurationFile);
-#pragma warning restore 618
         }
 
         [Fact]
         public void GetRuntimeInterfaceAsObject_Invoke_ThrowsPlatformNotSupportedException()
         {
-#pragma warning disable 618 // GetRuntimeInterfaceAsObject is marked as Obsolete
             Assert.Throws<PlatformNotSupportedException>(() => RuntimeEnvironment.GetRuntimeInterfaceAsObject(Guid.Empty, Guid.Empty));
-#pragma warning restore 618
         }
 
         [Fact]
         public void GetRuntimeInterfaceAsIntPtr_Invoke_ThrowsPlatformNotSupportedException()
         {
-#pragma warning disable 618 // GetRuntimeInterfaceAsIntPtr is marked as Obsolete
             Assert.Throws<PlatformNotSupportedException>(() => RuntimeEnvironment.GetRuntimeInterfaceAsIntPtr(Guid.Empty, Guid.Empty));
-#pragma warning restore 618
         }
+#pragma warning restore SYSLIB0019
 
         [Fact]
         public void FromGlobalAccessCache_nNvoke_ReturnsFalse()

--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
@@ -536,29 +536,29 @@ namespace System.Security.Policy
     public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
     {
         public Evidence() { }
-        [Obsolete("This constructor is obsolete. Please use the constructor which takes arrays of EvidenceBase instead.")]
+        [System.ObsoleteAttribute("This constructor is obsolete. Please use the constructor which takes arrays of EvidenceBase instead.")]
         public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
         public Evidence(System.Security.Policy.Evidence evidence) { }
         public Evidence(System.Security.Policy.EvidenceBase[] hostEvidence, System.Security.Policy.EvidenceBase[] assemblyEvidence) { }
-        [Obsolete("Evidence should not be treated as an ICollection. Please use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
+        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Please use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
         public int Count { get { throw null; } }
         public bool IsReadOnly { get { throw null; } }
         public bool IsSynchronized { get { throw null; } }
         public bool Locked { get { throw null; } set { } }
         public object SyncRoot { get { throw null; } }
-        [Obsolete("This method is obsolete. Please use AddAssemblyEvidence instead.")]
+        [System.ObsoleteAttribute("This method is obsolete. Please use AddAssemblyEvidence instead.")]
         public void AddAssembly(object id) { }
         public void AddAssemblyEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
-        [Obsolete("This method is obsolete. Please use AddHostEvidence instead.")]
+        [System.ObsoleteAttribute("This method is obsolete. Please use AddHostEvidence instead.")]
         public void AddHost(object id) { }
         public void AddHostEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
         public void Clear() { }
         public System.Security.Policy.Evidence? Clone() { throw null; }
-        [Obsolete("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
+        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(System.Array array, int index) { }
         public System.Collections.IEnumerator GetAssemblyEnumerator() { throw null; }
-        public T? GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }        
-        [Obsolete("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
+        public T? GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
+        [System.ObsoleteAttribute("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public System.Collections.IEnumerator GetHostEnumerator() { throw null; }
         public T? GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -17,7 +17,7 @@ namespace System
 }
 namespace System.Configuration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class ConfigurationPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -31,7 +31,7 @@ namespace System.Configuration
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true, Inherited=false)]
@@ -43,7 +43,7 @@ namespace System.Configuration
 }
 namespace System.Data.Common
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public abstract partial class DBDataPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -65,7 +65,7 @@ namespace System.Data.Common
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -84,7 +84,7 @@ namespace System.Data.Common
 }
 namespace System.Data.Odbc
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class OdbcPermission : System.Data.Common.DBDataPermission
@@ -95,7 +95,7 @@ namespace System.Data.Odbc
         public override void Add(string connectionString, string restrictions, System.Data.KeyRestrictionBehavior behavior) { }
         public override System.Security.IPermission Copy() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -107,7 +107,7 @@ namespace System.Data.Odbc
 }
 namespace System.Data.OleDb
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class OleDbPermission : System.Data.Common.DBDataPermission
@@ -120,7 +120,7 @@ namespace System.Data.OleDb
         public string Provider { get { throw null; } set { } }
         public override System.Security.IPermission Copy() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -135,7 +135,7 @@ namespace System.Data.OleDb
 }
 namespace System.Data.OracleClient
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class OraclePermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -151,7 +151,7 @@ namespace System.Data.OracleClient
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -171,7 +171,7 @@ namespace System.Data.OracleClient
 }
 namespace System.Data.SqlClient
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class SqlClientPermission : System.Data.Common.DBDataPermission
@@ -182,7 +182,7 @@ namespace System.Data.SqlClient
         public override void Add(string connectionString, string restrictions, System.Data.KeyRestrictionBehavior behavior) { }
         public override System.Security.IPermission Copy() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -194,7 +194,7 @@ namespace System.Data.SqlClient
 }
 namespace System.Diagnostics
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class EventLogPermission : System.Security.Permissions.ResourcePermissionBase
@@ -215,7 +215,7 @@ namespace System.Diagnostics
         Write = 16,
         Administer = 48,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -249,7 +249,7 @@ namespace System.Diagnostics
         protected override void OnSet(int index, object oldValue, object newValue) { }
         public void Remove(System.Diagnostics.EventLogPermissionEntry value) { }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PerformanceCounterPermission : System.Security.Permissions.ResourcePermissionBase
@@ -270,7 +270,7 @@ namespace System.Diagnostics
         Instrument = 3,
         Administer = 7,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -309,7 +309,7 @@ namespace System.Diagnostics
 }
 namespace System.Drawing.Printing
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PrintingPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -325,7 +325,7 @@ namespace System.Drawing.Printing
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true)]
@@ -345,7 +345,7 @@ namespace System.Drawing.Printing
 }
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class DnsPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -359,7 +359,7 @@ namespace System.Net
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -383,7 +383,7 @@ namespace System.Net
         Connect = 64,
         Accept = 128,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class SocketPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -402,7 +402,7 @@ namespace System.Net
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -423,7 +423,7 @@ namespace System.Net
         Tcp = 2,
         All = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class WebPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -444,7 +444,7 @@ namespace System.Net
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -466,7 +466,7 @@ namespace System.Net.Mail
         Connect = 1,
         ConnectToUnrestrictedPort = 2,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class SmtpPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -484,7 +484,7 @@ namespace System.Net.Mail
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -504,7 +504,7 @@ namespace System.Net.NetworkInformation
         Read = 1,
         Ping = 4,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class NetworkInformationPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -521,7 +521,7 @@ namespace System.Net.NetworkInformation
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -534,7 +534,7 @@ namespace System.Net.NetworkInformation
 }
 namespace System.Net.PeerToPeer
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PnrpPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -548,7 +548,7 @@ namespace System.Net.PeerToPeer
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -567,7 +567,7 @@ namespace System.Net.PeerToPeer
 }
 namespace System.Net.PeerToPeer.Collaboration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PeerCollaborationPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -581,7 +581,7 @@ namespace System.Net.PeerToPeer.Collaboration
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -593,7 +593,7 @@ namespace System.Net.PeerToPeer.Collaboration
 }
 namespace System.Security
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public abstract partial class CodeAccessPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.IStackWalk
@@ -619,7 +619,7 @@ namespace System.Security
         public abstract System.Security.SecurityElement ToXml();
         public virtual System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public partial class HostProtectionException : System.SystemException
@@ -677,7 +677,7 @@ namespace System.Security
         void PermitOnly();
     }
 #endif
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class NamedPermissionSet : System.Security.PermissionSet
@@ -763,7 +763,7 @@ namespace System.Security
         CurrentAppDomain = 0,
         CurrentAssembly = 1,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public static partial class SecurityManager
@@ -824,7 +824,7 @@ namespace System.Security
 }
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class DataProtectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -840,7 +840,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -854,7 +854,7 @@ namespace System.Security.Permissions
         public bool UnprotectMemory { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -867,7 +867,7 @@ namespace System.Security.Permissions
         UnprotectMemory = 8,
         AllFlags = 15,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class EnvironmentPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -885,7 +885,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -896,7 +896,7 @@ namespace System.Security.Permissions
         Write = 2,
         AllAccess = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -908,7 +908,7 @@ namespace System.Security.Permissions
         public string Write { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class FileDialogPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -924,7 +924,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -935,7 +935,7 @@ namespace System.Security.Permissions
         Save = 2,
         OpenSave = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -946,7 +946,7 @@ namespace System.Security.Permissions
         public bool Save { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class FileIOPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -973,7 +973,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -986,7 +986,7 @@ namespace System.Security.Permissions
         PathDiscovery = 8,
         AllAccess = 15,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1006,7 +1006,7 @@ namespace System.Security.Permissions
         public string Write { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class GacIdentityPermission : System.Security.CodeAccessPermission
@@ -1020,7 +1020,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1029,7 +1029,7 @@ namespace System.Security.Permissions
         public GacIdentityPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Delegate | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1049,7 +1049,7 @@ namespace System.Security.Permissions
         public bool UI { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -1067,7 +1067,7 @@ namespace System.Security.Permissions
         MayLeakOnAbort = 256,
         All = 511,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum IsolatedStorageContainment
@@ -1085,7 +1085,7 @@ namespace System.Security.Permissions
         AdministerIsolatedStorageByUser = 112,
         UnrestrictedIsolatedStorage = 240,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class IsolatedStorageFilePermission : System.Security.Permissions.IsolatedStoragePermission
@@ -1097,7 +1097,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1106,7 +1106,7 @@ namespace System.Security.Permissions
         public IsolatedStorageFilePermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public abstract partial class IsolatedStoragePermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1118,7 +1118,7 @@ namespace System.Security.Permissions
         public bool IsUnrestricted() { throw null; }
         public override System.Security.SecurityElement ToXml() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public abstract partial class IsolatedStoragePermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
@@ -1127,14 +1127,14 @@ namespace System.Security.Permissions
         public System.Security.Permissions.IsolatedStorageContainment UsageAllowed { get { throw null; } set { } }
         public long UserQuota { get { throw null; } set { } }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public partial interface IUnrestrictedPermission
     {
         bool IsUnrestricted();
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class KeyContainerPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1152,7 +1152,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class KeyContainerPermissionAccessEntry
@@ -1169,7 +1169,7 @@ namespace System.Security.Permissions
         public override bool Equals(object o) { throw null; }
         public override int GetHashCode() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class KeyContainerPermissionAccessEntryCollection : System.Collections.ICollection, System.Collections.IEnumerable
@@ -1188,7 +1188,7 @@ namespace System.Security.Permissions
         public void Remove(System.Security.Permissions.KeyContainerPermissionAccessEntry accessEntry) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class KeyContainerPermissionAccessEntryEnumerator : System.Collections.IEnumerator
@@ -1199,7 +1199,7 @@ namespace System.Security.Permissions
         public bool MoveNext() { throw null; }
         public void Reset() { }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1214,7 +1214,7 @@ namespace System.Security.Permissions
         public int ProviderType { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum KeyContainerPermissionFlags
@@ -1231,7 +1231,7 @@ namespace System.Security.Permissions
         ChangeAcl = 8192,
         AllFlags = 13111,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class MediaPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1253,7 +1253,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1265,7 +1265,7 @@ namespace System.Security.Permissions
         public System.Security.Permissions.MediaPermissionVideo Video { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum MediaPermissionAudio
@@ -1275,7 +1275,7 @@ namespace System.Security.Permissions
         SafeAudio = 2,
         AllAudio = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum MediaPermissionImage
@@ -1285,7 +1285,7 @@ namespace System.Security.Permissions
         SafeImage = 2,
         AllImage = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum MediaPermissionVideo
@@ -1295,7 +1295,7 @@ namespace System.Security.Permissions
         SafeVideo = 2,
         AllVideo = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1317,7 +1317,7 @@ namespace System.Security.Permissions
         Unrestricted = 1,
     }
 #endif
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PrincipalPermission : System.Security.IPermission, System.Security.ISecurityEncodable, System.Security.Permissions.IUnrestrictedPermission
@@ -1337,13 +1337,13 @@ namespace System.Security.Permissions
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
     public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", true, DiagnosticId = "SYSLIB0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -1352,7 +1352,7 @@ namespace System.Security.Permissions
         public string Role { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class PublisherIdentityPermission : System.Security.CodeAccessPermission
@@ -1367,7 +1367,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1379,7 +1379,7 @@ namespace System.Security.Permissions
         public string X509Certificate { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class ReflectionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1395,7 +1395,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1411,7 +1411,7 @@ namespace System.Security.Permissions
         public bool TypeInformation { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -1427,7 +1427,7 @@ namespace System.Security.Permissions
         AllFlags = 7,
         RestrictedMemberAccess = 8,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class RegistryPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1447,7 +1447,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -1459,7 +1459,7 @@ namespace System.Security.Permissions
         Create = 4,
         AllAccess = 7,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1476,7 +1476,7 @@ namespace System.Security.Permissions
         public string Write { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public abstract partial class ResourcePermissionBase : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1499,7 +1499,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public partial class ResourcePermissionBaseEntry
@@ -1509,7 +1509,7 @@ namespace System.Security.Permissions
         public int PermissionAccess { get { throw null; } }
         public string[] PermissionAccessPath { get { throw null; } }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class SecurityPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1525,7 +1525,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class SiteIdentityPermission : System.Security.CodeAccessPermission
@@ -1540,7 +1540,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1550,7 +1550,7 @@ namespace System.Security.Permissions
         public string Site { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class StorePermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1566,7 +1566,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1583,7 +1583,7 @@ namespace System.Security.Permissions
         public bool RemoveFromStore { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -1599,7 +1599,7 @@ namespace System.Security.Permissions
         EnumerateCertificates = 128,
         AllFlags = 247,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class StrongNameIdentityPermission : System.Security.CodeAccessPermission
@@ -1616,7 +1616,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1628,7 +1628,7 @@ namespace System.Security.Permissions
         public string Version { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class StrongNamePublicKeyBlob
@@ -1638,7 +1638,7 @@ namespace System.Security.Permissions
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class TypeDescriptorPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1654,7 +1654,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1665,7 +1665,7 @@ namespace System.Security.Permissions
         public bool RestrictedRegistrationAccess { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.FlagsAttribute]
@@ -1674,7 +1674,7 @@ namespace System.Security.Permissions
         NoFlags = 0,
         RestrictedRegistrationAccess = 1,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class UIPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1693,7 +1693,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1704,7 +1704,7 @@ namespace System.Security.Permissions
         public System.Security.Permissions.UIPermissionWindow Window { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum UIPermissionClipboard
@@ -1713,7 +1713,7 @@ namespace System.Security.Permissions
         OwnClipboard = 1,
         AllClipboard = 2,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum UIPermissionWindow
@@ -1723,7 +1723,7 @@ namespace System.Security.Permissions
         SafeTopLevelWindows = 2,
         AllWindows = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class UrlIdentityPermission : System.Security.CodeAccessPermission
@@ -1738,7 +1738,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1748,7 +1748,7 @@ namespace System.Security.Permissions
         public string Url { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class WebBrowserPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -1765,7 +1765,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1775,7 +1775,7 @@ namespace System.Security.Permissions
         public System.Security.Permissions.WebBrowserPermissionLevel Level { get { throw null; } set { } }
         public override System.Security.IPermission CreatePermission() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public enum WebBrowserPermissionLevel
@@ -1784,7 +1784,7 @@ namespace System.Security.Permissions
         Safe = 1,
         Unrestricted = 2,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class ZoneIdentityPermission : System.Security.CodeAccessPermission
@@ -1799,7 +1799,7 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
@@ -1851,14 +1851,14 @@ namespace System.Security.Policy
     {
         public ApplicationTrust() { }
         public ApplicationTrust(System.ApplicationIdentity identity) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public ApplicationTrust(System.Security.PermissionSet defaultGrantSet, System.Collections.Generic.IEnumerable<System.Security.Policy.StrongName> fullTrustAssemblies) { }
         public System.ApplicationIdentity ApplicationIdentity { get { throw null; } set { } }
         public System.Security.Policy.PolicyStatement DefaultGrantSet { get { throw null; } set { } }
         public object ExtraInfo { get { throw null; } set { } }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Collections.Generic.IList<System.Security.Policy.StrongName> FullTrustAssemblies { get { throw null; } }
@@ -1942,7 +1942,7 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class FileCodeGroup : System.Security.Policy.CodeGroup
@@ -1968,7 +1968,7 @@ namespace System.Security.Policy
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { throw null; }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class GacInstalled : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2023,7 +2023,7 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public partial interface IIdentityPermissionFactory
@@ -2087,18 +2087,18 @@ namespace System.Security.Policy
         public void AddFullTrustAssembly(System.Security.Policy.StrongName sn) { }
         [System.ObsoleteAttribute]
         public void AddFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public void AddNamedPermissionSet(System.Security.NamedPermissionSet permSet) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Security.NamedPermissionSet ChangeNamedPermissionSet(string name, System.Security.PermissionSet pSet) { throw null; }
         [System.ObsoleteAttribute("AppDomain policy levels are obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
         public static System.Security.Policy.PolicyLevel CreateAppDomainLevel() { throw null; }
         public void FromXml(System.Security.SecurityElement e) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Security.NamedPermissionSet GetNamedPermissionSet(string name) { throw null; }
@@ -2107,11 +2107,11 @@ namespace System.Security.Policy
         public void RemoveFullTrustAssembly(System.Security.Policy.StrongName sn) { }
         [System.ObsoleteAttribute]
         public void RemoveFullTrustAssembly(System.Security.Policy.StrongNameMembershipCondition snMC) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Security.NamedPermissionSet RemoveNamedPermissionSet(System.Security.NamedPermissionSet permSet) { throw null; }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Security.NamedPermissionSet RemoveNamedPermissionSet(string name) { throw null; }
@@ -2122,17 +2122,17 @@ namespace System.Security.Policy
     }
     public sealed partial class PolicyStatement : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable
     {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public PolicyStatement(System.Security.PermissionSet permSet) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public PolicyStatement(System.Security.PermissionSet permSet, System.Security.Policy.PolicyStatementAttribute attributes) { }
         public System.Security.Policy.PolicyStatementAttribute Attributes { get { throw null; } set { } }
         public string AttributeString { get { throw null; } }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public System.Security.PermissionSet PermissionSet { get { throw null; } set { } }
@@ -2152,7 +2152,7 @@ namespace System.Security.Policy
         LevelFinal = 2,
         All = 3,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class Publisher : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2179,7 +2179,7 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class Site : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2207,7 +2207,7 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class StrongName : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2222,7 +2222,7 @@ namespace System.Security.Policy
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class StrongNameMembershipCondition : System.Security.ISecurityEncodable, System.Security.ISecurityPolicyEncodable, System.Security.Policy.IMembershipCondition
@@ -2267,7 +2267,7 @@ namespace System.Security.Policy
         public override System.Security.Policy.PolicyStatement Resolve(System.Security.Policy.Evidence evidence) { throw null; }
         public override System.Security.Policy.CodeGroup ResolveMatchingCodeGroups(System.Security.Policy.Evidence evidence) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class Url : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2294,7 +2294,7 @@ namespace System.Security.Policy
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.SecurityElement ToXml(System.Security.Policy.PolicyLevel level) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class Zone : System.Security.Policy.EvidenceBase, System.Security.Policy.IIdentityPermissionFactory
@@ -2325,7 +2325,7 @@ namespace System.Security.Policy
 }
 namespace System.ServiceProcess
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class ServiceControllerPermission : System.Security.Permissions.ResourcePermissionBase
@@ -2343,7 +2343,7 @@ namespace System.ServiceProcess
         Browse = 2,
         Control = 6,
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
@@ -2383,7 +2383,7 @@ namespace System.ServiceProcess
 }
 namespace System.Transactions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class DistributedTransactionPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -2397,7 +2397,7 @@ namespace System.Transactions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true)]
@@ -2410,7 +2410,7 @@ namespace System.Transactions
 }
 namespace System.Web
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class AspNetHostingPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
@@ -2426,7 +2426,7 @@ namespace System.Web
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true, Inherited=false)]

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -6,10 +6,6 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
   </PropertyGroup>
-  <!-- We conditionally apply net5.0+ obsoletions -->
-  <PropertyGroup Condition="!($(TargetFramework.StartsWith('netcoreapp')) or $(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4')))">
-    <DefineConstants>$(DefineConstants);NET50_OBSOLETIONS</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Permissions.cs" />
     <Compile Include="System.Security.Permissions.Forwards.cs" />

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
@@ -6,7 +6,7 @@
 
 namespace System.Xaml.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
     public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -4,10 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);net5.0;netcoreapp3.0;netstandard2.0;net461</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
-  <!-- We conditionally apply net5.0+ obsoletions -->
-  <PropertyGroup Condition="!($(TargetFramework.StartsWith('netcoreapp')) or $(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4')))">
-    <DefineConstants>$(DefineConstants);NET50_OBSOLETIONS</DefineConstants>
-  </PropertyGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <Compile Include="System\ApplicationIdentity.cs" />
     <Compile Include="System\Configuration\ConfigurationPermission.cs" />

--- a/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Configuration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class ConfigurationPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Configuration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Data.Common
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public abstract class DBDataPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermissionAttribute.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Data.Common
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor| AttributeTargets.Method,

--- a/src/libraries/System.Security.Permissions/src/System/Data/Odbc/OdbcPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/Odbc/OdbcPermission.cs
@@ -7,7 +7,7 @@ using System.Security.Permissions;
 
 namespace System.Data.Odbc
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class OdbcPermission : DBDataPermission

--- a/src/libraries/System.Security.Permissions/src/System/Data/OleDb/OleDbPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/OleDb/OleDbPermission.cs
@@ -7,7 +7,7 @@ using System.Security.Permissions;
 
 namespace System.Data.OleDb
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class OleDbPermission : DBDataPermission

--- a/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Data.OracleClient
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class OraclePermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermissionAttribute.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Data.OracleClient
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |

--- a/src/libraries/System.Security.Permissions/src/System/Data/SqlClient/SqlClientPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/SqlClient/SqlClientPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Data.SqlClient
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class SqlClientPermission : DBDataPermission

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermission.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Diagnostics
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class EventLogPermission : ResourcePermissionBase

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Diagnostics
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermission.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Diagnostics
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class PerformanceCounterPermission : ResourcePermissionBase

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermissionAttribute.cs
@@ -5,7 +5,7 @@ using System.Security;
 using System.Security.Permissions;
 namespace System.Diagnostics
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Event,

--- a/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Drawing.Printing
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class PrintingPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Drawing.Printing
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]

--- a/src/libraries/System.Security.Permissions/src/System/Net/DnsPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/DnsPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class DnsPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/DnsPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/DnsPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |

--- a/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class SmtpPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |

--- a/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.NetworkInformation
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class NetworkInformationPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.NetworkInformation
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer.Collaboration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class PeerCollaborationPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer.Collaboration
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class PnrpPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |

--- a/src/libraries/System.Security.Permissions/src/System/Net/SocketPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/SocketPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class SocketPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/SocketPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/SocketPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |

--- a/src/libraries/System.Security.Permissions/src/System/Net/WebPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/WebPermission.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class WebPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Net/WebPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/WebPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |

--- a/src/libraries/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public abstract partial class CodeAccessPermission : IPermission, ISecurityEncodable, IStackWalk

--- a/src/libraries/System.Security.Permissions/src/System/Security/HostProtectionException.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/HostProtectionException.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Security
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Serializable]

--- a/src/libraries/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Security
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class NamedPermissionSet : PermissionSet

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class DataProtectionPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermissionFlags.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/DataProtectionPermissionFlags.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class EnvironmentPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAccess.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/EnvironmentPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class FileDialogPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAccess.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileDialogPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class FileIOPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAccess.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/FileIOPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class GacIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/GacIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/HostProtectionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(4205), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/HostProtectionResource.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IUnrestrictedPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public partial interface IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageContainment.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageContainment.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum IsolatedStorageContainment

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageFilePermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageFilePermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class IsolatedStorageFilePermission : IsolatedStoragePermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageFilePermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStorageFilePermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStoragePermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStoragePermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public abstract class IsolatedStoragePermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStoragePermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/IsolatedStoragePermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public abstract class IsolatedStoragePermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class KeyContainerPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntry.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntry.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class KeyContainerPermissionAccessEntry

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntryCollection.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntryCollection.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class KeyContainerPermissionAccessEntryCollection : ICollection

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntryEnumerator.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAccessEntryEnumerator.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class KeyContainerPermissionAccessEntryEnumerator : IEnumerator

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionFlags.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/KeyContainerPermissionFlags.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum KeyContainerPermissionFlags

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/MediaPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/MediaPermission.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum MediaPermissionAudio
@@ -13,7 +13,7 @@ namespace System.Security.Permissions
         AllAudio
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum MediaPermissionVideo
@@ -24,7 +24,7 @@ namespace System.Security.Permissions
         AllVideo,
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum MediaPermissionImage
@@ -35,7 +35,7 @@ namespace System.Security.Permissions
         AllImage,
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class MediaPermission : CodeAccessPermission, IUnrestrictedPermission
@@ -61,7 +61,7 @@ namespace System.Security.Permissions
         public MediaPermissionImage Image { get { return MediaPermissionImage.AllImage; } }
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PermissionSetAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class PrincipalPermission : IPermission, ISecurityEncodable, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
@@ -3,13 +3,13 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(68), AllowMultiple = true, Inherited = false)]
     public sealed partial class PrincipalPermissionAttribute : CodeAccessSecurityAttribute
     {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.PrincipalPermissionAttributeMessage, error: true, DiagnosticId = Obsoletions.PrincipalPermissionAttributeDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public PrincipalPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermission.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class PublisherIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PublisherIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class ReflectionPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermission.cs
@@ -5,7 +5,7 @@ using System.Security.AccessControl;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class RegistryPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAccess.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ResourcePermissionBase.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ResourcePermissionBase.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public abstract class ResourcePermissionBase : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ResourcePermissionBaseEntry.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ResourcePermissionBaseEntry.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public class ResourcePermissionBaseEntry

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SecurityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class SecurityPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class SiteIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/SiteIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class StorePermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermissionFlags.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StorePermissionFlags.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class StrongNameIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNameIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/StrongNamePublicKeyBlob.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class StrongNamePublicKeyBlob

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class TypeDescriptorPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/TypeDescriptorPermissionFlags.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [Flags]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class UIPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionClipboard.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum UIPermissionClipboard

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UIPermissionWindow.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum UIPermissionWindow

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class UrlIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/UrlIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/WebBrowserPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/WebBrowserPermission.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public enum WebBrowserPermissionLevel
@@ -12,7 +12,7 @@ namespace System.Security.Permissions
         Unrestricted
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class WebBrowserPermission : CodeAccessPermission, IUnrestrictedPermission
@@ -30,7 +30,7 @@ namespace System.Security.Permissions
         public WebBrowserPermissionLevel Level { get { return WebBrowserPermissionLevel.Unrestricted; } set { } }
     }
 
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermission.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class ZoneIdentityPermission : CodeAccessPermission

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ZoneIdentityPermissionAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage((AttributeTargets)(109), AllowMultiple = true, Inherited = false)]

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/ApplicationTrust.cs
@@ -9,14 +9,14 @@ namespace System.Security.Policy
     {
         public ApplicationTrust() { }
         public ApplicationTrust(ApplicationIdentity identity) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public ApplicationTrust(PermissionSet defaultGrantSet, IEnumerable<StrongName> fullTrustAssemblies) { }
         public ApplicationIdentity ApplicationIdentity { get; set; }
         public PolicyStatement DefaultGrantSet { get; set; }
         public object ExtraInfo { get; set; }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public IList<StrongName> FullTrustAssemblies { get { return default(IList<StrongName>); } }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/FileCodeGroup.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class FileCodeGroup : CodeGroup

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class GacInstalled : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public partial interface IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -19,18 +19,18 @@ namespace System.Security.Policy
         public void AddFullTrustAssembly(StrongName sn) { }
         [Obsolete("Because all GAC assemblies always get full trust, the full trust list is no longer meaningful. You should install any assemblies that are used in security policy in the GAC to ensure they are trusted.")]
         public void AddFullTrustAssembly(StrongNameMembershipCondition snMC) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public void AddNamedPermissionSet(NamedPermissionSet permSet) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public NamedPermissionSet ChangeNamedPermissionSet(string name, PermissionSet pSet) { return default(NamedPermissionSet); }
         [Obsolete("AppDomain policy levels are obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
         public static PolicyLevel CreateAppDomainLevel() { return default(PolicyLevel); }
         public void FromXml(SecurityElement e) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public NamedPermissionSet GetNamedPermissionSet(string name) { return default(NamedPermissionSet); }
@@ -39,11 +39,11 @@ namespace System.Security.Policy
         public void RemoveFullTrustAssembly(StrongName sn) { }
         [Obsolete("Because all GAC assemblies always get full trust, the full trust list is no longer meaningful. You should install any assemblies that are used in security policy in the GAC to ensure they are trusted.")]
         public void RemoveFullTrustAssembly(StrongNameMembershipCondition snMC) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public NamedPermissionSet RemoveNamedPermissionSet(NamedPermissionSet permSet) { return default(NamedPermissionSet); }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(NamedPermissionSet); }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
@@ -5,11 +5,11 @@ namespace System.Security.Policy
 {
     public sealed partial class PolicyStatement : ISecurityEncodable, ISecurityPolicyEncodable
     {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public PolicyStatement(PermissionSet permSet) { }
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
         [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public PolicyStatement(PermissionSet permSet, PolicyStatementAttribute attributes) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class Publisher : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Site.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Site.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class Site : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/StrongName.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class StrongName : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/StrongNameMembershipCondition.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class StrongNameMembershipCondition : ISecurityEncodable, ISecurityPolicyEncodable, IMembershipCondition

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Url.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Url.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class Url : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Zone.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Zone.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed partial class Zone : EvidenceBase, IIdentityPermissionFactory

--- a/src/libraries/System.Security.Permissions/src/System/Security/SecurityManager.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/SecurityManager.cs
@@ -6,7 +6,7 @@ using System.Collections;
 
 namespace System.Security
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public static partial class SecurityManager

--- a/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermission.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 
 namespace System.ServiceProcess
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class ServiceControllerPermission : ResourcePermissionBase

--- a/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.ServiceProcess
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly | AttributeTargets.Event, AllowMultiple = true, Inherited = false )]

--- a/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Transactions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class DistributedTransactionPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Transactions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]

--- a/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermission.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Web
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class AspNetHostingPermission :  CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermissionAttribute.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 
 namespace System.Web
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false )]

--- a/src/libraries/System.Security.Permissions/src/System/Xaml/Permissions/XamlLoadPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Xaml/Permissions/XamlLoadPermission.cs
@@ -10,7 +10,7 @@ using System.Security.Permissions;
 
 namespace System.Xaml.Permissions
 {
-#if NET50_OBSOLETIONS
+#if NET5_0_OR_GREATER
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
     public sealed class XamlLoadPermission : CodeAccessPermission, IUnrestrictedPermission

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -240,7 +240,7 @@ namespace System.Text.Json
         public System.Text.Json.Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
         public System.Text.Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
-        [System.ObsoleteAttribute("To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", false)]
+        [System.ObsoleteAttribute("JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", DiagnosticId = "SYSLIB0020", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool IgnoreNullValues { get { throw null; } set { } }
         public bool IgnoreReadOnlyFields { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);netcoreapp3.0;netstandard2.0;net461</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Text.Json.cs" />

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -8,6 +8,7 @@
     <!-- For this project, we want warnings if there are public APIs/types without properly formatted XML comments (particularly CS1591). -->
     <NoWarn />
     <Nullable>enable</Nullable>
+    <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -254,6 +255,7 @@
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.String.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.UnsignedNumber.cs" />
     <Compile Include="System\TypeExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -254,7 +254,7 @@ namespace System.Text.Json
         /// Thrown if this property is set after serialization or deserialization has occurred.
         /// or <see cref="DefaultIgnoreCondition"/> has been set to a non-default value. These properties cannot be used together.
         /// </exception>
-        [Obsolete("To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", error: false)]
+        [Obsolete(Obsoletions.JsonSerializerOptionsIgnoreNullValuesMessage, DiagnosticId = Obsoletions.JsonSerializerOptionsIgnoreNullValuesDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IgnoreNullValues
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -175,7 +175,7 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                 }
             }
-#pragma warning disable CS0618 // IgnoreNullValues is obsolete
+#pragma warning disable SYSLIB0020 // JsonSerializerOptions.IgnoreNullValues is obsolete
             else if (Options.IgnoreNullValues)
             {
                 Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
@@ -198,7 +198,7 @@ namespace System.Text.Json.Serialization.Metadata
                 Debug.Assert(!Options.IgnoreNullValues);
                 IgnoreDefaultValuesOnWrite = true;
             }
-#pragma warning restore CS0618 // IgnoreNullValues is obsolete
+#pragma warning restore SYSLIB0020
         }
 
         internal void DetermineNumberHandlingForTypeInfo(JsonNumberHandling? numberHandling)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Suppress warning 'JsonSerializerOptions.IgnoreNullValues' is obsolete. -->
-    <NoWarn>CS0618</NoWarn>
+    <!-- SYSLIB0020: JsonSerializerOptions.IgnoreNullValues is obsolete -->
+    <NoWarn>$(NoWarn);SYSLIB0020</NoWarn>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <DefineConstants Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants> 
+    <DefineConstants Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\WrappedMemoryStream.cs" Link="CommonTest\System\IO\WrappedMemoryStream.cs" />


### PR DESCRIPTION
I took a pass over all changes since `release/net5.0` snapped to find places where we didn't fully align to the new guidance for obsoleting APIs and using `SYSLIB0###` diagnostic id values; This PR updates those obsoletions to align to the guidance and gets us to a state where all new 6.0 obsoletions are using `SYSLIB0###` diagnostic ids.

Here are the PRs for which the obsoletions are revised:
* #41141: System.Text.Json -- JsonSerializerOptions.IgnoreNullValues (/cc @layomia)
* #49411: System.Security.AccessControl (this refactored existing obsoletions; the diagnostic id is not needed) (/cc @ericstj)
* #50666: System.Runtime.Interop -- RuntimeEnvironment (/cc @AaronRobinsonMSFT)

I was also able to replace a `NET50_OBSOLETIONS` build constant with the `NET5_0_OR_GREATER` constant that the SDK now provides.

To verify that this PR didn't result in any new or removed `[Obsolete]` attributes, I ran `ApiCompat` over all libraries comparing the main build to this branch's build. I verified that there were no occurrences of `"CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute'"` in either comparison direction (after confirming that accidental additions or removals of obsolete attributes would in fact produce a result of that search).

This change will need to be treated as a preview-to-preview breaking change since the obsoletions from #41141 and #50666 would previously require suppressing through the general `CS0618` ID and now they have their own diagnostic ids.