### PR TITLE
[mono] Add TARGET_TVOS to config.h.in.

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -890,6 +890,9 @@
 /* The JIT/AOT targets iOS */
 #cmakedefine TARGET_IOS 1
 
+/* The JIT/AOT targets tvOS */
+#cmakedefine TARGET_TVOS 1
+
 /* The JIT/AOT targets OSX */
 #cmakedefine TARGET_OSX 1
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51949.