### PR TITLE
Added an event source entry for `ServiceRealizationFailed`.

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Extensions.DependencyInjection
         // Event source doesn't support large payloads so we chunk formatted call site tree
         private int MaxChunkSize = 10 * 1024;
 
-
         private DependencyInjectionEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
         {
         }
@@ -62,6 +61,12 @@ namespace Microsoft.Extensions.DependencyInjection
             WriteEvent(5, serviceProviderHashCode, scopedServicesResolved, disposableServices);
         }
 
+        [Event(6, Level = EventLevel.Error)]
+        public void ServiceRealizationFailed(string? exceptionMessage)
+        {
+            WriteEvent(6, exceptionMessage);
+        }
+
         [NonEvent]
         public void ScopeDisposed(ServiceProviderEngine engine, ScopeState state)
         {
@@ -103,6 +108,15 @@ namespace Microsoft.Extensions.DependencyInjection
             if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
             {
                 DynamicMethodBuilt(serviceType.ToString(), methodSize);
+            }
+        }
+
+        [NonEvent]
+        public void ServiceRealizationFailed(Exception exception)
+        {
+            if (IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                ServiceRealizationFailed(exception.ToString());
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -28,15 +27,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 {
                     // Don't capture the ExecutionContext when forking to build the compiled version of the
                     // resolve function
-                    ThreadPool.UnsafeQueueUserWorkItem(state =>
+                    _ = ThreadPool.UnsafeQueueUserWorkItem(_ =>
                     {
                         try
                         {
                             base.RealizeService(callSite);
                         }
-                        catch
+                        catch (Exception ex)
                         {
-                            // Swallow the exception, we should log this via the event source in a non-patched release
+                            DependencyInjectionEventSource.Log.ServiceRealizationFailed(ex);
                         }
                     },
                     null);


### PR DESCRIPTION
If an `Exception` occurs during the execution of a background thread for resolving DI dependencies:

- Allow logging of any swallowed exception via the `DependencyInjectionEventSource`

Fixes #43083