### PR TITLE
Delete GTF_SIMD12_OP as it is not used

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -935,9 +935,6 @@ public:
 #define GTF_ARRLEN_ARR_IDX          0x80000000 // GT_ARR_LENGTH -- Length which feeds into an array index expression
 #define GTF_ARRLEN_NONFAULTING      0x20000000 // GT_ARR_LENGTH  -- An array length operation that cannot fault. Same as GT_IND_NONFAULTING.
 
-#define GTF_SIMD12_OP               0x80000000 // GT_SIMD -- Indicates that the operands need to be handled as SIMD12
-                                               //            even if they have been retyped as SIMD16.
-
 #define GTF_SIMDASHW_OP             0x80000000 // GT_HWINTRINSIC -- Indicates that the structHandle should be gotten from gtGetStructHandleForSIMD
                                                //                   rarther than from gtGetStructHandleForHWSIMD.
 


### PR DESCRIPTION
Text search (`ls * -r | sls "GTF_SIMD12_OP" -s`) for its mentions in `src/coreclr/jit` finds only the definition. It is possible that some code still depends on the value by some accident - I hope our testing is extensive enough to cover for that scenario.

It looks like the last uses of it have been removed in #37882.