### PR TITLE
Fix mscordbi RPATH to find libmscordaccore.dylib

### DIFF
--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -2,16 +2,10 @@
 # Set the RPATH of mscordbi so that it can find dependencies without needing to set LD_LIBRARY_PATH
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
 if(CORECLR_SET_RPATH)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
   if(CLR_CMAKE_HOST_OSX)
-    if(CLR_CMAKE_HOST_ARCH_ARM64)
-      set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
-      set(CMAKE_INSTALL_NAME_DIR "@rpath")
-    else(CLR_CMAKE_HOST_ARCH_ARM64)
-      set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-      set(CMAKE_INSTALL_RPATH "@loader_path")
-    endif(CLR_CMAKE_HOST_ARCH_ARM64)
+    set(CMAKE_INSTALL_RPATH "@loader_path")
   else()
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN")
   endif(CLR_CMAKE_HOST_OSX)
 endif(CORECLR_SET_RPATH)


### PR DESCRIPTION
Now LC_RPATH for libmscordbi.dylib on macOS ARM64 is set to @loader_path again.  This commit partly reverts #45978.

Similar to #50932.