### PR TITLE
- fixes a bug where CollectionExtensions.TryAdd would not be thread safe

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -32,8 +32,15 @@ namespace System.Collections.Generic
 
             if (!dictionary.ContainsKey(key))
             {
-                dictionary.Add(key, value);
-                return true;
+                try
+                {
+                    dictionary.Add(key, value);
+                    return true;
+                }
+                catch (ArgumentException)
+                {
+                    // this exception will be raised if an entry with the same key is added by another thread between the contains key and the add
+                }
             }
 
             return false;


### PR DESCRIPTION
When using IDictionary.TryAdd you might get a ArgumentException thrown by IDictionary.Add's implementation if another thread added an entry with the same key between the "ContainsKey" check and the "Add".

This behavior not only breaks the contract of TryAdd being safe if a key already exists but also "breaks the prototype" as the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.tryadd?view=net-5.0) does not document throwing ArgumentExceptions.


This pull request fixes that behavior by wrapping the "Add" call with a try catch.