### PR TITLE
Remove BaseAssemblySpec::HasUniqueIdentity (always returns true)

### DIFF
--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -50,7 +50,6 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     array.cpp
     assembly.cpp
     assemblyloadcontext.cpp
-    baseassemblyspec.cpp
     binder.cpp
     bundle.cpp
     castcache.cpp
@@ -62,10 +61,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     clsload.cpp
     codeman.cpp
     codeversion.cpp
-    comdelegate.cpp
     contractimpl.cpp
-    coreassemblyspec.cpp
-    corebindresult.cpp
     corhost.cpp
     crst.cpp
     debugdebugger.cpp
@@ -154,8 +150,6 @@ set(VM_HEADERS_DAC_AND_WKS_COMMON
     array.h
     assembly.hpp
     assemblyloadcontext.h
-    baseassemblyspec.h
-    baseassemblyspec.inl
     binder.h
     castcache.h
     callcounting.h
@@ -169,14 +163,12 @@ set(VM_HEADERS_DAC_AND_WKS_COMMON
     codeman.h
     codeman.inl
     codeversion.h
-    comdelegate.h
     contractimpl.h
     crst.h
     debugdebugger.h
     debuginfostore.h
     decodemd.h
     disassembler.h
-    dllimport.h
     domainfile.h
     domainfile.inl
     dynamicmethod.h
@@ -308,6 +300,7 @@ set(VM_SOURCES_WKS
     assemblyname.cpp
     assemblynative.cpp
     assemblyspec.cpp
+    baseassemblyspec.cpp
     cachelinealloc.cpp
     callhelpers.cpp
     callsiteinspect.cpp
@@ -315,6 +308,7 @@ set(VM_SOURCES_WKS
     clrex.cpp
     clrvarargs.cpp
     comdatetime.cpp
+    comdelegate.cpp
     comdependenthandle.cpp
     comdynamic.cpp
     commodule.cpp
@@ -323,6 +317,8 @@ set(VM_SOURCES_WKS
     comthreadpool.cpp
     comutilnative.cpp
     comwaithandle.cpp
+    coreassemblyspec.cpp
+    corebindresult.cpp
     corelib.cpp # <DisablePrecompiledHeaders>true</DisablePrecompiledHeaders>
     customattribute.cpp
     custommarshalerinfo.cpp
@@ -408,6 +404,8 @@ set(VM_HEADERS_WKS
     assemblynative.hpp
     assemblyspec.hpp
     assemblyspecbase.h
+    baseassemblyspec.h
+    baseassemblyspec.inl
     cachelinealloc.h
     callhelpers.h
     callsiteinspect.h
@@ -416,6 +414,7 @@ set(VM_HEADERS_WKS
     clrex.h
     clrvarargs.h
     comdatetime.h
+    comdelegate.h
     comdependenthandle.h
     comdynamic.h
     commodule.h
@@ -428,6 +427,7 @@ set(VM_HEADERS_WKS
     custommarshalerinfo.h
     autotrace.h
     diagnosticserveradapter.h
+    dllimport.h
     dllimportcallback.h
     eeconfig.h
     eecontract.h

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3096,10 +3096,10 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
     {
         AssemblySpec spec;
         spec.InitializeSpec(result->GetFile());
-        if (spec.CanUseWithBindingCache() && result->CanUseWithBindingCache())
+        if (result->CanUseWithBindingCache())
             GetAppDomain()->AddAssemblyToCache(&spec, result);
     }
-    else if (pIdentity->CanUseWithBindingCache() && result->CanUseWithBindingCache())
+    else if (result->CanUseWithBindingCache())
     {
         GetAppDomain()->AddAssemblyToCache(pIdentity, result);
     }
@@ -3698,9 +3698,6 @@ BOOL AppDomain::AddFileToCache(AssemblySpec* pSpec, PEAssembly *pFile, BOOL fAll
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pSpec));
-        // Hosted fusion binder makes an exception here, so we cannot assert.
-        //PRECONDITION(pSpec->CanUseWithBindingCache());
-        //PRECONDITION(pFile->CanUseWithBindingCache());
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
@@ -3731,7 +3728,6 @@ BOOL AppDomain::AddAssemblyToCache(AssemblySpec* pSpec, DomainAssembly *pAssembl
         MODE_ANY;
         PRECONDITION(CheckPointer(pSpec));
         PRECONDITION(CheckPointer(pAssembly));
-        PRECONDITION(pSpec->CanUseWithBindingCache());
         PRECONDITION(pAssembly->CanUseWithBindingCache());
         INJECT_FAULT(COMPlusThrowOM(););
     }
@@ -3751,7 +3747,6 @@ BOOL AppDomain::AddExceptionToCache(AssemblySpec* pSpec, Exception *ex)
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pSpec));
-        PRECONDITION(pSpec->CanUseWithBindingCache());
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
@@ -3778,7 +3773,7 @@ void AppDomain::AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HAN
     CONTRACTL_END;
 
     CrstHolder lock(&m_DomainCacheCrst);
-    
+
     const UnmanagedImageCacheEntry *existingEntry = m_unmanagedCache.LookupPtr(libraryName);
     if (existingEntry != NULL)
     {
@@ -3866,12 +3861,6 @@ BOOL AppDomain::IsCached(AssemblySpec *pSpec)
     return m_AssemblyCache.Contains(pSpec);
 }
 
-void AppDomain::GetCacheAssemblyList(SetSHash<PTR_DomainAssembly>& assemblyList)
-{
-    CrstHolder holder(&m_DomainCacheCrst);
-    m_AssemblyCache.GetAllAssemblies(assemblyList);
-}
-
 PEAssembly* AppDomain::FindCachedFile(AssemblySpec* pSpec, BOOL fThrow /*=TRUE*/)
 {
     CONTRACTL
@@ -3924,7 +3913,7 @@ BOOL AppDomain::PostBindResolveAssembly(AssemblySpec  *pPrePolicySpec,
     {
         result = TryResolveAssemblyUsingEvent(*ppFailedSpec);
 
-        if (result != NULL && pPrePolicySpec->CanUseWithBindingCache() && result->CanUseWithBindingCache())
+        if (result != NULL && result->CanUseWithBindingCache())
         {
             fFailure = FALSE;
 
@@ -3936,7 +3925,7 @@ BOOL AppDomain::PostBindResolveAssembly(AssemblySpec  *pPrePolicySpec,
             // original binding spec and therefore will not cause inconsistency here.
             // For the purposes of the resolve event, failure to add to the cache still is a success.
             AddFileToCache(pPrePolicySpec, result, TRUE /* fAllowFailure */);
-            if (*ppFailedSpec != pPrePolicySpec && pPostPolicySpec->CanUseWithBindingCache())
+            if (*ppFailedSpec != pPrePolicySpec)
             {
                 AddFileToCache(pPostPolicySpec, result, TRUE /* fAllowFailure */ );
             }
@@ -3963,188 +3952,176 @@ PEAssembly * AppDomain::BindAssemblySpec(
 
     BinderTracing::AssemblyBindOperation bindOperation(pSpec);
 
-    if (pSpec->HasUniqueIdentity())
+    HRESULT hrBindResult = S_OK;
+    PEAssemblyHolder result;
+
+    bool isCached = false;
+    EX_TRY
     {
-        HRESULT hrBindResult = S_OK;
-        PEAssemblyHolder result;
-
-        bool isCached = false;
-        EX_TRY
+        isCached = IsCached(pSpec);
+        if (!isCached)
         {
-            isCached = IsCached(pSpec);
-            if (!isCached)
+
             {
+                // Use CoreClr's fusion alternative
+                CoreBindResult bindResult;
 
+                pSpec->Bind(this, FALSE /* fThrowOnFileNotFound */, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */);
+                hrBindResult = bindResult.GetHRBindResult();
+
+                if (bindResult.Found())
                 {
-                    // Use CoreClr's fusion alternative
-                    CoreBindResult bindResult;
-
-                    pSpec->Bind(this, FALSE /* fThrowOnFileNotFound */, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */);
-                    hrBindResult = bindResult.GetHRBindResult();
-
-                    if (bindResult.Found())
+                    if (SystemDomain::SystemFile() && bindResult.IsCoreLib())
                     {
-                        if (SystemDomain::SystemFile() && bindResult.IsCoreLib())
-                        {
-                            // Avoid rebinding to another copy of CoreLib
-                            result = SystemDomain::SystemFile();
-                            result.SuppressRelease(); // Didn't get a refcount
-                        }
-                        else
-                        {
-                            // IsSystem on the PEFile should be false, even for CoreLib satellites
-                            result = PEAssembly::Open(&bindResult,
-                                                      FALSE);
-                        }
-
-                        // Setup the reference to the binder, which performed the bind, into the AssemblySpec
-                        ICLRPrivBinder* pBinder = result->GetBindingContext();
-                        _ASSERTE(pBinder != NULL);
-                        pSpec->SetBindingContext(pBinder);
-
-                        if (pSpec->CanUseWithBindingCache() && result->CanUseWithBindingCache())
-                        {
-                            // Failure to add simply means someone else beat us to it. In that case
-                            // the FindCachedFile call below (after catch block) will update result
-                            // to the cached value.
-                            AddFileToCache(pSpec, result, TRUE /*fAllowFailure*/);
-                        }
+                        // Avoid rebinding to another copy of CoreLib
+                        result = SystemDomain::SystemFile();
+                        result.SuppressRelease(); // Didn't get a refcount
                     }
                     else
                     {
-                        // Don't trigger the resolve event for the CoreLib satellite assembly. A misbehaving resolve event may
-                        // return an assembly that does not match, and this can cause recursive resource lookups during error
-                        // reporting. The CoreLib satellite assembly is loaded from relative locations based on the culture, see
-                        // AssemblySpec::Bind().
-                        if (!pSpec->IsCoreLibSatellite())
+                        // IsSystem on the PEFile should be false, even for CoreLib satellites
+                        result = PEAssembly::Open(&bindResult,
+                                                    FALSE);
+                    }
+
+                    // Setup the reference to the binder, which performed the bind, into the AssemblySpec
+                    ICLRPrivBinder* pBinder = result->GetBindingContext();
+                    _ASSERTE(pBinder != NULL);
+                    pSpec->SetBindingContext(pBinder);
+
+                    if (result->CanUseWithBindingCache())
+                    {
+                        // Failure to add simply means someone else beat us to it. In that case
+                        // the FindCachedFile call below (after catch block) will update result
+                        // to the cached value.
+                        AddFileToCache(pSpec, result, TRUE /*fAllowFailure*/);
+                    }
+                }
+                else
+                {
+                    // Don't trigger the resolve event for the CoreLib satellite assembly. A misbehaving resolve event may
+                    // return an assembly that does not match, and this can cause recursive resource lookups during error
+                    // reporting. The CoreLib satellite assembly is loaded from relative locations based on the culture, see
+                    // AssemblySpec::Bind().
+                    if (!pSpec->IsCoreLibSatellite())
+                    {
+                        // Trigger the resolve event also for non-throw situation.
+                        AssemblySpec NewSpec(this);
+                        AssemblySpec *pFailedSpec = NULL;
+
+                        fForceReThrow = TRUE; // Managed resolve event handler can throw
+
+                        BOOL fFailure = PostBindResolveAssembly(pSpec, &NewSpec, hrBindResult, &pFailedSpec);
+
+                        if (fFailure && fThrowOnFileNotFound)
                         {
-                            // Trigger the resolve event also for non-throw situation.
-                            AssemblySpec NewSpec(this);
-                            AssemblySpec *pFailedSpec = NULL;
-
-                            fForceReThrow = TRUE; // Managed resolve event handler can throw
-
-                            BOOL fFailure = PostBindResolveAssembly(pSpec, &NewSpec, hrBindResult, &pFailedSpec);
-
-                            if (fFailure && fThrowOnFileNotFound)
-                            {
-                                EEFileLoadException::Throw(pFailedSpec, COR_E_FILENOTFOUND, NULL);
-                            }
+                            EEFileLoadException::Throw(pFailedSpec, COR_E_FILENOTFOUND, NULL);
                         }
                     }
                 }
             }
         }
-        EX_CATCH
+    }
+    EX_CATCH
+    {
+        Exception *ex = GET_EXCEPTION();
+
+        AssemblySpec NewSpec(this);
+        AssemblySpec *pFailedSpec = NULL;
+
+        // Let transient exceptions or managed resolve event handler exceptions propagate
+        if (ex->IsTransient() || fForceReThrow)
         {
-            Exception *ex = GET_EXCEPTION();
+            EX_RETHROW;
+        }
 
-            AssemblySpec NewSpec(this);
-            AssemblySpec *pFailedSpec = NULL;
-
-            // Let transient exceptions or managed resolve event handler exceptions propagate
-            if (ex->IsTransient() || fForceReThrow)
+        {
+            BOOL fFailure = PostBindResolveAssembly(pSpec, &NewSpec, ex->GetHR(), &pFailedSpec);
+            if (fFailure)
             {
-                EX_RETHROW;
-            }
+                BOOL bFileNotFoundException =
+                    (EEFileLoadException::GetFileLoadKind(ex->GetHR()) == kFileNotFoundException);
 
-            {
-                BOOL fFailure = PostBindResolveAssembly(pSpec, &NewSpec, ex->GetHR(), &pFailedSpec);
+                if (!bFileNotFoundException)
+                {
+                    fFailure = AddExceptionToCache(pFailedSpec, ex);
+                } // else, fFailure stays TRUE
+                // Effectively, fFailure == bFileNotFoundException || AddExceptionToCache(pFailedSpec, ex)
+
+                // Only throw this exception if we are the first in the cache
                 if (fFailure)
                 {
-                    BOOL bFileNotFoundException =
-                        (EEFileLoadException::GetFileLoadKind(ex->GetHR()) == kFileNotFoundException);
-
-                    if (!bFileNotFoundException)
-                    {
-                        fFailure = AddExceptionToCache(pFailedSpec, ex);
-                    } // else, fFailure stays TRUE
-                    // Effectively, fFailure == bFileNotFoundException || AddExceptionToCache(pFailedSpec, ex)
-
-                    // Only throw this exception if we are the first in the cache
-                    if (fFailure)
-                    {
-                        // Store the failure information for DAC to read
-                        if (IsDebuggerAttached()) {
-                            FailedAssembly *pFailed = new FailedAssembly();
-                            pFailed->Initialize(pFailedSpec, ex);
-                            IfFailThrow(m_failedAssemblies.Append(pFailed));
-                        }
-
-                        if (!bFileNotFoundException || fThrowOnFileNotFound)
-                        {
-                            // V1.1 App-compatibility workaround. See VSW530166 if you want to whine about it.
-                            //
-                            // In Everett, if we failed to download an assembly because of a broken network cable,
-                            // we returned a FileNotFoundException with a COR_E_FILENOTFOUND hr embedded inside
-                            // (which would be exposed when marshaled to native.)
-                            //
-                            // In Whidbey, we now set the more appropriate INET_E_RESOURCE_NOT_FOUND hr. But
-                            // the online/offline switch code in VSTO for Everett hardcoded a check for
-                            // COR_E_FILENOTFOUND.
-                            //
-                            // So now, to keep that code from breaking, we have to remap INET_E_RESOURCE_NOT_FOUND
-                            // back to COR_E_FILENOTFOUND. We're doing it here rather down in Fusion so as to affect
-                            // the least number of callers.
-
-                            if (ex->GetHR() == INET_E_RESOURCE_NOT_FOUND)
-                            {
-                                EEFileLoadException::Throw(pFailedSpec, COR_E_FILENOTFOUND, ex);
-                            }
-
-                            if (EEFileLoadException::CheckType(ex))
-                            {
-                                if (pFailedSpec == pSpec)
-                                {
-                                    EX_RETHROW; //preserve the information
-                                }
-                                else
-                                {
-                                    StackSString exceptionDisplayName, failedSpecDisplayName;
-
-                                    ((EEFileLoadException*)ex)->GetName(exceptionDisplayName);
-                                    pFailedSpec->GetFileOrDisplayName(0, failedSpecDisplayName);
-
-                                    if (exceptionDisplayName.CompareCaseInsensitive(failedSpecDisplayName) == 0)
-                                    {
-                                        EX_RETHROW; // Throw the original exception. Otherwise, we'd throw an exception that contains the same message twice.
-                                    }
-                                }
-                            }
-
-                            EEFileLoadException::Throw(pFailedSpec, ex->GetHR(), ex);
-                        }
-
+                    // Store the failure information for DAC to read
+                    if (IsDebuggerAttached()) {
+                        FailedAssembly *pFailed = new FailedAssembly();
+                        pFailed->Initialize(pFailedSpec, ex);
+                        IfFailThrow(m_failedAssemblies.Append(pFailed));
                     }
+
+                    if (!bFileNotFoundException || fThrowOnFileNotFound)
+                    {
+                        // V1.1 App-compatibility workaround. See VSW530166 if you want to whine about it.
+                        //
+                        // In Everett, if we failed to download an assembly because of a broken network cable,
+                        // we returned a FileNotFoundException with a COR_E_FILENOTFOUND hr embedded inside
+                        // (which would be exposed when marshaled to native.)
+                        //
+                        // In Whidbey, we now set the more appropriate INET_E_RESOURCE_NOT_FOUND hr. But
+                        // the online/offline switch code in VSTO for Everett hardcoded a check for
+                        // COR_E_FILENOTFOUND.
+                        //
+                        // So now, to keep that code from breaking, we have to remap INET_E_RESOURCE_NOT_FOUND
+                        // back to COR_E_FILENOTFOUND. We're doing it here rather down in Fusion so as to affect
+                        // the least number of callers.
+
+                        if (ex->GetHR() == INET_E_RESOURCE_NOT_FOUND)
+                        {
+                            EEFileLoadException::Throw(pFailedSpec, COR_E_FILENOTFOUND, ex);
+                        }
+
+                        if (EEFileLoadException::CheckType(ex))
+                        {
+                            if (pFailedSpec == pSpec)
+                            {
+                                EX_RETHROW; //preserve the information
+                            }
+                            else
+                            {
+                                StackSString exceptionDisplayName, failedSpecDisplayName;
+
+                                ((EEFileLoadException*)ex)->GetName(exceptionDisplayName);
+                                pFailedSpec->GetFileOrDisplayName(0, failedSpecDisplayName);
+
+                                if (exceptionDisplayName.CompareCaseInsensitive(failedSpecDisplayName) == 0)
+                                {
+                                    EX_RETHROW; // Throw the original exception. Otherwise, we'd throw an exception that contains the same message twice.
+                                }
+                            }
+                        }
+
+                        EEFileLoadException::Throw(pFailedSpec, ex->GetHR(), ex);
+                    }
+
                 }
             }
         }
-        EX_END_CATCH(RethrowTerminalExceptions);
-
-        // Now, if it's a cacheable bind we need to re-fetch the result from the cache, as we may have been racing with another
-        // thread to store our result.  Note that we may throw from here, if there is a cached exception.
-        // This will release the refcount of the current result holder (if any), and will replace
-        // it with a non-addref'ed result
-        if (pSpec->CanUseWithBindingCache() && (result== NULL || result->CanUseWithBindingCache()))
-        {
-            result = FindCachedFile(pSpec);
-
-            if (result != NULL)
-                result->AddRef();
-        }
-
-        bindOperation.SetResult(result.GetValue(), isCached);
-        return result.Extract();
     }
-    else
+    EX_END_CATCH(RethrowTerminalExceptions);
+
+    // Now, if it's a cacheable bind we need to re-fetch the result from the cache, as we may have been racing with another
+    // thread to store our result.  Note that we may throw from here, if there is a cached exception.
+    // This will release the refcount of the current result holder (if any), and will replace
+    // it with a non-addref'ed result
+    if (result== NULL || result->CanUseWithBindingCache())
     {
-        // Unsupported content type
-        if (fThrowOnFileNotFound)
-        {
-            ThrowHR(COR_E_BADIMAGEFORMAT);
-        }
-        return nullptr;
+        result = FindCachedFile(pSpec);
+
+        if (result != NULL)
+            result->AddRef();
     }
+
+    bindOperation.SetResult(result.GetValue(), isCached);
+    return result.Extract();
 } // AppDomain::BindAssemblySpec
 
 

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1859,8 +1859,6 @@ public:
 
 #ifndef DACCESS_COMPILE // needs AssemblySpec
 
-    void GetCacheAssemblyList(SetSHash<PTR_DomainAssembly>& assemblyList);
-
     //****************************************************************************************
     // Returns and Inserts assemblies into a lookup cache based on the binding information
     // in the AssemblySpec. There can be many AssemblySpecs to a single assembly.

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -22,11 +22,9 @@
 #include "comreflectioncache.hpp"
 #include "comutilnative.h"
 #include "domainfile.h"
-#include "objectlist.h"
 #include "fptrstubs.h"
 #include "gcheaputilities.h"
 #include "gchandleutilities.h"
-#include "../binder/inc/applicationcontext.hpp"
 #include "rejit.h"
 
 #ifdef FEATURE_MULTICOREJIT

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -94,11 +94,6 @@ void QCALLTYPE AssemblyNative::InternalLoad(QCall::ObjectHandleOnStack assemblyN
 
     spec.SetCodeBase(NULL);
 
-    if (!spec.HasUniqueIdentity())
-    {   // Insuficient assembly name for binding (e.g. ContentType=WindowsRuntime cannot bind by assembly name)
-        EEFileLoadException::Throw(&spec, COR_E_NOTSUPPORTED);
-    }
-
     if (pParentAssembly != NULL)
         spec.SetParentAssembly(pParentAssembly);
 

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -799,12 +799,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     ETWOnStartup (LoaderCatchCall_V1, LoaderCatchCallEnd_V1);
     AppDomain* pDomain = GetAppDomain();
 
-    DomainAssembly* pAssembly = nullptr;
-    if (CanUseWithBindingCache())
-    {
-        pAssembly = pDomain->FindCachedAssembly(this);
-    }
-
+    DomainAssembly* pAssembly = pDomain->FindCachedAssembly(this);
     if (pAssembly)
     {
         BinderTracing::AssemblyBindOperation bindOperation(this);

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -15,7 +15,6 @@
 #ifndef _ASSEMBLYSPEC_H
 #define _ASSEMBLYSPEC_H
 #include "hash.h"
-#include "memorypool.h"
 #include "assemblyspecbase.h"
 #include "domainfile.h"
 #include "holder.h"
@@ -28,10 +27,6 @@ enum FileLoadLevel;
 class AssemblySpec  : public BaseAssemblySpec
 {
   private:
-
-    friend class AppDomain;
-    friend class AssemblyNameNative;
-
     AppDomain       *m_pAppDomain;
     DWORD            m_dwHashAlg;
     DomainAssembly  *m_pParentAssembly;
@@ -243,12 +238,6 @@ class AssemblySpec  : public BaseAssemblySpec
             _ASSERTE(!"Unexpected content type.");
             return E_UNEXPECTED;
         }
-    }
-
-    inline BOOL CanUseWithBindingCache() const
-    {
-        STATIC_CONTRACT_LIMITED_METHOD;
-        return HasUniqueIdentity();
     }
 };
 

--- a/src/coreclr/vm/baseassemblyspec.cpp
+++ b/src/coreclr/vm/baseassemblyspec.cpp
@@ -70,7 +70,6 @@ VOID BaseAssemblySpec::CloneFieldsToStackingAllocator( StackingAllocator* alloc)
 
 }
 
-#ifndef DACCESS_COMPILE
 BOOL BaseAssemblySpec::IsCoreLib()
 {
     CONTRACTL
@@ -361,5 +360,3 @@ VOID BaseAssemblySpec::SetName(SString const & ssName)
 
     m_ownedFlags |= NAME_OWNED;
 }
-
-#endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/baseassemblyspec.h
+++ b/src/coreclr/vm/baseassemblyspec.h
@@ -106,13 +106,6 @@ public:
     BOOL IsCoreLibSatellite() const;
     BOOL IsCoreLib();
 
-    // Returns true
-    inline BOOL HasUniqueIdentity() const
-    {
-        STATIC_CONTRACT_LIMITED_METHOD;
-        return TRUE;
-    }
-
     enum CompareExFlags
     {
         ASC_Default                 = 0x00, // Default comparison policy.

--- a/src/coreclr/vm/compile.cpp
+++ b/src/coreclr/vm/compile.cpp
@@ -313,7 +313,7 @@ HRESULT CEECompileInfo::LoadAssemblyByPath(
             // Now load assembly into domain.
             DomainAssembly * pDomainAssembly = pDomain->LoadDomainAssembly(&spec, pAssemblyHolder, FILE_LOAD_BEGIN);
 
-            if (spec.CanUseWithBindingCache() && pDomainAssembly->CanUseWithBindingCache())
+            if (pDomainAssembly->CanUseWithBindingCache())
                 pDomain->AddAssemblyToCache(&spec, pDomainAssembly);
 
             pAssembly = pDomain->LoadAssembly(&spec, pAssemblyHolder, FILE_LOADED);
@@ -6480,8 +6480,6 @@ HRESULT CompilationDomain::AddDependency(AssemblySpec *pRefSpec,
         spec.ConvertPublicKeyToToken();
         pRefSpec = &spec;
     }
-
-    _ASSERTE(pRefSpec->HasUniqueIdentity());
 
     //
     // See if we've already added the contents of the ref

--- a/src/coreclr/vm/compile.cpp
+++ b/src/coreclr/vm/compile.cpp
@@ -313,8 +313,7 @@ HRESULT CEECompileInfo::LoadAssemblyByPath(
             // Now load assembly into domain.
             DomainAssembly * pDomainAssembly = pDomain->LoadDomainAssembly(&spec, pAssemblyHolder, FILE_LOAD_BEGIN);
 
-            if (pDomainAssembly->CanUseWithBindingCache())
-                pDomain->AddAssemblyToCache(&spec, pDomainAssembly);
+            pDomain->AddAssemblyToCache(&spec, pDomainAssembly);
 
             pAssembly = pDomain->LoadAssembly(&spec, pAssemblyHolder, FILE_LOADED);
 

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -32,7 +32,6 @@
 
 #include "../binder/inc/coreclrbindercommon.h"
 #include "../binder/inc/applicationcontext.hpp"
-#ifndef DACCESS_COMPILE
 
 STDAPI BinderAddRefPEImage(PEImage *pPEImage)
 {
@@ -438,8 +437,6 @@ void BaseAssemblySpec::InitializeWithAssemblyIdentity(BINDER_SPACE::AssemblyIden
         }
     }
 }
-
-#endif // DACCESS_COMPILE
 
 VOID BaseAssemblySpec::GetFileOrDisplayName(DWORD flags, SString &result) const
 {

--- a/src/coreclr/vm/corebindresult.cpp
+++ b/src/coreclr/vm/corebindresult.cpp
@@ -14,8 +14,6 @@
 
 #include "../binder/inc/assembly.hpp"
 
-#ifndef DACCESS_COMPILE
-
 STDMETHODIMP CoreBindResult::QueryInterface(REFIID   riid,
                                           void   **ppv)
 {
@@ -58,6 +56,3 @@ STDMETHODIMP_(ULONG) CoreBindResult::Release()
 
     return ulRef;
 }
-
-
-#endif  // DACCES_COMPILE

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -1445,23 +1445,14 @@ void DomainAssembly::Allocate()
     SetAssembly(pAssembly);
 
 #ifdef FEATURE_PREJIT
-    BOOL fInsertIntoAssemblySpecBindingCache = TRUE;
-
-    // Insert AssemblyDef details into AssemblySpecBindingCache if appropriate
-
-
-    fInsertIntoAssemblySpecBindingCache = fInsertIntoAssemblySpecBindingCache && GetFile()->CanUseWithBindingCache();
-
-    if (fInsertIntoAssemblySpecBindingCache)
+    // Insert AssemblyDef details into AssemblySpecBindingCache
+    AssemblySpec specAssemblyDef;
+    specAssemblyDef.InitializeSpec(GetFile());
+    if (specAssemblyDef.IsStrongNamed() && specAssemblyDef.HasPublicKey())
     {
-        AssemblySpec specAssemblyDef;
-        specAssemblyDef.InitializeSpec(GetFile());
-        if (specAssemblyDef.IsStrongNamed() && specAssemblyDef.HasPublicKey())
-        {
-            specAssemblyDef.ConvertPublicKeyToToken();
-        }
-        m_pDomain->AddAssemblyToCache(&specAssemblyDef, this);
+        specAssemblyDef.ConvertPublicKeyToToken();
     }
+    m_pDomain->AddAssemblyToCache(&specAssemblyDef, this);
 #endif
 } // DomainAssembly::Allocate
 

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -740,10 +740,6 @@ private:
           _ASSERTE(m_NextDomainAssemblyInSameALC == NULL);
           m_NextDomainAssemblyInSameALC = domainAssembly;
       }
-
-    // Indicates if the assembly can be cached in a binding cache such as AssemblySpecBindingCache.
-    inline bool CanUseWithBindingCache()
-    { STATIC_CONTRACT_WRAPPER; return GetFile()->CanUseWithBindingCache(); }
 };
 
 typedef DomainAssembly::ModuleIterator DomainModuleIterator;

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -28,7 +28,6 @@
 
 #ifdef FEATURE_COMINTEROP
 #include "cominterfacemarshaler.h"
-#include <roerrorapi.h>
 #endif
 
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -591,9 +591,6 @@ public:
     bool HasHostAssembly()
     { STATIC_CONTRACT_WRAPPER; return GetHostAssembly() != nullptr; }
 
-    bool CanUseWithBindingCache()
-    { LIMITED_METHOD_CONTRACT; return !HasHostAssembly(); }
-
     PTR_ICLRPrivBinder GetFallbackLoadContextBinder()
     {
         LIMITED_METHOD_CONTRACT;
@@ -709,7 +706,6 @@ class PEAssembly : public PEFile
     // Loader access API
     // ------------------------------------------------------------
 
-    friend class DomainAssembly;
 #ifdef FEATURE_PREJIT
 
     void SetNativeImage(PEImage *image);
@@ -724,17 +720,6 @@ class PEAssembly : public PEFile
     // ------------------------------------------------------------
 
     PTR_PEFile               m_creator;
-
-  public:
-    PTR_PEFile GetCreator()
-    { LIMITED_METHOD_CONTRACT; return m_creator; }
-
-    // Indicates if the assembly can be cached in a binding cache such as AssemblySpecBindingCache.
-    inline bool CanUseWithBindingCache()
-    {
-        STATIC_CONTRACT_WRAPPER;
-        return true;
-    }
 };
 
 
@@ -745,10 +730,5 @@ typedef ReleaseHolder<PEAssembly> PEAssemblyHolder;
 BOOL RuntimeVerifyNativeImageDependency(const CORCOMPILE_DEPENDENCY   *pExpected,
     const CORCOMPILE_VERSION_INFO *pActual,
     PEAssembly                    *pLogAsm);
-
-// ================================================================================
-// Inline definitions
-// ================================================================================
-
 
 #endif  // PEFILE_H_


### PR DESCRIPTION
`BaseAssemblySpec::HasUniqueIdentity` is a remnant from built-in WinRT support. It always returns true now that built-in WinRT support is gone.

Also moved some assembly spec files out of DAC compile that don't need to be there.

cc @AaronRobinsonMSFT @jkoritzinsky @vitek-karas 