### PR TITLE
Make EventSourceAutoGenerateAttribute conditional to not be emitted into

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Diagnostics.Tracing
 #else
 namespace System.Diagnostics.Tracing
 {
+    [Conditional("NEEDED_FOR_SOURCE_GENERATOR_ONLY")]
     [AttributeUsage(AttributeTargets.Class)]
     internal sealed class EventSourceAutoGenerateAttribute : Attribute
     {


### PR DESCRIPTION
output assembly