### PR TITLE
Move AssemblyExtensions.GetApplyUpdateCapabilities to be guarded by Debugger.IsSupported

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -55,20 +55,16 @@
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />
     </type>
+
+     <!-- methods used by hot reload --> 
+    <type fullname="System.Reflection.Metadata.AssemblyExtensions">
+      <method name="GetApplyUpdateCapabilities" />
+    </type>
   </assembly>
 
   <assembly fullname="System.Private.CoreLib" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="true" featuredefault="true">
     <type fullname="System.Diagnostics.Tracing.RuntimeEventSource">
       <method signature="System.Void Initialize()" />
-    </type>
-  </assembly>
-
-  <!-- methods used by hot reload.
-       TODO: once there's a feature flag, add it to the linker descriptor
-  -->
-  <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Reflection.Metadata.AssemblyExtensions">
-      <method name="GetApplyUpdateCapabilities" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
We are currently using the `Debugger.IsSupported` feature switch to trim out hot reload support. So moving this method to only be preserved when `Debugger.IsSupported` is true.

https://github.com/dotnet/runtime/issues/51159 tracks using a separate "hot reload" feature switch if we don't want to tie "debugging" and "hot reload" together.