### PR TITLE
Disable regression test 49826 failing after a library refactoring

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -11,6 +11,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_49826/test49826/*">
+            <Issue>https://github.com/dotnet/runtime/issues/51542</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/51542