### PR TITLE
Liveness fix for struct enreg.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4747,15 +4747,21 @@ void CodeGen::genCheckUseBlockInit()
             continue;
         }
 
-        if (varDsc->lvIsTemp && !varDsc->HasGCPtr())
+        const bool isTemp      = varDsc->lvIsTemp;
+        const bool hasGCPtr    = varDsc->HasGCPtr();
+        const bool isTracked   = varDsc->lvTracked;
+        const bool isStruct    = varTypeIsStruct(varDsc);
+        const bool compInitMem = compiler->info.compInitMem;
+
+        if (isTemp && !hasGCPtr)
         {
             varDsc->lvMustInit = 0;
             continue;
         }
 
-        if (compiler->info.compInitMem || varDsc->HasGCPtr() || varDsc->lvMustInit)
+        if (compInitMem || hasGCPtr || varDsc->lvMustInit)
         {
-            if (varDsc->lvTracked)
+            if (isTracked)
             {
                 /* For uninitialized use of tracked variables, the liveness
                  * will bubble to the top (compiler->fgFirstBB) in fgInterBlockLocalVarLiveness()
@@ -4794,47 +4800,42 @@ void CodeGen::genCheckUseBlockInit()
                 }
             }
 
-            bool mustInitThisVar = false;
-
-            const bool isTemp      = varDsc->lvIsTemp;
-            const bool hasGCPtr    = varDsc->HasGCPtr();
-            const bool isTracked   = varDsc->lvTracked;
-            const bool isStruct    = varTypeIsStruct(varDsc);
-            const bool compInitMem = compiler->info.compInitMem;
-
-            if (hasGCPtr && !isTracked)
+            if (varDsc->lvOnFrame)
             {
-                JITDUMP("must init V%02u because it has a GC ref\n", varNum);
-                mustInitThisVar = true;
-            }
-            else if (hasGCPtr && isStruct)
-            {
-                // TODO-1stClassStructs: support precise liveness reporting for such structs.
-                JITDUMP("must init a tracked V%02u because it a struct with a GC ref\n", varNum);
-                mustInitThisVar = true;
-            }
-            else
-            {
-                // We are done with tracked or GC vars, now look at untracked vars without GC refs.
-                if (!isTracked)
+                bool mustInitThisVar = false;
+                if (hasGCPtr && !isTracked)
                 {
-                    assert(!hasGCPtr);
-                    if (compInitMem && !isTemp)
+                    JITDUMP("must init V%02u because it has a GC ref\n", varNum);
+                    mustInitThisVar = true;
+                }
+                else if (hasGCPtr && isStruct)
+                {
+                    // TODO-1stClassStructs: support precise liveness reporting for such structs.
+                    JITDUMP("must init a tracked V%02u because it a struct with a GC ref\n", varNum);
+                    mustInitThisVar = true;
+                }
+                else
+                {
+                    // We are done with tracked or GC vars, now look at untracked vars without GC refs.
+                    if (!isTracked)
                     {
-                        JITDUMP("must init V%02u because compInitMem is set and it is not a temp\n", varNum);
-                        mustInitThisVar = true;
+                        assert(!hasGCPtr && !isTemp);
+                        if (compInitMem)
+                        {
+                            JITDUMP("must init V%02u because compInitMem is set and it is not a temp\n", varNum);
+                            mustInitThisVar = true;
+                        }
                     }
                 }
-            }
-
-            if (mustInitThisVar)
-            {
-                varDsc->lvMustInit = true;
-
-                if (!counted)
+                if (mustInitThisVar)
                 {
-                    initStkLclCnt += roundUp(compiler->lvaLclSize(varNum), TARGET_POINTER_SIZE) / sizeof(int);
-                    counted = true;
+                    varDsc->lvMustInit = true;
+
+                    if (!counted)
+                    {
+                        initStkLclCnt += roundUp(compiler->lvaLclSize(varNum), TARGET_POINTER_SIZE) / sizeof(int);
+                        counted = true;
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -971,7 +971,7 @@ public:
     var_types lvaArgType();
 
     // Returns true if this variable contains GC pointers (including being a GC pointer itself).
-    bool HasGCPtr()
+    bool HasGCPtr() const
     {
         return varTypeIsGC(lvType) || ((lvType == TYP_STRUCT) && m_layout->HasGCPtr());
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5915,16 +5915,33 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
         {
             unsigned   lclNum = node->AsLclVarCommon()->GetLclNum();
             LclVarDsc* lclVar = &compiler->lvaTable[lclNum];
-#ifdef DEBUG
             if (node->TypeIs(TYP_SIMD12))
             {
                 assert(compiler->lvaIsFieldOfDependentlyPromotedStruct(lclVar) || (lclVar->lvSize() == 12));
             }
-#endif // DEBUG
         }
         break;
 #endif // TARGET_64BIT
 #endif // SIMD
+
+        case GT_LCL_VAR_ADDR:
+        case GT_LCL_FLD_ADDR:
+        {
+            const GenTreeLclVarCommon* lclVarAddr = node->AsLclVarCommon();
+            const LclVarDsc*           varDsc     = compiler->lvaGetDesc(lclVarAddr);
+            if (((lclVarAddr->gtFlags & GTF_VAR_DEF) != 0) && varDsc->HasGCPtr())
+            {
+                // Emitter does not correctly handle live updates for LCL_VAR_ADDR
+                // when they are not contained, for example, `STOREIND byref(GT_LCL_VAR_ADDR not-contained)`
+                // would generate:
+                // add     r1, sp, 48   // r1 contains address of a lclVar V01.
+                // str     r0, [r1]     // a gc ref becomes live in V01, but emitter would not report it.
+                // Make sure that we use uncontained address nodes only for variables
+                // that will be marked as mustInit and will be alive throught the whole block even when tracked.
+                assert(lclVarAddr->isContained() || !varDsc->lvTracked || varTypeIsStruct(varDsc));
+                // TODO: support this assert for uses, see https://github.com/dotnet/runtime/issues/51900.
+            }
+        }
 
         default:
             break;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5937,7 +5937,7 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
                 // add     r1, sp, 48   // r1 contains address of a lclVar V01.
                 // str     r0, [r1]     // a gc ref becomes live in V01, but emitter would not report it.
                 // Make sure that we use uncontained address nodes only for variables
-                // that will be marked as mustInit and will be alive throught the whole block even when tracked.
+                // that will be marked as mustInit and will be alive throughout the whole block even when tracked.
                 assert(lclVarAddr->isContained() || !varDsc->lvTracked || varTypeIsStruct(varDsc));
                 // TODO: support this assert for uses, see https://github.com/dotnet/runtime/issues/51900.
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5941,6 +5941,7 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
                 assert(lclVarAddr->isContained() || !varDsc->lvTracked || varTypeIsStruct(varDsc));
                 // TODO: support this assert for uses, see https://github.com/dotnet/runtime/issues/51900.
             }
+            break;
         }
 
         default:

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9760,7 +9760,8 @@ void Compiler::optRemoveRedundantZeroInits()
                                 if (BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclNum) ||
                                     (lclDsc->lvIsStructField &&
                                      BitVecOps::IsMember(&bitVecTraits, zeroInitLocals, lclDsc->lvParentLcl)) ||
-                                    (!lclDsc->lvTracked && !fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn)))
+                                    ((!lclDsc->lvTracked || !isEntire) &&
+                                     !fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn)))
                                 {
                                     // We are guaranteed to have a zero initialization in the prolog or a
                                     // dominating explicit zero initialization and the local hasn't been redefined


### PR DESCRIPTION
Delete some unnecessary `mustInit`. The change is required for a small struct enreg change.

spmi changes:
```
benchmarks.run.windows.x64.checked.mch
Total bytes of delta: -725 (-1.10% of base)
71 total files with Code Size differences (69 improved, 2 regressed), 0 unchanged.

libraries.crossgen.windows.x64.checked
Total bytes of delta: -479 (-0.37% of base)
42 total files with Code Size differences (41 improved, 1 regressed), 0 unchanged.

libraries.crossgen2.windows.x64.checked.mch
Total bytes of delta: -3296 (-0.90% of base)
373 total files with Code Size differences (345 improved, 28 regressed), 8 unchanged.

libraries.pmi.windows.x64.checked
Total bytes of delta: -2101 (-0.62% of base)
243 total files with Code Size differences (214 improved, 29 regressed), 0 unchanged.

tests.pmi.windows.x64.checked
Total bytes of delta: -18637 (-0.81% of base)
1475 total files with Code Size differences (1472 improved, 3 regressed), 2 unchanged.

```
