### PR TITLE
Don't forget to pass instantiation context after devirtualizing

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1179,6 +1179,11 @@ namespace Internal.JitInterface
                 return false;
             }
 
+            TypeDesc owningType = impl.OwningType;
+
+            // RyuJIT expects to get the canonical form back
+            impl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
             if (impl.OwningType.IsValueType)
             {
                 impl = getUnboxingThunk(impl);
@@ -1186,7 +1191,7 @@ namespace Internal.JitInterface
 
             info->devirtualizedMethod = ObjectToHandle(impl);
             info->requiresInstMethodTableArg = false;
-            info->exactContext = contextFromType(impl.OwningType);
+            info->exactContext = contextFromType(owningType);
 
             return true;
         }

--- a/src/tests/JIT/opt/Devirtualization/generic_noinline.cs
+++ b/src/tests/JIT/opt/Devirtualization/generic_noinline.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static int Main()
+    {
+        MyStruct<Atom> s = default;
+
+        // RyuJIT can devirtualize this, but NoInlining prevents the inline
+        // This checks that we properly pass the instantiation context to the shared generic method.
+        return ((IFoo)s).GetTheType() == typeof(Atom) ? 100 : -1;
+    }
+}
+
+interface IFoo
+{
+    Type GetTheType();
+}
+
+struct MyStruct<T> : IFoo
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    Type IFoo.GetTheType() => typeof(T);
+}
+
+class Atom { }

--- a/src/tests/JIT/opt/Devirtualization/generic_noinline.csproj
+++ b/src/tests/JIT/opt/Devirtualization/generic_noinline.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="generic_noinline.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is a difference between CoreCLR and the managed type system - the result of interface method resolution is going to be a canonical method on the CoreCLR side, but exact on the managed side.

So this implementation is slightly different from how it looks like on the VM side. We slightly touched on the difference in https://github.com/dotnet/runtime/pull/45744 but there was more to it.