### PR TITLE
Add parameter descriptions to address System.Linq documentation debt

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -295,6 +295,10 @@ namespace System.Linq
         /// <typeparam name="TAccumulate">The type of the accumulated value.</typeparam>
         /// <typeparam name="TResult">The type of result returned by the result selector.</typeparam>
         /// <typeparam name="T">The type of element contained by the collection.</typeparam>
+        /// <param name="immutableArray">An immutable array to aggregate over.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element.</param>
+        /// <param name="resultSelector">A function to transform the final accumulator value into the result type.</param>
         public static TResult Aggregate<TAccumulate, TResult, T>(this ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
         {
             Requires.NotNull(resultSelector, nameof(resultSelector));
@@ -468,6 +472,8 @@ namespace System.Linq
         /// Returns the only element of a sequence that satisfies a specified condition, and throws an exception if more than one such element exists.
         /// </summary>
         /// <typeparam name="T">The type of element contained by the collection.</typeparam>
+        /// <param name="immutableArray">The immutable array to return a single element from.</param>
+        /// <param name="predicate">The function to test whether an element should be returned.</param>
         public static T Single<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
             Requires.NotNull(predicate, nameof(predicate));
@@ -613,7 +619,7 @@ namespace System.Linq
         /// Copies the contents of this array to a mutable array.
         /// </summary>
         /// <typeparam name="T">The type of element contained by the collection.</typeparam>
-        /// <param name="immutableArray"></param>
+        /// <param name="immutableArray">The immutable array to copy into a mutable one.</param>
         /// <returns>The newly instantiated array.</returns>
         public static T[] ToArray<T>(this ImmutableArray<T> immutableArray)
         {


### PR DESCRIPTION
Addresses documentation debt from #43854. Most parameter descriptions are based on the text from the non-immutableArray versions. There appears to be several docid's that are also missing parameter descriptions but these were not listed in the reference issue. I've not fixed these in case these are intentional, please let me know if you'd like me to do a pass through this file and ensure all parameters and return value are documented in this file.