### PR TITLE
Fix handling of multidimensional arrays in type system and dotnet-pgo

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -27,7 +27,8 @@ namespace Internal.TypeSystem
     public enum EmbeddedSignatureDataKind
     {
         RequiredCustomModifier = 0,
-        OptionalCustomModifier = 1
+        OptionalCustomModifier = 1,
+        ArrayShape = 2
     }
 
     public struct EmbeddedSignatureData

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -36,6 +36,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="../../Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs" />
     <Compile Include="ArchitectureSpecificFieldLayoutTests.cs" />
     <Compile Include="CanonicalizationTests.cs" />
     <Compile Include="ConstraintsValidationTest.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
@@ -29,6 +29,11 @@
   {
      ret
   }
+
+  .method public hidebysig instance int32 modopt([CoreTestAssembly]System.Void) [3,1 ... 4] Method4(int32 modopt(FooModifier)[2 ...,0...8], int32 modopt(FooModifier)[0...,...], int32 [,,,]) cil managed
+  {
+     ret
+  }
 }
 
 .class private auto ansi beforefieldinit Atom

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
+
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 using Internal.IL;
 using Internal.TypeSystem;
@@ -37,7 +41,10 @@ namespace TypeSystemTests
             {
                 sb.Append(data.kind.ToString());
                 sb.Append(data.index);
-                sb.Append(((MetadataType)data.type).Name);
+                if (data.type != null)
+                    sb.Append(((MetadataType)data.type).Name);
+                else
+                    sb.Append("<null>");
             }
             return sb.ToString();
         }
@@ -80,6 +87,19 @@ namespace TypeSystemTests
         }
 
         [Fact]
+        public void TestSignatureMatchesForArrayShapeDetails()
+        {
+            MetadataType modOptTester = _testModule.GetType("", "ModOptTester");
+            MethodSignature methodWithModOpt = modOptTester.GetMethods().Single(m => string.Equals(m.Name, "Method4")).Signature;
+
+            Assert.Equal(6, methodWithModOpt.GetEmbeddedSignatureData().Length);
+            Assert.Equal(MethodSignature.GetIndexOfCustomModifierOnPointedAtTypeByParameterIndex(0), methodWithModOpt.GetEmbeddedSignatureData()[0].index);
+            Assert.Equal(MethodSignature.GetIndexOfCustomModifierOnPointedAtTypeByParameterIndex(1), methodWithModOpt.GetEmbeddedSignatureData()[2].index);
+            Assert.Equal(MethodSignature.GetIndexOfCustomModifierOnPointedAtTypeByParameterIndex(2), methodWithModOpt.GetEmbeddedSignatureData()[4].index);
+            Assert.Equal("OptionalCustomModifier0.1.1.2.1.1VoidArrayShape1.2.1.1|3,4|0,1<null>OptionalCustomModifier0.1.1.2.2.1FooModifierArrayShape1.2.2.1|0,9|2,0<null>OptionalCustomModifier0.1.1.2.3.1FooModifierArrayShape1.2.3.1||0<null>", GetModOptMethodSignatureInfo(methodWithModOpt));
+        }
+
+        [Fact]
         public void TestSignatureMatches()
         {
             MetadataType atomType = _testModule.GetType("", "Atom");
@@ -100,6 +120,62 @@ namespace TypeSystemTests
             IEnumerable<bool> matches = derivedClassMethods.Select(m => matchingSignature.Equals(m.Signature));
             int matchCount = matches.Select(b => b ? 1 : 0).Sum();
             Assert.Equal(1, matchCount);
+        }
+
+        [Fact]
+        public void TestSerializedSignatureWithArrayShapes()
+        {
+            MetadataType modOptTester = _testModule.GetType("", "ModOptTester");
+            MethodDesc methodWithInterestingShapes = modOptTester.GetMethods().Single(m => string.Equals(m.Name, "Method4"));
+
+            // Create assembly with reference to interesting method
+            TypeSystemMetadataEmitter metadataEmitter = new TypeSystemMetadataEmitter(new System.Reflection.AssemblyName("Lookup"), _context);
+            var token = metadataEmitter.GetMethodRef(methodWithInterestingShapes);
+            Stream peStream = new MemoryStream();
+            metadataEmitter.SerializeToStream(peStream);
+            peStream.Seek(0, SeekOrigin.Begin);
+
+
+            // Create new TypeSystemContext with just created assembly inside
+            var lookupContext = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = lookupContext.CreateModuleForSimpleName("CoreTestAssembly");
+            lookupContext.SetSystemModule(systemModule);
+
+            lookupContext.CreateModuleForSimpleName("Lookup", peStream);
+
+            // Use generated assembly to trigger a load through the token created above and verify that it loads correctly
+            var ilLookupModule = (EcmaModule)lookupContext.GetModuleForSimpleName("Lookup");
+            MethodDesc method4 = ilLookupModule.GetMethod(token);
+
+            Assert.Equal("Method4", method4.Name);
+        }
+
+
+        [Fact]
+        public void TestSerializedSignatureWithReferenceToMDIntArray()
+        {
+            var typeInInitialContext = _context.GetWellKnownType(WellKnownType.Int32).MakeArrayType(3);
+
+            // Create assembly with reference to interesting type
+            TypeSystemMetadataEmitter metadataEmitter = new TypeSystemMetadataEmitter(new System.Reflection.AssemblyName("Lookup"), _context);
+            var token = metadataEmitter.GetTypeRef(typeInInitialContext);
+            Stream peStream = new MemoryStream();
+            metadataEmitter.SerializeToStream(peStream);
+            peStream.Seek(0, SeekOrigin.Begin);
+
+
+            // Create new TypeSystemContext with just created assembly inside
+            var lookupContext = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = lookupContext.CreateModuleForSimpleName("CoreTestAssembly");
+            lookupContext.SetSystemModule(systemModule);
+            lookupContext.CreateModuleForSimpleName("Lookup", peStream);
+
+            // Use generated assembly to trigger a load through the token created above and verify that it loads correctly
+            var ilLookupModule = (EcmaModule)lookupContext.GetModuleForSimpleName("Lookup");
+            TypeDesc int32ArrayFromLookup = ilLookupModule.GetType(token);
+            var typeInLookupContext = lookupContext.GetWellKnownType(WellKnownType.Int32).MakeArrayType(3);
+
+            Assert.Equal(typeInLookupContext, int32ArrayFromLookup);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/TestTypeSystemContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/TestTypeSystemContext.cs
@@ -43,11 +43,17 @@ namespace TypeSystemTests
             return CreateModuleForSimpleName(simpleName);
         }
 
-        public ModuleDesc CreateModuleForSimpleName(string simpleName)
+        public ModuleDesc CreateModuleForSimpleName(string simpleName, Stream preLoadedFile = null)
         {
             string bindingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string filePath = Path.Combine(bindingDirectory, simpleName + ".dll");
-            ModuleDesc module = Internal.TypeSystem.Ecma.EcmaModule.Create(this, new PEReader(File.OpenRead(filePath)), containingAssembly: null);
+            Stream peStream = preLoadedFile;
+            if (peStream == null)
+            {
+                peStream = File.OpenRead(filePath);
+            }
+
+            ModuleDesc module = Internal.TypeSystem.Ecma.EcmaModule.Create(this, new PEReader(peStream), containingAssembly: null);
             _modules.Add(simpleName, module);
             return module;
         }

--- a/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
+++ b/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\aot\ILCompiler.ReadyToRun\Compiler\ProfileData.cs" Link="ProfileData.cs" />
     <Compile Include="..\Common\Pgo\TypeSystemEntityOrUnknown.cs" Link="TypeSystemEntityOrUnknown.cs" />
     <Compile Include="..\Common\TypeSystem\IL\ILReader.cs" Link="ILReader.cs" />
+    <Compile Include="..\Common\TypeSystem\MetadataEmitter\TypeSystemMetadataEmitter.cs" Link="TypeSystemMetadataEmitter" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Provide representation for multidimensional array non-standard shapes in embedded signature data (to allow overloads)
  - This fixes possible issues in interop with C++ and IL generated binaries in crossgen2 as well as these issues in dotnet-pgo
- Move type system metadata emitter logic from dotnet-pgo source base to common
  - Enables creation of unittests to cover the bugs identified
- Fix emission of multidimensional arrays in signature emitter
  - Emit complex array shape when available
  - Even when standard shape is in place, pass empty ImmutableArrays for bounds and lobounds, not just default
- Fix handling of multidimensional arrays when generating a type reference
  - If a type isn't a MetadataType don't treat it as one

Also a small drive-by fix to reduce unnecessary throwing of exceptions while running dotnet-pgo