### PR TITLE
Avoid dictionary lookup for singleton services

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopeState.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ScopeState.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
@@ -10,16 +9,15 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     internal class ScopeState
     {
-        public IDictionary<ServiceCacheKey, object> ResolvedServices { get; }
+        public Dictionary<ServiceCacheKey, object> ResolvedServices { get; }
         public List<object> Disposables { get; set; }
 
         public int DisposableServicesCount => Disposables?.Count ?? 0;
         public int ResolvedServicesCount => ResolvedServices.Count;
 
-        public ScopeState(bool isRoot)
+        public ScopeState()
         {
-            // When isRoot is true to reduce lock contention for singletons upon resolve we use a concurrent dictionary.
-            ResolvedServices = isRoot ? new ConcurrentDictionary<ServiceCacheKey, object>() : new Dictionary<ServiceCacheKey, object>();
+            ResolvedServices = new Dictionary<ServiceCacheKey, object>();
         }
 
         public void Track(ServiceProviderEngine engine)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -130,7 +130,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private ServiceCallSite TryCreateEnumerable(Type serviceType, CallSiteChain callSiteChain)
         {
-            if (_callSiteCache.TryGetValue(new ServiceCacheKey(serviceType, DefaultSlot), out ServiceCallSite serviceCallSite))
+            ServiceCacheKey callSiteKey = new ServiceCacheKey(serviceType, DefaultSlot);
+            if (_callSiteCache.TryGetValue(callSiteKey, out ServiceCallSite serviceCallSite))
             {
                 return serviceCallSite;
             }
@@ -191,10 +192,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ResultCache resultCache = ResultCache.None;
                     if (cacheLocation == CallSiteResultCacheLocation.Scope || cacheLocation == CallSiteResultCacheLocation.Root)
                     {
-                        resultCache = new ResultCache(cacheLocation, new ServiceCacheKey(serviceType, DefaultSlot));
+                        resultCache = new ResultCache(cacheLocation, callSiteKey);
                     }
 
-                    return _callSiteCache[new ServiceCacheKey(serviceType, DefaultSlot)] = new IEnumerableCallSite(resultCache, itemType, callSites.ToArray());
+                    return _callSiteCache[callSiteKey] = new IEnumerableCallSite(resultCache, itemType, callSites.ToArray());
                 }
 
                 return null;
@@ -214,7 +215,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             if (serviceType == descriptor.ServiceType)
             {
-                if (_callSiteCache.TryGetValue(new ServiceCacheKey(serviceType, slot), out ServiceCallSite serviceCallSite))
+                ServiceCacheKey callSiteKey = new ServiceCacheKey(serviceType, slot);
+                if (_callSiteCache.TryGetValue(callSiteKey, out ServiceCallSite serviceCallSite))
                 {
                     return serviceCallSite;
                 }
@@ -238,7 +240,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     throw new InvalidOperationException(SR.InvalidServiceDescriptor);
                 }
 
-                return _callSiteCache[new ServiceCacheKey(serviceType, slot)] = callSite;
+                return _callSiteCache[callSiteKey] = callSite;
             }
 
             return null;
@@ -249,7 +251,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             if (serviceType.IsConstructedGenericType &&
                 serviceType.GetGenericTypeDefinition() == descriptor.ServiceType)
             {
-                if (_callSiteCache.TryGetValue(new ServiceCacheKey(serviceType, slot), out ServiceCallSite serviceCallSite))
+                ServiceCacheKey callSiteKey = new ServiceCacheKey(serviceType, slot);
+                if (_callSiteCache.TryGetValue(callSiteKey, out ServiceCallSite serviceCallSite))
                 {
                     return serviceCallSite;
                 }
@@ -271,7 +274,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     return null;
                 }
 
-                return _callSiteCache[new ServiceCacheKey(serviceType, slot)] = CreateConstructorCallSite(lifetime, serviceType, closedType, callSiteChain);
+                return _callSiteCache[callSiteKey] = CreateConstructorCallSite(lifetime, serviceType, closedType, callSiteChain);
             }
 
             return null;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             bool lockTaken = false;
             object sync = serviceProviderEngine.Sync;
             Dictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
-
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
             // always know that we are going to wait the other thread to finish before

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             object sync = serviceProviderEngine.Sync;
             Dictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
 
+
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
             // always know that we are going to wait the other thread to finish before

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             bool lockTaken = false;
             object sync = serviceProviderEngine.Sync;
-            IDictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
+            Dictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
 
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
@@ -114,7 +114,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             try
             {
                 // Note: This method has already taken lock by the caller for resolution and access synchronization.
-                // For root: uses a concurrent dictionary and takes a per singleton lock for resolution.
                 // For scoped: takes a dictionary as both a resolution lock and a dictionary access lock.
                 if (resolvedServices.TryGetValue(callSite.Cache.Key, out object resolved))
                 {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -102,7 +102,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             object sync = serviceProviderEngine.Sync;
             Dictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
 
-
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
             // always know that we are going to wait the other thread to finish before

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -62,12 +61,25 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             var lockType = RuntimeResolverLock.Root;
             bool lockTaken = false;
+            ServiceProviderEngineScope serviceProviderEngine = context.Scope.Engine.Root;
 
             // using more granular locking (per singleton) for the root
             Monitor.Enter(callSite, ref lockTaken);
             try
             {
-                return ResolveService(callSite, context, lockType, serviceProviderEngine: context.Scope.Engine.Root);
+                if (callSite.Value is object value)
+                {
+                    return value;
+                }
+
+                object resolved = VisitCallSiteMain(callSite, new RuntimeResolverContext
+                {
+                    Scope = serviceProviderEngine,
+                    AcquiredLocks = context.AcquiredLocks | lockType
+                });
+                serviceProviderEngine.CaptureDisposable(resolved);
+                callSite.Value = resolved;
+                return resolved;
             }
             finally
             {
@@ -91,6 +103,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             bool lockTaken = false;
             object sync = serviceProviderEngine.Sync;
+            IDictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
 
             // Taking locks only once allows us to fork resolution process
             // on another thread without causing the deadlock because we
@@ -103,7 +116,22 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             try
             {
-                return ResolveService(callSite, context, lockType, serviceProviderEngine);
+                // Note: This method has already taken lock by the caller for resolution and access synchronization.
+                // For root: uses a concurrent dictionary and takes a per singleton lock for resolution.
+                // For scoped: takes a dictionary as both a resolution lock and a dictionary access lock.
+                if (resolvedServices.TryGetValue(callSite.Cache.Key, out object resolved))
+                {
+                    return resolved;
+                }
+
+                resolved = VisitCallSiteMain(callSite, new RuntimeResolverContext
+                {
+                    Scope = serviceProviderEngine,
+                    AcquiredLocks = context.AcquiredLocks | lockType
+                });
+                serviceProviderEngine.CaptureDisposable(resolved);
+                resolvedServices.Add(callSite.Cache.Key, resolved);
+                return resolved;
             }
             finally
             {
@@ -112,32 +140,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     Monitor.Exit(sync);
                 }
             }
-        }
-
-        private object ResolveService(ServiceCallSite callSite, RuntimeResolverContext context, RuntimeResolverLock lockType, ServiceProviderEngineScope serviceProviderEngine)
-        {
-            IDictionary<ServiceCacheKey, object> resolvedServices = serviceProviderEngine.ResolvedServices;
-
-            // Note: This method has already taken lock by the caller for resolution and access synchronization.
-            // For root: uses a concurrent dictionary and takes a per singleton lock for resolution.
-            // For scoped: takes a dictionary as both a resolution lock and a dictionary access lock.
-            Debug.Assert(
-                (lockType == RuntimeResolverLock.Root && resolvedServices is ConcurrentDictionary<ServiceCacheKey, object>) ||
-                (lockType == RuntimeResolverLock.Scope && Monitor.IsEntered(serviceProviderEngine.Sync)));
-
-            if (resolvedServices.TryGetValue(callSite.Cache.Key, out object resolved))
-            {
-                return resolved;
-            }
-
-            resolved = VisitCallSiteMain(callSite, new RuntimeResolverContext
-            {
-                Scope = serviceProviderEngine,
-                AcquiredLocks = context.AcquiredLocks | lockType
-            });
-            serviceProviderEngine.CaptureDisposable(resolved);
-            resolvedServices.Add(callSite.Cache.Key, resolved);
-            return resolved;
         }
 
         protected override object VisitConstant(ConstantCallSite constantCallSite, RuntimeResolverContext context)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal sealed class ConstantCallSite : ServiceCallSite
     {
         private readonly Type _serviceType;
-        internal object DefaultValue { get; }
+        internal object DefaultValue => Value;
 
         public ConstantCallSite(Type serviceType, object defaultValue): base(ResultCache.None)
         {
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 throw new ArgumentException(SR.Format(SR.ConstantCantBeConvertedToServiceType, defaultValue.GetType(), serviceType));
             }
 
-            DefaultValue = defaultValue;
+            Value = defaultValue;
         }
 
         public override Type ServiceType => DefaultValue?.GetType() ?? _serviceType;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal struct ServiceCacheKey : IEquatable<ServiceCacheKey>
+    internal readonly struct ServiceCacheKey : IEquatable<ServiceCacheKey>
     {
         public static ServiceCacheKey Empty { get; } = new ServiceCacheKey(null, 0);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal struct ServiceCacheKey: IEquatable<ServiceCacheKey>
+    internal struct ServiceCacheKey : IEquatable<ServiceCacheKey>
     {
         public static ServiceCacheKey Empty { get; } = new ServiceCacheKey(null, 0);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public abstract Type ImplementationType { get; }
         public abstract CallSiteKind Kind { get; }
         public ResultCache Cache { get; }
+        public object Value { get; set; }
 
         public bool CaptureDisposable =>
             ImplementationType == null ||

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// </summary>
     internal abstract class ServiceCallSite
     {
-        private volatile object _value;
-
         protected ServiceCallSite(ResultCache cache)
         {
             Cache = cache;
@@ -21,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public abstract Type ImplementationType { get; }
         public abstract CallSiteKind Kind { get; }
         public ResultCache Cache { get; }
-        public object Value { get => _value; set => _value = value; }
+        public object Value { get; set; }
 
         public bool CaptureDisposable =>
             ImplementationType == null ||

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// </summary>
     internal abstract class ServiceCallSite
     {
+        private volatile object _value;
+
         protected ServiceCallSite(ResultCache cache)
         {
             Cache = cache;
@@ -19,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public abstract Type ImplementationType { get; }
         public abstract CallSiteKind Kind { get; }
         public ResultCache Cache { get; }
-        public object Value { get; set; }
+        public object Value { get => _value; set => _value = value; }
 
         public bool CaptureDisposable =>
             ImplementationType == null ||

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected ServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors)
         {
             _createServiceAccessor = CreateServiceAccessor;
-            Root = new ServiceProviderEngineScope(this, isRoot: true);
+            Root = new ServiceProviderEngineScope(this);
             RuntimeResolver = new CallSiteRuntimeResolver();
             CallSiteFactory = new CallSiteFactory(serviceDescriptors);
             CallSiteFactory.Add(typeof(IServiceProvider), new ServiceProviderCallSite());

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private bool _disposed;
         private readonly ScopeState _state;
 
-        public ServiceProviderEngineScope(ServiceProviderEngine engine, bool isRoot = false)
+        public ServiceProviderEngineScope(ServiceProviderEngine engine)
         {
             Engine = engine;
-            _state = new ScopeState(isRoot);
+            _state = new ScopeState();
         }
 
-        internal IDictionary<ServiceCacheKey, object> ResolvedServices => _state.ResolvedServices;
+        internal Dictionary<ServiceCacheKey, object> ResolvedServices => _state.ResolvedServices;
 
         // This lock protects state on the scope, in particular, for the root scope, it protects
         // the list of disposable entries only, since ResolvedServices is a concurrent dictionary.

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -89,9 +89,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var compiledCallSite = CompileCallSite(callSite, provider);
             var compiledCollectionCallSite = CompileCallSite(collectionCallSite, provider);
 
-            var service1 = Invoke(callSite, provider);
-            var service2 = compiledCallSite(provider.Root);
-            var serviceEnumerator = ((IEnumerable)compiledCollectionCallSite(provider.Root)).GetEnumerator();
+            using var scope = (ServiceProviderEngineScope)provider.CreateScope();
+
+            var service1 = Invoke(callSite, scope);
+            var service2 = compiledCallSite(scope);
+            var serviceEnumerator = ((IEnumerable)compiledCollectionCallSite(scope)).GetEnumerator();
 
             Assert.NotNull(service1);
             Assert.True(compare(service1, service2));
@@ -114,10 +116,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
-            var serviceC = (ServiceC)compiledCallSite(provider.Root);
+            using var scope = (ServiceProviderEngineScope)provider.CreateScope();
+
+            var serviceC = (ServiceC)compiledCallSite(scope);
 
             Assert.NotNull(serviceC.ServiceB.ServiceA);
-            Assert.Equal(serviceC, Invoke(callSite, provider));
+            Assert.Equal(serviceC, Invoke(callSite, scope));
         }
 
         [Theory]
@@ -371,9 +375,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        private static object Invoke(ServiceCallSite callSite, ServiceProviderEngine provider)
+        private static object Invoke(ServiceCallSite callSite, ServiceProviderEngineScope scope)
         {
-            return CallSiteRuntimeResolver.Resolve(callSite, provider.Root);
+            return CallSiteRuntimeResolver.Resolve(callSite, scope);
         }
 
         private static Func<ServiceProviderEngineScope, object> CompileCallSite(ServiceCallSite callSite, ServiceProviderEngine engine)


### PR DESCRIPTION
- Stash the instance on the callsite itself and avoid the resolved services lookup.
- This mainly benefits the reflection only path as the ILEmit codegen path will replace this code with an optimized delegate. This should help resolving singletons in the blazor code path and for nativeAOT.
- The other benefit is that the concurrent dictionary that was used before to store singletons will be empty in the common case.
- This change also introduces callsite caching (memoization). Today callsites are cached but only the root type (A -> B -> C), `GetService<A>` will only cache the A callsite. This change will result in caching A, B and C.

~PS: Still testing this.~