### PR TITLE
Do not count page cache towards cgroup’s memory load

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -84,11 +84,10 @@ public:
         }
         else
         {
-            s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names[0] = "inactive_anon ";
-            s_mem_stat_key_names[1] = "active_anon ";
-            s_mem_stat_key_names[2] = "file_dirty ";
-            s_mem_stat_key_names[3] = "unevictable ";
+            s_mem_stat_n_keys = 3;
+            s_mem_stat_key_names[0] = "anon ";
+            s_mem_stat_key_names[1] = "file_dirty ";
+            s_mem_stat_key_names[2] = "unevictable ";
         }
 
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
@@ -450,7 +449,7 @@ private:
         char* endptr;
 
         *val = 0;
-        while (getline(&line, &lineLen, stat_file) != -1)
+        while (getline(&line, &lineLen, stat_file) != -1 && readValues < s_mem_stat_n_keys)
         {
             for (size_t i = 0; i < s_mem_stat_n_keys; i++)
             {

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -67,14 +67,13 @@ class CGroup
     static const char **s_mem_stat_key_names;
     static size_t *s_mem_stat_key_lengths;
     static size_t s_mem_stat_n_keys;
-    
 public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
         s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
         s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
-        
+
         if (s_cgroup_version == 1)
         {
             s_mem_stat_n_keys = 4;
@@ -93,9 +92,9 @@ public:
             s_mem_stat_key_names[2] = "file_dirty ";
             s_mem_stat_key_names[3] = "unevictable ";
         }
-        
+
         s_mem_stat_key_lengths = new size_t[s_mem_stat_n_keys];
-        
+
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
         {
             s_mem_stat_key_lengths[i] = strlen(s_mem_stat_key_names[i]);
@@ -280,7 +279,7 @@ private:
 
             // See man page of proc to get format for /proc/self/mountinfo file
             int sscanfRet = sscanf(separatorChar,
-                                     " - %s %*s %s",
+                                   " - %s %*s %s",
                                    filesystemType,
                                    options);
             if (sscanfRet != 2)
@@ -305,23 +304,23 @@ private:
                 if (isSubsystemMatch)
                 {
                         mountpath = (char*)malloc(lineLen+1);
-                    if (mountpath == nullptr)
-                        goto done;
+                        if (mountpath == nullptr)
+                            goto done;
                         mountroot = (char*)malloc(lineLen+1);
-                    if (mountroot == nullptr)
-                        goto done;
+                        if (mountroot == nullptr)
+                            goto done;
 
                         sscanfRet = sscanf(line,
-                                        "%*s %*s %*s %s %s ",
+                                           "%*s %*s %*s %s %s ",
                                            mountroot,
                                            mountpath);
-                    if (sscanfRet != 2)
+                        if (sscanfRet != 2)
                             assert(!"Failed to parse mount info file contents with sscanf.");
 
-                    // assign the output arguments and clear the locals so we don't free them.
-                    *pmountpath = mountpath;
-                    *pmountroot = mountroot;
-                    mountpath = mountroot = nullptr;
+                        // assign the output arguments and clear the locals so we don't free them.
+                        *pmountpath = mountpath;
+                        *pmountroot = mountroot;
+                        mountpath = mountroot = nullptr;
                 }
             }
         }
@@ -369,7 +368,7 @@ private:
             {
                 // See man page of proc to get format for /proc/self/cgroup file
                 int sscanfRet = sscanf(line,
-                                         "%*[^:]:%[^:]:%s",
+                                       "%*[^:]:%[^:]:%s",
                                        subsystem_list,
                                        cgroup_path);
                 if (sscanfRet != 2)
@@ -395,7 +394,7 @@ private:
                 // See https://www.kernel.org/doc/Documentation/cgroup-v2.txt
                 // Look for a "0::/some/path"
                 int sscanfRet = sscanf(line,
-                                         "0::%s",
+                                       "0::%s",
                                        cgroup_path);
                 if (sscanfRet == 1)
                 {
@@ -434,7 +433,7 @@ private:
         free(mem_limit_filename);
         return result;
     }
-    
+
     static bool GetCGroupMemoryUsage(size_t *val)
     {
         if (s_memory_cgroup_path == nullptr)
@@ -466,7 +465,7 @@ private:
                     *val += strtoll(startptr, &endptr, 10);
                     if (endptr != startptr && errno == 0)
                         readValues++;
-                        
+
                     break;
                 }
             }
@@ -598,7 +597,7 @@ private:
         result = ReadLongLongValueFromFile(filename, &val);
         free(filename);
         if (!result)
-            return -1;
+             return -1;
 
         return val;
     }
@@ -724,15 +723,15 @@ bool GetPhysicalMemoryUsed(size_t* val)
 
         errno = 0;
         *val = strtoull(strTok, nullptr, 0);
-        if(errno == 0)
+        if (errno == 0)
         {
             long pageSize = sysconf(_SC_PAGE_SIZE);
             if (pageSize != -1)
             {
                 *val = *val * pageSize;
-            result = true;
+                result = true;
+            }
         }
-    }
     }
 
     if (file)

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -64,8 +64,8 @@ class CGroup
     static char *s_memory_cgroup_path;
     static char *s_cpu_cgroup_path;
 
-    static const char **s_mem_stat_key_names;
-    static size_t *s_mem_stat_key_lengths;
+    static const char *s_mem_stat_key_names[];
+    static size_t s_mem_stat_key_lengths[];
     static size_t s_mem_stat_n_keys;
 public:
     static void Initialize()
@@ -77,7 +77,6 @@ public:
         if (s_cgroup_version == 1)
         {
             s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names = new const char*[s_mem_stat_n_keys];
             s_mem_stat_key_names[0] = "total_inactive_anon ";
             s_mem_stat_key_names[1] = "total_active_anon ";
             s_mem_stat_key_names[2] = "total_dirty ";
@@ -86,14 +85,11 @@ public:
         else
         {
             s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names = new const char*[s_mem_stat_n_keys];
             s_mem_stat_key_names[0] = "inactive_anon ";
             s_mem_stat_key_names[1] = "active_anon ";
             s_mem_stat_key_names[2] = "file_dirty ";
             s_mem_stat_key_names[3] = "unevictable ";
         }
-
-        s_mem_stat_key_lengths = new size_t[s_mem_stat_n_keys];
 
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
         {
@@ -637,8 +633,8 @@ int CGroup::s_cgroup_version = 0;
 char *CGroup::s_memory_cgroup_path = nullptr;
 char *CGroup::s_cpu_cgroup_path = nullptr;
 
-const char **CGroup::s_mem_stat_key_names = nullptr;
-size_t *CGroup::s_mem_stat_key_lengths = nullptr;
+const char *CGroup::s_mem_stat_key_names[4] = {};
+size_t CGroup::s_mem_stat_key_lengths[4] = {};
 size_t CGroup::s_mem_stat_n_keys = 0;
 
 void InitializeCGroup()

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -264,7 +264,7 @@ private:
 
             // See man page of proc to get format for /proc/self/mountinfo file
             int sscanfRet = sscanf(separatorChar,
-                                     " - %s %*s %s",
+                                   " - %s %*s %s",
                                    filesystemType,
                                    options);
             if (sscanfRet != 2)
@@ -289,23 +289,23 @@ private:
                 if (isSubsystemMatch)
                 {
                         mountpath = (char*)malloc(lineLen+1);
-                    if (mountpath == nullptr)
-                        goto done;
+                        if (mountpath == nullptr)
+                            goto done;
                         mountroot = (char*)malloc(lineLen+1);
-                    if (mountroot == nullptr)
-                        goto done;
+                        if (mountroot == nullptr)
+                            goto done;
 
                         sscanfRet = sscanf(line,
-                                        "%*s %*s %*s %s %s ",
+                                           "%*s %*s %*s %s %s ",
                                            mountroot,
                                            mountpath);
-                    if (sscanfRet != 2)
+                        if (sscanfRet != 2)
                             assert(!"Failed to parse mount info file contents with sscanf.");
 
-                    // assign the output arguments and clear the locals so we don't free them.
-                    *pmountpath = mountpath;
-                    *pmountroot = mountroot;
-                    mountpath = mountroot = nullptr;
+                        // assign the output arguments and clear the locals so we don't free them.
+                        *pmountpath = mountpath;
+                        *pmountroot = mountroot;
+                        mountpath = mountroot = nullptr;
                 }
             }
         }
@@ -353,7 +353,7 @@ private:
             {
                 // See man page of proc to get format for /proc/self/cgroup file
                 int sscanfRet = sscanf(line,
-                                         "%*[^:]:%[^:]:%s",
+                                       "%*[^:]:%[^:]:%s",
                                        subsystem_list,
                                        cgroup_path);
                 if (sscanfRet != 2)
@@ -379,7 +379,7 @@ private:
                 // See https://www.kernel.org/doc/Documentation/cgroup-v2.txt
                 // Look for a "0::/some/path"
                 int sscanfRet = sscanf(line,
-                                         "0::%s",
+                                       "0::%s",
                                        cgroup_path);
                 if (sscanfRet == 1)
                 {
@@ -625,7 +625,7 @@ private:
         result = ReadLongLongValueFromFile(filename, &val);
         free(filename);
         if (!result)
-            return -1;
+             return -1;
 
         return val;
     }
@@ -754,15 +754,15 @@ bool GetPhysicalMemoryUsed(size_t* val)
 
         errno = 0;
         *val = strtoull(strTok, nullptr, 0);
-        if(errno == 0)
+        if (errno == 0)
         {
             long pageSize = sysconf(_SC_PAGE_SIZE);
             if (pageSize != -1)
             {
                 *val = *val * pageSize;
-            result = true;
+                result = true;
+            }
         }
-    }
     }
 
     if (file)

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -436,6 +436,7 @@ private:
             return false;
 
         FILE *stat_file = fopen(stat_filename, "r");
+        free(stat_filename);
         if (stat_file == nullptr)
             return false;
 
@@ -471,7 +472,6 @@ private:
         }
 
         fclose(stat_file);
-        free(stat_filename);
         free(line);
 
         if (readValues == 2)

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -50,8 +50,8 @@ class CGroup
     static char *s_memory_cgroup_path;
     static char *s_cpu_cgroup_path;
 
-    static const char **s_mem_stat_key_names;
-    static size_t *s_mem_stat_key_lengths;
+    static const char *s_mem_stat_key_names[];
+    static size_t s_mem_stat_key_lengths[];
     static size_t s_mem_stat_n_keys;
 public:
     static void Initialize()
@@ -63,7 +63,6 @@ public:
         if (s_cgroup_version == 1)
         {
             s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names = new const char*[s_mem_stat_n_keys];
             s_mem_stat_key_names[0] = "total_inactive_anon ";
             s_mem_stat_key_names[1] = "total_active_anon ";
             s_mem_stat_key_names[2] = "total_dirty ";
@@ -72,14 +71,11 @@ public:
         else
         {
             s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names = new const char*[s_mem_stat_n_keys];
             s_mem_stat_key_names[0] = "inactive_anon ";
             s_mem_stat_key_names[1] = "active_anon ";
             s_mem_stat_key_names[2] = "file_dirty ";
             s_mem_stat_key_names[3] = "unevictable ";
         }
-
-        s_mem_stat_key_lengths = new size_t[s_mem_stat_n_keys];
 
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
         {
@@ -629,8 +625,8 @@ int CGroup::s_cgroup_version = 0;
 char *CGroup::s_memory_cgroup_path = nullptr;
 char *CGroup::s_cpu_cgroup_path = nullptr;
 
-const char **CGroup::s_mem_stat_key_names = nullptr;
-size_t *CGroup::s_mem_stat_key_lengths = nullptr;
+const char *CGroup::s_mem_stat_key_names[4] = {};
+size_t CGroup::s_mem_stat_key_lengths[4] = {};
 size_t CGroup::s_mem_stat_n_keys = 0;
 
 void InitializeCGroup()

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -70,11 +70,10 @@ public:
         }
         else
         {
-            s_mem_stat_n_keys = 4;
-            s_mem_stat_key_names[0] = "inactive_anon ";
-            s_mem_stat_key_names[1] = "active_anon ";
-            s_mem_stat_key_names[2] = "file_dirty ";
-            s_mem_stat_key_names[3] = "unevictable ";
+            s_mem_stat_n_keys = 3;
+            s_mem_stat_key_names[0] = "anon ";
+            s_mem_stat_key_names[1] = "file_dirty ";
+            s_mem_stat_key_names[2] = "unevictable ";
         }
 
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
@@ -437,7 +436,7 @@ private:
         char* endptr;
 
         *val = 0;
-        while (getline(&line, &lineLen, stat_file) != -1)
+        while (getline(&line, &lineLen, stat_file) != -1 && readValues < s_mem_stat_n_keys)
         {
             for (size_t i = 0; i < s_mem_stat_n_keys; i++)
             {

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -39,6 +39,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #define CGROUP2_MEMORY_LIMIT_FILENAME "/memory.max"
 #define CGROUP1_MEMORY_USAGE_FILENAME "/memory.usage_in_bytes"
 #define CGROUP2_MEMORY_USAGE_FILENAME "/memory.current"
+#define CGROUP_MEMORY_STAT_FILENAME "/memory.stat"
 #define CGROUP1_CFS_QUOTA_FILENAME "/cpu.cfs_quota_us"
 #define CGROUP1_CFS_PERIOD_FILENAME "/cpu.cfs_period_us"
 #define CGROUP2_CPU_MAX_FILENAME "/cpu.max"
@@ -50,12 +51,22 @@ class CGroup
 
     static char *s_memory_cgroup_path;
     static char *s_cpu_cgroup_path;
+
+    static const char *s_active_file_key_name;
+    static const char *s_inactive_file_key_name;
+    static size_t s_active_file_key_length;
+    static size_t s_inactive_file_key_length;
+
 public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
         s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
         s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
+        s_active_file_key_name = s_cgroup_version == 1 ? "total_active_file " : "active_file ";
+        s_inactive_file_key_name = s_cgroup_version == 1 ? "total_inactive_file " : "inactive_file ";
+        s_active_file_key_length = strlen(s_active_file_key_name);
+        s_inactive_file_key_length = strlen(s_inactive_file_key_name);
     }
 
     static void Cleanup()
@@ -401,22 +412,73 @@ private:
         if (asprintf(&mem_usage_filename, "%s%s", s_memory_cgroup_path, filename) < 0)
             return false;
 
-        uint64_t temp = 0;
-        bool result = ReadMemoryValueFromFile(mem_usage_filename, &temp);
-        if (result)
+        uint64_t usage = 0;
+        bool success = ReadMemoryValueFromFile(mem_usage_filename, &usage);
+        free(mem_usage_filename);
+
+        if (!success)
+            return false;
+
+        char* stat_filename = nullptr;
+        if (asprintf(&stat_filename, "%s%s", s_memory_cgroup_path, CGROUP_MEMORY_STAT_FILENAME) < 0)
+            return false;
+
+        FILE *stat_file = fopen(stat_filename, "r");
+        free(stat_filename);
+        if (stat_file == nullptr)
+            return false;
+
+        char *line = nullptr;
+        size_t lineLen = 0;
+        size_t readValues = 0;
+        size_t active_file = 0;
+        size_t inactive_file = 0;
+        char* endptr;
+
+        while (readValues != 2 && getline(&line, &lineLen, stat_file) != -1)
         {
-            if (temp > std::numeric_limits<size_t>::max())
+            if (strncmp(line, s_active_file_key_name, s_active_file_key_length) == 0)
+            {
+                errno = 0;
+                const char* startptr = line + s_active_file_key_length;
+                active_file = strtoll(startptr, &endptr, 10);
+                if (endptr == startptr || errno != 0)
+                    continue;
+
+                readValues++;
+            }
+            else if (strncmp(line, s_inactive_file_key_name, s_inactive_file_key_length) == 0)
+            {
+                errno = 0;
+                const char* startptr = line + s_inactive_file_key_length;
+                inactive_file = strtoll(startptr, &endptr, 10);
+                if (endptr == startptr || errno != 0)
+                    continue;
+
+                readValues++;
+            }
+        }
+
+        fclose(stat_file);
+        free(line);
+
+        if (readValues == 2)
+        {
+            if (usage > std::numeric_limits<size_t>::max())
             {
                 *val = std::numeric_limits<size_t>::max();
             }
             else
             {
-                *val = (size_t)temp;
+                // Since file cache pages can be easily evicted and re-used
+                // they should not be considered as used memory.
+                *val = (size_t)usage - active_file - inactive_file;
             }
+
+            return true;
         }
 
-        free(mem_usage_filename);
-        return result;
+        return false;
     }
 
     static bool ReadMemoryValueFromFile(const char* filename, uint64_t* val)
@@ -580,6 +642,11 @@ private:
 int CGroup::s_cgroup_version = 0;
 char *CGroup::s_memory_cgroup_path = nullptr;
 char *CGroup::s_cpu_cgroup_path = nullptr;
+
+const char *CGroup::s_active_file_key_name = nullptr;
+const char *CGroup::s_inactive_file_key_name = nullptr;
+size_t CGroup::s_active_file_key_length = 0;
+size_t CGroup::s_inactive_file_key_length = 0;
 
 void InitializeCGroup()
 {

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -53,14 +53,13 @@ class CGroup
     static const char **s_mem_stat_key_names;
     static size_t *s_mem_stat_key_lengths;
     static size_t s_mem_stat_n_keys;
-    
 public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
         s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
         s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
-        
+
         if (s_cgroup_version == 1)
         {
             s_mem_stat_n_keys = 4;
@@ -79,9 +78,9 @@ public:
             s_mem_stat_key_names[2] = "file_dirty ";
             s_mem_stat_key_names[3] = "unevictable ";
         }
-        
+
         s_mem_stat_key_lengths = new size_t[s_mem_stat_n_keys];
-        
+
         for (size_t i = 0; i < s_mem_stat_n_keys; i++)
         {
             s_mem_stat_key_lengths[i] = strlen(s_mem_stat_key_names[i]);
@@ -453,7 +452,7 @@ private:
                     *val += strtoll(startptr, &endptr, 10);
                     if (endptr != startptr && errno == 0)
                         readValues++;
-                        
+
                     break;
                 }
             }


### PR DESCRIPTION
As reported in the https://github.com/dotnet/runtime/issues/49058 there are scenarios in which GC is too aggressive when the app runs inside a Linux container (cgroups v1 & cgroups v2).
One of the factors considered for deciding whether it is necessary to run GC is a [memory load](https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/coreclr/vm/gcenv.os.cpp#L915-L989).
A memory load value is supposed to mean the approximate percentage of physical memory that is in use. 
Unlike on Windows, memory load on Linux containers also includes a page cache which makes the memory load value larger than it ought to be.
This PR changes how the memory load is calculated on Linux containers to match Windows.

Fixes : https://github.com/dotnet/runtime/issues/49058