### PR TITLE
Closing opened handles to avoid resource leak.

### DIFF
--- a/src/coreclr/debug/ildbsymlib/symread.cpp
+++ b/src/coreclr/debug/ildbsymlib/symread.cpp
@@ -722,6 +722,12 @@ SymReader::InitializeFromFile(
     }
 
 ErrExit:
+    if (hMod)
+        UnmapViewOfFile(hMod);
+    if (hMapFile != INVALID_HANDLE_VALUE)
+        CloseHandle(hMapFile);
+    if (hFile != INVALID_HANDLE_VALUE)
+        CloseHandle(hFile);
 
     return hr;
 }


### PR DESCRIPTION
SymReader::InitializeFromFile opens file handles which were not closed causing resource leaks on each call.

Fix #50422