### PR TITLE
Mark SIMD assignments as related to SIMD intrinsics

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1980,7 +1980,7 @@ void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
     }
     genProduceReg(lclNode);
 #else  // !UNIX_AMD64_ABI
-    assert(!"Multireg store to SIMD reg not supported on X64 Windows");
+    assert(!"Multireg store to SIMD reg not supported on Windows");
 #endif // !UNIX_AMD64_ABI
 }
 #endif // FEATURE_SIMD

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6759,7 +6759,7 @@ GenTreeOp* Compiler::gtNewAssignNode(GenTree* dst, GenTree* src)
     }
     dst->gtFlags |= GTF_DONT_CSE;
 
-    /* Create the assignment node */
+/* Create the assignment node */
 
 #if FEATURE_SIMD
     if (varTypeIsSIMD(dst->gtType))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6759,9 +6759,9 @@ GenTreeOp* Compiler::gtNewAssignNode(GenTree* dst, GenTree* src)
     }
     dst->gtFlags |= GTF_DONT_CSE;
 
-/* Create the assignment node */
+#if defined(FEATURE_SIMD) && !defined(TARGET_X86)
+    // TODO-CQ: x86 Windows supports multi-reg returns but not SIMD multi-reg returns
 
-#if FEATURE_SIMD
     if (varTypeIsSIMD(dst->gtType))
     {
         // We want to track SIMD assignments as being intrinsics since they
@@ -6772,6 +6772,8 @@ GenTreeOp* Compiler::gtNewAssignNode(GenTree* dst, GenTree* src)
         SetOpLclRelatedToSIMDIntrinsic(src);
     }
 #endif // FEATURE_SIMD
+
+    /* Create the assignment node */
 
     GenTreeOp* asg = gtNewOperNode(GT_ASG, dst->TypeGet(), dst, src)->AsOp();
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18949,16 +18949,27 @@ GenTreeSIMD* Compiler::gtNewSIMDNode(var_types       type,
 //
 void Compiler::SetOpLclRelatedToSIMDIntrinsic(GenTree* op)
 {
-    if (op != nullptr)
+    if (op == nullptr)
     {
-        if (op->OperIsLocal())
+        return;
+    }
+
+    if (op->OperIsLocal())
+    {
+        setLclRelatedToSIMDIntrinsic(op);
+    }
+    else if (op->OperIs(GT_OBJ))
+    {
+        GenTree* addr = op->AsIndir()->Addr();
+
+        if (addr->OperIs(GT_ADDR))
         {
-            setLclRelatedToSIMDIntrinsic(op);
-        }
-        else if ((op->OperGet() == GT_OBJ) && (op->AsOp()->gtOp1->OperGet() == GT_ADDR) &&
-                 op->AsOp()->gtOp1->AsOp()->gtOp1->OperIsLocal())
-        {
-            setLclRelatedToSIMDIntrinsic(op->AsOp()->gtOp1->AsOp()->gtOp1);
+            GenTree* addrOp1 = addr->AsOp()->gtGetOp1();
+
+            if (addrOp1->OperIsLocal())
+            {
+                setLclRelatedToSIMDIntrinsic(addrOp1);
+            }
         }
     }
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6761,6 +6761,18 @@ GenTreeOp* Compiler::gtNewAssignNode(GenTree* dst, GenTree* src)
 
     /* Create the assignment node */
 
+#if FEATURE_SIMD
+    if (varTypeIsSIMD(dst->gtType))
+    {
+        // We want to track SIMD assignments as being intrinsics since they
+        // are functionally SIMD `mov` instructions and are more efficient
+        // when we don't promote, particularly when it occurs due to inlining
+
+        SetOpLclRelatedToSIMDIntrinsic(dst);
+        SetOpLclRelatedToSIMDIntrinsic(src);
+    }
+#endif // FEATURE_SIMD
+
     GenTreeOp* asg = gtNewOperNode(GT_ASG, dst->TypeGet(), dst, src)->AsOp();
 
     /* Mark the expression as containing an assignment */

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4847,7 +4847,7 @@ struct GenTreeIntrinsic : public GenTreeOp
 struct GenTreeJitIntrinsic : public GenTreeOp
 {
 private:
-    ClassLayout* m_layout;
+    ClassLayout* gtLayout;
 
     unsigned char  gtAuxiliaryJitType; // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by element))
     regNumberSmall gtOtherReg;         // For intrinsics that return 2 registers
@@ -4867,13 +4867,13 @@ public:
 
     ClassLayout* GetLayout() const
     {
-        return m_layout;
+        return gtLayout;
     }
 
     void SetLayout(ClassLayout* layout)
     {
         assert(layout != nullptr);
-        m_layout = layout;
+        gtLayout = layout;
     }
 
     regNumber GetOtherReg() const
@@ -4927,6 +4927,9 @@ public:
     GenTreeJitIntrinsic(
         genTreeOps oper, var_types type, GenTree* op1, GenTree* op2, CorInfoType simdBaseJitType, unsigned simdSize)
         : GenTreeOp(oper, type, op1, op2)
+        , gtLayout(nullptr)
+        , gtAuxiliaryJitType(CORINFO_TYPE_UNDEF)
+        , gtOtherReg(REG_NA)
         , gtSimdBaseJitType((unsigned char)simdBaseJitType)
         , gtSimdSize((unsigned char)simdSize)
         , gtHWIntrinsicId(NI_Illegal)


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/50939 by ensuring that SIMD assignments are treated as related to SIMD intrinsics to avoid promotion. More details are listed here: https://github.com/dotnet/runtime/issues/51569#issuecomment-825317265

Treating SIMD assignment as an intrinsic and avoiding promotion makes sense because a SIMD copy is logically an intrinsic operation and will generate a `movaps` or `movups`. We already handle similar scenarios for `blockOpInit`, `simdInit`, and others by doing similar checks and calling `setLclRelatedToSIMDIntrinsic`. -- Noting that SIMD types are spilled to the stack as 8, 16, or 32-byte arguments. When loading from a field, array, or byref `Vector2` generates a `movsd` and `Vector3` generates a `movsd`+`movss` instead.

Notably, we only really allow promotion for `Vector2/3/4`. We don't currently allow it for the "opaque" kinds, meaning `Vector<T>`, `Vector64<T>`, `Vector128<T>`, or `Vector256<T>`. This leads to poorer code quality for `Vector2/3/4` particularly when inlining is involved due to additional copies inserted for passing the arguments around.

It also isn't clear to me why we would want to promote SIMD types anyways, as it will almost certainly be more efficient to keep the entire value enregistered (when registers are available) and to perform the relevant insertions/extractions using the appropriate SIMD instructions instead.

### PMI Diffs

The gains listed below are all from no longer promoting.

#### Frameworks
Noting that there was an assert that fired which I logged under: https://github.com/dotnet/runtime/issues/51728
```
Found 273 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 51225304
Total bytes of diff: 51224803
Total bytes of delta: -501 (-0.00% of base)
    diff is an improvement.


Top file improvements (bytes):
        -426 : System.Private.CoreLib.dasm (-0.02% of base)
         -75 : System.Drawing.Common.dasm (-0.02% of base)

2 total files with Code Size differences (2 improved, 0 regressed), 269 unchanged.

Top method regressions (bytes):
          59 ( 3.61% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
          13 ( 3.29% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Quaternion):Plane

Top method improvements (bytes):
        -103 (-8.62% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -76 (-12.82% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
         -50 (-5.43% of base) : System.Drawing.Common.dasm - Graphics:GetContextInfo(byref,bool,byref):this
         -47 (-37.01% of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3
         -40 (-35.09% of base) : System.Private.CoreLib.dasm - Vector3:Normalize(Vector3):Vector3
         -31 (-37.35% of base) : System.Private.CoreLib.dasm - Vector3:Multiply(float,Vector3):Vector3
         -23 (-4.65% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4
         -21 (-2.79% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4
         -16 (-16.84% of base) : System.Drawing.Common.dasm - Graphics:GetContextInfo(byref):this
         -15 (-53.57% of base) : System.Private.CoreLib.dasm - Vector2:get_Zero():Vector2
         -15 (-34.09% of base) : System.Private.CoreLib.dasm - Vector2:Multiply(float,Vector2):Vector2
         -15 (-23.44% of base) : System.Private.CoreLib.dasm - Vector2:Normalize(Vector2):Vector2
         -15 (-23.81% of base) : System.Private.CoreLib.dasm - Vector2:Reflect(Vector2,Vector2):Vector2
         -14 (-2.31% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateBillboard(Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -12 (-2.20% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateShadow(Vector3,Plane):Matrix4x4
         -12 (-14.29% of base) : System.Private.CoreLib.dasm - Plane:Dot(Plane,Vector4):float
         -12 (-2.54% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Matrix4x4):Plane
         -11 (-3.86% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
         -10 (-7.69% of base) : System.Private.CoreLib.dasm - Plane:op_Equality(Plane,Plane):bool
         -10 (-22.22% of base) : System.Private.CoreLib.dasm - Vector2:CopyTo(Span`1):this

Top method regressions (percentages):
          59 ( 3.61% of base) : System.Private.CoreLib.dasm - Matrix4x4:Decompose(Matrix4x4,byref,byref,byref):bool
          13 ( 3.29% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Quaternion):Plane

Top method improvements (percentages):
         -15 (-53.57% of base) : System.Private.CoreLib.dasm - Vector2:get_Zero():Vector2
         -31 (-37.35% of base) : System.Private.CoreLib.dasm - Vector3:Multiply(float,Vector3):Vector3
         -47 (-37.01% of base) : System.Private.CoreLib.dasm - Vector3:Reflect(Vector3,Vector3):Vector3
         -40 (-35.09% of base) : System.Private.CoreLib.dasm - Vector3:Normalize(Vector3):Vector3
         -15 (-34.09% of base) : System.Private.CoreLib.dasm - Vector2:Multiply(float,Vector2):Vector2
         -10 (-25.64% of base) : System.Private.CoreLib.dasm - Vector2:TryCopyTo(Span`1):bool:this
         -15 (-23.81% of base) : System.Private.CoreLib.dasm - Vector2:Reflect(Vector2,Vector2):Vector2
         -15 (-23.44% of base) : System.Private.CoreLib.dasm - Vector2:Normalize(Vector2):Vector2
         -10 (-22.22% of base) : System.Private.CoreLib.dasm - Vector2:CopyTo(Span`1):this
         -16 (-16.84% of base) : System.Drawing.Common.dasm - Graphics:GetContextInfo(byref):this
         -12 (-14.29% of base) : System.Private.CoreLib.dasm - Plane:Dot(Plane,Vector4):float
         -76 (-12.82% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateWorld(Vector3,Vector3,Vector3):Matrix4x4
          -9 (-10.00% of base) : System.Drawing.Common.dasm - Graphics:GetContextInfo(byref,byref):this
        -103 (-8.62% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateConstrainedBillboard(Vector3,Vector3,Vector3,Vector3,Vector3):Matrix4x4
         -10 (-7.69% of base) : System.Private.CoreLib.dasm - Plane:op_Equality(Plane,Plane):bool
         -50 (-5.43% of base) : System.Drawing.Common.dasm - Graphics:GetContextInfo(byref,bool,byref):this
         -23 (-4.65% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4
          -6 (-4.44% of base) : System.Private.CoreLib.dasm - Plane:op_Inequality(Plane,Plane):bool
         -11 (-3.86% of base) : System.Private.CoreLib.dasm - Plane:CreateFromVertices(Vector3,Vector3,Vector3):Plane
         -21 (-2.79% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateLookAt(Vector3,Vector3,Vector3):Matrix4x4

25 total methods with Code Size differences (23 improved, 2 regressed), 258893 unchanged.
```

#### Benchmarks
```
Found 84 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 505974
Total bytes of diff: 505594
Total bytes of delta: -380 (-0.08% of base)
    diff is an improvement.


Top file improvements (bytes):
        -380 : SIMD\RayTracer\RayTracer\RayTracer.dasm (-1.51% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 81 unchanged.

Top method improvements (bytes):
         -84 (-7.19% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetNaturalColor(SceneObject,Vector,Vector,Vector,Scene):Color:this
         -66 (-7.28% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Camera:Create(Vector,Vector):Camera
         -63 (-6.50% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:Shade(ISect,Scene,int):Color:this
         -42 (-13.04% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -31 (-35.63% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Times(double,Vector):Vector
         -21 (-5.57% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetReflectionColor(SceneObject,Vector,Vector,Vector,Scene,int):Color:this
         -18 (-11.84% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Sphere:Normal(Vector):Vector:this
         -18 (-14.06% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Norm(Vector):Vector
          -4 (-1.79% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Cross(Vector,Vector):Vector
          -1 (-0.43% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - <>c:<.cctor>b__3_0(Vector):Color:this
          -1 (-0.94% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - <>c:<.cctor>b__3_2(Vector):double:this

Top method improvements (percentages):
         -31 (-35.63% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Times(double,Vector):Vector
         -18 (-14.06% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Norm(Vector):Vector
         -42 (-13.04% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -18 (-11.84% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Sphere:Normal(Vector):Vector:this
         -66 (-7.28% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Camera:Create(Vector,Vector):Camera
         -84 (-7.19% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetNaturalColor(SceneObject,Vector,Vector,Vector,Scene):Color:this
         -63 (-6.50% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:Shade(ISect,Scene,int):Color:this
         -21 (-5.57% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetReflectionColor(SceneObject,Vector,Vector,Vector,Scene,int):Color:this
          -4 (-1.79% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Cross(Vector,Vector):Vector
          -1 (-0.94% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - <>c:<.cctor>b__3_2(Vector):double:this
          -1 (-0.43% of base) : SIMD\RayTracer\RayTracer\RayTracer.dasm - <>c:<.cctor>b__3_0(Vector):Color:this

12 total methods with Code Size differences (12 improved, 0 regressed), 1886 unchanged.
```

#### Tests
```
Found 3585 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 137419378
Total bytes of diff: 137417151
Total bytes of delta: -2227 (-0.00% of base)
    diff is an improvement.


Top file regressions (bytes):
          27 : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm (0.65% of base)
           4 : JIT\SIMD\Dup_r\Dup_r.dasm (1.98% of base)

Top file improvements (bytes):
        -759 : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm (-5.71% of base)
        -380 : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm (-1.51% of base)
        -293 : JIT\Regression\JitBlue\GitHub_21546\GitHub_21546\GitHub_21546.dasm (-17.27% of base)
        -292 : Interop\PInvoke\Vector2_3_4\Vector2_3_4\Vector2_3_4.dasm (-6.62% of base)
        -158 : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm (-3.35% of base)
         -60 : JIT\SIMD\VectorReturn_r\VectorReturn_r.dasm (-0.07% of base)
         -51 : JIT\Regression\JitBlue\GitHub_8220\GitHub_8220\GitHub_8220.dasm (-1.56% of base)
         -28 : JIT\HardwareIntrinsics\General\Vector128_1\Vector128_1_ro\Vector128_1_ro.dasm (-0.01% of base)
         -24 : JIT\SIMD\VectorAbs_r\VectorAbs_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorMin_r\VectorMin_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorMul_r\VectorMul_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorDiv_r\VectorDiv_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorAdd_r\VectorAdd_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorSub_r\VectorSub_r.dasm (-0.03% of base)
         -24 : JIT\SIMD\VectorMax_r\VectorMax_r.dasm (-0.03% of base)
         -16 : JIT\SIMD\Ldfld_ro\Ldfld_ro.dasm (-4.04% of base)
         -12 : JIT\SIMD\CircleInConvex_r\CircleInConvex_r.dasm (-0.17% of base)
         -11 : JIT\Regression\JitBlue\GitHub_7508\Vector3Test\Vector3Test.dasm (-0.67% of base)
         -11 : JIT\SIMD\Plane_ro\Plane_ro.dasm (-3.49% of base)
         -10 : JIT\SIMD\Dup_ro\Dup_ro.dasm (-8.62% of base)

23 total files with Code Size differences (21 improved, 2 regressed), 3519 unchanged.

Top method regressions (bytes):
          22 (48.89% of base) : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm - Runtime_31615:G3():Vector3
          13 (22.41% of base) : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm - Runtime_31615:G4():Vector4
          10 ( 1.95% of base) : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm - test:y_radius(float,List`1,List`1,byref):float
           4 ( 2.55% of base) : JIT\SIMD\Dup_r\Dup_r.dasm - Program:Main(ref):int

Top method improvements (bytes):
        -311 (-20.18% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:Main():int
        -209 (-44.95% of base) : JIT\Regression\JitBlue\GitHub_21546\GitHub_21546\GitHub_21546.dasm - test:FailureCase(List`1)
        -187 (-16.33% of base) : Interop\PInvoke\Vector2_3_4\Vector2_3_4\Vector2_3_4.dasm - Vector2_3_4Test:RunVector2Tests()
        -133 (-7.93% of base) : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm - test:convex_hull(List`1)
        -114 (-24.36% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F1_v3(float):Vector3
        -114 (-13.35% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F2_v3(float):Vector3
        -110 (-27.85% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F1_v2(float):Vector2
        -110 (-16.64% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F2_v2(float):Vector2
        -105 (-6.79% of base) : Interop\PInvoke\Vector2_3_4\Vector2_3_4\Vector2_3_4.dasm - Vector2_3_4Test:RunVector3Tests()
         -84 (-7.19% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetNaturalColor(SceneObject,Vector,Vector,Vector,Scene):Color:this
         -84 (-15.70% of base) : JIT\Regression\JitBlue\GitHub_21546\GitHub_21546\GitHub_21546.dasm - test:Main():int
         -66 (-7.28% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Camera:Create(Vector,Vector):Camera
         -63 (-6.50% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:Shade(ISect,Scene,int):Color:this
         -52 (-3.66% of base) : JIT\SIMD\VectorReturn_r\VectorReturn_r.dasm - VectorTest:Main():int
         -51 (-9.43% of base) : JIT\Regression\JitBlue\GitHub_8220\GitHub_8220\GitHub_8220.dasm - Program:testDotProduct(Vector3):int
         -42 (-13.04% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -31 (-35.63% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Times(double,Vector):Vector
         -27 (-2.34% of base) : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm - test:FindCircle(List`1,byref,byref):bool
         -21 (-5.57% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetReflectionColor(SceneObject,Vector,Vector,Vector,Scene,int):Color:this

Top method regressions (percentages):
          22 (48.89% of base) : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm - Runtime_31615:G3():Vector3
          13 (22.41% of base) : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm - Runtime_31615:G4():Vector4
           4 ( 2.55% of base) : JIT\SIMD\Dup_r\Dup_r.dasm - Program:Main(ref):int
          10 ( 1.95% of base) : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm - test:y_radius(float,List`1,List`1,byref):float

Top method improvements (percentages):
        -209 (-44.95% of base) : JIT\Regression\JitBlue\GitHub_21546\GitHub_21546\GitHub_21546.dasm - test:FailureCase(List`1)
         -31 (-35.63% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Times(double,Vector):Vector
        -110 (-27.85% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F1_v2(float):Vector2
        -114 (-24.36% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F1_v3(float):Vector3
        -311 (-20.18% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:Main():int
        -110 (-16.64% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F2_v2(float):Vector2
        -187 (-16.33% of base) : Interop\PInvoke\Vector2_3_4\Vector2_3_4\Vector2_3_4.dasm - Vector2_3_4Test:RunVector2Tests()
         -84 (-15.70% of base) : JIT\Regression\JitBlue\GitHub_21546\GitHub_21546\GitHub_21546.dasm - test:Main():int
         -18 (-14.06% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Vector:Norm(Vector):Vector
        -114 (-13.35% of base) : JIT\SIMD\VectorReturn_ro\VectorReturn_ro.dasm - VectorTest:F2_v3(float):Vector3
         -42 (-13.04% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -18 (-11.84% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Sphere:Normal(Vector):Vector:this
         -20 (-11.05% of base) : JIT\HardwareIntrinsics\General\Vector128_1\Vector128_1_ro\Vector128_1_ro.dasm - VectorAs__AsVector2Single:RunBasicScenario():this
          -5 (-10.87% of base) : JIT\Regression\JitBlue\Runtime_31615\Runtime_31615\Runtime_31615.dasm - Runtime_31615:G2():Vector2
         -51 (-9.43% of base) : JIT\Regression\JitBlue\GitHub_8220\GitHub_8220\GitHub_8220.dasm - Program:testDotProduct(Vector3):int
         -10 (-8.70% of base) : JIT\SIMD\Dup_ro\Dup_ro.dasm - Program:Main(ref):int
        -133 (-7.93% of base) : JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.dasm - test:convex_hull(List`1)
         -66 (-7.28% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - Camera:Create(Vector,Vector):Camera
         -84 (-7.19% of base) : JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.dasm - RayTracer:GetNaturalColor(SceneObject,Vector,Vector,Vector,Scene):Color:this

63 total methods with Code Size differences (59 improved, 4 regressed), 484444 unchanged.
```

#### dotnet/performance - MicroBenchmarks.dll
```
Found 2 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1817262
Total bytes of diff: 1816306
Total bytes of delta: -956 (-0.05% of base)
    diff is an improvement.


Top file improvements (bytes):
        -956 : MicroBenchmarks.dasm (-0.05% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions (bytes):
          36 (17.48% of base) : MicroBenchmarks.dasm - Perf_Vector3:CrossBenchmark():Vector3:this
          18 (10.29% of base) : MicroBenchmarks.dasm - Perf_Vector3:TransformByQuaternionBenchmark():Vector3:this
          18 ( 9.89% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformByQuaternionBenchmark():Vector4:this
          18 ( 9.89% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformVector3ByQuaternionBenchmark():Vector4:this
          12 ( 7.74% of base) : MicroBenchmarks.dasm - Perf_Plane:EqualityOperatorBenchmark():bool:this
           7 ( 4.93% of base) : MicroBenchmarks.dasm - Perf_Plane:DotBenchmark():float:this
           6 ( 4.88% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateScaleFromVectorBenchmark():Matrix4x4:this
           3 ( 3.45% of base) : MicroBenchmarks.dasm - Perf_Matrix3x2:CreateScaleFromVectorBenchmark():Matrix3x2:this
           1 ( 0.93% of base) : MicroBenchmarks.dasm - Perf_Vector2:TransformByQuaternionBenchmark():Vector2:this
           1 ( 0.69% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformVector2ByQuaternionBenchmark():Vector4:this

Top method improvements (bytes):
         -84 (-7.19% of base) : MicroBenchmarks.dasm - RayTracer:GetNaturalColor(SceneObject,Vector,Vector,Vector,Scene):Color:this
         -66 (-7.28% of base) : MicroBenchmarks.dasm - Camera:Create(Vector,Vector):Camera
         -63 (-6.50% of base) : MicroBenchmarks.dasm - RayTracer:Shade(ISect,Scene,int):Color:this
         -54 (-28.57% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateConstrainedBillboardBenchmark():Matrix4x4:this
         -52 (-38.81% of base) : MicroBenchmarks.dasm - Perf_Vector2:DistanceBenchmark():float:this
         -52 (-31.14% of base) : MicroBenchmarks.dasm - Perf_Vector2:LerpBenchmark():Vector2:this
         -48 (-30.77% of base) : MicroBenchmarks.dasm - Perf_Vector3:DistanceBenchmark():float:this
         -48 (-23.30% of base) : MicroBenchmarks.dasm - Perf_Vector3:LerpBenchmark():Vector3:this
         -42 (-13.04% of base) : MicroBenchmarks.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -36 (-25.53% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateBillboardBenchmark():Matrix4x4:this
         -35 (-12.20% of base) : MicroBenchmarks.dasm - Perf_Plane:CreateFromVerticesBenchmark():Plane:this
         -31 (-35.63% of base) : MicroBenchmarks.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : MicroBenchmarks.dasm - Vector:Times(double,Vector):Vector
         -26 (-24.07% of base) : MicroBenchmarks.dasm - Perf_Vector2:DivideByScalarBenchmark():Vector2:this
         -26 (-29.21% of base) : MicroBenchmarks.dasm - Perf_Vector2:NegateBenchmark():Vector2:this
         -24 (-17.65% of base) : MicroBenchmarks.dasm - Perf_Vector3:DivideByScalarBenchmark():Vector3:this
         -24 (-19.05% of base) : MicroBenchmarks.dasm - Perf_Vector3:MultiplyByScalarBenchmark():Vector3:this
         -24 (-20.51% of base) : MicroBenchmarks.dasm - Perf_Vector3:NegateBenchmark():Vector3:this
         -21 (-5.57% of base) : MicroBenchmarks.dasm - RayTracer:GetReflectionColor(SceneObject,Vector,Vector,Vector,Scene,int):Color:this
         -18 (-11.84% of base) : MicroBenchmarks.dasm - Sphere:Normal(Vector):Vector:this

Top method regressions (percentages):
          36 (17.48% of base) : MicroBenchmarks.dasm - Perf_Vector3:CrossBenchmark():Vector3:this
          18 (10.29% of base) : MicroBenchmarks.dasm - Perf_Vector3:TransformByQuaternionBenchmark():Vector3:this
          18 ( 9.89% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformByQuaternionBenchmark():Vector4:this
          18 ( 9.89% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformVector3ByQuaternionBenchmark():Vector4:this
          12 ( 7.74% of base) : MicroBenchmarks.dasm - Perf_Plane:EqualityOperatorBenchmark():bool:this
           7 ( 4.93% of base) : MicroBenchmarks.dasm - Perf_Plane:DotBenchmark():float:this
           6 ( 4.88% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateScaleFromVectorBenchmark():Matrix4x4:this
           3 ( 3.45% of base) : MicroBenchmarks.dasm - Perf_Matrix3x2:CreateScaleFromVectorBenchmark():Matrix3x2:this
           1 ( 0.93% of base) : MicroBenchmarks.dasm - Perf_Vector2:TransformByQuaternionBenchmark():Vector2:this
           1 ( 0.69% of base) : MicroBenchmarks.dasm - Perf_Vector4:TransformVector2ByQuaternionBenchmark():Vector4:this

Top method improvements (percentages):
         -52 (-38.81% of base) : MicroBenchmarks.dasm - Perf_Vector2:DistanceBenchmark():float:this
         -31 (-35.63% of base) : MicroBenchmarks.dasm - Color:Times(double,Color):Color
         -31 (-35.63% of base) : MicroBenchmarks.dasm - Vector:Times(double,Vector):Vector
         -52 (-31.14% of base) : MicroBenchmarks.dasm - Perf_Vector2:LerpBenchmark():Vector2:this
         -48 (-30.77% of base) : MicroBenchmarks.dasm - Perf_Vector3:DistanceBenchmark():float:this
         -26 (-29.21% of base) : MicroBenchmarks.dasm - Perf_Vector2:NegateBenchmark():Vector2:this
         -54 (-28.57% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateConstrainedBillboardBenchmark():Matrix4x4:this
         -36 (-25.53% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateBillboardBenchmark():Matrix4x4:this
         -26 (-24.07% of base) : MicroBenchmarks.dasm - Perf_Vector2:DivideByScalarBenchmark():Vector2:this
         -48 (-23.30% of base) : MicroBenchmarks.dasm - Perf_Vector3:LerpBenchmark():Vector3:this
         -24 (-20.51% of base) : MicroBenchmarks.dasm - Perf_Vector3:NegateBenchmark():Vector3:this
         -24 (-19.05% of base) : MicroBenchmarks.dasm - Perf_Vector3:MultiplyByScalarBenchmark():Vector3:this
         -24 (-17.65% of base) : MicroBenchmarks.dasm - Perf_Vector3:DivideByScalarBenchmark():Vector3:this
         -18 (-14.06% of base) : MicroBenchmarks.dasm - Vector:Norm(Vector):Vector
         -42 (-13.04% of base) : MicroBenchmarks.dasm - RayTracer:GetPoint(double,double,Camera):Vector:this
         -12 (-12.90% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateLookAtBenchmark():Matrix4x4:this
         -12 (-12.90% of base) : MicroBenchmarks.dasm - Perf_Matrix4x4:CreateWorldBenchmark():Matrix4x4:this
         -12 (-12.50% of base) : MicroBenchmarks.dasm - Perf_Quaternion:CreateFromAxisAngleBenchmark():Quaternion:this
         -35 (-12.20% of base) : MicroBenchmarks.dasm - Perf_Plane:CreateFromVerticesBenchmark():Plane:this
         -18 (-11.84% of base) : MicroBenchmarks.dasm - Sphere:Normal(Vector):Vector:this

52 total methods with Code Size differences (42 improved, 10 regressed), 8728 unchanged
```