### PR TITLE
Add Infra for porting lib only packages to use dotnet pack instead of pkgprojs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -230,9 +230,9 @@
     <RepositoryUrl>https://github.com/dotnet/$(GitHubRepositoryName)</RepositoryUrl>
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <Owners>microsoft,dotnetframework</Owners>
+    <IncludeSymbols>true</IncludeSymbols>
     <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
-    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>$(CopyrightNetFoundation)</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -232,7 +232,10 @@
     <Owners>microsoft,dotnetframework</Owners>
     <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
+    <PackageProjectUrl>$(ProjectUrl)</PackageProjectUrl>
+    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -232,7 +232,6 @@
     <Owners>microsoft,dotnetframework</Owners>
     <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
-    <PackageProjectUrl>$(ProjectUrl)</PackageProjectUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsPackagesDir)', 'specs'))</NuSpecOutputPath>
     <PkgProjPath>$(MSBuildProjectDirectory)\..\pkg\$(MSBuildProjectName).pkgproj</PkgProjPath>
   </PropertyGroup>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -230,7 +230,7 @@
     <ExcludeFromPackage Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(ExcludeCurrentNetCoreAppFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true' and '$(IsPackable)' == 'true' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(TargetFrameworkIdentifier)' != '.NETStandard' and '$(TargetFrameworkVersion)' != 'v2.0'">
+  <PropertyGroup Condition="'$(IsCrossTargetingBuild)' != 'true' and '$(DotnetBuildFromSource)' == 'true' and '$(IsPackable)' == 'true' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(TargetFrameworkIdentifier)' != '.NETStandard' and '$(TargetFrameworkVersion)' != 'v2.0'">
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -281,9 +281,9 @@
 
   <Target Name="LibIntellisenseDocs" Condition="'$(IncludeBuildOutput)' == 'true'">
    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(XmlDocFileRoot)1033\$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)1033\$(TargetName).xml')">
-        <PackagePath>lib/$(TargetFramework)</PackagePath>
-      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(XmlDocFileRoot)1033\$(TargetName).xml"
+                              Condition="Exists('$(XmlDocFileRoot)1033\$(TargetName).xml')"
+                              PackagePath="lib/$(TargetFramework)" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -230,6 +230,10 @@
     <ExcludeFromPackage Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(ExcludeCurrentNetCoreAppFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true' and '$(TargetFramework)' != ''">
+    <IncludeBuildOutput Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)')) and '$(TargetFramework)' != 'netstandard2.0'">false</IncludeBuildOutput>
+  </PropertyGroup>
+
   <!-- If a project is downlevel from net5.0 but uses the platform support attributes, then we include the
        System.Runtime.Versioning*Platform* annotation attribute classes in the project as internal.
 
@@ -274,7 +278,7 @@
     </When>
   </Choose>
 
-  <Target Name="LibIntellisenseDocs">
+  <Target Name="LibIntellisenseDocs" Condition="'$(IncludeBuildOutput)' == 'true'">
    <ItemGroup>
       <TfmSpecificPackageFile Include="$(XmlDocFileRoot)/1033/$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)/1033/$(TargetName).xml')">
         <PackagePath>lib/$(TargetFramework)</PackagePath>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -12,7 +12,7 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage Condition="'$(IsPackable)' == 'true'">AddLibIntelDocs;$(TargetsForTfmSpecificContentInPackage)</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(IsPackable)' == 'true'">LibIntellisenseDocs;$(TargetsForTfmSpecificContentInPackage)</TargetsForTfmSpecificContentInPackage>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable;CA1052</NoWarn>
@@ -274,7 +274,7 @@
     </When>
   </Choose>
 
-  <Target Name="AddLibIntelDocs">
+  <Target Name="LibIntellisenseDocs">
    <ItemGroup>
       <TfmSpecificPackageFile Include="$(XmlDocFileRoot)/1033/$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)/1033/$(TargetName).xml')">
         <PackagePath>lib/$(TargetFramework)</PackagePath>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -232,6 +232,7 @@
 
   <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true' and '$(TargetFramework)' != ''">
     <IncludeBuildOutput Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)')) and '$(TargetFramework)' != 'netstandard2.0'">false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)')) and '$(TargetFramework)' != 'netstandard2.0'">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <!-- If a project is downlevel from net5.0 but uses the platform support attributes, then we include the

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -12,6 +12,7 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(IsPackable)' == 'true'">AddLibIntelDocs;$(TargetsForTfmSpecificContentInPackage)</TargetsForTfmSpecificContentInPackage>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable;CA1052</NoWarn>
@@ -272,4 +273,20 @@
       </ItemGroup>
     </When>
   </Choose>
+
+  <Target Name="AddLibIntelDocs">
+   <ItemGroup>
+      <TfmSpecificPackageFile Include="$(XmlDocFileRoot)/1033/$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)/1033/$(TargetName).xml')">
+        <PackagePath>lib/$(TargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveXmlFilesFromBuildOutput" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll;.exe;.winmd;.json;.pri;</AllowedOutputExtensionsInPackageBuildOutputFolder> 
+      <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb;.mdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -281,7 +281,7 @@
 
   <Target Name="LibIntellisenseDocs" Condition="'$(IncludeBuildOutput)' == 'true'">
    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(XmlDocFileRoot)/1033/$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)/1033/$(TargetName).xml')">
+      <TfmSpecificPackageFile Include="$(XmlDocFileRoot)1033\$(TargetName).xml" Condition="Exists('$(XmlDocFileRoot)1033\$(TargetName).xml')">
         <PackagePath>lib/$(TargetFramework)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -12,7 +12,7 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage Condition="'$(IsPackable)' == 'true'">LibIntellisenseDocs;$(TargetsForTfmSpecificContentInPackage)</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(IsPackable)' == 'true'">$(TargetsForTfmSpecificContentInPackage);LibIntellisenseDocs</TargetsForTfmSpecificContentInPackage>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable;CA1052</NoWarn>
@@ -286,6 +286,7 @@
     </ItemGroup>
   </Target>
 
+  <!-- TODO: Remove this after https://github.com/NuGet/NuGet.Client/pull/3980 is merged.-->
   <Target Name="RemoveXmlFilesFromBuildOutput" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
       <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll;.exe;.winmd;.json;.pri;</AllowedOutputExtensionsInPackageBuildOutputFolder> 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -230,9 +230,9 @@
     <ExcludeFromPackage Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(ExcludeCurrentNetCoreAppFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true' and '$(TargetFramework)' != ''">
-    <IncludeBuildOutput Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)')) and '$(TargetFramework)' != 'netstandard2.0'">false</IncludeBuildOutput>
-    <SuppressDependenciesWhenPacking Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)')) and '$(TargetFramework)' != 'netstandard2.0'">true</SuppressDependenciesWhenPacking>
+  <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true' and '$(IsPackable)' == 'true' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')) and '$(TargetFrameworkIdentifier)' != '.NETStandard' and '$(TargetFrameworkVersion)' != 'v2.0'">
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <!-- If a project is downlevel from net5.0 but uses the platform support attributes, then we include the

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageDescription>Environment variables configuration provider implementation for Microsoft.Extensions.Configuration.</PackageDescription>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/pkg/Microsoft.Extensions.Configuration.EnvironmentVariables.pkgproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/pkg/Microsoft.Extensions.Configuration.EnvironmentVariables.pkgproj
@@ -1,9 +1,0 @@
-<Project DefaultTargets="Build">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
-  <ItemGroup>
-    <ProjectReference Include="..\src\Microsoft.Extensions.Configuration.EnvironmentVariables.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
-</Project> 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <IncludeSymbols>true</IncludeSymbols>
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>Environment variables configuration provider implementation for Microsoft.Extensions.Configuration.</PackageDescription>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -5,6 +5,7 @@
     <IsPackable>true</IsPackable>
     <EnableDefaultItems>true</EnableDefaultItems>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <PackageDescription>Environment variables configuration provider implementation for Microsoft.Extensions.Configuration.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -9,6 +9,7 @@
     <IsSourceProject>false</IsSourceProject>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- No Dependencies-->
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
+    <TraversalGlobalProperties>BuildAllProjects=true;BuildTargetFramework=</TraversalGlobalProperties>
     <AdditionalBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalBuildTargetFrameworks);package-$(Configuration)</AdditionalBuildTargetFrameworks>
   </PropertyGroup>
 

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TraversalGlobalProperties>BuildAllProjects=true;BuildTargetFramework=</TraversalGlobalProperties>
+    <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
     <AdditionalBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalBuildTargetFrameworks);package-$(Configuration)</AdditionalBuildTargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Related PR https://github.com/dotnet/runtime/pull/48385

Design Changes
- no more pkgproj
- separate symbol nuspec files
- minor change in metadata like no owners (Metadata not supported by the nuget pack)
- nuspec name contains package version
- no more pkgpath files (not sure why we were producing it in the first place)
- no more package reports
- removed implicit framework assembly references from the package like mscorlib.dll for net472
- exclude="Build,Analyzers"  for all dependencies

Validation changes
- Closure verification in the all config
- Package validation during build packages is no longer done as it was not doing any substantial work for extensions packages.

Test
- verified the nuspec files to check
- did a beynd comparer for the overall artifacts, changes were expected


- moving just one proj to unblock this effort and to add infra, (will start moving similar projs after this one is merged) 



Added few comments in response to the comments to the previous linked pr