### PR TITLE
Add validation for MetadataType attribute - Issue #46678

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -116,7 +116,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <param name="type">The type whose store item is needed.  It cannot be null</param>
         /// <returns>The type store item.  It will not be null.</returns>
-        private TypeStoreItem GetTypeStoreItem([DynamicallyAccessedMembers(TypeStoreItem.DynamicallyAccessedTypes)] Type type)
+        private TypeStoreItem GetTypeStoreItem([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             Debug.Assert(type != null);
 
@@ -170,19 +170,18 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         private sealed class TypeStoreItem : StoreItem
         {
-            internal const DynamicallyAccessedMemberTypes DynamicallyAccessedTypes = DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties;
-
             private readonly object _syncRoot = new object();
-            [DynamicallyAccessedMembers(DynamicallyAccessedTypes)]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             private readonly Type _type;
             private Dictionary<string, PropertyStoreItem>? _propertyStoreItems;
 
-            internal TypeStoreItem([DynamicallyAccessedMembers(DynamicallyAccessedTypes)] Type type, IEnumerable<Attribute> attributes)
+            internal TypeStoreItem([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, IEnumerable<Attribute> attributes)
                 : base(attributes)
             {
                 _type = type;
             }
 
+            [RequiresUnreferencedCode("The Type of _type cannot be statically discovered.")]
             internal PropertyStoreItem GetPropertyStoreItem(string propertyName)
             {
                 if (!TryGetPropertyStoreItem(propertyName, out PropertyStoreItem? item))
@@ -194,6 +193,7 @@ namespace System.ComponentModel.DataAnnotations
                 return item;
             }
 
+            [RequiresUnreferencedCode("The Type of _type cannot be statically discovered.")]
             internal bool TryGetPropertyStoreItem(string propertyName, [NotNullWhen(true)] out PropertyStoreItem? item)
             {
                 if (string.IsNullOrEmpty(propertyName))
@@ -215,22 +215,49 @@ namespace System.ComponentModel.DataAnnotations
                 return _propertyStoreItems.TryGetValue(propertyName, out item);
             }
 
+            [RequiresUnreferencedCode("The Types of _type's properties cannot be statically discovered.")]
             private Dictionary<string, PropertyStoreItem> CreatePropertyStoreItems()
             {
-                var propertyStoreItems = new Dictionary<string, PropertyStoreItem>();
-
-                // exclude index properties to match old TypeDescriptor functionality
-                var properties = _type.GetRuntimeProperties()
-                    .Where(prop => IsPublic(prop) && !prop.GetIndexParameters().Any());
-                foreach (PropertyInfo property in properties)
+                Dictionary<string, PropertyStoreItem> propertyStoreItems = new Dictionary<string, PropertyStoreItem>();
+                PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this._type);
+                foreach (PropertyDescriptor property in properties)
                 {
-                    // use CustomAttributeExtensions.GetCustomAttributes() to get inherited attributes as well as direct ones
-                    var item = new PropertyStoreItem(property.PropertyType,
-                        CustomAttributeExtensions.GetCustomAttributes(property, true));
+                    PropertyStoreItem item = new PropertyStoreItem(property.PropertyType, GetExplicitAttributes(property).Cast<Attribute>());
                     propertyStoreItems[property.Name] = item;
                 }
 
                 return propertyStoreItems;
+            }
+
+            /// <summary>
+            /// Method to extract only the explicitly specified attributes from a <see cref="PropertyDescriptor"/>
+            /// </summary>
+            /// <remarks>
+            /// Normal TypeDescriptor semantics are to inherit the attributes of a property's type.  This method
+            /// exists to suppress those inherited attributes.
+            /// </remarks>
+            /// <param name="propertyDescriptor">The property descriptor whose attributes are needed.</param>
+            /// <returns>A new <see cref="AttributeCollection"/> stripped of any attributes from the property's type.</returns>
+            [RequiresUnreferencedCode("The Type of propertyDescriptor.PropertyType cannot be statically discovered. ")]
+            private AttributeCollection GetExplicitAttributes(PropertyDescriptor propertyDescriptor)
+            {
+                List<Attribute> attributes = new List<Attribute>(propertyDescriptor.Attributes.Cast<Attribute>());
+                IEnumerable<Attribute> typeAttributes = TypeDescriptor.GetAttributes(propertyDescriptor.PropertyType).Cast<Attribute>();
+                bool removedAttribute = false;
+                foreach (Attribute attr in typeAttributes)
+                {
+                    for (int i = attributes.Count - 1; i >= 0; --i)
+                    {
+                        // We must use ReferenceEquals since attributes could Match if they are the same.
+                        // Only ReferenceEquals will catch actual duplications.
+                        if (object.ReferenceEquals(attr, attributes[i]))
+                        {
+                            attributes.RemoveAt(i);
+                            removedAttribute = true;
+                        }
+                    }
+                }
+                return removedAttribute ? new AttributeCollection(attributes.ToArray()) : propertyDescriptor.Attributes;
             }
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -514,17 +514,16 @@ namespace System.ComponentModel.DataAnnotations
         private static ICollection<KeyValuePair<ValidationContext, object?>> GetPropertyValues(object instance,
             ValidationContext validationContext)
         {
-            var properties = instance.GetType().GetRuntimeProperties()
-                                .Where(p => ValidationAttributeStore.IsPublic(p) && !p.GetIndexParameters().Any());
-            var items = new List<KeyValuePair<ValidationContext, object?>>(properties.Count());
-            foreach (var property in properties)
+            var properties = TypeDescriptor.GetProperties(instance);
+            var items = new List<KeyValuePair<ValidationContext, object?>>(properties.Count);
+            foreach (PropertyDescriptor property in properties)
             {
                 var context = CreateValidationContext(instance, validationContext);
                 context.MemberName = property.Name;
 
                 if (_store.GetPropertyValidationAttributes(context).Any())
                 {
-                    items.Add(new KeyValuePair<ValidationContext, object?>(context, property.GetValue(instance, null)));
+                    items.Add(new KeyValuePair<ValidationContext, object?>(context, property.GetValue(instance)));
                 }
             }
 

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -231,6 +231,108 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Contains("Required", Assert.Single(results).ErrorMessage);
         }
 
+        [Fact]
+        public static void TryValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_required_attribute_fails_validation()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Valid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Equal("The SecondPropertyToBeTested field is required.", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static void TryValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_attribute_fails_validation()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Valid Value",
+                SecondPropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static void TryValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_has_unmatched_property_name()
+        {
+            var objectToBeValidated = new HasMetadataTypeWithUnmatchedProperties()
+            {
+                PropertyToBeTested = "Valid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithUnmatchedProperties), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithUnmatchedProperties));
+
+            var validationResults = new List<ValidationResult>();
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal("The associated metadata type for type 'System.ComponentModel.DataAnnotations.Tests.ValidatorTests+HasMetadataTypeWithUnmatchedProperties' contains the following unknown properties or fields: SecondPropertyToBeTested. Please make sure that the names of these members match the names of the properties on the main type.",
+                exception.Message);
+        }
+
+        [Fact]
+        public static void TryValidateObject_returns_false_if_property_attribute_is_not_removed_by_metadatatype_class()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(2, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value");
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is required.");
+        }
+
+        [Fact]
+        public static void TryValidateObject_returns_false_if_property_has_attributes_from_base_and_metadatatype_classes()
+        {
+            var objectToBeValidated = new HasMetadataTypeWithComplementaryRequirements()
+            {
+                SecondPropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithComplementaryRequirements), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithComplementaryRequirements));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(2, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is not a valid phone number.");
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.");
+        }
+
+        [Fact]
+        public static void TryValidateObject_returns_false_if_validation_fails_when_class_references_itself_as_a_metadatatype()
+        {
+            var objectToBeValidated = new SelfMetadataType()
+            {
+                PropertyToBeTested = "Invalid Value",
+                SecondPropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SelfMetadataType), typeof(SelfMetadataType)), typeof(SelfMetadataType));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(2, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value");
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is not a valid phone number.");
+        }
+
         public class RequiredFailure
         {
             [Required]
@@ -365,6 +467,125 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
             Validator.ValidateObject(instance, context);
         }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_required_attribute_fails_validation()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Valid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The SecondPropertyToBeTested field is required.", exception.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_attribute_fails_validation()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Valid Value",
+                SecondPropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.", exception.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_all_properties_are_valid_but_metadatatype_class_has_unmatched_property_name()
+        {
+            var objectToBeValidated = new HasMetadataTypeWithUnmatchedProperties()
+            {
+                PropertyToBeTested = "Valid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithUnmatchedProperties), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithUnmatchedProperties));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The associated metadata type for type 'System.ComponentModel.DataAnnotations.Tests.ValidatorTests+HasMetadataTypeWithUnmatchedProperties' contains the following unknown properties or fields: SecondPropertyToBeTested. Please make sure that the names of these members match the names of the properties on the main type.",
+                exception.Message);
+        }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_property_attribute_is_not_removed_by_metadatatype_class()
+        {
+            var objectToBeValidated = new HasMetadataTypeToBeValidated()
+            {
+                PropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value",
+                exception.Message);
+        }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_property_has_attributes_from_base_and_metadatatype_classes()
+        {
+            var objectToBeValidated = new HasMetadataTypeWithComplementaryRequirements()
+            {
+                PropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithComplementaryRequirements), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithComplementaryRequirements));
+
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value",
+                exception.Message);
+
+            objectToBeValidated.PropertyToBeTested = null;
+            objectToBeValidated.SecondPropertyToBeTested = "Not Phone #";
+
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The SecondPropertyToBeTested field is not a valid phone number.",
+                exception.Message);
+
+            objectToBeValidated.SecondPropertyToBeTested = "0800123456789";
+
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.",
+                exception.Message);
+        }
+
+        [Fact]
+        public static void ValidateObject_returns_false_if_validation_fails_when_class_references_itself_as_a_metadatatype()
+        {
+            var objectToBeValidated = new SelfMetadataType()
+            {
+                PropertyToBeTested = "Invalid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SelfMetadataType), typeof(SelfMetadataType)), typeof(SelfMetadataType));
+
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value",
+                exception.Message);
+
+            objectToBeValidated.PropertyToBeTested = null;
+            objectToBeValidated.SecondPropertyToBeTested = "Not Phone #";
+
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateObject(objectToBeValidated, validationContext, true));
+            Assert.Equal("The SecondPropertyToBeTested field is not a valid phone number.",
+                exception.Message);
+        }
+
         #endregion ValidateObject
 
         #region TryValidateProperty
@@ -521,6 +742,84 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(0, validationResults.Count);
         }
 
+        [Fact]
+        public static void TryValidateProperty_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_required_attribute_fails_validation()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            Assert.False(Validator.TryValidateProperty(null, validationContext, null));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateProperty(null, validationContext, validationResults));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Equal("The SecondPropertyToBeTested field is required.", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static void TryValidateProperty_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_attribute_fails_validation()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, null));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, validationResults));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static void TryValidateProperty_returns_true_if_property_attribute_is_not_removed_by_metadatatype_class()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "PropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, null));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, validationResults));
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static void TryValidateProperty_returns_true_if_property_has_attributes_from_base_and_metadatatype_classes()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeWithComplementaryRequirements());
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithComplementaryRequirements), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithComplementaryRequirements));
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, null));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, validationResults));
+            Assert.Equal(2, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is not a valid phone number.");
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.");
+        }
+
+        [Fact]
+        public static void TryValidateProperty_returns_false_if_validation_fails_when_class_references_itself_as_a_metadatatype()
+        {
+            var validationContext = new ValidationContext(new SelfMetadataType());
+            validationContext.MemberName = "PropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SelfMetadataType), typeof(SelfMetadataType)), typeof(SelfMetadataType));
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, null));
+
+            var validationResults = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, validationResults));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value");
+
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, null));
+
+            validationResults.Clear();
+            Assert.False(Validator.TryValidateProperty("Invalid Value", validationContext, validationResults));
+            //Assert.Equal(1, validationResults.Count);
+            Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is not a valid phone number.");
+        }
+
         #endregion TryValidateProperty
 
         #region ValidateProperty
@@ -651,6 +950,89 @@ namespace System.ComponentModel.DataAnnotations.Tests
             var validationContext = new ValidationContext(new ToBeValidated());
             validationContext.MemberName = "PropertyWithRequiredAttribute";
             Validator.ValidateProperty("Valid Value", validationContext);
+        }
+
+        [Fact]
+        public static void ValidateProperty_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_required_attribute_fails_validation()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty(null, validationContext));
+            Assert.IsType<RequiredAttribute>(exception.ValidationAttribute);
+            Assert.Null(exception.Value);
+        }
+
+        [Fact]
+        public static void ValidateProperty_returns_false_if_all_properties_are_valid_but_metadatatype_class_property_attribute_fails_validation()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Invalid Value", validationContext));
+            Assert.IsType<MaxLengthAttribute>(exception.ValidationAttribute);
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.", exception.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static void ValidateProperty_returns_false_if_property_attribute_is_not_removed_by_metadatatype_class()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeToBeValidated());
+            validationContext.MemberName = "PropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeToBeValidated), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeToBeValidated));
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Invalid Value", validationContext));
+            Assert.IsType<ValidValueStringPropertyAttribute>(exception.ValidationAttribute);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", exception.Value);
+        }
+
+        [Fact]
+        public static void ValidateProperty_returns_false_if_property_has_attributes_from_base_and_metadatatype_classes()
+        {
+            var validationContext = new ValidationContext(new HasMetadataTypeWithComplementaryRequirements());
+            validationContext.MemberName = "PropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(HasMetadataTypeWithComplementaryRequirements), typeof(MetadataTypeToAddValidationAttributes)), typeof(HasMetadataTypeWithComplementaryRequirements));
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Invalid Value", validationContext));
+            Assert.IsType<ValidValueStringPropertyAttribute>(exception.ValidationAttribute);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", exception.Value);
+
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Not Phone #", validationContext));
+            Assert.IsType<PhoneAttribute>(exception.ValidationAttribute);
+            Assert.Equal("The SecondPropertyToBeTested field is not a valid phone number.", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("Not Phone #", exception.Value);
+
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("0800123456789", validationContext));
+            Assert.IsType<MaxLengthAttribute>(exception.ValidationAttribute);
+            Assert.Equal("The field SecondPropertyToBeTested must be a string or array type with a maximum length of '11'.", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("0800123456789", exception.Value);
+        }
+
+        [Fact]
+        public static void ValidateProperty_returns_false_if_validation_fails_when_class_references_itself_as_a_metadatatype()
+        {
+            var validationContext = new ValidationContext(new SelfMetadataType());
+            validationContext.MemberName = "PropertyToBeTested";
+            TypeDescriptor.AddProviderTransparent(new AssociatedMetadataTypeTypeDescriptionProvider(typeof(SelfMetadataType), typeof(SelfMetadataType)), typeof(SelfMetadataType));
+            var exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Invalid Value", validationContext));
+            Assert.IsType<ValidValueStringPropertyAttribute>(exception.ValidationAttribute);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", exception.Value);
+
+            validationContext.MemberName = "SecondPropertyToBeTested";
+            exception = Assert.Throws<ValidationException>(
+                () => Validator.ValidateProperty("Invalid Value", validationContext));
+            Assert.IsType<PhoneAttribute>(exception.ValidationAttribute);
+            Assert.Equal("The SecondPropertyToBeTested field is not a valid phone number.", exception.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", exception.Value);
         }
 
         #endregion ValidateProperty
@@ -996,6 +1378,47 @@ namespace System.ComponentModel.DataAnnotations.Tests
             [Required]
             [ValidValueStringProperty]
             public string PropertyWithRequiredAttribute { get; set; }
+        }
+
+        public class HasMetadataTypeToBeValidated
+        {
+            [ValidValueStringProperty]
+            public string PropertyToBeTested { get; set; }
+
+            public string SecondPropertyToBeTested { get; set; }
+        }
+
+        public class HasMetadataTypeWithUnmatchedProperties
+        {
+            [ValidValueStringProperty]
+            public string PropertyToBeTested { get; set; }
+
+            public string MismatchedNameProperty { get; set; }
+        }
+
+        public class HasMetadataTypeWithComplementaryRequirements
+        {
+            [ValidValueStringProperty]
+            public string PropertyToBeTested { get; set; }
+
+            [Phone]
+            public string SecondPropertyToBeTested { get; set; }
+        }
+
+        public class SelfMetadataType
+        {
+            [ValidValueStringProperty]
+            public string PropertyToBeTested { get; set; }
+
+            [Phone]
+            public string SecondPropertyToBeTested { get; set; }
+        }
+
+        public class MetadataTypeToAddValidationAttributes
+        {
+            [Required]
+            [MaxLength(11)]
+            public string SecondPropertyToBeTested { get; set; }
         }
     }
 }


### PR DESCRIPTION
If a MetadataType attribute is applied to a class the associated metadata class is now validated in .NET Core. 

In .NET Framework 4.8 and older versions a similar behavior already exists if you use associate a type and handler like so: 
`TypeDescriptor.AddProviderTransparent(
                new AssociatedMetadataTypeTypeDescriptionProvider(typeof(Person), typeof(PersonMetadata)),
                typeof(Person));` 

To do this the System.ComponentModel.DataAnnotations.**ValidationAttributeStore** class was altered to check for a MetadataType attribute. If found it inspects the associated class and merges any validation attributes with any from the class being validated.

Added tests to the System.ComponentModel.DataAnnotations.**Validator** for as many scenarios as I could think of.

Fixes #46678