### PR TITLE
Pass TYP_FLOAT to gtNewDconNode instead of creating a new scope

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11463,11 +11463,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             case CEE_LDC_R4:
                 cval.dblVal = getR4LittleEndian(codeAddr);
                 JITDUMP(" %#.17g", cval.dblVal);
-                {
-                    GenTree* cnsOp = gtNewDconNode(cval.dblVal);
-                    cnsOp->gtType  = TYP_FLOAT;
-                    impPushOnStack(cnsOp, typeInfo(TI_DOUBLE));
-                }
+                impPushOnStack(gtNewDconNode(cval.dblVal, TYP_FLOAT), typeInfo(TI_DOUBLE));
                 break;
 
             case CEE_LDSTR:


### PR DESCRIPTION
No reason not to except debugging?
But if we want to improve debugging experience, we would need to introduce many more scopes.