### PR TITLE
Add another try/catch into IBC parser

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -130,7 +130,14 @@ namespace ILCompiler.IBC
                                     fixed (byte* pb = &paramSignatureEntry.Signature[0])
                                     {
                                         BlobReader br = new BlobReader(pb, paramSignatureEntry.Signature.Length);
-                                        associatedMethod = GetSigMethodInstantiationFromIBCMethodSpec(ibcModule, br);
+                                        try
+                                        {
+                                            associatedMethod = GetSigMethodInstantiationFromIBCMethodSpec(ibcModule, br);
+                                        }
+                                        catch
+                                        {
+                                            associatedMethod = null;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Parsing MethodSpecs from an IBC file can fail with an exception (the IBC format is not safely parseable)
- Add a try catch, to prevent errors from killing the process.

Partial fix for #51732