### PR TITLE
[wasm][debugger] - RuntimeError: memory access out of bounds

### DIFF
--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -137,7 +137,9 @@ To run a test with `FooBar` in the name:
 
 (See https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit for filter options)
 
-Additional arguments for `dotnet test` can be passed via `TEST_ARGS`. Though only one of `TEST_ARGS`, or `TEST_FILTER` can be used at a time.
+Additional arguments for `dotnet test` can be passed via `MSBUILD_ARGS` or `TEST_ARGS`. 
+For example `MSBUILD_ARGS="/p:WasmDebugLevel=5"`
+Though only one of `TEST_ARGS`, or `TEST_FILTER` can be used at a time.
 
 ## Run samples
 

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -137,9 +137,7 @@ To run a test with `FooBar` in the name:
 
 (See https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit for filter options)
 
-Additional arguments for `dotnet test` can be passed via `MSBUILD_ARGS` or `TEST_ARGS`. 
-For example `MSBUILD_ARGS="/p:WasmDebugLevel=5"`
-Though only one of `TEST_ARGS`, or `TEST_FILTER` can be used at a time.
+Additional arguments for `dotnet test` can be passed via `MSBUILD_ARGS` or `TEST_ARGS`. For example `MSBUILD_ARGS="/p:WasmDebugLevel=5"`. Though only one of `TEST_ARGS`, or `TEST_FILTER` can be used at a time.
 
 ## Run samples
 

--- a/src/mono/wasm/build/WasmApp.InTree.targets
+++ b/src/mono/wasm/build/WasmApp.InTree.targets
@@ -25,7 +25,7 @@
 
     <MSBuild Projects="@(WasmAppBuildProject)"
          Properties="Configuration=Debug"
-         Targets="Build;Publish"/>
+         Targets="Build"/>
   </Target>
 
   <Target Name="CopyAppZipToHelixTestDir"

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -86,6 +86,7 @@
     <Error Condition="'@(_WasmAssembliesInternal)' == ''" Text="Item _WasmAssembliesInternal is empty" />
     <Error Condition="'$(_IsEMSDKMissing)' == 'true'"
            Text="$(_EMSDKMissingErrorMessage) Emscripten SDK is required for AOT'ing assemblies." />
+    <Error Condition="!Exists('$(MonoAotCrossCompilerPath)')" Text="MonoAotCrossCompilerPath=$(MonoAotCrossCompilerPath) doesn't exist" />
 
     <ItemGroup>
       <MonoAOTCompilerDefaultAotArguments Include="no-opt" />
@@ -221,7 +222,7 @@
 
       <MicrosoftNetCoreAppRuntimePackRidDir>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidDir)))</MicrosoftNetCoreAppRuntimePackRidDir>
       <MicrosoftNetCoreAppRuntimePackRidNativeDir>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidDir), 'native'))</MicrosoftNetCoreAppRuntimePackRidNativeDir>
-      <MonoAotCrossCompilerPath Condition="'$(MonoAotCrossCompilerPath)' == ''">$([MSBuild]::NormalizePath($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'cross', $(PackageRID), 'mono-aot-cross$(_ExeExt)'))</MonoAotCrossCompilerPath>
+      <MonoAotCrossCompilerPath Condition="'$(MonoAotCrossCompilerPath)' == ''">$([MSBuild]::NormalizePath($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'cross', $(RuntimeIdentifier), 'mono-aot-cross$(_ExeExt)'))</MonoAotCrossCompilerPath>
       <!-- emcc, and mono-aot-cross don't like relative paths for output files -->
       <_WasmIntermediateOutputPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'wasm'))</_WasmIntermediateOutputPath>
     </PropertyGroup>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
@@ -187,7 +187,7 @@ namespace DebuggerTests
         {
             await InspectAssignmentDuringSteppingIn("MONO_TYPE_GENERICINST",
                 (locals) => CheckObject(locals, "r", "System.Func<int>", is_null: true),
-                (locals) => CheckObject(locals, "r", "System.Func<int>", description: "int OuterMethod ()")
+                (locals) => CheckObject(locals, "r", "System.Func<int>", description: "int Prepare ()")
                 );
         }
 
@@ -211,10 +211,11 @@ namespace DebuggerTests
 
         private async Task InspectAssignmentDuringSteppingIn(string clazz, Action<JToken> checkDefault, Action<JToken> checkValue)
         {
-            await SetBreakpointInMethod("debugger-test", "DebuggerTests." + clazz, "OuterMethod", 2);
-            await EvaluateAndCheck("window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests." + clazz + ":OuterMethod'); })", null, -1, -1, "OuterMethod");
+            await SetBreakpointInMethod("debugger-test", "DebuggerTests." + clazz, "Prepare", 2);
+            await EvaluateAndCheck("window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests." + clazz + ":Prepare'); })", null, -1, -1, "Prepare");
 
-            await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-stepping-test.cs", -1, -1, "InnerMethod",
+            // 1) check un-assigned variables
+            await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-assignment-test.cs", -1, -1, "TestedMethod",
                 locals_fn: (locals) =>
                 {
                     Console.WriteLine(locals);
@@ -222,7 +223,9 @@ namespace DebuggerTests
                     checkDefault(locals);
                 }
             );
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-stepping-test.cs", -1, -1, "InnerMethod", times: 3,
+
+            // 2) check assigned variables
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-assignment-test.cs", -1, -1, "TestedMethod", times: 3,
                 locals_fn: (locals) =>
                 {
                     Console.WriteLine(locals);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
@@ -1,0 +1,235 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DebuggerTests
+{
+    public class AssignmentTests : DebuggerTestBase
+    {
+        [Fact]
+        async Task InspectObjectAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_OBJECT",
+                (locals) => CheckObject(locals, "r", "object", is_null: true),
+                (locals) => CheckObject(locals, "r", "object")
+                );
+        }
+
+        [Fact]
+        async Task InspectClassAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_CLASS",
+                (locals) => CheckObject(locals, "r", "DebuggerTests.MONO_TYPE_CLASS", is_null: true),
+                (locals) => CheckObject(locals, "r", "DebuggerTests.MONO_TYPE_CLASS")
+                );
+        }
+
+        [Fact]
+        async Task InspectBoolAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_BOOLEAN",
+                (locals) => CheckBool(locals, "r", default),
+                (locals) => CheckBool(locals, "r", true)
+                );
+        }
+
+        [Fact]
+        async Task InspectCharAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_CHAR",
+                (locals) => CheckSymbol(locals, "r", "0 '\u0000'"),
+                (locals) => CheckSymbol(locals, "r", "97 'a'")
+                );
+        }
+
+        [Fact]
+        async Task InspectSByteAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I1",
+                (locals) => CheckNumber<sbyte>(locals, "r", default),
+                (locals) => CheckNumber<sbyte>(locals, "r", -1)
+                );
+        }
+
+        [Fact]
+        async Task InspectShortAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I2",
+                (locals) => CheckNumber<short>(locals, "r", default),
+                (locals) => CheckNumber<short>(locals, "r", -1)
+                );
+        }
+
+        [Fact]
+        async Task InspectIntAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I4",
+                (locals) => CheckNumber<int>(locals, "r", default),
+                (locals) => CheckNumber<int>(locals, "r", -1)
+                );
+        }
+
+        [Fact]
+        async Task InspectLongAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I8",
+                (locals) => CheckNumber<long>(locals, "r", default),
+                (locals) => CheckNumber<long>(locals, "r", -1)
+                );
+        }
+
+        [Fact]
+        async Task InspectByteAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U1",
+                (locals) => CheckNumber<byte>(locals, "r", default),
+                (locals) => CheckNumber<byte>(locals, "r", 1)
+                );
+        }
+
+        [Fact]
+        async Task InspectUShortAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U2",
+                (locals) => CheckNumber<ushort>(locals, "r", default),
+                (locals) => CheckNumber<ushort>(locals, "r", 1)
+                );
+        }
+
+        [Fact]
+        async Task InspectUIntAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U4",
+                (locals) => CheckNumber<uint>(locals, "r", default),
+                (locals) => CheckNumber<uint>(locals, "r", 1)
+                );
+        }
+
+        [Fact]
+        async Task InspectULongAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U8",
+                (locals) => CheckNumber<ulong>(locals, "r", default),
+                (locals) => CheckNumber<ulong>(locals, "r", 1)
+                );
+        }
+
+        [Fact]
+        async Task InspectFloatAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_R4",
+                (locals) => CheckNumber<float>(locals, "r", default),
+                (locals) => CheckNumber<float>(locals, "r", 3.1415F)
+                );
+        }
+
+        [Fact]
+        async Task InspectDoubleAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_R8",
+                (locals) => CheckNumber<double>(locals, "r", default),
+                (locals) => CheckNumber<double>(locals, "r", 3.1415D)
+                );
+        }
+
+        [Fact]
+        async Task InspectStringAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_STRING",
+                (locals) => CheckString(locals, "r", default),
+                (locals) => CheckString(locals, "r", "hello")
+                );
+        }
+
+        [Fact]
+        async Task InspectEnumAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_ENUM",
+                (locals) => CheckEnum(locals, "r", "DebuggerTests.RGB", "Red"),
+                (locals) => CheckEnum(locals, "r", "DebuggerTests.RGB", "Blue")
+                );
+        }
+
+        [Fact]
+        async Task InspectArrayAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_ARRAY",
+                (locals) => CheckObject(locals, "r", "byte[]", is_null: true),
+                (locals) => CheckArray(locals, "r", "byte[]", 2)
+                );
+        }
+
+        [Fact]
+        async Task InspectStructAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_VALUETYPE",
+                (locals) => CheckValueType(locals, "r", "DebuggerTests.Point"),
+                (locals) => CheckValueType(locals, "r", "DebuggerTests.Point")
+                );
+        }
+
+        [Fact]
+        async Task InspectDecimalAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_VALUETYPE2",
+                (locals) => CheckValueType(locals, "r", "System.Decimal", description: "0"),
+                (locals) => CheckValueType(locals, "r", "System.Decimal", description: "1.1")
+                );
+        }
+
+        [Fact]
+        async Task InspectFunctionAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_GENERICINST",
+                (locals) => CheckObject(locals, "r", "System.Func<int>", is_null: true),
+                (locals) => CheckObject(locals, "r", "System.Func<int>", description: "int OuterMethod ()")
+                );
+        }
+
+        [Fact]
+        async Task InspectFunctionPtrAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_FNPTR",
+                (locals) => CheckSymbol(locals, "r", "(*()) 0"),
+                (locals) => { } // CheckObject(locals, "r", "(*()) 0x22dd230") // FixMe: Could we do better ?
+                );
+        }
+
+        [Fact]
+        async Task InspectIntPtrAssignmentsDuringSteppingIn()
+        {
+            await InspectAssignmentDuringSteppingIn("MONO_TYPE_PTR",
+                (locals) => CheckSymbol(locals, "r", "(int*) 0"),
+                (locals) => { } //CheckObject(locals, "r", "(int*) 0x211c058") // FixMe: Could we do better ?
+                );
+        }
+
+        private async Task InspectAssignmentDuringSteppingIn(string clazz, Action<JToken> checkDefault, Action<JToken> checkValue)
+        {
+            await SetBreakpointInMethod("debugger-test", "DebuggerTests." + clazz, "OuterMethod", 2);
+            await EvaluateAndCheck("window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests." + clazz + ":OuterMethod'); })", null, -1, -1, "OuterMethod");
+
+            await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-stepping-test.cs", -1, -1, "InnerMethod",
+                locals_fn: (locals) =>
+                {
+                    Console.WriteLine(locals);
+                    Assert.Equal(2, locals.Count());
+                    checkDefault(locals);
+                }
+            );
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-stepping-test.cs", -1, -1, "InnerMethod", times: 3,
+                locals_fn: (locals) =>
+                {
+                    Console.WriteLine(locals);
+                    Assert.Equal(2, locals.Count());
+                    checkValue(locals);
+                }
+            );
+        }
+    }
+}

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
@@ -11,205 +11,35 @@ namespace DebuggerTests
 {
     public class AssignmentTests : DebuggerTestBase
     {
-        [Fact]
-        async Task InspectObjectAssignmentsDuringSteppingIn()
+        public static TheoryData<string, JObject, JObject> GetTestData => new TheoryData<string, JObject, JObject>
         {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_OBJECT",
-                (locals) => CheckObject(locals, "r", "object", is_null: true),
-                (locals) => CheckObject(locals, "r", "object")
-                );
-        }
+            { "MONO_TYPE_OBJECT",      TObject("object", is_null: true),                        TObject("object") },
+            { "MONO_TYPE_CLASS",       TObject("DebuggerTests.MONO_TYPE_CLASS", is_null: true), TObject("DebuggerTests.MONO_TYPE_CLASS") },
+            { "MONO_TYPE_BOOLEAN",     TBool(default),                                          TBool(true) },
+            { "MONO_TYPE_CHAR",        TSymbol("0 '\u0000'"),                                   TSymbol("97 'a'") },
+            { "MONO_TYPE_STRING",      TString(default),                                        TString("hello") },
+            { "MONO_TYPE_ENUM",        TEnum("DebuggerTests.RGB", "Red"),                       TEnum("DebuggerTests.RGB", "Blue") },
+            { "MONO_TYPE_ARRAY",       TObject("byte[]", is_null: true),                        TArray("byte[]", 2) },
+            { "MONO_TYPE_VALUETYPE",   TValueType("DebuggerTests.Point"),                       TValueType("DebuggerTests.Point") },
+            { "MONO_TYPE_VALUETYPE2",  TValueType("System.Decimal","0"),                        TValueType("System.Decimal", "1.1") },
+            { "MONO_TYPE_GENERICINST", TObject("System.Func<int>", is_null: true),              TDelegate("System.Func<int>", "int Prepare ()") },
+            { "MONO_TYPE_FNPTR",       TPointer("*()",  is_null: true),                         TPointer("*()") },
+            { "MONO_TYPE_PTR",         TPointer("int*", is_null: true),                         TPointer("int*") },
+            { "MONO_TYPE_I1",          TNumber(0),                                              TNumber(-1) },
+            { "MONO_TYPE_I2",          TNumber(0),                                              TNumber(-1) },
+            { "MONO_TYPE_I4",          TNumber(0),                                              TNumber(-1) },
+            { "MONO_TYPE_I8",          TNumber(0),                                              TNumber(-1) },
+            { "MONO_TYPE_U1",          TNumber(0),                                              TNumber(1) },
+            { "MONO_TYPE_U2",          TNumber(0),                                              TNumber(1) },
+            { "MONO_TYPE_U4",          TNumber(0),                                              TNumber(1) },
+            { "MONO_TYPE_U8",          TNumber(0),                                              TNumber(1) },
+            { "MONO_TYPE_R4",          TNumber(0),                                              TNumber("3.1414999961853027") },
+            { "MONO_TYPE_R8",          TNumber(0),                                              TNumber("3.1415") },
+        };
 
-        [Fact]
-        async Task InspectClassAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_CLASS",
-                (locals) => CheckObject(locals, "r", "DebuggerTests.MONO_TYPE_CLASS", is_null: true),
-                (locals) => CheckObject(locals, "r", "DebuggerTests.MONO_TYPE_CLASS")
-                );
-        }
-
-        [Fact]
-        async Task InspectBoolAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_BOOLEAN",
-                (locals) => CheckBool(locals, "r", default),
-                (locals) => CheckBool(locals, "r", true)
-                );
-        }
-
-        [Fact]
-        async Task InspectCharAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_CHAR",
-                (locals) => CheckSymbol(locals, "r", "0 '\u0000'"),
-                (locals) => CheckSymbol(locals, "r", "97 'a'")
-                );
-        }
-
-        [Fact]
-        async Task InspectSByteAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I1",
-                (locals) => CheckNumber<sbyte>(locals, "r", default),
-                (locals) => CheckNumber<sbyte>(locals, "r", -1)
-                );
-        }
-
-        [Fact]
-        async Task InspectShortAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I2",
-                (locals) => CheckNumber<short>(locals, "r", default),
-                (locals) => CheckNumber<short>(locals, "r", -1)
-                );
-        }
-
-        [Fact]
-        async Task InspectIntAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I4",
-                (locals) => CheckNumber<int>(locals, "r", default),
-                (locals) => CheckNumber<int>(locals, "r", -1)
-                );
-        }
-
-        [Fact]
-        async Task InspectLongAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_I8",
-                (locals) => CheckNumber<long>(locals, "r", default),
-                (locals) => CheckNumber<long>(locals, "r", -1)
-                );
-        }
-
-        [Fact]
-        async Task InspectByteAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U1",
-                (locals) => CheckNumber<byte>(locals, "r", default),
-                (locals) => CheckNumber<byte>(locals, "r", 1)
-                );
-        }
-
-        [Fact]
-        async Task InspectUShortAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U2",
-                (locals) => CheckNumber<ushort>(locals, "r", default),
-                (locals) => CheckNumber<ushort>(locals, "r", 1)
-                );
-        }
-
-        [Fact]
-        async Task InspectUIntAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U4",
-                (locals) => CheckNumber<uint>(locals, "r", default),
-                (locals) => CheckNumber<uint>(locals, "r", 1)
-                );
-        }
-
-        [Fact]
-        async Task InspectULongAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_U8",
-                (locals) => CheckNumber<ulong>(locals, "r", default),
-                (locals) => CheckNumber<ulong>(locals, "r", 1)
-                );
-        }
-
-        [Fact]
-        async Task InspectFloatAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_R4",
-                (locals) => CheckNumber<float>(locals, "r", default),
-                (locals) => CheckNumber<float>(locals, "r", 3.1415F)
-                );
-        }
-
-        [Fact]
-        async Task InspectDoubleAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_R8",
-                (locals) => CheckNumber<double>(locals, "r", default),
-                (locals) => CheckNumber<double>(locals, "r", 3.1415D)
-                );
-        }
-
-        [Fact]
-        async Task InspectStringAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_STRING",
-                (locals) => CheckString(locals, "r", default),
-                (locals) => CheckString(locals, "r", "hello")
-                );
-        }
-
-        [Fact]
-        async Task InspectEnumAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_ENUM",
-                (locals) => CheckEnum(locals, "r", "DebuggerTests.RGB", "Red"),
-                (locals) => CheckEnum(locals, "r", "DebuggerTests.RGB", "Blue")
-                );
-        }
-
-        [Fact]
-        async Task InspectArrayAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_ARRAY",
-                (locals) => CheckObject(locals, "r", "byte[]", is_null: true),
-                (locals) => CheckArray(locals, "r", "byte[]", 2)
-                );
-        }
-
-        [Fact]
-        async Task InspectStructAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_VALUETYPE",
-                (locals) => CheckValueType(locals, "r", "DebuggerTests.Point"),
-                (locals) => CheckValueType(locals, "r", "DebuggerTests.Point")
-                );
-        }
-
-        [Fact]
-        async Task InspectDecimalAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_VALUETYPE2",
-                (locals) => CheckValueType(locals, "r", "System.Decimal", description: "0"),
-                (locals) => CheckValueType(locals, "r", "System.Decimal", description: "1.1")
-                );
-        }
-
-        [Fact]
-        async Task InspectFunctionAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_GENERICINST",
-                (locals) => CheckObject(locals, "r", "System.Func<int>", is_null: true),
-                (locals) => CheckObject(locals, "r", "System.Func<int>", description: "int Prepare ()")
-                );
-        }
-
-        [Fact]
-        async Task InspectFunctionPtrAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_FNPTR",
-                (locals) => CheckSymbol(locals, "r", "(*()) 0"),
-                (locals) => { } // CheckObject(locals, "r", "(*()) 0x22dd230") // FixMe: Could we do better ?
-                );
-        }
-
-        [Fact]
-        async Task InspectIntPtrAssignmentsDuringSteppingIn()
-        {
-            await InspectAssignmentDuringSteppingIn("MONO_TYPE_PTR",
-                (locals) => CheckSymbol(locals, "r", "(int*) 0"),
-                (locals) => { } //CheckObject(locals, "r", "(int*) 0x211c058") // FixMe: Could we do better ?
-                );
-        }
-
-        private async Task InspectAssignmentDuringSteppingIn(string clazz, Action<JToken> checkDefault, Action<JToken> checkValue)
+        [Theory]
+        [MemberData("GetTestData")]
+        async Task InspectVariableBeforeAndAfterAssignment(string clazz, JObject checkDefault, JObject checkValue)
         {
             await SetBreakpointInMethod("debugger-test", "DebuggerTests." + clazz, "Prepare", 2);
             await EvaluateAndCheck("window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests." + clazz + ":Prepare'); })", null, -1, -1, "Prepare");
@@ -218,9 +48,8 @@ namespace DebuggerTests
             await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-assignment-test.cs", -1, -1, "TestedMethod",
                 locals_fn: (locals) =>
                 {
-                    Console.WriteLine(locals);
                     Assert.Equal(2, locals.Count());
-                    checkDefault(locals);
+                    Check(locals, "r", checkDefault);
                 }
             );
 
@@ -228,9 +57,8 @@ namespace DebuggerTests
             await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-assignment-test.cs", -1, -1, "TestedMethod", times: 3,
                 locals_fn: (locals) =>
                 {
-                    Console.WriteLine(locals);
                     Assert.Equal(2, locals.Count());
-                    checkValue(locals);
+                    Check(locals, "r", checkValue);
                 }
             );
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -53,6 +53,7 @@ namespace DebuggerTests
             "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
             "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
             "/usr/bin/chromium",
+            "C:/Program Files/Google/Chrome/Application/chrome.exe",
             "/usr/bin/chromium-browser",
         };
         static string chrome_path;
@@ -85,19 +86,19 @@ namespace DebuggerTests
 
         public virtual async Task InitializeAsync()
         {
-           Func<InspectorClient, CancellationToken, List<(string, Task<Result>)>> fn = (client, token) =>
-            {
-                Func<string, (string, Task<Result>)> getInitCmdFn = (cmd) => (cmd, client.SendCommand(cmd, null, token));
-                var init_cmds = new List<(string, Task<Result>)>
-                {
+            Func<InspectorClient, CancellationToken, List<(string, Task<Result>)>> fn = (client, token) =>
+             {
+                 Func<string, (string, Task<Result>)> getInitCmdFn = (cmd) => (cmd, client.SendCommand(cmd, null, token));
+                 var init_cmds = new List<(string, Task<Result>)>
+                 {
                     getInitCmdFn("Profiler.enable"),
                     getInitCmdFn("Runtime.enable"),
                     getInitCmdFn("Debugger.enable"),
                     getInitCmdFn("Runtime.runIfWaitingForDebugger")
-                };
+                 };
 
-                return init_cmds;
-            };
+                 return init_cmds;
+             };
 
             await Ready();
             await insp.OpenSessionAsync(fn);
@@ -149,9 +150,9 @@ namespace DebuggerTests
                 function_name,
                 wait_for_event_fn: async (pause_location) =>
                {
-                       //make sure we're on the right bp
+                   //make sure we're on the right bp
 
-                       Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
+                   Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
 
                    var top_frame = pause_location!["callFrames"]?[0];
 
@@ -258,11 +259,11 @@ namespace DebuggerTests
             return l;
         }
 
-        internal JToken CheckObject(JToken locals, string name, string class_name, string subtype = null, bool is_null = false)
+        internal JToken CheckObject(JToken locals, string name, string class_name, string subtype = null, bool is_null = false, string description = null)
         {
             var l = GetAndAssertObjectWithName(locals, name);
             var val = l["value"];
-            CheckValue(val, TObject(class_name, is_null: is_null), name).Wait();
+            CheckValue(val, TObject(class_name, is_null: is_null, description: description), name).Wait();
             Assert.True(val["isValueType"] == null || !val["isValueType"].Value<bool>());
 
             return l;
@@ -326,10 +327,10 @@ namespace DebuggerTests
             Assert.Equal(value, val);
         }
 
-        internal JToken CheckValueType(JToken locals, string name, string class_name)
+        internal JToken CheckValueType(JToken locals, string name, string class_name, string description=null)
         {
             var l = GetAndAssertObjectWithName(locals, name);
-            CheckValue(l["value"], TValueType(class_name), name).Wait();
+            CheckValue(l["value"], TValueType(class_name, description: description), name).Wait();
             return l;
         }
 
@@ -409,7 +410,7 @@ namespace DebuggerTests
             {
                 functionDeclaration = fn,
                 objectId = obj["value"]?["objectId"]?.Value<string>(),
-                arguments = new[] { new { value = property } , new { value = newvalue } },
+                arguments = new[] { new { value = property }, new { value = newvalue } },
                 silent = true
             });
             var res = await cli.SendCommand("Runtime.callFunctionOn", req, token);
@@ -467,7 +468,14 @@ namespace DebuggerTests
             if (locals_fn != null)
             {
                 var locals = await GetProperties(wait_res["callFrames"][0]["callFrameId"].Value<string>());
-                locals_fn(locals);
+                try
+                {
+                    locals_fn(locals);
+                }
+                catch (System.AggregateException ex)
+                {
+                    throw new AggregateException(ex.Message + " \n" + locals.ToString(), ex);
+                }
             }
 
             return wait_res;
@@ -697,9 +705,9 @@ namespace DebuggerTests
                     AssertEqual(exp_val_str, actual_field_val_str, $"[{label}] Value for json property named {jp.Name} didn't match.");
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                Console.WriteLine($"Expected: {exp_val}. Actual: {actual_val}");
+                Console.WriteLine($"{ex.Message} \nExpected: {exp_val} \nActual: {actual_val}");
                 throw;
             }
         }
@@ -844,8 +852,8 @@ namespace DebuggerTests
         internal async Task<Result> SetBreakpoint(string url_key, int line, int column, bool expect_ok = true, bool use_regex = false, string condition = "")
         {
             var bp1_req = !use_regex ?
-                JObject.FromObject(new { lineNumber = line, columnNumber = column, url = dicFileToUrl[url_key], condition}) :
-                JObject.FromObject(new { lineNumber = line, columnNumber = column, urlRegex = url_key, condition});
+                JObject.FromObject(new { lineNumber = line, columnNumber = column, url = dicFileToUrl[url_key], condition }) :
+                JObject.FromObject(new { lineNumber = line, columnNumber = column, urlRegex = url_key, condition });
 
             var bp1_res = await cli.SendCommand("Debugger.setBreakpointByUrl", bp1_req, token);
             Assert.True(expect_ok ? bp1_res.IsOk : bp1_res.IsErr);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -259,6 +259,13 @@ namespace DebuggerTests
             return l;
         }
 
+        internal JToken Check(JToken locals, string name, JObject expected)
+        {
+            var l = GetAndAssertObjectWithName(locals, name);
+            CheckValue(l["value"], expected, name).Wait();
+            return l;
+        }
+
         internal JToken CheckObject(JToken locals, string name, string class_name, string subtype = null, bool is_null = false, string description = null)
         {
             var l = GetAndAssertObjectWithName(locals, name);
@@ -932,6 +939,9 @@ namespace DebuggerTests
 
         internal static JObject TNumber(uint value) =>
             JObject.FromObject(new { type = "number", value = @value.ToString(), description = value.ToString() });
+
+        internal static JObject TNumber(string value) =>
+            JObject.FromObject(new { type = "number", value = @value.ToString(), description = value });
 
         internal static JObject TValueType(string className, string description = null, object members = null) =>
             JObject.FromObject(new { type = "object", isValueType = true, className = className, description = description ?? className });

--- a/src/mono/wasm/debugger/tests/Directory.Build.props
+++ b/src/mono/wasm/debugger/tests/Directory.Build.props
@@ -16,9 +16,4 @@
 
     <MicrosoftNetCoreAppRuntimePackRidDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(RuntimeConfiguration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackRidDir>
   </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(RuntimeConfiguration)'=='Debug'">
-    <WasmDebugLevel>5</WasmDebugLevel>
-  </PropertyGroup>
-
 </Project>

--- a/src/mono/wasm/debugger/tests/Directory.Build.props
+++ b/src/mono/wasm/debugger/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
     <OutputType>Library</OutputType>
     <Configuration>Debug</Configuration>
-    <RuntimeConfiguration>Release</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)'==''">Release</RuntimeConfiguration>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>219</NoWarn>
@@ -16,4 +16,9 @@
 
     <MicrosoftNetCoreAppRuntimePackRidDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(RuntimeConfiguration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackRidDir>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(RuntimeConfiguration)'=='Debug'">
+    <WasmDebugLevel>5</WasmDebugLevel>
+  </PropertyGroup>
+
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-assignment-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-assignment-test.cs
@@ -8,205 +8,207 @@ using System.Text;
 using System.Threading.Tasks;
 namespace DebuggerTests
 {
-    public struct StepInTest<T>
+    public class StepInTest<T>
     {
-        public static int InnerMethod(T value)
+        public static int TestedMethod(T value)
         {
+            // 1) break here and check un-assigned variables
             T r;
             r = value;
+            // 2) break here and check assigned variables
             return 0;
         }
     }
 
     public class MONO_TYPE_OBJECT
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             var value = new object();
-            return StepInTest<object>.InnerMethod(value);
+            return StepInTest<object>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_CLASS
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             var value = new MONO_TYPE_CLASS();
-            return StepInTest<MONO_TYPE_CLASS>.InnerMethod(value);
+            return StepInTest<MONO_TYPE_CLASS>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_BOOLEAN
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             var value = true;
-            return StepInTest<bool>.InnerMethod(value);
+            return StepInTest<bool>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_CHAR
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             var value = 'a';
-            return StepInTest<char>.InnerMethod(value);
+            return StepInTest<char>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_I1
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             sbyte value = -1;
-            return StepInTest<sbyte>.InnerMethod(value);
+            return StepInTest<sbyte>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_I2
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             short value = -1;
-            return StepInTest<short>.InnerMethod(value);
+            return StepInTest<short>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_I4
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             int value = -1;
-            return StepInTest<int>.InnerMethod(value);
+            return StepInTest<int>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_I8
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             long value = -1;
-            return StepInTest<long>.InnerMethod(value);
+            return StepInTest<long>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_U1
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             byte value = 1;
-            return StepInTest<byte>.InnerMethod(value);
+            return StepInTest<byte>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_U2
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             ushort value = 1;
-            return StepInTest<ushort>.InnerMethod(value);
+            return StepInTest<ushort>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_U4
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             uint value = 1;
-            return StepInTest<uint>.InnerMethod(value);
+            return StepInTest<uint>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_U8
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             ulong value = 1;
-            return StepInTest<ulong>.InnerMethod(value);
+            return StepInTest<ulong>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_R4
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             float value = 3.1415F;
-            return StepInTest<float>.InnerMethod(value);
+            return StepInTest<float>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_R8
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             double value = 3.1415D;
-            return StepInTest<double>.InnerMethod(value);
+            return StepInTest<double>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_STRING
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             string value = "hello";
-            return StepInTest<string>.InnerMethod(value);
+            return StepInTest<string>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_ENUM
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             RGB value = RGB.Blue;
-            return StepInTest<RGB>.InnerMethod(value);
+            return StepInTest<RGB>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_ARRAY
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             byte[] value = new byte[2] { 1, 2 };
-            return StepInTest<byte[]>.InnerMethod(value);
+            return StepInTest<byte[]>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_VALUETYPE
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             Point value = new Point();
-            return StepInTest<Point>.InnerMethod(value);
+            return StepInTest<Point>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_VALUETYPE2
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
             Decimal value = 1.1m;
-            return StepInTest<Decimal>.InnerMethod(value);
+            return StepInTest<Decimal>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_GENERICINST
     {
-        public static int OuterMethod()
+        public static int Prepare()
         {
-            Func<int> value = MONO_TYPE_GENERICINST.OuterMethod;
-            return StepInTest<Func<int>>.InnerMethod(value);
+            Func<int> value = MONO_TYPE_GENERICINST.Prepare;
+            return StepInTest<Func<int>>.TestedMethod(value);
         }
     }
 
     public class MONO_TYPE_FNPTR
     {
-        public unsafe static int OuterMethod()
+        public unsafe static int Prepare()
         {
-            delegate*<int> value = &MONO_TYPE_FNPTR.OuterMethod;
-            return InnerMethod(value);
+            delegate*<int> value = &MONO_TYPE_FNPTR.Prepare;
+            return TestedMethod(value);
         }
 
-        public unsafe static int InnerMethod(delegate*<int> value)
+        public unsafe static int TestedMethod(delegate*<int> value)
         {
             delegate*<int> r;
             r = value;
@@ -216,13 +218,13 @@ namespace DebuggerTests
 
     public class MONO_TYPE_PTR
     {
-        public unsafe static int OuterMethod()
+        public unsafe static int Prepare()
         {
             int a = 1; int* value = &a;
-            return InnerMethod(value);
+            return TestedMethod(value);
         }
 
-        public unsafe static int InnerMethod(int* value)
+        public unsafe static int TestedMethod(int* value)
         {
             int* r;
             r = value;

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-stepping-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-stepping-test.cs
@@ -1,0 +1,232 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+namespace DebuggerTests
+{
+    public struct StepInTest<T>
+    {
+        public static int InnerMethod(T value)
+        {
+            T r;
+            r = value;
+            return 0;
+        }
+    }
+
+    public class MONO_TYPE_OBJECT
+    {
+        public static int OuterMethod()
+        {
+            var value = new object();
+            return StepInTest<object>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_CLASS
+    {
+        public static int OuterMethod()
+        {
+            var value = new MONO_TYPE_CLASS();
+            return StepInTest<MONO_TYPE_CLASS>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_BOOLEAN
+    {
+        public static int OuterMethod()
+        {
+            var value = true;
+            return StepInTest<bool>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_CHAR
+    {
+        public static int OuterMethod()
+        {
+            var value = 'a';
+            return StepInTest<char>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_I1
+    {
+        public static int OuterMethod()
+        {
+            sbyte value = -1;
+            return StepInTest<sbyte>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_I2
+    {
+        public static int OuterMethod()
+        {
+            short value = -1;
+            return StepInTest<short>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_I4
+    {
+        public static int OuterMethod()
+        {
+            int value = -1;
+            return StepInTest<int>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_I8
+    {
+        public static int OuterMethod()
+        {
+            long value = -1;
+            return StepInTest<long>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_U1
+    {
+        public static int OuterMethod()
+        {
+            byte value = 1;
+            return StepInTest<byte>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_U2
+    {
+        public static int OuterMethod()
+        {
+            ushort value = 1;
+            return StepInTest<ushort>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_U4
+    {
+        public static int OuterMethod()
+        {
+            uint value = 1;
+            return StepInTest<uint>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_U8
+    {
+        public static int OuterMethod()
+        {
+            ulong value = 1;
+            return StepInTest<ulong>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_R4
+    {
+        public static int OuterMethod()
+        {
+            float value = 3.1415F;
+            return StepInTest<float>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_R8
+    {
+        public static int OuterMethod()
+        {
+            double value = 3.1415D;
+            return StepInTest<double>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_STRING
+    {
+        public static int OuterMethod()
+        {
+            string value = "hello";
+            return StepInTest<string>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_ENUM
+    {
+        public static int OuterMethod()
+        {
+            RGB value = RGB.Blue;
+            return StepInTest<RGB>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_ARRAY
+    {
+        public static int OuterMethod()
+        {
+            byte[] value = new byte[2] { 1, 2 };
+            return StepInTest<byte[]>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_VALUETYPE
+    {
+        public static int OuterMethod()
+        {
+            Point value = new Point();
+            return StepInTest<Point>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_VALUETYPE2
+    {
+        public static int OuterMethod()
+        {
+            Decimal value = 1.1m;
+            return StepInTest<Decimal>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_GENERICINST
+    {
+        public static int OuterMethod()
+        {
+            Func<int> value = MONO_TYPE_GENERICINST.OuterMethod;
+            return StepInTest<Func<int>>.InnerMethod(value);
+        }
+    }
+
+    public class MONO_TYPE_FNPTR
+    {
+        public unsafe static int OuterMethod()
+        {
+            delegate*<int> value = &MONO_TYPE_FNPTR.OuterMethod;
+            return InnerMethod(value);
+        }
+
+        public unsafe static int InnerMethod(delegate*<int> value)
+        {
+            delegate*<int> r;
+            r = value;
+            return 0;
+        }
+    }
+
+    public class MONO_TYPE_PTR
+    {
+        public unsafe static int OuterMethod()
+        {
+            int a = 1; int* value = &a;
+            return InnerMethod(value);
+        }
+
+        public unsafe static int InnerMethod(int* value)
+        {
+            int* r;
+            r = value;
+            return 0;
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -36,8 +36,6 @@
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
-
-      <WasmExtraConfig Condition="'$(RuntimeConfiguration)'=='Debug'" Include="environment_variables" Value="{ &quot;MONO_LOG_LEVEL&quot;: &quot;debug&quot;, &quot;MONO_LOG_MASK&quot; : &quot;all&quot; }"/>
     </ItemGroup>
   </Target>
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -24,7 +24,7 @@
     <PropertyGroup>
       <WasmAppDir>$(AppDir)</WasmAppDir>
       <WasmMainJSPath>$(MonoProjectRoot)wasm\runtime-test.js</WasmMainJSPath>
-      <WasmDebugLevel>1</WasmDebugLevel>
+      <WasmDebugLevel Condition="'$(WasmDebugLevel)'==''">1</WasmDebugLevel>
 
       <WasmResolveAssembliesBeforeBuild>true</WasmResolveAssembliesBeforeBuild>
     </PropertyGroup>
@@ -36,6 +36,8 @@
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
+
+      <WasmExtraConfig Condition="'$(RuntimeConfiguration)'=='Debug'" Include="environment_variables" Value="{ &quot;MONO_LOG_LEVEL&quot;: &quot;debug&quot;, &quot;MONO_LOG_MASK&quot; : &quot;all&quot; }"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51276

- fix null reference in describe_value() + add test for it
- fix null reference in PDB load
- improved handling of targetCrashed in Inspector

On top of that
- improve Makefile to allow passing test arguments together with filters
- add windows chrome to probe path
- include debugging payload into test failure exception for easier debugging
- make it possible to compile with WasmBuildNative=true
- make it possible to compile with Debug runtime
- enable Mono logging in debug mode