### PR TITLE
add NegotiateClientCertificateAsync support on Windows

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -50,5 +50,6 @@ internal static partial class Interop
         BadBinding = unchecked((int)0x80090346),
         DowngradeDetected = unchecked((int)0x80090350),
         ApplicationProtocolMismatch = unchecked((int)0x80090367),
+        NoRenegotiation = unchecked((int)0x00090360),
     }
 }

--- a/src/libraries/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -9,7 +9,7 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private const int StatusDictionarySize = 42;
+        private const int StatusDictionarySize = 43;
 
 #if DEBUG
         static SecurityStatusAdapterPal()
@@ -61,7 +61,8 @@ namespace System.Net
             { Interop.SECURITY_STATUS.UnsupportedPreauth, SecurityStatusPalErrorCode.UnsupportedPreauth },
             { Interop.SECURITY_STATUS.Unsupported, SecurityStatusPalErrorCode.Unsupported },
             { Interop.SECURITY_STATUS.UntrustedRoot, SecurityStatusPalErrorCode.UntrustedRoot },
-            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal }
+            { Interop.SECURITY_STATUS.WrongPrincipal, SecurityStatusPalErrorCode.WrongPrincipal },
+            { Interop.SECURITY_STATUS.NoRenegotiation, SecurityStatusPalErrorCode.NoRenegotiation }
         };
 
         internal static SecurityStatusPal GetSecurityStatusPalFromNativeInt(int win32SecurityStatus)

--- a/src/libraries/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/libraries/Common/src/System/Net/SecurityStatusPal.cs
@@ -69,6 +69,7 @@ namespace System.Net
         UnsupportedPreauth,
         BadBinding,
         DowngradeDetected,
-        ApplicationProtocolMismatch
+        ApplicationProtocolMismatch,
+        NoRenegotiation
     }
 }

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -214,6 +214,7 @@ namespace System.Net.Security
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { throw null; }
+        public System.Threading.Tasks.Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, System.Threading.CancellationToken cancellationToken = default) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.AsyncCallback? asyncCallback, object? asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection? clientCertificates, bool checkCertificateRevocation, System.AsyncCallback? asyncCallback, object? asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection? clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, System.AsyncCallback? asyncCallback, object? asyncState) { throw null; }
@@ -231,6 +232,7 @@ namespace System.Net.Security
         ~SslStream() { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.Task NegotiateClientCertificateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -242,7 +244,6 @@ namespace System.Net.Security
         public override void Write(byte[] buffer, int offset, int count) { }
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     public enum TlsCipherSuite : ushort

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -452,4 +452,7 @@
   <data name="net_ssl_certificate_exist" xml:space="preserve">
     <value>Remote certificate is already available.</value>
   </data>
+  <data name="net_ssl_renegotiate_data" xml:space="preserve">
+    <value>Received data during renegotiation.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -449,4 +449,7 @@
   <data name="SystemNetSecurity_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.Security is not supported on this platform.</value>
   </data>
+  <data name="net_ssl_certificate_exist" xml:space="preserve">
+    <value>Remote certificate is already available.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -830,6 +830,15 @@ namespace System.Net.Security
             return status;
         }
 
+        internal SecurityStatusPal Renegotiate(out byte[]? output)
+        {
+            return SslStreamPal.Renegotiate(
+                                      ref _credentialsHandle!,
+                                      ref _securityContext,
+                                      _sslAuthenticationOptions,
+                                      out output);
+        }
+
         /*++
             ProcessHandshakeSuccess -
                Called on successful completion of Handshake -

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -667,6 +667,7 @@ namespace System.Net.Security
 
             if (_nestedAuth != 1)
             {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Ignoring unsolicited renegotiated certificate.");
                 // ignore certificates received outside of handshake or requested renegotiation.
                 sslPolicyErrors = SslPolicyErrors.None;
                 chainStatus = X509ChainStatusFlags.NoError;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -313,12 +313,12 @@ namespace System.Net.Security
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "NegotiateClientCertificateAsync", "renegotiate"));
             }
 
-            if (Interlocked.CompareExchange(ref _nestedRead, 1, 0) == 1)
+            if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(SslStream.ReadAsync), "read"));
             }
 
-            if (Interlocked.CompareExchange(ref _nestedWrite, 1, 0) == 1)
+            if (Interlocked.Exchange(ref _nestedWrite, 1) == 1)
             {
                 _nestedRead = 0;
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(WriteAsync), "write"));

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -306,7 +306,7 @@ namespace System.Net.Security
         }
 
         // This will initiate renegotiation or PHA for Tls1.3
-        private async Task Renegotiate(CancellationToken cancellationToken)
+        private async Task RenegotiateAsync(CancellationToken cancellationToken)
         {
             if (Interlocked.Exchange(ref _nestedAuth, 1) == 1)
             {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -823,8 +823,13 @@ namespace System.Net.Security
             {
                 while (true)
                 {
-                    if (_decryptedBytesCount != 0 && !renegotiation)
+                    if (_decryptedBytesCount != 0)
                     {
+                        if (renegotiation)
+                        {
+                            throw new InvalidOperationException(SR.net_ssl_renegotiate_data);
+                        }
+
                         return CopyDecryptedData(buffer);
                     }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -26,7 +26,7 @@ namespace System.Net.Security
             BeforeSSL3,     // SSlv2
             SinceSSL3,      // SSlv3 & TLS
             Unified,        // Intermediate on first frame until response is processes.
-            Invalid         // Somthing is wrong.
+            Invalid         // Something is wrong.
         }
 
         // This is set on the first packet to figure out the framing style.
@@ -302,6 +302,59 @@ namespace System.Net.Security
             {
                 _handshakeWaiter!.SetResult(true);
                 _handshakeWaiter = null;
+            }
+        }
+
+        // This will initiate renegotiation or PHA for Tls1.3
+        private async Task Renegotiate(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Exchange(ref _nestedAuth, 1) == 1)
+            {
+                throw new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "NegotiateClientCertificateAsync", "renegotiate"));
+            }
+
+            if (Interlocked.CompareExchange(ref _nestedRead, 1, 0) == 1)
+            {
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(SslStream.ReadAsync), "read"));
+            }
+
+            if (Interlocked.CompareExchange(ref _nestedWrite, 1, 0) == 1)
+            {
+                _nestedRead = 0;
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(WriteAsync), "write"));
+            }
+
+            _sslAuthenticationOptions!.RemoteCertRequired = true;
+            IReadWriteAdapter adapter = new AsyncReadWriteAdapter(InnerStream, cancellationToken);
+
+            try
+            {
+                SecurityStatusPal status = _context!.Renegotiate(out byte[]? nextmsg);
+                if (nextmsg?.Length > 0)
+                {
+                    await adapter.WriteAsync(nextmsg, 0, nextmsg.Length).ConfigureAwait(false);
+                    await adapter.FlushAsync().ConfigureAwait(false);
+                }
+
+                if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
+                {
+                    if (status.ErrorCode == SecurityStatusPalErrorCode.NoRenegotiation)
+                    {
+                        // peer does not want to renegotiate. That should keep session usable.
+                        return;
+                    }
+
+                    throw SslStreamPal.GetException(status);
+                }
+
+                // Issue empty read to get renegotiation going.
+                await ReadAsyncInternal(adapter, Memory<byte>.Empty, renegotiation: true).ConfigureAwait(false);
+            }
+            finally
+            {
+                _nestedRead = 0;
+                _nestedWrite = 0;
+                // We will not release _nestedAuth at this point to prevent another renegotiation attempt.
             }
         }
 
@@ -753,12 +806,15 @@ namespace System.Net.Security
             }
         }
 
-        private async ValueTask<int> ReadAsyncInternal<TIOAdapter>(TIOAdapter adapter, Memory<byte> buffer)
+        private async ValueTask<int> ReadAsyncInternal<TIOAdapter>(TIOAdapter adapter, Memory<byte> buffer, bool renegotiation = false)
             where TIOAdapter : IReadWriteAdapter
         {
-            if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
+            if (!renegotiation)
             {
-                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(SslStream.ReadAsync), "read"));
+                if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
+                {
+                    throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(SslStream.ReadAsync), "read"));
+                }
             }
 
             Debug.Assert(_internalBuffer is null || _internalBufferCount > 0 || _decryptedBytesCount > 0, "_internalBuffer allocated when no data is buffered.");
@@ -767,12 +823,12 @@ namespace System.Net.Security
             {
                 while (true)
                 {
-                    if (_decryptedBytesCount != 0)
+                    if (_decryptedBytesCount != 0 && !renegotiation)
                     {
                         return CopyDecryptedData(buffer);
                     }
 
-                    if (buffer.Length == 0 && _internalBuffer is null)
+                    if (buffer.Length == 0 && _internalBuffer is null && !renegotiation)
                     {
                         // User requested a zero-byte read, and we have no data available in the buffer for processing.
                         // This zero-byte read indicates their desire to trade off the extra cost of a zero-byte read
@@ -844,7 +900,6 @@ namespace System.Net.Security
                             // If that happen before EncryptData() runs, _handshakeWaiter will be set to null
                             // and EncryptData() will work normally e.g. no waiting, just exclusion with DecryptData()
 
-
                             if (_sslAuthenticationOptions!.AllowRenegotiation || SslProtocol == SslProtocols.Tls13)
                             {
                                 // create TCS only if we plan to proceed. If not, we will throw in block bellow outside of the lock.
@@ -880,8 +935,11 @@ namespace System.Net.Security
                             {
                                 throw new IOException(SR.net_ssl_io_renego);
                             }
-
                             await ReplyOnReAuthenticationAsync(adapter, extraBuffer).ConfigureAwait(false);
+                            if (renegotiation)
+                            {
+                                return 0;
+                            }
                             // Loop on read.
                             continue;
                         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -697,7 +697,7 @@ namespace System.Net.Security
                 throw new InvalidOperationException(SR.net_ssl_certificate_exist);
             }
 
-            return Renegotiate(cancellationToken);
+            return RenegotiateAsync(cancellationToken);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -689,6 +689,17 @@ namespace System.Net.Security
 
         public override Task FlushAsync(CancellationToken cancellationToken) => InnerStream.FlushAsync(cancellationToken);
 
+        public virtual Task NegotiateClientCertificateAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfExceptionalOrNotAuthenticated();
+            if (RemoteCertificate != null)
+            {
+                throw new InvalidOperationException(SR.net_ssl_certificate_exist);
+            }
+
+            return Renegotiate(cancellationToken);
+        }
+
         protected override void Dispose(bool disposing)
         {
             try

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -45,6 +45,11 @@ namespace System.Net.Security
             return HandshakeInternal(credential, ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions);
         }
 
+        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static SafeFreeCredentials AcquireCredentialsHandle(
             SslStreamCertificateContext? certificateContext,
             SslProtocols protocols,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -52,6 +52,11 @@ namespace System.Net.Security
             return HandshakeInternal(credential, ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions);
         }
 
+        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static SafeFreeCredentials AcquireCredentialsHandle(
             SslStreamCertificateContext? certificateContext,
             SslProtocols protocols,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -36,6 +36,11 @@ namespace System.Net.Security
             return HandshakeInternal(credential!, ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions);
         }
 
+        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static SafeFreeCredentials AcquireCredentialsHandle(SslStreamCertificateContext? certificateContext,
             SslProtocols protocols, EncryptionPolicy policy, bool isServer)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -110,6 +110,14 @@ namespace System.Net.Security
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 
+        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer )
+        {
+            byte[]? output = Array.Empty<byte>();
+            SecurityStatusPal status =  AcceptSecurityContext(ref credentialsHandle, ref context, Span<byte>.Empty, ref output, sslAuthenticationOptions);
+            outputBuffer = output;
+            return status;
+        }
+
         public static SafeFreeCredentials AcquireCredentialsHandle(SslStreamCertificateContext? certificateContext, SslProtocols protocols, EncryptionPolicy policy, bool isServer)
         {
             // New crypto API supports TLS1.3 but it does not allow to force NULL encryption.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -171,7 +171,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -42,8 +42,8 @@ namespace System.Net.Security.Tests
         private static readonly X509BasicConstraintsExtension s_eeConstraints =
             new X509BasicConstraintsExtension(false, false, 0, false);
 
-        private static readonly byte[] s_ping = Encoding.UTF8.GetBytes("PING");
-        private static readonly byte[] s_pong = Encoding.UTF8.GetBytes("PONG");
+        public static readonly byte[] s_ping = Encoding.UTF8.GetBytes("PING");
+        public static readonly byte[] s_pong = Encoding.UTF8.GetBytes("PONG");
 
         public static (SslStream ClientStream, SslStream ServerStream) GetConnectedSslStreams()
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -195,26 +196,26 @@ namespace System.Net.Security.Tests
             return (endEntity, chain);
         }
 
-        internal static async Task PingPong(SslStream client, SslStream server)
+        internal static async Task PingPong(SslStream client, SslStream server, CancellationToken cancellationToken = default)
         {
             byte[] buffer = new byte[s_ping.Length];
-            ValueTask t = client.WriteAsync(s_ping);
+            ValueTask t = client.WriteAsync(s_ping, cancellationToken);
 
             int remains = s_ping.Length;
             while (remains > 0)
             {
-                int readLength = await server.ReadAsync(buffer, buffer.Length - remains, remains);
+                int readLength = await server.ReadAsync(buffer, buffer.Length - remains, remains, cancellationToken);
                 Assert.True(readLength > 0);
                 remains -= readLength;
             }
             Assert.Equal(s_ping, buffer);
             await t;
 
-            t = server.WriteAsync(s_pong);
+            t = server.WriteAsync(s_pong, cancellationToken);
             remains = s_pong.Length;
             while (remains > 0)
             {
-                int readLength = await client.ReadAsync(buffer, buffer.Length - remains, remains);
+                int readLength = await client.ReadAsync(buffer, buffer.Length - remains, remains, cancellationToken);
                 Assert.True(readLength > 0);
                 remains -= readLength;
             }

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -59,7 +59,7 @@ namespace System.Net.Security
             return Task.Run(() => {});
         }
 
-        private Task Renegotiate(CancellationToken cancellationToken) => throw new PlatformNotSupportedException();
+        private Task RenegotiateAsync(CancellationToken cancellationToken) => throw new PlatformNotSupportedException();
 
         private void ReturnReadBufferIfEmpty()
         {

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -59,6 +59,8 @@ namespace System.Net.Security
             return Task.Run(() => {});
         }
 
+        private Task Renegotiate(CancellationToken cancellationToken) => throw new PlatformNotSupportedException();
+
         private void ReturnReadBufferIfEmpty()
         {
         }


### PR DESCRIPTION
This may still need some more work but this change brings basic support for `NegotiateClientCertificateAsync` e.g. ability to ask for peer certificate late in TLS session.

I wanted to lay out some tests and restrictions as well as provide some implementation so it can be tested with Kestrel. 
Linux/OpenSSL will be different with similar structure. We need to trigger the renegotiation and then we simply crank the state machine until it is finished. 
On Windows, Tls12 and Tls13 has same code path. Linux will be different as the feature is implemented on top of different mechanisms. 

cc: @davidfowl @Tratcher 

contributes to  #49346
