### PR TITLE
Reduce unnecessary allocation of SeldomUsedFields in MemoryCache.

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
@@ -144,7 +144,7 @@ namespace System.Runtime.Caching
 
             _callback = removedCallback;
 
-            // CacheItemPolicy.ChangeMonitors is frequntly the source for 'dependencies', and that property
+            // CacheItemPolicy.ChangeMonitors is frequently the source for 'dependencies', and that property
             // is never null. So check that the collection of dependencies is not empty before allocating
             // the 'seldom' used fields.
             if (dependencies != null && dependencies.Count > 0)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
@@ -144,7 +144,10 @@ namespace System.Runtime.Caching
 
             _callback = removedCallback;
 
-            if (dependencies != null)
+            // CacheItemPolicy.ChangeMonitors is frequntly the source for 'dependencies', and that property
+            // is never null. So check that the collection of dependencies is not empty before allocating
+            // the 'seldom' used fields.
+            if (dependencies != null && dependencies.Count > 0)
             {
                 _fields = new SeldomUsedFields();
                 _fields._dependencies = dependencies;


### PR DESCRIPTION
Reduce unnecessary allocation of SeldomUsedFields in MemoryCache.

Checking for the existence of a 'seldom used field' would trigger
the allocation of this object, even if none of the fields were being
used. And this check/trigger happens on just about every item
inserted in the cache, meaning this perf optimization wasn't actually
saving anything. The fix is to not allocate when simply checking
for the existence of these fields.

Fix #1425