### PR TITLE
Add AssemblyExtensions.GetApplyUpdateCapabilities method

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -81,5 +81,10 @@ namespace System.Reflection.Metadata
                 }
             }
         }
+
+        internal static string GetApplyUpdateCapabilities()
+        {
+            return "Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition";
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -62,4 +62,13 @@
       <method signature="System.Void Initialize()" />
     </type>
   </assembly>
+
+  <!-- methods used by hot reload.
+       TODO: once there's a feature flag, add it to the linker descriptor
+  -->
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Reflection.Metadata.AssemblyExtensions">
+      <method name="GetApplyUpdateCapabilities" />
+    </type>
+  </assembly>
 </linker>

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
@@ -40,17 +40,17 @@ namespace System.Reflection.Metadata
             }
         }
 
-	[Fact]
-	public void GetApplyUpdateCapabilitiesIsCallable()
-	{
-	    var ty = typeof(System.Reflection.Metadata.AssemblyExtensions);
-	    var mi = ty.GetMethod ("GetApplyUpdateCapabilities", BindingFlags.NonPublic | BindingFlags.Static, Array.Empty<Type>());
+        [Fact]
+        public void GetApplyUpdateCapabilitiesIsCallable()
+        {
+            var ty = typeof(System.Reflection.Metadata.AssemblyExtensions);
+            var mi = ty.GetMethod("GetApplyUpdateCapabilities", BindingFlags.NonPublic | BindingFlags.Static, Array.Empty<Type>());
 
-	    Assert.NotNull (mi);
+            Assert.NotNull(mi);
 
-	    var result = mi.Invoke(null, null);
+            var result = mi.Invoke(null, null);
 
-	    Assert.NotNull (result);
-	}
+            Assert.NotNull(result);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
@@ -39,5 +39,18 @@ namespace System.Reflection.Metadata
                     AssemblyExtensions.ApplyUpdate(typeof(AssemblyExtensions).Assembly, new ReadOnlySpan<byte>(metadataDelta), new ReadOnlySpan<byte>(ilDelta), ReadOnlySpan<byte>.Empty));
             }
         }
+
+	[Fact]
+	public void GetApplyUpdateCapabilitiesIsCallable()
+	{
+	    var ty = typeof(System.Reflection.Metadata.AssemblyExtensions);
+	    var mi = ty.GetMethod ("GetApplyUpdateCapabilities", BindingFlags.NonPublic | BindingFlags.Static, Array.Empty<Type>());
+
+	    Assert.NotNull (mi);
+
+	    var result = mi.Invoke(null, null);
+
+	    Assert.NotNull (result);
+	}
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
@@ -51,6 +51,7 @@ namespace System.Reflection.Metadata
             var result = mi.Invoke(null, null);
 
             Assert.NotNull(result);
+            Assert.Equal(typeof(string), result.GetType());
         }
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -51,12 +51,13 @@ namespace System.Reflection.Metadata
 #endif
         }
 
-        internal static void ApplyUpdateSdb(Assembly assembly, byte[] metadataDelta, byte[] ilDelta, byte[]? pdbDelta)
+        internal static string GetApplyUpdateCapabilities()
         {
-            ReadOnlySpan<byte> md = metadataDelta;
-            ReadOnlySpan<byte> il = ilDelta;
-            ReadOnlySpan<byte> dpdb = pdbDelta == null ? default : pdbDelta;
-            ApplyUpdate (assembly, md, il, dpdb);
+#if !FEATURE_METADATA_UPDATE
+            return string.Empty;
+#else
+            return "Baseline";
+#endif
         }
 
 #if FEATURE_METADATA_UPDATE


### PR DESCRIPTION
Implement a private API that returns the hot reload capabilities of the current runtime.

The corresponding Roslyn API work is https://github.com/dotnet/roslyn/pull/52566

Resolves #50111 

