### PR TITLE
Stop harvesting old frameworks in more libraries

### DIFF
--- a/src/libraries/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
+++ b/src/libraries/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;uap10.0.16299;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -4,13 +4,13 @@
     <ProjectReference Include="..\ref\System.IO.Pipes.AccessControl.csproj">
       <SupportedFramework>$(NetCoreAppCurrent)</SupportedFramework>
     </ProjectReference>
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
     <HarvestIncludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" />
-    <HarvestIncludePaths Include="ref/netstandard1.3;lib/netstandard1.3" />
     <HarvestIncludePaths Include="ref/netstandard2.0;lib/netstandard2.0" />
     <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.1" />
     <HarvestIncludePaths Include="ref/net5.0;lib/net5.0;runtimes/win/lib/net5.0" />
-    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/libraries/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3">
-      <SupportedFramework>netcore50</SupportedFramework>
-    </HarvestIncludePaths>
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
+++ b/src/libraries/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
@@ -5,11 +5,8 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.Windows.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
-    <!-- this package is part of the implementation closure of NETStandard.Library
-         therefore it cannot reference NETStandard.Library -->
-    <SuppressMetaPackage Include="NETStandard.Library" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
+++ b/src/libraries/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
@@ -7,8 +7,8 @@
     <ProjectReference Include="..\src\System.Text.Encoding.CodePages.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <HarvestIncludePaths Include="lib/net46" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/libraries/pkg/test/packageSettings/System.Buffers/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Buffers/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Reflection.TypeExtensions/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Reflection.TypeExtensions/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Runtime.WindowsRuntime/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Runtime.WindowsRuntime/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Security.Cryptography.Cng/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Security.Cryptography.Cng/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Security.Principal.Windows/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Security.Principal.Windows/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
The removed configurations (few netstandard1.x, portable*, netcore50,
net46) of the touched packages aren't built anymore. Instead
the already built matching binaries from the latest available packages
are redistributed when packaging these libraries.

Dropping these assets as the minimum supported set of platforms are ones
that support netstandard2.0. For .NET Framework, there's still a net461
configuration present to avoid binding redirect issues.

Contributes to https://github.com/dotnet/runtime/issues/47530