### PR TITLE
Issue 50442

### DIFF
--- a/src/coreclr/debug/shim/debugshim.cpp
+++ b/src/coreclr/debug/shim/debugshim.cpp
@@ -323,6 +323,12 @@ STDMETHODIMP CLRDebuggingImpl::OpenVirtualProcess(
     {
         pDt->Release();
     }
+    
+    if (hDac != NULL)
+    {
+        FreeLibrary(hDac);
+    }
+
 
     return hr;
 }

--- a/src/coreclr/debug/shim/debugshim.cpp
+++ b/src/coreclr/debug/shim/debugshim.cpp
@@ -329,6 +329,10 @@ STDMETHODIMP CLRDebuggingImpl::OpenVirtualProcess(
         FreeLibrary(hDac);
     }
 
+    if (hDbi != NULL)
+    {
+        FreeLibrary(hDbi);
+    }
 
     return hr;
 }


### PR DESCRIPTION
`hDac` and `hDbi` to be freed at the end of the function

Fix #50442