### PR TITLE
Use PooledByteBufferWriter to save 1K in trimmed System.Memory.dll

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51571

Per that issue there was a ~1K regression.
```
Benchmark | Baseline | Test | Test/Base | Baseline IR | Compare IR | IR Ratio | Baseline ETL | Compare ETL
-- | -- | -- | -- | -- | -- | -- | -- | --
SOD - New Blazor Template - Publish - pub/wwwroot/_framework/System.Memory.dll.gz | 8.59 KB | 9.26 KB | 1.08
-- | -- | -- | --
```

Verified the ~1K savings locally (in self-contained trimmed console app):
```
Before: 35,840 bytes
After: 34,816 bytes
```