### PR TITLE
Add SupportedOSPlatformGuard, UnsupportedOSPlatformGuard attributes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
@@ -131,7 +131,7 @@ namespace System.Runtime.Versioning
     }
 
     /// <summary>
-    /// Annotates the custom guard field, property or method witha  unsupported platform name and optional version.
+    /// Annotates the custom guard field, property or method with an unsupported platform name and optional version.
     /// Multiple attributes can be applied to indicate guard for multiple unsupported platforms.
     /// </summary>
     /// <remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
@@ -103,4 +103,56 @@ namespace System.Runtime.Versioning
         {
         }
     }
+
+    /// <summary>
+    /// Annotates a custom guard field, property or method with a supported platform name and optional version.
+    /// Multiple attributes can be applied to indicate guard for multiple supported platforms.
+    /// </summary>
+    /// <remarks>
+    /// Callers can apply a <see cref="System.Runtime.Versioning.SupportedOSPlatformGuardAttribute " /> to a field, property or method
+    /// and use that field, property or method in a conditional or assert statements in order to safely call platform specific APIs.
+    ///
+    /// The type of the field or property should be boolean, the method return type should be boolean in order to be used as platform guard.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Field |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property,
+                    AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class SupportedOSPlatformGuardAttribute : OSPlatformAttribute
+    {
+        public SupportedOSPlatformGuardAttribute(string platformName) : base(platformName)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Annotates the custom guard field, property or method witha  unsupported platform name and optional version.
+    /// Multiple attributes can be applied to indicate guard for multiple unsupported platforms.
+    /// </summary>
+    /// <remarks>
+    /// Callers can apply a <see cref="System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute " /> to a field, property or method
+    /// and use that  field, property or method in a conditional or assert statements as a guard to safely call APIs unsupported on those platforms.
+    ///
+    /// The type of the field or property should be boolean, the method return type should be boolean in order to be used as platform guard.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Field |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property,
+                    AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class UnsupportedOSPlatformGuardAttribute : OSPlatformAttribute
+    {
+        public UnsupportedOSPlatformGuardAttribute(string platformName) : base(platformName)
+        {
+        }
+    }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10334,20 +10334,10 @@ namespace System.Runtime.Versioning
         public static bool operator !=(System.Runtime.Versioning.FrameworkName? left, System.Runtime.Versioning.FrameworkName? right) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
-    public sealed class SupportedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
-    {
-        public SupportedOSPlatformAttribute(string platformName) : base(platformName) { }
-    }
     public abstract class OSPlatformAttribute : System.Attribute
     {
         private protected OSPlatformAttribute(string platformName) { }
         public string PlatformName { get; }
-    }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
-    public sealed class UnsupportedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
-    {
-        public UnsupportedOSPlatformAttribute(string platformName) : base(platformName) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited=false)]
     [System.Diagnostics.ConditionalAttribute("RESOURCE_ANNOTATION_WORK")]
@@ -10376,6 +10366,16 @@ namespace System.Runtime.Versioning
         Private = 16,
         Assembly = 32,
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    public sealed class SupportedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    {
+        public SupportedOSPlatformAttribute(string platformName) : base(platformName) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public sealed class SupportedOSPlatformGuardAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    {
+        public SupportedOSPlatformGuardAttribute(string platformName) : base(platformName) { }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, AllowMultiple=false, Inherited=false)]
     public sealed partial class TargetFrameworkAttribute : System.Attribute
     {
@@ -10387,6 +10387,16 @@ namespace System.Runtime.Versioning
     public sealed class TargetPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
         public TargetPlatformAttribute(string platformName) : base(platformName) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    public sealed class UnsupportedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    {
+        public UnsupportedOSPlatformAttribute(string platformName) : base(platformName) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field |System.AttributeTargets.Method | System.AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public sealed class UnsupportedOSPlatformGuardAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    {
+        public UnsupportedOSPlatformGuardAttribute(string platformName) : base(platformName) { }
     }
     public static partial class VersioningHelper
     {

--- a/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
@@ -40,5 +40,27 @@ namespace System.Runtime.Versioning.Tests
 
             Assert.Equal(platformName, tpa.PlatformName);
         }
+
+        [Theory]
+        [InlineData("Windows8.0")]
+        [InlineData("Android4.1")]
+        [InlineData("")]
+        public void TestUnsupportedOSPlatformGuardAttribute(string platformName)
+        {
+            var uopga = new UnsupportedOSPlatformGuardAttribute(platformName);
+
+            Assert.Equal(platformName, uopga.PlatformName);
+        }
+
+        [Theory]
+        [InlineData("Windows10.0")]
+        [InlineData("OSX")]
+        [InlineData("")]
+        public void TestSupportedOSPlatformGuargAttribute(string platformName)
+        {
+            var sopga = new SupportedOSPlatformGuardAttribute(platformName);
+
+            Assert.Equal(platformName, sopga.PlatformName);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51541
Add SupportedOSPlatformGuard and UnsupportedOSPlatformGuard attributes which can be applied to boolean Field, Property or Method and used as a custom guard for platform check functionality in flow analysis of Platform Compatibility Analyzer (CA1416) using. 

See more from https://github.com/dotnet/runtime/issues/51541