### PR TITLE
Implement CryptoConfig.CreateFromName() for wasm

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -101,13 +101,17 @@ namespace System.Security.Cryptography
     {
         public CryptoConfig() { }
         public static bool AllowOnlyFipsAlgorithms { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void AddAlgorithm(System.Type algorithm, params string[] names) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void AddOID(string oid, params string[] names) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
         public static object? CreateFromName(string name) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
         public static object? CreateFromName(string name, params object?[]? args) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static byte[] EncodeOID(string str) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static string? MapNameToOID(string name) { throw null; }
     }
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/ExcludeApiList.PNSE.Browser.txt
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/ExcludeApiList.PNSE.Browser.txt
@@ -1,3 +1,4 @@
+T:System.Security.Cryptography.CryptoConfig
 T:System.Security.Cryptography.RandomNumberGenerator
 T:System.Security.Cryptography.IncrementalHash
 T:System.Security.Cryptography.SHA1

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -675,6 +675,7 @@
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Browser.cs" />
     <Compile Include="Internal\Cryptography\SHAHashProvider.Browser.cs" />
+    <Compile Include="System\Security\Cryptography\CryptoConfig.Browser.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGenerator.cs" />
     <Compile Include="System\Security\Cryptography\IncrementalHash.cs" />
     <Compile Include="System\Security\Cryptography\SHA1.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.Browser.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.Browser.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.Versioning;
+
+namespace System.Security.Cryptography
+{
+    public partial class CryptoConfig
+    {
+        [UnsupportedOSPlatform("browser")]
+        public static void AddAlgorithm(Type algorithm, params string[] names) => throw new PlatformNotSupportedException(SR.SystemSecurityCryptographyAlgorithms_PlatformNotSupported);
+
+        [UnsupportedOSPlatform("browser")]
+        public static void AddOID(string oid, params string[] names) => throw new PlatformNotSupportedException(SR.SystemSecurityCryptographyAlgorithms_PlatformNotSupported);
+
+        [UnsupportedOSPlatform("browser")]
+        public static string? MapNameToOID(string name) => throw new PlatformNotSupportedException(SR.SystemSecurityCryptographyAlgorithms_PlatformNotSupported);
+
+        [UnsupportedOSPlatform("browser")]
+        public static byte[] EncodeOID(string str) => throw new PlatformNotSupportedException(SR.SystemSecurityCryptographyAlgorithms_PlatformNotSupported);
+
+        [RequiresUnreferencedCode("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+        public static object? CreateFromName(string name, params object?[]? args)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            switch (name)
+            {
+                // hardcode mapping for SHA* algorithm names from https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptoconfig?view=net-5.0#remarks
+                case "SHA":
+                case "SHA1":
+                case "System.Security.Cryptography.SHA1":
+                    return new SHA1Managed();
+                case "SHA256":
+                case "SHA-256":
+                case "System.Security.Cryptography.SHA256":
+                    return new SHA256Managed();
+                case "SHA384":
+                case "SHA-384":
+                case "System.Security.Cryptography.SHA384":
+                    return new SHA384Managed();
+                case "SHA512":
+                case "SHA-512":
+                case "System.Security.Cryptography.SHA512":
+                    return new SHA512Managed();
+            }
+
+            return null;
+        }
+
+        [RequiresUnreferencedCode(CreateFromNameUnreferencedCodeMessage)]
+        public static object? CreateFromName(string name)
+        {
+            return CreateFromName(name, null);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.Common.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.Common.cs
@@ -6,5 +6,8 @@ namespace System.Security.Cryptography
     public partial class CryptoConfig
     {
         internal const string CreateFromNameUnreferencedCodeMessage = "The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.";
+
+        // .NET Core does not support AllowOnlyFipsAlgorithms
+        public static bool AllowOnlyFipsAlgorithms => false;
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -36,9 +37,6 @@ namespace System.Security.Cryptography
         private static volatile Dictionary<string, object>? s_defaultNameHT;
         private static readonly ConcurrentDictionary<string, Type> appNameHT = new ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, string> appOidHT = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-        // .NET Core does not support AllowOnlyFipsAlgorithms
-        public static bool AllowOnlyFipsAlgorithms => false;
 
         private static Dictionary<string, string> DefaultOidHT
         {
@@ -294,6 +292,7 @@ namespace System.Security.Cryptography
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void AddAlgorithm(Type algorithm, params string[] names)
         {
             if (algorithm == null)
@@ -450,6 +449,7 @@ namespace System.Security.Cryptography
             return CreateFromName(name, null);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void AddOID(string oid, params string[] names)
         {
             if (oid == null)
@@ -477,6 +477,7 @@ namespace System.Security.Cryptography
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static string? MapNameToOID(string name)
         {
             if (name == null)
@@ -497,6 +498,7 @@ namespace System.Security.Cryptography
             return oidName;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static byte[] EncodeOID(string str)
         {
             if (str == null)

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.CryptoConfigTests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public static class CryptoConfigTests
     {
         [Fact]
@@ -19,6 +18,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddOID_MapNameToOID_ReturnsMapped()
         {
             CryptoConfig.AddOID("1.3.14.3.2.28", "SHAFancy");
@@ -26,12 +26,14 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddOID_EmptyString_Throws()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => CryptoConfig.AddOID(string.Empty, string.Empty));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddOID_EmptyNamesArray()
         {
             CryptoConfig.AddOID("1.3.14.3.2.28", new string[0]);
@@ -39,18 +41,21 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddOID_NullOid_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("oid", () => CryptoConfig.AddOID(null, string.Empty));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddOID_NullNames_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("names", () => CryptoConfig.AddOID(string.Empty, null));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_CreateFromName_ReturnsMapped()
         {
             CryptoConfig.AddAlgorithm(typeof(AesCryptoServiceProvider), "AESFancy");
@@ -58,6 +63,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_NonVisibleType()
         {
             AssertExtensions.Throws<ArgumentException>("algorithm", () => CryptoConfig.AddAlgorithm(typeof(AESFancy), "AESFancy"));
@@ -68,12 +74,14 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_EmptyString_Throws()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_EmptyNamesArray()
         {
             CryptoConfig.AddAlgorithm(typeof(AesCryptoServiceProvider), new string[0]);
@@ -81,18 +89,21 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_NullAlgorithm_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("algorithm", () => CryptoConfig.AddAlgorithm(null, string.Empty));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AddAlgorithm_NullNames_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("names", () => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), null));
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void StaticCreateMethods()
         {
             // Ensure static create methods exist and don't throw
@@ -120,6 +131,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void MapNameToOID()
         {
             Assert.Throws<ArgumentNullException>(() => CryptoConfig.MapNameToOID(null));
@@ -137,6 +149,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void CreateFromName_validation()
         {
             Assert.Throws<ArgumentNullException>(() => CryptoConfig.CreateFromName(null));
@@ -150,105 +163,124 @@ namespace System.Security.Cryptography.CryptoConfigTests
         {
             get
             {
-                // Random number generator
-                yield return new object[] { "RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", true };
+                if (PlatformDetection.IsBrowser)
+                {
+                    // Hash functions
+                    yield return new object[] { "SHA", typeof(SHA1Managed).FullName, true };
+                    yield return new object[] { "SHA1", typeof(SHA1Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA1", typeof(SHA1Managed).FullName, true };
+                    yield return new object[] { "SHA256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "SHA-256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "SHA384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "SHA-384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "SHA512", typeof(SHA512Managed).FullName, true };
+                    yield return new object[] { "SHA-512", typeof(SHA512Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA512", typeof(SHA512Managed).FullName, true };
+                }
+                else
+                {
+                    // Random number generator
+                    yield return new object[] { "RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", true };
 
-                // Hash functions
-                yield return new object[] { "SHA", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
-                yield return new object[] { "SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.HashAlgorithm", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
-                yield return new object[] { "MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", true };
-                yield return new object[] { "SHA256", typeof(SHA256Managed).FullName, true };
-                yield return new object[] { "SHA-256", typeof(SHA256Managed).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.SHA256", typeof(SHA256Managed).FullName, true };
-                yield return new object[] { "SHA384", typeof(SHA384Managed).FullName, true };
-                yield return new object[] { "SHA-384", typeof(SHA384Managed).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.SHA384", typeof(SHA384Managed).FullName, true };
-                yield return new object[] { "SHA512", typeof(SHA512Managed).FullName, true };
-                yield return new object[] { "SHA-512", typeof(SHA512Managed).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.SHA512", typeof(SHA512Managed).FullName, true };
+                    // Hash functions
+                    yield return new object[] { "SHA", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
+                    yield return new object[] { "SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.HashAlgorithm", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
+                    yield return new object[] { "MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", true };
+                    yield return new object[] { "SHA256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "SHA-256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "SHA384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "SHA-384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "SHA512", typeof(SHA512Managed).FullName, true };
+                    yield return new object[] { "SHA-512", typeof(SHA512Managed).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SHA512", typeof(SHA512Managed).FullName, true };
 
-                // Keyed Hash Algorithms
-                yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
-                yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
-                yield return new object[] { "HMACMD5", "System.Security.Cryptography.HMACMD5", true };
-                yield return new object[] { "System.Security.Cryptography.HMACMD5", null, true };
-                yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };
-                yield return new object[] { "System.Security.Cryptography.HMACSHA1", null, true };
-                yield return new object[] { "HMACSHA256", "System.Security.Cryptography.HMACSHA256", true };
-                yield return new object[] { "System.Security.Cryptography.HMACSHA256", null, true };
-                yield return new object[] { "HMACSHA384", "System.Security.Cryptography.HMACSHA384", true };
-                yield return new object[] { "System.Security.Cryptography.HMACSHA384", null, true };
-                yield return new object[] { "HMACSHA512", "System.Security.Cryptography.HMACSHA512", true };
-                yield return new object[] { "System.Security.Cryptography.HMACSHA512", null, true };
+                    // Keyed Hash Algorithms
+                    yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
+                    yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
+                    yield return new object[] { "HMACMD5", "System.Security.Cryptography.HMACMD5", true };
+                    yield return new object[] { "System.Security.Cryptography.HMACMD5", null, true };
+                    yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };
+                    yield return new object[] { "System.Security.Cryptography.HMACSHA1", null, true };
+                    yield return new object[] { "HMACSHA256", "System.Security.Cryptography.HMACSHA256", true };
+                    yield return new object[] { "System.Security.Cryptography.HMACSHA256", null, true };
+                    yield return new object[] { "HMACSHA384", "System.Security.Cryptography.HMACSHA384", true };
+                    yield return new object[] { "System.Security.Cryptography.HMACSHA384", null, true };
+                    yield return new object[] { "HMACSHA512", "System.Security.Cryptography.HMACSHA512", true };
+                    yield return new object[] { "System.Security.Cryptography.HMACSHA512", null, true };
 
-                // Asymmetric algorithms
-                yield return new object[] { "RSA", "System.Security.Cryptography.RSACryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.RSA", "System.Security.Cryptography.RSACryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.AsymmetricAlgorithm", "System.Security.Cryptography.RSACryptoServiceProvider", true };
-                yield return new object[] { "DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
-                yield return new object[] { "ECDsa", "System.Security.Cryptography.ECDsaCng", true };
-                yield return new object[] { "ECDsaCng", "System.Security.Cryptography.ECDsaCng", false };
-                yield return new object[] { "System.Security.Cryptography.ECDsaCng", null, false };
-                yield return new object[] { "DES", "System.Security.Cryptography.DESCryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.DES", "System.Security.Cryptography.DESCryptoServiceProvider", true };
-                yield return new object[] { "3DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "Triple DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", true };
-                yield return new object[] { "Rijndael", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.Rijndael", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.SymmetricAlgorithm", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "AES", "System.Security.Cryptography.AesCryptoServiceProvider", true };
-                yield return new object[] { "AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", true };
-                yield return new object[] { "System.Security.Cryptography.AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", true };
-                yield return new object[] { "AesManaged", typeof(AesManaged).FullName, true };
-                yield return new object[] { "System.Security.Cryptography.AesManaged", typeof(AesManaged).FullName, true };
+                    // Asymmetric algorithms
+                    yield return new object[] { "RSA", "System.Security.Cryptography.RSACryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.RSA", "System.Security.Cryptography.RSACryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.AsymmetricAlgorithm", "System.Security.Cryptography.RSACryptoServiceProvider", true };
+                    yield return new object[] { "DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.DSA", "System.Security.Cryptography.DSACryptoServiceProvider", true };
+                    yield return new object[] { "ECDsa", "System.Security.Cryptography.ECDsaCng", true };
+                    yield return new object[] { "ECDsaCng", "System.Security.Cryptography.ECDsaCng", false };
+                    yield return new object[] { "System.Security.Cryptography.ECDsaCng", null, false };
+                    yield return new object[] { "DES", "System.Security.Cryptography.DESCryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.DES", "System.Security.Cryptography.DESCryptoServiceProvider", true };
+                    yield return new object[] { "3DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "Triple DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", true };
+                    yield return new object[] { "Rijndael", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.Rijndael", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.SymmetricAlgorithm", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "AES", "System.Security.Cryptography.AesCryptoServiceProvider", true };
+                    yield return new object[] { "AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", true };
+                    yield return new object[] { "System.Security.Cryptography.AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", true };
+                    yield return new object[] { "AesManaged", typeof(AesManaged).FullName, true };
+                    yield return new object[] { "System.Security.Cryptography.AesManaged", typeof(AesManaged).FullName, true };
 
-                // Xml Dsig/ Enc Hash algorithms
-                yield return new object[] { "http://www.w3.org/2000/09/xmldsig#sha1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha256", typeof(SHA256Managed).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha512", typeof(SHA512Managed).FullName, true };
+                    // Xml Dsig/ Enc Hash algorithms
+                    yield return new object[] { "http://www.w3.org/2000/09/xmldsig#sha1", "System.Security.Cryptography.SHA1CryptoServiceProvider", true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha256", typeof(SHA256Managed).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha512", typeof(SHA512Managed).FullName, true };
 
-                // Xml Encryption symmetric keys
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#des-cbc", "System.Security.Cryptography.DESCryptoServiceProvider", true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#tripledes-cbc", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-tripledes", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes128-cbc", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes128", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes192-cbc", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes192", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes256-cbc", typeof(RijndaelManaged).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes256", typeof(RijndaelManaged).FullName, true };
+                    // Xml Encryption symmetric keys
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#des-cbc", "System.Security.Cryptography.DESCryptoServiceProvider", true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#tripledes-cbc", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-tripledes", "System.Security.Cryptography.TripleDESCryptoServiceProvider", true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes128-cbc", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes128", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes192-cbc", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes192", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes256-cbc", typeof(RijndaelManaged).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes256", typeof(RijndaelManaged).FullName, true };
 
-                // Xml Dsig HMAC URIs from http://www.w3.org/TR/xmldsig-core/
-                yield return new object[] { "http://www.w3.org/2000/09/xmldsig#hmac-sha1", typeof(HMACSHA1).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#sha384", typeof(SHA384Managed).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-md5", typeof(HMACMD5).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256", typeof(HMACSHA256).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384", typeof(HMACSHA384).FullName, true };
-                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512", typeof(HMACSHA512).FullName, true };
+                    // Xml Dsig HMAC URIs from http://www.w3.org/TR/xmldsig-core/
+                    yield return new object[] { "http://www.w3.org/2000/09/xmldsig#hmac-sha1", typeof(HMACSHA1).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#sha384", typeof(SHA384Managed).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-md5", typeof(HMACMD5).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256", typeof(HMACSHA256).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384", typeof(HMACSHA384).FullName, true };
+                    yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512", typeof(HMACSHA512).FullName, true };
 
-                // X509
-                yield return new object[] { "2.5.29.10", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
-                yield return new object[] { "2.5.29.19", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
-                yield return new object[] { "2.5.29.14", "System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension", true };
-                yield return new object[] { "2.5.29.15", "System.Security.Cryptography.X509Certificates.X509KeyUsageExtension", true };
-                yield return new object[] { "2.5.29.37", "System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension", true };
-                yield return new object[] { "X509Chain", "System.Security.Cryptography.X509Certificates.X509Chain", true };
+                    // X509
+                    yield return new object[] { "2.5.29.10", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
+                    yield return new object[] { "2.5.29.19", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
+                    yield return new object[] { "2.5.29.14", "System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension", true };
+                    yield return new object[] { "2.5.29.15", "System.Security.Cryptography.X509Certificates.X509KeyUsageExtension", true };
+                    yield return new object[] { "2.5.29.37", "System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension", true };
+                    yield return new object[] { "X509Chain", "System.Security.Cryptography.X509Certificates.X509Chain", true };
 
-                // PKCS9 attributes
-                yield return new object[] { "1.2.840.113549.1.9.3", "System.Security.Cryptography.Pkcs.Pkcs9ContentType", true };
-                yield return new object[] { "1.2.840.113549.1.9.4", "System.Security.Cryptography.Pkcs.Pkcs9MessageDigest", true };
-                yield return new object[] { "1.2.840.113549.1.9.5", "System.Security.Cryptography.Pkcs.Pkcs9SigningTime", true };
-                yield return new object[] { "1.3.6.1.4.1.311.88.2.1", "System.Security.Cryptography.Pkcs.Pkcs9DocumentName", true };
-                yield return new object[] { "1.3.6.1.4.1.311.88.2.2", "System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription", true };
+                    // PKCS9 attributes
+                    yield return new object[] { "1.2.840.113549.1.9.3", "System.Security.Cryptography.Pkcs.Pkcs9ContentType", true };
+                    yield return new object[] { "1.2.840.113549.1.9.4", "System.Security.Cryptography.Pkcs.Pkcs9MessageDigest", true };
+                    yield return new object[] { "1.2.840.113549.1.9.5", "System.Security.Cryptography.Pkcs.Pkcs9SigningTime", true };
+                    yield return new object[] { "1.3.6.1.4.1.311.88.2.1", "System.Security.Cryptography.Pkcs.Pkcs9DocumentName", true };
+                    yield return new object[] { "1.3.6.1.4.1.311.88.2.2", "System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription", true };
+                }
             }
         }
 
@@ -290,6 +322,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void CreateFromName_CtorArguments()
         {
             string className = typeof(ClassWithCtorArguments).FullName + ", System.Security.Cryptography.Algorithms.Tests";
@@ -307,6 +340,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void EncodeOID_Validation()
         {
             Assert.Throws<ArgumentNullException>(() => CryptoConfig.EncodeOID(null));
@@ -317,6 +351,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void EncodeOID_Compat()
         {
             string actual = CryptoConfig.EncodeOID("-1.2.-3").ByteArrayToHex();
@@ -324,6 +359,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void EncodeOID_Length_Boundary()
         {
             string valueToRepeat = "1.1";
@@ -341,6 +377,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [InlineData(0x4000, "0603818028")]
         [InlineData(0x200000, "060481808028")]
         [InlineData(0x10000000, "06058180808028")]
@@ -356,6 +393,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
 
         [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [InlineData("SHA1", "1.3.14.3.2.26", "06052B0E03021A")]
         [InlineData("DES", "1.3.14.3.2.7", "06052B0E030207")]
         [InlineData("MD5", "1.2.840.113549.2.5", "06082A864886F70D0205")]


### PR DESCRIPTION
Hardcodes the mapping for the SHA* hashes supported on WebAssembly from https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptoconfig?view=net-5.0#remarks

Fixes https://github.com/dotnet/runtime/issues/44996