### PR TITLE
Fix reference assembly output paths

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -9,7 +9,7 @@
     <IsGeneratorProject Condition="'$(_projectDirName)' == 'gen'">true</IsGeneratorProject>
 
     <!-- Set OutDirName to change BaseOutputPath and BaseIntermediateOutputPath to include the ref subfolder. -->
-    <OutDirName Condition="'$(IsReferenceAssembly)' == 'true'">$(MSBuildProjectName)$(_sepChar)ref</OutDirName>
+    <OutDirName Condition="'$(IsReferenceAssembly)' == 'true'">$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref</OutDirName>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/commit/9580b7dbe54c52a8b977ed4bb5819f43d6eb5e93. Didn't result in any issues as there is no dependency on reference assemblies' output path. Hence I won't add CI protection for it.