### PR TITLE
Add few SupportedOSPlatform UnsupportedOSPlatform attributes

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
@@ -372,6 +372,7 @@ namespace System.DirectoryServices.Protocols
         public bool RootDseCache { get { throw null; } set { } }
         public string SaslMethod { get { throw null; } set { } }
         public bool Sealing { get { throw null; } set { } }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public bool SecureSocketLayer { get { throw null; } set { } }
         public object SecurityContext { get { throw null; } }
         public System.TimeSpan SendTimeout { get { throw null; } set { } }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.DirectoryServices.Protocols
 {
     public partial class LdapSessionOptions
     {
         private static void PALCertFreeCRLContext(IntPtr certPtr) { /* No op */ }
 
+        [SupportedOSPlatform("windows")]
         public bool SecureSocketLayer
         {
             get => throw new PlatformNotSupportedException();

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.DirectoryServices.Protocols
 {
     public partial class LdapSessionOptions
     {
         private static void PALCertFreeCRLContext(IntPtr certPtr) => Interop.Ldap.CertFreeCRLContext(certPtr);
 
+        [SupportedOSPlatform("windows")]
         public bool SecureSocketLayer
         {
             get

--- a/src/libraries/System.Private.CoreLib/src/System/Text/NormalizationForm.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/NormalizationForm.cs
@@ -1,13 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Text
 {
     public enum NormalizationForm
     {
         FormC = 1,
         FormD = 2,
+        [UnsupportedOSPlatform("browser")]
         FormKC = 5,
+        [UnsupportedOSPlatform("browser")]
         FormKD = 6
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10963,7 +10963,9 @@ namespace System.Text
     {
         FormC = 1,
         FormD = 2,
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         FormKC = 5,
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         FormKD = 6,
     }
     public readonly partial struct Rune : System.IComparable, System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>, System.ISpanFormattable


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/issues/47228 run an analyzer detecting PNSEs for cross-platform builds. Most of the findings were APIs supported on .Net framework but not supported in .Net Core which we are obsoleting. Few of them need SupportedOSPlatform or UnSupportedOSPlatform attribute which applied with this PR