### PR TITLE
Revert "Fix ber scanf/printf. (#51205)"

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ber.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ber.cs
@@ -4,14 +4,11 @@
 using System;
 using System.Runtime.InteropServices;
 using System.DirectoryServices.Protocols;
-using System.Diagnostics;
 
 internal static partial class Interop
 {
     internal static partial class Ldap
     {
-        private const int ber_default_successful_return_code = 0;
-
         [DllImport(Libraries.OpenLdap, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
         public static extern IntPtr ber_alloc(int option);
 
@@ -21,105 +18,17 @@ internal static partial class Interop
         [DllImport(Libraries.OpenLdap, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
         public static extern IntPtr ber_free([In] IntPtr berelement, int option);
 
-        public static int ber_printf_emptyarg(SafeBerHandle berElement, string format, int tag)
-        {
-            if (format == "{")
-            {
-                return ber_start_seq(berElement, tag);
-            }
-            else if (format == "}")
-            {
-                return ber_put_seq(berElement, tag);
-            }
-            else if (format == "[")
-            {
-                return ber_start_set(berElement, tag);
-            }
-            else if (format == "]")
-            {
-                return ber_put_set(berElement, tag);
-            }
-            else
-            {
-                Debug.Assert(format == "n");
-                return ber_put_null(berElement, tag);
-            }
-        }
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_printf", CharSet = CharSet.Ansi)]
+        public static extern int ber_printf_emptyarg(SafeBerHandle berElement, string format);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_start_seq", CharSet = CharSet.Ansi)]
-        public static extern int ber_start_seq(SafeBerHandle berElement, int tag);
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_printf", CharSet = CharSet.Ansi)]
+        public static extern int ber_printf_int(SafeBerHandle berElement, string format, int value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_start_set", CharSet = CharSet.Ansi)]
-        public static extern int ber_start_set(SafeBerHandle berElement, int tag);
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_printf", CharSet = CharSet.Ansi)]
+        public static extern int ber_printf_bytearray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_seq", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_seq(SafeBerHandle berElement, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_set", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_set(SafeBerHandle berElement, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_null", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_null(SafeBerHandle berElement, int tag);
-
-
-        public static int ber_printf_tag(SafeBerHandle berElement, string format, int tag)
-        {
-            // Ber Linux tags are passed with the values that they affect, like `ber_printf_int(.., tag)`.
-            // So this function does nothing on Linux.
-            return ber_default_successful_return_code;
-        }
-
-        public static int ber_printf_int(SafeBerHandle berElement, string format, int value, int tag)
-        {
-            if (format == "i")
-            {
-                return ber_put_int(berElement, value, tag);
-            }
-            else if (format == "e")
-            {
-                return ber_put_enum(berElement, value, tag);
-            }
-            else
-            {
-                Debug.Assert(format == "b");
-                return ber_put_boolean(berElement, value, tag);
-            }
-        }
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_int", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_int(SafeBerHandle berElement, int value, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_enum", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_enum(SafeBerHandle berElement, int value, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_boolean", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_boolean(SafeBerHandle berElement, int value, int tag);
-
-        public static int ber_printf_bytearray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length, int tag)
-        {
-            if (format == "o")
-            {
-                return ber_put_ostring(berElement, value, length, tag);
-            }
-            else if (format == "s")
-            {
-                return ber_put_string(berElement, value, tag);
-            }
-            else
-            {
-                Debug.Assert(format == "X");
-                return ber_put_bitstring(berElement, value, length, tag);
-            }
-        }
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_ostring", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_ostring(SafeBerHandle berElement, HGlobalMemHandle value, int length, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_string", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_string(SafeBerHandle berElement, HGlobalMemHandle value, int tag);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_bitstring", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_bitstring(SafeBerHandle berElement, HGlobalMemHandle value, int length, int tag);
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_printf", CharSet = CharSet.Ansi)]
+        public static extern int ber_printf_berarray(SafeBerHandle berElement, string format, IntPtr value);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ber_flatten", CharSet = CharSet.Ansi)]
         public static extern int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
@@ -130,87 +39,16 @@ internal static partial class Interop
         [DllImport(Libraries.OpenLdap, EntryPoint = "ber_bvecfree", CharSet = CharSet.Ansi)]
         public static extern int ber_bvecfree(IntPtr value);
 
-        public static int ber_scanf_emptyarg(SafeBerHandle berElement, string format)
-        {
-            Debug.Assert(format == "{" || format == "}" || format == "[" || format == "]" || format == "n" || format == "x");
-            if (format == "{" || format == "[")
-            {
-                int len = 0;
-                return ber_skip_tag(berElement, ref len);
-            }
-            else if (format == "]" || format == "}")
-            {
-                return ber_default_successful_return_code;
-            }
-            else
-            {
-                Debug.Assert(format == "n" || format == "x");
-                return ber_get_null(berElement);
-            }
-        }
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_scanf", CharSet = CharSet.Ansi)]
+        public static extern int ber_scanf(SafeBerHandle berElement, string format);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_skip_tag", CharSet = CharSet.Ansi)]
-        private static extern int ber_skip_tag(SafeBerHandle berElement, ref int len);
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_scanf", CharSet = CharSet.Ansi)]
+        public static extern int ber_scanf_int(SafeBerHandle berElement, string format, ref int value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_null", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_null(SafeBerHandle berElement);
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_scanf", CharSet = CharSet.Ansi)]
+        public static extern int ber_scanf_bitstring(SafeBerHandle berElement, string format, ref IntPtr value, ref int bitLength);
 
-        public static int ber_scanf_int(SafeBerHandle berElement, string format, ref int value)
-        {
-            if (format == "i")
-            {
-                return ber_get_int(berElement, ref value);
-            }
-            else if (format == "e")
-            {
-                return ber_get_enum(berElement, ref value);
-            }
-            else
-            {
-                Debug.Assert(format == "b");
-                return ber_get_boolean(berElement, ref value);
-            }
-        }
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_int", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_int(SafeBerHandle berElement, ref int value);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_enum", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_enum(SafeBerHandle berElement, ref int value);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_boolean", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_boolean(SafeBerHandle berElement, ref int value);
-
-        public static int ber_scanf_bitstring(SafeBerHandle berElement, string format, ref IntPtr value, ref int bitLength)
-        {
-            Debug.Assert(format == "B");
-            return ber_get_stringb(berElement, ref value, ref bitLength);
-        }
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringb", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_stringb(SafeBerHandle berElement, ref IntPtr value, ref int bitLength);
-
-        public static int ber_scanf_ptr(SafeBerHandle berElement, string format, ref IntPtr value)
-        {
-            Debug.Assert(format == "O");
-            return ber_get_stringal(berElement, ref value);
-        }
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringal", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_stringal(SafeBerHandle berElement, ref IntPtr value);
-
-        public static int ber_printf_berarray(SafeBerHandle berElement, string format, IntPtr value, int tag)
-        {
-            Debug.Assert(format == "v" || format == "V");
-            // V and v are not supported on Unix yet.
-            return -1;
-        }
-
-        public static int ber_scanf_multibytearray(SafeBerHandle berElement, string format, ref IntPtr value)
-        {
-            Debug.Assert(format == "v" || format == "V");
-            // V and v are not supported on Unix yet.
-            return -1;
-        }
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_scanf", CharSet = CharSet.Ansi)]
+        public static extern int ber_scanf_ptr(SafeBerHandle berElement, string format, ref IntPtr value);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ber.cs
+++ b/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ber.cs
@@ -16,7 +16,16 @@ internal static partial class Interop
         public static extern IntPtr ber_alloc(int option);
 
         [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_printf", CharSet = CharSet.Unicode)]
-        public static extern int ber_printf(SafeBerHandle berElement, string format, __arglist);
+        public static extern int ber_printf_emptyarg(SafeBerHandle berElement, string format);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_printf", CharSet = CharSet.Unicode)]
+        public static extern int ber_printf_int(SafeBerHandle berElement, string format, int value);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_printf", CharSet = CharSet.Unicode)]
+        public static extern int ber_printf_bytearray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_printf", CharSet = CharSet.Unicode)]
+        public static extern int ber_printf_berarray(SafeBerHandle berElement, string format, IntPtr value);
 
         [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_flatten", CharSet = CharSet.Unicode)]
         public static extern int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
@@ -25,7 +34,16 @@ internal static partial class Interop
         public static extern IntPtr ber_init(berval value);
 
         [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode)]
-        public static extern int ber_scanf(SafeBerHandle berElement, string format, __arglist);
+        public static extern int ber_scanf(SafeBerHandle berElement, string format);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode)]
+        public static extern int ber_scanf_int(SafeBerHandle berElement, string format, ref int value);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode)]
+        public static extern int ber_scanf_ptr(SafeBerHandle berElement, string format, ref IntPtr value);
+
+        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode)]
+        public static extern int ber_scanf_bitstring(SafeBerHandle berElement, string format, ref IntPtr value, ref int bitLength);
 
         [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_bvfree", CharSet = CharSet.Unicode)]
         public static extern int ber_bvfree(IntPtr value);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/BerPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/BerPal.Linux.cs
@@ -13,25 +13,21 @@ namespace System.DirectoryServices.Protocols
 
         internal static int FlattenBerElement(SafeBerHandle berElement, ref IntPtr flattenptr) => Interop.Ldap.ber_flatten(berElement, ref flattenptr);
 
-        internal static int PrintBerArray(SafeBerHandle berElement, string format, IntPtr value, int tag) => Interop.Ldap.ber_printf_berarray(berElement, format, value, tag);
+        internal static int PrintBerArray(SafeBerHandle berElement, string format, IntPtr value) => Interop.Ldap.ber_printf_berarray(berElement, format, value);
 
-        internal static int PrintByteArray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length, int tag) => Interop.Ldap.ber_printf_bytearray(berElement, format, value, length, tag);
+        internal static int PrintByteArray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length) => Interop.Ldap.ber_printf_bytearray(berElement, format, value, length);
 
-        internal static int PrintEmptyArgument(SafeBerHandle berElement, string format, int tag) => Interop.Ldap.ber_printf_emptyarg(berElement, format, tag);
+        internal static int PrintEmptyArgument(SafeBerHandle berElement, string format) => Interop.Ldap.ber_printf_emptyarg(berElement, format);
 
-        internal static int PrintInt(SafeBerHandle berElement, string format, int value, int tag) => Interop.Ldap.ber_printf_int(berElement, format, value, tag);
+        internal static int PrintInt(SafeBerHandle berElement, string format, int value) => Interop.Ldap.ber_printf_int(berElement, format, value);
 
-        internal static int PrintTag(SafeBerHandle berElement, string format, int tag) => Interop.Ldap.ber_printf_tag(berElement, format, tag);
-
-        internal static int ScanNext(SafeBerHandle berElement, string format) => Interop.Ldap.ber_scanf_emptyarg(berElement, format);
+        internal static int ScanNext(SafeBerHandle berElement, string format) => Interop.Ldap.ber_scanf(berElement, format);
 
         internal static int ScanNextBitString(SafeBerHandle berElement, string format, ref IntPtr ptrResult, ref int bitLength) => Interop.Ldap.ber_scanf_bitstring(berElement, format, ref ptrResult, ref bitLength);
 
         internal static int ScanNextInt(SafeBerHandle berElement, string format, ref int result) => Interop.Ldap.ber_scanf_int(berElement, format, ref result);
 
         internal static int ScanNextPtr(SafeBerHandle berElement, string format, ref IntPtr value) => Interop.Ldap.ber_scanf_ptr(berElement, format, ref value);
-
-        internal static int ScanNextMultiByteArray(SafeBerHandle berElement, string format, ref IntPtr value) => Interop.Ldap.ber_scanf_multibytearray(berElement, format, ref value);
 
         internal static bool IsBerDecodeError(int errorCode) => errorCode == -1;
     }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/BerPal.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/BerPal.Windows.cs
@@ -15,25 +15,21 @@ namespace System.DirectoryServices.Protocols
 
         internal static int FlattenBerElement(SafeBerHandle berElement, ref IntPtr flattenptr) => Interop.Ldap.ber_flatten(berElement, ref flattenptr);
 
-        internal static int PrintBerArray(SafeBerHandle berElement, string format, IntPtr value, int tag) => Interop.Ldap.ber_printf(berElement, format, __arglist(value));
+        internal static int PrintBerArray(SafeBerHandle berElement, string format, IntPtr value) => Interop.Ldap.ber_printf_berarray(berElement, format, value);
 
-        internal static int PrintByteArray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length, int tag) => Interop.Ldap.ber_printf(berElement, format, __arglist(value, length));
+        internal static int PrintByteArray(SafeBerHandle berElement, string format, HGlobalMemHandle value, int length) => Interop.Ldap.ber_printf_bytearray(berElement, format, value, length);
 
-        internal static int PrintEmptyArgument(SafeBerHandle berElement, string format, int tag) => Interop.Ldap.ber_printf(berElement, format, __arglist());
+        internal static int PrintEmptyArgument(SafeBerHandle berElement, string format) => Interop.Ldap.ber_printf_emptyarg(berElement, format);
 
-        internal static int PrintInt(SafeBerHandle berElement, string format, int value, int tag) => Interop.Ldap.ber_printf(berElement, format, __arglist(value));
+        internal static int PrintInt(SafeBerHandle berElement, string format, int value) => Interop.Ldap.ber_printf_int(berElement, format, value);
 
-        internal static int PrintTag(SafeBerHandle berElement, string format, int tag) => Interop.Ldap.ber_printf(berElement, format, __arglist(tag));
+        internal static int ScanNext(SafeBerHandle berElement, string format) => Interop.Ldap.ber_scanf(berElement, format);
 
-        internal static int ScanNext(SafeBerHandle berElement, string format) => Interop.Ldap.ber_scanf(berElement, format, __arglist());
+        internal static int ScanNextBitString(SafeBerHandle berElement, string format, ref IntPtr ptrResult, ref int bitLength) => Interop.Ldap.ber_scanf_bitstring(berElement, format, ref ptrResult, ref bitLength);
 
-        internal static int ScanNextBitString(SafeBerHandle berElement, string format, ref IntPtr ptrResult, ref int bitLength) => Interop.Ldap.ber_scanf(berElement, format, __arglist(ref ptrResult, ref bitLength));
+        internal static int ScanNextInt(SafeBerHandle berElement, string format, ref int result) => Interop.Ldap.ber_scanf_int(berElement, format, ref result);
 
-        internal static int ScanNextInt(SafeBerHandle berElement, string format, ref int result) => Interop.Ldap.ber_scanf(berElement, format, __arglist(ref result));
-
-        internal static int ScanNextPtr(SafeBerHandle berElement, string format, ref IntPtr value) => Interop.Ldap.ber_scanf(berElement, format, __arglist(ref value));
-
-        internal static int ScanNextMultiByteArray(SafeBerHandle berElement, string format, ref IntPtr value) => Interop.Ldap.ber_scanf(berElement, format, __arglist(ref value));
+        internal static int ScanNextPtr(SafeBerHandle berElement, string format, ref IntPtr value) => Interop.Ldap.ber_scanf_ptr(berElement, format, ref value);
 
         internal static bool IsBerDecodeError(int errorCode) => errorCode != 0;
     }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/AsqRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/AsqRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class AsqRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConversionExceptionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConversionExceptionTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class BerConversionExceptionTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class BerConverterTests
     {
         public static IEnumerable<object[]> Encode_TestData()
@@ -29,10 +30,6 @@ namespace System.DirectoryServices.Protocols.Tests
             yield return new object[] { "[]", new object[] { "a" }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 49, 132, 0, 0, 0, 0 } : new byte[] { 49, 0 } };
             yield return new object[] { "n", new object[] { "a" }, new byte[] { 5, 0 } };
 
-            yield return new object[] { "e", new object[] { 128 }, new byte[] { 10, 2, 0, 128 } };
-            yield return new object[] { "te", new object[] { 128, 0 }, new byte[] { 128, 1, 0 } };
-            yield return new object[] { "tet", new object[] { 128, 0, 133 }, new byte[] { 128, 1, 0 } };
-
             yield return new object[] { "tetie", new object[] { 128, 0, 133, 2, 3 }, new byte[] { 128, 1, 0, 133, 1, 2, 10, 1, 3 } };
             yield return new object[] { "{tetie}", new object[] { 128, 0, 133, 2, 3 }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 9, 128, 1, 0, 133, 1, 2, 10, 1, 3 } : new byte[] { 48, 9, 128, 1, 0, 133, 1, 2, 10, 1, 3 } };
 
@@ -40,16 +37,10 @@ namespace System.DirectoryServices.Protocols.Tests
             yield return new object[] { "{bb}", new object[] { true, false }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 6, 1, 1, 255, 1, 1, 0 } : new byte[] { 48, 6, 1, 1, 255, 1, 1, 0 } };
 
             yield return new object[] { "ssss", new object[] { null, "", "abc", "\0" }, new byte[] { 4, 0, 4, 0, 4, 3, 97, 98, 99, 4, 1, 0 } };
-
-            yield return new object[] { "o", new object[] { null },  new byte[] { 4, 0} };
-            yield return new object[] { "X", new object[] { new byte[] { 0, 1, 2, 255 } }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 3, 4, 0, 1, 2, 255 } : new byte[] { 3, 2, 4, 0 } };
             yield return new object[] { "oXo", new object[] { null, new byte[] { 0, 1, 2, 255 }, new byte[0] }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 4, 0, 3, 4, 0, 1, 2, 255, 4, 0 } : new byte[] { 4, 0, 3, 2, 4, 0, 4, 0 } };
             yield return new object[] { "vv", new object[] { null, new string[] { "abc", "", null } }, new byte[] { 4, 3, 97, 98, 99, 4, 0, 4, 0 } };
             yield return new object[] { "{vv}", new object[] { null, new string[] { "abc", "", null } }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 } : new byte[] { 48, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 } };
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                yield return new object[] { "VVVV", new object[] { null, new byte[][] { new byte[] { 0, 1, 2, 3 }, null }, new byte[][] { new byte[0] }, new byte[0][] }, new byte[] { 4, 4, 0, 1, 2, 3, 4, 0, 4, 0 } };
-            }
+            yield return new object[] { "VVVV", new object[] { null, new byte[][] { new byte[] { 0, 1, 2, 3 }, null }, new byte[][] { new byte[0] }, new byte[0][] }, new byte[] { 4, 4, 0, 1, 2, 3, 4, 0, 4, 0 } };
         }
 
         [Theory]
@@ -126,7 +117,6 @@ namespace System.DirectoryServices.Protocols.Tests
         {
             yield return new object[] { "{}", new byte[] { 48, 0, 0, 0, 0, 0 }, new object[0] };
             yield return new object[] { "{a}", new byte[] { 48, 132, 0, 0, 0, 5, 4, 3, 97, 98, 99 }, new object[] { "abc" } };
-            yield return new object[] { "{i}", new byte[] { 48, 132, 0, 0, 0, 3, 2, 1, 10 }, new object[] { 10 } };
             yield return new object[] { "{ie}", new byte[] { 48, 132, 0, 0, 0, 6, 1, 1, 255, 1, 1, 0 }, new object[] { -1, 0 } };
             yield return new object[] { "{bb}", new byte[] { 48, 132, 0, 0, 0, 6, 1, 1, 255, 1, 1, 0 }, new object[] { true, false } };
             yield return new object[] { "{OO}", new byte[] { 48, 132, 0, 0, 0, 6, 1, 1, 255, 1, 1, 0 }, new object[] { new byte[] { 255 }, new byte[] { 0 } } };

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirSyncRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class DirSyncRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class DirectoryControlTests
     {
         [Theory]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public partial class DirectoryServicesProtocolsTests
     {
         internal static bool IsLdapConfigurationExist => LdapConfiguration.Configuration != null;

--- a/src/libraries/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/ExtendedDNControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class ExtendedDNControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/PageResultRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class PageResultRequestControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class QuotaControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/SearchOptionsControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class SearchOptionsControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/SecurityDescriptorFlagControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/SecurityDescriptorFlagControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class SecurityDescriptorFlagControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/VerifyNameControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class VerifyNameControlTests
     {
         [Fact]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/VlvRequestControlTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.DirectoryServices.Protocols.Tests
 {
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49105", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class VlvRequestControlTests
     {
         [Fact]


### PR DESCRIPTION
This reverts commit f66434893685743c35de013dd42ca05107955b67.

The change caused failures in "runtime" pipeline that I guess is our inerloop, so I want to unblock it. https://dev.azure.com/dnceng/public/_build?definitionId=686&_a=summary

link https://github.com/dotnet/runtime/issues/52031 to see if it stops failing after the revert.