### PR TITLE
Stop harvesting S.Security.Crypto.ProtectedData

### DIFF
--- a/src/libraries/System.Security.Cryptography.ProtectedData/pkg/System.Security.Cryptography.ProtectedData.pkgproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/pkg/System.Security.Cryptography.ProtectedData.pkgproj
@@ -5,11 +5,9 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.ProtectedData.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;;lib/netstandard1.3" />
-  </ItemGroup>
-  <ItemGroup>
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
The netstandard1.3 and net46 configurations of the
System.Security.Cryptography.ProtectedData packages aren't built
anymore. Instead the already built matching binary from the latest
available package version is redistributed when packaging these
libraries.

Dropping the netstandard1.3 asset and the net46 one as the
minimum supported set of platforms are ones that support netstandard2.0.
For .NET Framework, there's still a net461 configuration to avoid
binding redirect issues.

Contributes to https://github.com/dotnet/runtime/issues/47530