### PR TITLE
Updating the JIT to recognize and handle Vector64/128/256<T> for nint/nuint

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8297,6 +8297,8 @@ private:
         CORINFO_CLASS_HANDLE Vector64LongHandle;
         CORINFO_CLASS_HANDLE Vector64UIntHandle;
         CORINFO_CLASS_HANDLE Vector64ULongHandle;
+        CORINFO_CLASS_HANDLE Vector64NIntHandle;
+        CORINFO_CLASS_HANDLE Vector64NUIntHandle;
 #endif // defined(TARGET_ARM64)
         CORINFO_CLASS_HANDLE Vector128FloatHandle;
         CORINFO_CLASS_HANDLE Vector128DoubleHandle;
@@ -8308,6 +8310,8 @@ private:
         CORINFO_CLASS_HANDLE Vector128LongHandle;
         CORINFO_CLASS_HANDLE Vector128UIntHandle;
         CORINFO_CLASS_HANDLE Vector128ULongHandle;
+        CORINFO_CLASS_HANDLE Vector128NIntHandle;
+        CORINFO_CLASS_HANDLE Vector128NUIntHandle;
 #if defined(TARGET_XARCH)
         CORINFO_CLASS_HANDLE Vector256FloatHandle;
         CORINFO_CLASS_HANDLE Vector256DoubleHandle;
@@ -8319,6 +8323,8 @@ private:
         CORINFO_CLASS_HANDLE Vector256LongHandle;
         CORINFO_CLASS_HANDLE Vector256UIntHandle;
         CORINFO_CLASS_HANDLE Vector256ULongHandle;
+        CORINFO_CLASS_HANDLE Vector256NIntHandle;
+        CORINFO_CLASS_HANDLE Vector256NUIntHandle;
 #endif // defined(TARGET_XARCH)
 #endif // FEATURE_HW_INTRINSICS
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17601,6 +17601,12 @@ GenTree* Compiler::gtGetSIMDZero(var_types simdType, CorInfoType simdBaseJitType
                     case CORINFO_TYPE_ULONG:
                         assert(simdHandle == m_simdHandleCache->Vector128ULongHandle);
                         break;
+                    case CORINFO_TYPE_NATIVEINT:
+                        assert(simdHandle == m_simdHandleCache->Vector128NIntHandle);
+                        break;
+                    case CORINFO_TYPE_NATIVEUINT:
+                        assert(simdHandle == m_simdHandleCache->Vector128NUIntHandle);
+                        break;
 #endif // defined(FEATURE_HW_INTRINSICS)
 
                     default:
@@ -17641,6 +17647,12 @@ GenTree* Compiler::gtGetSIMDZero(var_types simdType, CorInfoType simdBaseJitType
                         break;
                     case CORINFO_TYPE_ULONG:
                         assert(simdHandle == m_simdHandleCache->Vector256ULongHandle);
+                        break;
+                    case CORINFO_TYPE_NATIVEINT:
+                        assert(simdHandle == m_simdHandleCache->Vector256NIntHandle);
+                        break;
+                    case CORINFO_TYPE_NATIVEUINT:
+                        assert(simdHandle == m_simdHandleCache->Vector256NUIntHandle);
                         break;
                     default:
                         break;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -117,9 +117,9 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
             case CORINFO_TYPE_ULONG:
                 return m_simdHandleCache->Vector128ULongHandle;
             case CORINFO_TYPE_NATIVEINT:
-                break;
+                return m_simdHandleCache->Vector128NIntHandle;
             case CORINFO_TYPE_NATIVEUINT:
-                break;
+                return m_simdHandleCache->Vector128NUIntHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
@@ -150,9 +150,9 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
             case CORINFO_TYPE_ULONG:
                 return m_simdHandleCache->Vector256ULongHandle;
             case CORINFO_TYPE_NATIVEINT:
-                break;
+                return m_simdHandleCache->Vector256NIntHandle;
             case CORINFO_TYPE_NATIVEUINT:
-                break;
+                return m_simdHandleCache->Vector256NUIntHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
@@ -184,9 +184,9 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
             case CORINFO_TYPE_ULONG:
                 return m_simdHandleCache->Vector64ULongHandle;
             case CORINFO_TYPE_NATIVEINT:
-                break;
+                return m_simdHandleCache->Vector64NIntHandle;
             case CORINFO_TYPE_NATIVEUINT:
-                break;
+                return m_simdHandleCache->Vector64NUIntHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
@@ -663,6 +663,12 @@ static bool isSupportedBaseType(NamedIntrinsic intrinsic, CorInfoType baseJitTyp
 {
     if (baseJitType == CORINFO_TYPE_UNDEF)
     {
+        return false;
+    }
+
+    if ((baseJitType == CORINFO_TYPE_NATIVEINT) || (baseJitType == CORINFO_TYPE_NATIVEUINT))
+    {
+        // We don't want to support the general purpose helpers for nint/nuint until after they go through API review.
         return false;
     }
 

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -846,12 +846,12 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             break;
                         case CORINFO_TYPE_NATIVEINT:
                             m_simdHandleCache->Vector64NIntHandle = typeHnd;
-                            simdBaseJitType                        = CORINFO_TYPE_NATIVEINT;
+                            simdBaseJitType                       = CORINFO_TYPE_NATIVEINT;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nint>\n");
                             break;
                         case CORINFO_TYPE_NATIVEUINT:
                             m_simdHandleCache->Vector64NUIntHandle = typeHnd;
-                            simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
+                            simdBaseJitType                        = CORINFO_TYPE_NATIVEUINT;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nuint>\n");
                             break;
 

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -547,7 +547,7 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
         {
             simdBaseJitType = CORINFO_TYPE_NATIVEINT;
             size            = Vector128SizeBytes;
-            JITDUMP("  Known type Vector256<nint>\n");
+            JITDUMP("  Known type Vector128<nint>\n");
         }
         else if (typeHnd == m_simdHandleCache->Vector128NUIntHandle)
         {
@@ -707,7 +707,7 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector256<nint>\n");
                             break;
                         case CORINFO_TYPE_NATIVEUINT:
-                            m_simdHandleCache->Vector256ULongHandle = typeHnd;
+                            m_simdHandleCache->Vector256NUIntHandle = typeHnd;
                             simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector256<nuint>\n");
                             break;
@@ -779,7 +779,7 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector128<nint>\n");
                             break;
                         case CORINFO_TYPE_NATIVEUINT:
-                            m_simdHandleCache->Vector128ULongHandle = typeHnd;
+                            m_simdHandleCache->Vector128NUIntHandle = typeHnd;
                             simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector128<nuint>\n");
                             break;
@@ -850,7 +850,7 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nint>\n");
                             break;
                         case CORINFO_TYPE_NATIVEUINT:
-                            m_simdHandleCache->Vector64ULongHandle = typeHnd;
+                            m_simdHandleCache->Vector64NUIntHandle = typeHnd;
                             simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nuint>\n");
                             break;

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -469,6 +469,18 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
             size            = Vector256SizeBytes;
             JITDUMP("  Known type Vector256<ulong>\n");
         }
+        else if (typeHnd == m_simdHandleCache->Vector256NIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEINT;
+            size            = Vector256SizeBytes;
+            JITDUMP("  Known type Vector256<nint>\n");
+        }
+        else if (typeHnd == m_simdHandleCache->Vector256NUIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEUINT;
+            size            = Vector256SizeBytes;
+            JITDUMP("  Known type Vector256<nuint>\n");
+        }
         else
 #endif // defined(TARGET_XARCH)
             if (typeHnd == m_simdHandleCache->Vector128FloatHandle)
@@ -531,6 +543,18 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
             size            = Vector128SizeBytes;
             JITDUMP("  Known type Vector128<ulong>\n");
         }
+        else if (typeHnd == m_simdHandleCache->Vector128NIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEINT;
+            size            = Vector128SizeBytes;
+            JITDUMP("  Known type Vector256<nint>\n");
+        }
+        else if (typeHnd == m_simdHandleCache->Vector128NUIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEUINT;
+            size            = Vector128SizeBytes;
+            JITDUMP("  Known type Vector128<nuint>\n");
+        }
         else
 #if defined(TARGET_ARM64)
             if (typeHnd == m_simdHandleCache->Vector64FloatHandle)
@@ -592,6 +616,18 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
             simdBaseJitType = CORINFO_TYPE_ULONG;
             size            = Vector64SizeBytes;
             JITDUMP("  Known type Vector64<ulong>\n");
+        }
+        else if (typeHnd == m_simdHandleCache->Vector64NIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEINT;
+            size            = Vector64SizeBytes;
+            JITDUMP("  Known type Vector64<nint>\n");
+        }
+        else if (typeHnd == m_simdHandleCache->Vector64NUIntHandle)
+        {
+            simdBaseJitType = CORINFO_TYPE_NATIVEUINT;
+            size            = Vector64SizeBytes;
+            JITDUMP("  Known type Vector64<nuint>\n");
         }
 #endif // defined(TARGET_ARM64)
 
@@ -665,6 +701,16 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             simdBaseJitType                        = CORINFO_TYPE_BYTE;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector256<sbyte>\n");
                             break;
+                        case CORINFO_TYPE_NATIVEINT:
+                            m_simdHandleCache->Vector256NIntHandle = typeHnd;
+                            simdBaseJitType                        = CORINFO_TYPE_NATIVEINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector256<nint>\n");
+                            break;
+                        case CORINFO_TYPE_NATIVEUINT:
+                            m_simdHandleCache->Vector256ULongHandle = typeHnd;
+                            simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector256<nuint>\n");
+                            break;
 
                         default:
                             JITDUMP("  Unknown Hardware Intrinsic SIMD Type Vector256<T>\n");
@@ -727,6 +773,16 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             simdBaseJitType                        = CORINFO_TYPE_BYTE;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector128<sbyte>\n");
                             break;
+                        case CORINFO_TYPE_NATIVEINT:
+                            m_simdHandleCache->Vector128NIntHandle = typeHnd;
+                            simdBaseJitType                        = CORINFO_TYPE_NATIVEINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector128<nint>\n");
+                            break;
+                        case CORINFO_TYPE_NATIVEUINT:
+                            m_simdHandleCache->Vector128ULongHandle = typeHnd;
+                            simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector128<nuint>\n");
+                            break;
 
                         default:
                             JITDUMP("  Unknown Hardware Intrinsic SIMD Type Vector128<T>\n");
@@ -787,6 +843,16 @@ CorInfoType Compiler::getBaseJitTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeH
                             m_simdHandleCache->Vector64ByteHandle = typeHnd;
                             simdBaseJitType                       = CORINFO_TYPE_BYTE;
                             JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<sbyte>\n");
+                            break;
+                        case CORINFO_TYPE_NATIVEINT:
+                            m_simdHandleCache->Vector64NIntHandle = typeHnd;
+                            simdBaseJitType                        = CORINFO_TYPE_NATIVEINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nint>\n");
+                            break;
+                        case CORINFO_TYPE_NATIVEUINT:
+                            m_simdHandleCache->Vector64ULongHandle = typeHnd;
+                            simdBaseJitType                         = CORINFO_TYPE_NATIVEUINT;
+                            JITDUMP("  Found type Hardware Intrinsic SIMD Vector64<nuint>\n");
                             break;
 
                         default:

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -217,6 +217,8 @@ namespace Internal.TypeSystem
                     case TypeFlags.UInt32:
                     case TypeFlags.Int64:
                     case TypeFlags.UInt64:
+                    case TypeFlags.IntPtr:
+                    case TypeFlags.UIntPtr:
                     case TypeFlags.Single:
                     case TypeFlags.Double:
                         return true;

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1502,7 +1502,7 @@ int MethodTable::GetVectorSize()
             // We need to verify that T (the element or "base" type) is a primitive type.
             TypeHandle typeArg = GetInstantiation()[0];
             CorElementType corType = typeArg.GetSignatureCorElementType();
-            if (corType >= ELEMENT_TYPE_I1 && corType <= ELEMENT_TYPE_R8)
+            if (((corType >= ELEMENT_TYPE_I1) && (corType <= ELEMENT_TYPE_R8)) || (corType == ELEMENT_TYPE_I) || (corType == ELEMENT_TYPE_U))
             {
                 _ASSERTE(strcmp(namespaceName, "System.Runtime.Intrinsics") == 0);
                 return vectorSize;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -4384,6 +4384,12 @@ CorInfoType CEEInfo::getTypeForPrimitiveNumericClass(
     case ELEMENT_TYPE_R8:
         result = CORINFO_TYPE_DOUBLE;
         break;
+    case ELEMENT_TYPE_I:
+        result = CORINFO_TYPE_NATIVEINT;
+        break;
+    case ELEMENT_TYPE_U:
+        result = CORINFO_TYPE_NATIVEUINT;
+        break;
 
     default:
         // Error case, we will return CORINFO_TYPE_UNDEF


### PR DESCRIPTION
This resolves the dotnet/runtime side for https://github.com/dotnet/runtimelab/pull/1035 by recognizing `nint` and `nuint` for `Vector64/128/256<T>` as valid ABI types.

The general-purpose methods (such as `As`, `GetElement`, `WithElement`, etc) are blocked until they go through API review.

CC. @jkotas, @AntonLapounov 