### PR TITLE
Fix a Windows-only test for cultures not using . as decimal seperator

### DIFF
--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.cs
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.cs
@@ -40,7 +40,7 @@ namespace PInvokeTests
             int arg2 = 20;
             double arg3 = 12.5;
 
-            string expected = $"{arg1}, {arg2}, {arg3:F1}";
+            string expected = FormattableString.Invariant($"{arg1}, {arg2}, {arg3:F1}");
 
             StringBuilder builder;
 


### PR DESCRIPTION
This test fails on my machine as the native `printf` uses `.` as decimal seperator while the managed side uses comma for me.