### PR TITLE
Adds extension method to create service scope that implements IAsyncDisposable.

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -19,6 +19,15 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public ActivatorUtilitiesConstructorAttribute() { }
     }
+    public struct AsyncServiceScope : Microsoft.Extensions.DependencyInjection.IServiceScope, System.IAsyncDisposable
+    {
+        public AsyncServiceScope(Microsoft.Extensions.DependencyInjection.IServiceScope serviceScope)
+        {
+        }
+        public System.IServiceProvider ServiceProvider { get { throw null; } }
+        public void Dispose() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+    }
     public partial interface IServiceCollection : System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
     {
     }
@@ -106,6 +115,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
     public static partial class ServiceProviderServiceExtensions
     {
+        public static Microsoft.Extensions.DependencyInjection.AsyncServiceScope CreateAsyncScope(this System.IServiceProvider provider) { throw null; }
         public static Microsoft.Extensions.DependencyInjection.IServiceScope CreateScope(this System.IServiceProvider provider) { throw null; }
         public static object GetRequiredService(this System.IServiceProvider provider, System.Type serviceType) { throw null; }
         public static T GetRequiredService<T>(this System.IServiceProvider provider) where T : notnull { throw null; }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public ActivatorUtilitiesConstructorAttribute() { }
     }
-    public readonly struct AsyncServiceScope : Microsoft.Extensions.DependencyInjection.IServiceScope, System.IAsyncDisposable
+    public readonly partial struct AsyncServiceScope : Microsoft.Extensions.DependencyInjection.IServiceScope, System.IAsyncDisposable, System.IDisposable
     {
-        public AsyncServiceScope(Microsoft.Extensions.DependencyInjection.IServiceScope serviceScope)
-        {
-        }
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public AsyncServiceScope(Microsoft.Extensions.DependencyInjection.IServiceScope serviceScope) { throw null; }
         public System.IServiceProvider ServiceProvider { get { throw null; } }
         public void Dispose() { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public ActivatorUtilitiesConstructorAttribute() { }
     }
-    public struct AsyncServiceScope : Microsoft.Extensions.DependencyInjection.IServiceScope, System.IAsyncDisposable
+    public readonly struct AsyncServiceScope : Microsoft.Extensions.DependencyInjection.IServiceScope, System.IAsyncDisposable
     {
         public AsyncServiceScope(Microsoft.Extensions.DependencyInjection.IServiceScope serviceScope)
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.DependencyInjection.Abstractions.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or
+                        $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -20,12 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public AsyncServiceScope(IServiceScope serviceScope)
         {
-            if (serviceScope is null)
-            {
-                throw new ArgumentNullException(nameof(serviceScope));
-            }
-
-            _serviceScope = serviceScope;
+            _serviceScope = serviceScope ?? throw new ArgumentNullException(nameof(serviceScope));
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 return ad.DisposeAsync();
             }
             _serviceScope.Dispose();
+
+            // ValueTask.CompletedTask is only available in net5.0 and later.
             return default;
         }
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// A <see cref="IServiceScope" /> implementation that implements <see cref="IAsyncDisposable" />.
     /// </summary>
-    public struct AsyncServiceScope : IServiceScope, IAsyncDisposable
+    public readonly struct AsyncServiceScope : IServiceScope, IAsyncDisposable
     {
         private readonly IServiceScope _serviceScope;
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A <see cref="IServiceScope" /> implementation that implements <see cref="IAsyncDisposable" />.
+    /// </summary>
+    public struct AsyncServiceScope : IServiceScope, IAsyncDisposable
+    {
+        private readonly IServiceScope _serviceScope;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncServiceScope"/> struct.
+        /// Wraps an instance of <see cref="IServiceScope" />.
+        /// <param name="serviceScope">The <see cref="IServiceScope"/> instance to wrap.</param>
+        /// </summary>
+        public AsyncServiceScope(IServiceScope serviceScope)
+        {
+            if (serviceScope is null)
+            {
+                throw new ArgumentNullException(nameof(serviceScope));
+            }
+
+            _serviceScope = serviceScope;
+        }
+
+        /// <inheritdoc />
+        public IServiceProvider ServiceProvider => _serviceScope.ServiceProvider;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _serviceScope.Dispose();
+        }
+
+        /// <inheritdoc />
+        public ValueTask DisposeAsync()
+        {
+            if (_serviceScope is IAsyncDisposable ad)
+            {
+                return ad.DisposeAsync();
+            }
+            _serviceScope.Dispose();
+            return default;
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,6 +12,12 @@
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or
+                        $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -125,5 +125,15 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
         }
+
+        /// <summary>
+        /// Creates a new <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.
+        /// </summary>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to create the scope from.</param>
+        /// <returns>A <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.</returns>
+        public static AsyncServiceScope CreateAsyncScope(this IServiceProvider provider)
+        {
+            return new AsyncServiceScope(provider.CreateScope());
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/AsyncServiceScopeTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/AsyncServiceScopeTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    public class AsyncServiceScopeTests
+    {
+        [Fact]
+        public void ThrowsIfServiceScopeIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new AsyncServiceScope(null));
+            Assert.Equal("serviceScope", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReturnsServiceProviderFromWrappedScope()
+        {
+            var wrappedScope = new FakeSyncServiceScope();
+            var asyncScope = new AsyncServiceScope(wrappedScope);
+
+            Assert.Same(wrappedScope.ServiceProvider, asyncScope.ServiceProvider);
+        }
+
+        [Fact]
+        public void CallsDisposeOnWrappedSyncScopeOnDispose()
+        {
+            var wrappedScope = new FakeSyncServiceScope();
+            var asyncScope = new AsyncServiceScope(wrappedScope);
+
+            asyncScope.Dispose();
+
+            Assert.True(wrappedScope.DisposeCalled);
+        }
+
+        [Fact]
+        public async ValueTask CallsDisposeOnWrappedSyncScopeOnDisposeAsync()
+        {
+            var wrappedScope = new FakeSyncServiceScope();
+            var asyncScope = new AsyncServiceScope(wrappedScope);
+
+            await asyncScope.DisposeAsync();
+
+            Assert.True(wrappedScope.DisposeCalled);
+        }
+
+        [Fact]
+        public void CallsDisposeOnWrappedAsyncScopeOnDispose()
+        {
+            var wrappedScope = new FakeAsyncServiceScope();
+            var asyncScope = new AsyncServiceScope(wrappedScope);
+
+            asyncScope.Dispose();
+
+            Assert.True(wrappedScope.DisposeCalled);
+            Assert.False(wrappedScope.DisposeAsyncCalled);
+        }
+
+        [Fact]
+        public async ValueTask CallsDisposeAsyncOnWrappedSyncScopeOnDisposeAsync()
+        {
+            var wrappedScope = new FakeAsyncServiceScope();
+            var asyncScope = new AsyncServiceScope(wrappedScope);
+
+            await asyncScope.DisposeAsync();
+
+            Assert.False(wrappedScope.DisposeCalled);
+            Assert.True(wrappedScope.DisposeAsyncCalled);
+        }
+
+        public class FakeServiceProvider : IServiceProvider
+        {
+            public object? GetService(Type serviceType) => throw new NotImplementedException();
+        }
+
+        public class FakeSyncServiceScope : IServiceScope
+        {
+            public FakeSyncServiceScope()
+            {
+                ServiceProvider = new FakeServiceProvider();
+            }
+
+            public IServiceProvider ServiceProvider { get; }
+
+            public bool DisposeCalled { get; private set; }
+
+            public void Dispose()
+            {
+                DisposeCalled = true;
+            }
+        }
+
+        public class FakeAsyncServiceScope : FakeSyncServiceScope, IAsyncDisposable
+        {
+            public FakeAsyncServiceScope() : base()
+            {
+            }
+
+            public bool DisposeAsyncCalled { get; private set; }
+
+            public ValueTask DisposeAsync()
+            {
+                DisposeAsyncCalled = true;
+
+                return default;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
 
             await sp.DisposeAsync();
-            
+
             Assert.True(disposable.Disposed);
             Assert.True(asyncDisposable.DisposeAsyncCalled);
             if (includeDelayedAsyncDisposable)
@@ -449,7 +449,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             public InnerSingleton(ManualResetEvent mre1, ManualResetEvent mre2)
             {
                 // Making sure ctor gets called only once
-                Assert.True(!mre1.WaitOne(0) && !mre2.WaitOne(0)); 
+                Assert.True(!mre1.WaitOne(0) && !mre2.WaitOne(0));
 
                 // Then use mre2 to signal execution reached this ctor call
                 mre2.Set();
@@ -493,13 +493,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                     // This waits on InnerSingleton singleton lock that is taken in thread 1
                     innerSingleton = sp.GetRequiredService<InnerSingleton>();
                 });
-                
+
                 mreForThread3.WaitOne();
 
                 // Set a timeout before unblocking execution of both thread1 and thread2 via mre1:
                 Assert.False(mreForThread1.WaitOne(10));
 
-                // By this time thread 1 has already reached InnerSingleton ctor and is waiting for mre1. 
+                // By this time thread 1 has already reached InnerSingleton ctor and is waiting for mre1.
                 // within the GetRequiredService call, thread 2 should be waiting on a singleton lock for InnerSingleton
                 // (rather than trying to instantiating InnerSingleton twice).
                 mreForThread1.Set();
@@ -546,7 +546,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                     sb.Append("3");
                     mreForThread2.Set();   // Now that thread 1 holds lazy lock, allow thread 2 to continue
 
-                    // by this time, Thread 2 is holding a singleton lock for Thing2, 
+                    // by this time, Thread 2 is holding a singleton lock for Thing2,
                     // and Thread one holds the lazy lock
                     // the call below to resolve Thing0 does not hang
                     // since singletons do not share the same lock upon resolve anymore.
@@ -905,7 +905,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var scope = serviceProvider.CreateAsyncScope();
             var disposable = scope.ServiceProvider.GetService<AsyncDisposable>();
 
-            await (scope as IAsyncDisposable).DisposeAsync();
+            await scope.DisposeAsync();
 
             Assert.True(disposable.DisposeAsyncCalled);
         }
@@ -920,7 +920,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var scope = serviceProvider.CreateAsyncScope();
             var disposable = scope.ServiceProvider.GetService<SyncAsyncDisposable>();
 
-            await (scope as IAsyncDisposable).DisposeAsync();
+            await scope.DisposeAsync();
 
             Assert.True(disposable.DisposeAsyncCalled);
         }
@@ -935,7 +935,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var scope = serviceProvider.CreateScope();
             var disposable = scope.ServiceProvider.GetService<SyncAsyncDisposable>();
 
-            (scope as IDisposable).Dispose();
+            scope.Dispose();
 
             Assert.True(disposable.DisposeCalled);
         }
@@ -950,7 +950,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var scope = serviceProvider.CreateScope();
             var disposable = scope.ServiceProvider.GetService<AsyncDisposable>();
 
-            var exception = Assert.Throws<InvalidOperationException>(() => (scope as IDisposable).Dispose());
+            var exception = Assert.Throws<InvalidOperationException>(() => scope.Dispose());
             Assert.Equal(
                 "'Microsoft.Extensions.DependencyInjection.Tests.ServiceProviderContainerTests+AsyncDisposable' type only implements IAsyncDisposable. Use DisposeAsync to dispose the container.",
                 exception.Message);
@@ -1092,7 +1092,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             var types = new Type[]
             {
-                typeof(A), typeof(B), typeof(C), typeof(D), typeof(E), 
+                typeof(A), typeof(B), typeof(C), typeof(D), typeof(E),
                 typeof(F), typeof(G), typeof(H), typeof(I), typeof(J)
             };
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -211,6 +212,23 @@ namespace Microsoft.Extensions.DependencyInjection
             // Assert
             Assert.Empty(services);
             Assert.IsType<List<IFoo>>(services);
+        }
+
+        [Fact]
+        public async Task CreateAsyncScope_Returns_AsyncServiceScope_Wrapping_ServiceScope()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IFoo, Foo1>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            await using var scope = serviceProvider.CreateAsyncScope();
+
+            // Act
+            var service = scope.ServiceProvider.GetService<IFoo>();
+
+            // Assert
+            Assert.IsType<Foo1>(service);
         }
 
         private static IServiceProvider CreateTestServiceProvider(int count)


### PR DESCRIPTION
- Introduces a new type AsyncServiceScope that implements IServiceScope and IAsyncDisposable. The type just wraps an existing IServiceScope instance, which it tries to cast it to an IAsyncDisposable when DisposeAsync is called.
- Adds netstandard2.1 target to avoid bringing in System.Threading.Tasks.Extensions and Microsoft.Bcl.AsyncInterfaces if not needed.
- Fixes #43970

Can't remember (nor find info) whether we agreed on putting this in `Microsoft.Extensions.DependencyInjection` or `Microsoft.Extensions.DependencyInjection.Abstractions`. I added it to `Microsoft.Extensions.DependencyInjection.Abstractions`, which however only targeted `net461` and `netstandard2.0`. This means that we have to pull in `System.Threading.Tasks.Extensions` (for `ValueTask`) and `Microsoft.Bcl.AsyncInterfaces` (for `IAsyncDisposable`). Because of this, I think it would be wise to add a `netstandard2.1` target so that these dependencies can be ignored on `net5` and newer,

// cc @davidfowl 