### PR TITLE
Generate coredumps on signals

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -663,6 +663,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_DbgEnableMiniDump, W("DbgEnableMiniDump"), 0, 
 RETAIL_CONFIG_STRING_INFO(INTERNAL_DbgMiniDumpName, W("DbgMiniDumpName"), "Crash dump name")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_DbgMiniDumpType, W("DbgMiniDumpType"), 0, "Crash dump type: 1 normal, 2 withheap, 3 triage, 4 full")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_CreateDumpDiagnostics, W("CreateDumpDiagnostics"), 0, "Enable crash dump generation diagnostic logging")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_EnableDumpOnSigTerm, W("EnableDumpOnSigTerm"), 0, "Enable crash dump generation on SIGTERM")
 
 ///
 /// Zap

--- a/src/coreclr/pal/src/exception/machexception.cpp
+++ b/src/coreclr/pal/src/exception/machexception.cpp
@@ -1411,13 +1411,6 @@ SEHInitializeMachExceptions(DWORD flags)
 #endif // _DEBUG
     }
 
-    // Tell the system to ignore SIGPIPE signals rather than use the default
-    // behavior of terminating the process. Ignoring SIGPIPE will cause
-    // calls that would otherwise raise that signal to return EPIPE instead.
-    // The PAL expects EPIPE from those functions and won't handle a
-    // SIGPIPE signal.
-    signal(SIGPIPE, SIG_IGN);
-
     // We're done
     return TRUE;
 }

--- a/src/coreclr/pal/src/exception/machmessage.h
+++ b/src/coreclr/pal/src/exception/machmessage.h
@@ -44,7 +44,8 @@ using namespace CorUnix;
 // This macro terminates the process with some useful debug info as above, but for the general failure points
 // that have nothing to do with Mach.
 #define NONPAL_RETAIL_ASSERT(_msg, ...) do {                                    \
-        printf("%s: %u: " _msg "\n", __FUNCTION__, __LINE__, ## __VA_ARGS__);   \
+        fprintf(stdout, "%s: %u: " _msg "\n", __FUNCTION__, __LINE__, ## __VA_ARGS__);   \
+        fflush(stdout);                                                         \
         abort();                                                                \
     } while (false)
 
@@ -67,7 +68,7 @@ using namespace CorUnix;
 
 // Debug-only output with printf-style formatting.
 #define NONPAL_TRACE(_format, ...) do {                                              \
-        if (NONPAL_TRACE_ENABLED) printf("NONPAL_TRACE: " _format, ## __VA_ARGS__);  \
+        if (NONPAL_TRACE_ENABLED) { fprintf(stdout, "NONPAL_TRACE: " _format, ## __VA_ARGS__); fflush(stdout); }  \
     } while (false)
 
 #else // _DEBUG

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -271,6 +271,7 @@ void SEHCleanupSignals()
 #endif
         restore_signal(SIGFPE, &g_previous_sigfpe);
         restore_signal(SIGBUS, &g_previous_sigbus);
+        restore_signal(SIGABRT, &g_previous_sigabrt);
         restore_signal(SIGSEGV, &g_previous_sigsegv);
         restore_signal(SIGINT, &g_previous_sigint);
         restore_signal(SIGQUIT, &g_previous_sigquit);

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -215,7 +215,6 @@ BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
 #endif // HAVE_MACH_EXCEPTIONS
     }
 
-#if !HAVE_MACH_EXCEPTIONS
     /* The default action for SIGPIPE is process termination.
        Since SIGPIPE can be signaled when trying to write on a socket for which
        the connection has been dropped, we need to tell the system we want
@@ -225,7 +224,6 @@ BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
        issued a SIGPIPE will, instead, report an error and set errno to EPIPE.
     */
     signal(SIGPIPE, SIG_IGN);
-#endif // !HAVE_MACH_EXCEPTIONS
 
     if (flags & PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER)
     {
@@ -285,6 +283,22 @@ void SEHCleanupSignals()
     if (g_registered_sigterm_handler)
     {
         restore_signal(SIGTERM, &g_previous_sigterm);
+    }
+}
+
+/*++
+Function :
+    SEHCleanupAbort()
+
+    Restore default SIGABORT signal handlers
+
+    (no parameters, no return value)
+--*/
+void SEHCleanupAbort()
+{
+    if (g_registered_signal_handlers)
+    {
+        restore_signal(SIGABRT, &g_previous_sigabrt);
     }
 }
 

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -62,8 +62,6 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 using namespace CorUnix;
 
-extern bool g_enableDumpOnSigTerm;
-
 /* local type definitions *****************************************************/
 
 typedef void (*SIGFUNC)(int, siginfo_t *, void *);
@@ -724,11 +722,6 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         _ASSERTE(g_pSynchronizationManager != nullptr);
 
         g_pSynchronizationManager->SendTerminationRequestToWorkerThread();
-
-        if (g_enableDumpOnSigTerm)
-        {
-            PROCCreateCrashDumpIfEnabled();
-        }
     }
     else
     {

--- a/src/coreclr/pal/src/include/pal/signal.hpp
+++ b/src/coreclr/pal/src/include/pal/signal.hpp
@@ -117,4 +117,14 @@ Function :
 --*/
 void SEHCleanupSignals();
 
+/*++
+Function :
+    SEHCleanupAbort()
+
+    Restore default SIGABORT signal handlers
+
+    (no parameters, no return value)
+--*/
+void SEHCleanupAbort();
+
 #endif /* _PAL_SIGNAL_HPP_ */

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3360,7 +3360,8 @@ PROCAbort()
 
     PROCCreateCrashDumpIfEnabled();
 
-    SEHCleanupSignals();
+    // Restore the SIGABORT handler to prevent recursion
+    SEHCleanupAbort();
 
     // Abort the process after waiting for the core dump to complete
     abort();

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -233,7 +233,6 @@ Volatile<PSHUTDOWN_CALLBACK> g_shutdownCallback = nullptr;
 
 // Crash dump generating program arguments. Initialized in PROCAbortInitialize().
 char* g_argvCreateDump[8] = { nullptr };
-bool g_enableDumpOnSigTerm = false;
 
 //
 // Key used for associating CPalThread's with the underlying pthread
@@ -3255,9 +3254,6 @@ PROCAbortInitialize()
     char* enabled = getenv("COMPlus_DbgEnableMiniDump");
     if (enabled != nullptr && _stricmp(enabled, "1") == 0)
     {
-        char* sigterm = getenv("COMPlus_EnableDumpOnSigTerm");
-        g_enableDumpOnSigTerm = sigterm != nullptr && strcmp(sigterm, "1") == 0;
-
         char* dumpName = getenv("COMPlus_DbgMiniDumpName");
         char* dumpType = getenv("COMPlus_DbgMiniDumpType");
         char* diagStr = getenv("COMPlus_CreateDumpDiagnostics");

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -26,13 +26,16 @@ HRESULT EnsureEEStarted();
 //    shutdown normally ends. "Shutdown" methods that take this action as an argument
 //    do not return when SCA_ExitProcessWhenShutdownComplete is passed.
 //
-// 2. Return after performing all shutdown processing. This is a special case used
+// 2. Terminate process and generate a dump if enabled.
+//
+// 3. Return after performing all shutdown processing. This is a special case used
 //    by a shutdown initiated via the Shim, and is used to ensure that all runtimes
 //    loaded SxS are shutdown gracefully. "Shutdown" methods that take this action
 //    as an argument return when SCA_ReturnWhenShutdownComplete is passed.
 enum ShutdownCompleteAction
 {
     SCA_ExitProcessWhenShutdownComplete,
+    SCA_TerminateProcessWhenShutdownComplete,
     SCA_ReturnWhenShutdownComplete
 };
 

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -212,7 +212,8 @@ void HandleTerminationRequest(int terminationExitCode)
     {
         SetLatchedExitCode(terminationExitCode);
 
-        ForceEEShutdown(SCA_ExitProcessWhenShutdownComplete);
+        DWORD enabled = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EnableDumpOnSigTerm);
+        ForceEEShutdown(enabled == 1 ? SCA_TerminateProcessWhenShutdownComplete : SCA_ExitProcessWhenShutdownComplete);
     }
 }
 #endif


### PR DESCRIPTION
On MacOS, coredumps are generated if there is an unhandled managed exception
but signals don't generate them.

Enable a stripped down version of the Linux signal handlers for MacOS.

Add a SIGABRT handler so calls to abort() in other native code causes dump to be generated.

Add COMPlus_EnableDumpOnSigTerm that enables dump generation on 
SIGTERM.

Issue: https://github.com/dotnet/runtime/issues/51268