### PR TITLE
Fix runtimelab build and add support for runtimeVariant and pgoType builds

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -14,6 +14,7 @@ parameters:
   dependsOn: []
   pool: ''
   platform: ''
+  pgoType: ''
   condition: true
   useContinueOnErrorDuringBuild: false
   shouldContinueOnError: false
@@ -21,6 +22,7 @@ parameters:
   isOfficialBuild: false
   buildingOnSourceBuildImage: false
   runtimeFlavor: 'coreclr'
+  runtimeVariant: ''
   helixQueues: ''
   enablePublishTestResults: false
   testResultsFormat: ''
@@ -153,10 +155,12 @@ jobs:
           archType: ${{ parameters.archType }}
           buildConfig: ${{ parameters.buildConfig }}
           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+          runtimeVariant: ${{ parameters.runtimeVariant }}
           helixQueues: ${{ parameters.helixQueues }}
           targetRid: ${{ parameters.targetRid }}
           nameSuffix: ${{ parameters.nameSuffix }}
           platform: ${{ parameters.platform }}
+          pgoType: ${{ parameters.pgoType }}
           shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
           ${{ insert }}: ${{ parameters.extraStepsParameters }}
 

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -83,6 +83,7 @@ stages:
       - Linux_x64
       - windows_x64
       jobParameters:
+        timeoutInMinutes: 100
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         testGroup: innerloop
         extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -5,6 +5,8 @@ parameters:
   osSubgroup: ''
   nameSuffix: ''
   platform: ''
+  pgoType: ''
+  runtimeVariant: ''
   librariesBinArtifactName: ''
   isOfficialBuild: false
   uploadLibrariesTests: false
@@ -30,7 +32,7 @@ steps:
       tarCompression: $(tarCompression)
       includeRootFolder: false
       archiveExtension: $(archiveExtension)
-      artifactName: CoreCLRProduct__${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
+      artifactName: CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
       displayName: 'CoreCLR product build'
 
   # Zip Test Build


### PR DESCRIPTION
When `pgoType` was introduced it updated the "expected" name for the artifacts to download on libraries test run jobs. However, in runtimelab we had hardcoded the number of `_` that we expected the name to have when `runtimeVariant` was empty. Rather than hardcoding 3 underscores I rather add support for these parameters in case there is an experiment sometime that wants to use a special runtime variant or pgo type.

cc: @ViktorHofer @danmoseley @agocke 