### PR TITLE
Add diagnostic for Logging Generator: can't have malformed format strings 

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/DiagnosticDescriptors.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Extensions.Logging.Generators
 
         public static DiagnosticDescriptor MalformedFormatStrings { get; } = new DiagnosticDescriptor(
             id: "SYSLIB1022",
-            title: new LocalizableResourceString(nameof(SR.MalformedFormatStringsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
+            title: new LocalizableResourceString(nameof(SR.MalformedFormatStringsTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MalformedFormatStringsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             category: "LoggingGenerator",
             DiagnosticSeverity.Error,

--- a/src/libraries/Microsoft.Extensions.Logging/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/LoggerMessageGenerator.Parser.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                         {
                                             TemplateHelper.Parse(msg, lm.TemplateList);
                                         }
-                                        catch (Exception ex)
+                                        catch (ArgumentException ex)
                                         {
                                             Diag(DiagnosticDescriptors.MalformedFormatStrings, ma.GetLocation(), ex.Message);
                                             keepMethod = false;

--- a/src/libraries/Microsoft.Extensions.Logging/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/LoggerMessageGenerator.Parser.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text;
 
 namespace Microsoft.Extensions.Logging.Generators
 {
@@ -193,6 +194,16 @@ namespace Microsoft.Extensions.Logging.Generators
                                             || msg.StartsWith("ERR:", StringComparison.OrdinalIgnoreCase))
                                         {
                                             Diag(DiagnosticDescriptors.RedundantQualifierInMessage, ma.GetLocation(), method.Identifier.ToString());
+                                        }
+
+                                        try
+                                        {
+                                            TemplateHelper.Parse(msg, lm.TemplateList);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Diag(DiagnosticDescriptors.MalformedFormatStrings, ma.GetLocation(), ex.Message);
+                                            keepMethod = false;
                                         }
 
                                         bool foundLogger = false;

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/Strings.resx
@@ -209,8 +209,11 @@
   <data name="InconsistentTemplateCasingMessage" xml:space="preserve">
     <value>Can't have the same template with different casing</value>
   </data>
+  <data name="MalformedFormatStringsTitle" xml:space="preserve">
+    <value>Can't have malformed format strings (like dangling curly brackets, etc).</value>
+  </data>
   <data name="MalformedFormatStringsMessage" xml:space="preserve">
-    <value>Can't have malformed format strings (like dangling {, etc)</value>
+    <value>Can't have malformed format strings (like dangling curly brackets, etc). {0}</value>
   </data>
   <data name="GeneratingForMax6ArgumentsMessage" xml:space="preserve">
     <value>Generating more than 6 arguments is not supported</value>

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.cs.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.de.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.es.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.fr.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.it.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ja.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ko.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.pl.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.ru.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.tr.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -63,8 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
-        <source>Can't have malformed format strings (like dangling {, etc)</source>
-        <target state="new">Can't have malformed format strings (like dangling {, etc)</target>
+        <source>Can't have malformed format strings (like dangling curly brackets, etc). {0}</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MalformedFormatStringsTitle">
+        <source>Can't have malformed format strings (like dangling curly brackets, etc).</source>
+        <target state="new">Can't have malformed format strings (like dangling curly brackets, etc).</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingLogLevelMessage">

--- a/src/libraries/Microsoft.Extensions.Logging/gen/TemplateHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/gen/TemplateHelper.cs
@@ -1,0 +1,346 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Text
+{
+    internal static class TemplateHelper
+    {
+        /// <summary>
+        /// Parses the message template and throws exception for malformed messages.
+        /// </summary>
+        internal static string Parse(this string msg, List<string>? templates)
+        {
+            ReadOnlySpan<char> format = msg.AsSpan();
+            var builder = new StringBuilder(msg.Length);
+            var pos = 0;
+            var len = format.Length;
+            var ch = '\0';
+            var segments = new List<Segment>();
+            var numArgs = 0;
+
+            while (true)
+            {
+                var segStart = builder.Length;
+                while (pos < len)
+                {
+                    ch = format[pos];
+
+                    pos++;
+                    if (ch == '}')
+                    {
+                        if (pos < len && format[pos] == '}')
+                        {
+                            // double }, treat as escape sequence
+                            pos++;
+                        }
+                        else
+                        {
+                            // dangling }, fail
+                            throw new ArgumentException($"Dangling }} in format string at position {pos}", nameof(format));
+                        }
+                    }
+                    else if (ch == '{')
+                    {
+                        if (pos < len && format[pos] == '{')
+                        {
+                            // double {, treat as escape sequence
+                            pos++;
+                        }
+                        else
+                        {
+                            // start of a format specification
+                            pos--;
+                            break;
+                        }
+                    }
+
+                    builder.Append(ch);
+                }
+
+                if (pos == len)
+                {
+                    var totalLit = builder.Length - segStart;
+                    while (totalLit > 0)
+                    {
+                        var num = totalLit;
+                        if (num > short.MaxValue)
+                        {
+                            num = short.MaxValue;
+                        }
+
+                        segments.Add(new Segment((short)num, -1, 0, string.Empty));
+                        totalLit -= num;
+                    }
+
+                    return builder.ToString();
+                }
+
+                // extract the argument index
+                var argIndex = 0;
+                if (templates == null)
+                {
+                    // classic composite format string
+
+                    pos++;
+                    if (pos == len || (ch = format[pos]) < '0' || ch > '9')
+                    {
+                        // we need an argument index
+                        throw new ArgumentException($"Missing argument index in format string at position {pos}", nameof(format));
+                    }
+
+                    do
+                    {
+                        argIndex = (argIndex * 10) + (ch - '0');
+                        pos++;
+
+                        // make sure we get a suitable end to the argument index
+                        if (pos == len)
+                        {
+                            throw new ArgumentException($"Invalid argument index in format string at position {pos}", nameof(format));
+                        }
+
+                        ch = format[pos];
+                    }
+                    while (ch >= '0' && ch <= '9');
+                }
+                else
+                {
+                    // template-based format string
+
+                    pos++;
+                    if (pos == len)
+                    {
+                        // we need a template name
+                        throw new ArgumentException($"Missing template name in format string at position {pos}", nameof(format));
+                    }
+
+                    ch = format[pos];
+                    if (!ValidTemplateNameChar(ch, true))
+                    {
+                        // we need a template name
+                        throw new ArgumentException($"Missing template name in format string at position {pos}", nameof(format));
+                    }
+
+                    // extract the template name
+                    var start = pos;
+                    do
+                    {
+                        pos++;
+
+                        // make sure we get a suitable end
+                        if (pos == len)
+                        {
+                            throw new ArgumentException($"Invalid template name in format string at position {pos}", nameof(format));
+                        }
+
+                        ch = format[pos];
+                    }
+                    while (ValidTemplateNameChar(ch, false));
+
+                    // get an argument index for the given template
+                    var template = format.Slice(start, pos - start).ToString();
+                    argIndex = templates.IndexOf(template);
+                    if (argIndex < 0)
+                    {
+                        templates.Add(template);
+                        argIndex = numArgs;
+                    }
+                }
+
+                if (argIndex >= numArgs)
+                {
+                    // new max arg count
+                    numArgs = argIndex + 1;
+                }
+
+                // skip whitespace
+                while (pos < len && (ch = format[pos]) == ' ')
+                {
+                    pos++;
+                }
+
+                // parse the optional field width
+                var leftAligned = false;
+                var argWidth = 0;
+                if (ch == ',')
+                {
+                    pos++;
+
+                    // skip whitespace
+                    while (pos < len && format[pos] == ' ')
+                    {
+                        pos++;
+                    }
+
+                    // did we run out of steam
+                    if (pos == len)
+                    {
+                        throw new ArgumentException($"Invalid field width for argument {numArgs + 1} in format string", nameof(format));
+                    }
+
+                    ch = format[pos];
+                    if (ch == '-')
+                    {
+                        leftAligned = true;
+                        pos++;
+
+                        // did we run out of steam?
+                        if (pos == len)
+                        {
+                            throw new ArgumentException($"Invalid field width for argument {numArgs + 1} in format string", nameof(format));
+                        }
+
+                        ch = format[pos];
+                    }
+
+                    if (ch < '0' || ch > '9')
+                    {
+                        throw new ArgumentException($"Invalid character in field width for argument {numArgs + 1} in format string", nameof(format));
+                    }
+
+                    var val = 0;
+                    do
+                    {
+                        val = (val * 10) + (ch - '0');
+                        pos++;
+
+                        // did we run out of steam?
+                        if (pos == len)
+                        {
+                            throw new ArgumentException($"Incomplete field width at position {pos}", nameof(format));
+                        }
+
+                        // did we get a number that's too big?
+                        if (val > short.MaxValue)
+                        {
+                            throw new ArgumentException($"Field width value exceeds limit for argument {numArgs + 1} in format string", nameof(format));
+                        }
+
+                        ch = format[pos];
+                    }
+                    while (ch >= '0' && ch <= '9');
+
+                    argWidth = val;
+                }
+
+                if (leftAligned)
+                {
+                    argWidth = -argWidth;
+                }
+
+                // skip whitespace
+                while (pos < len && (ch = format[pos]) == ' ')
+                {
+                    pos++;
+                }
+
+                // parse the optional argument format string
+
+                var argFormat = string.Empty;
+                if (ch == ':')
+                {
+                    pos++;
+                    var argFormatStart = pos;
+
+                    while (true)
+                    {
+                        if (pos == len)
+                        {
+                            throw new ArgumentException($"Unterminated format specification at position {pos}", nameof(format));
+                        }
+
+                        ch = format[pos];
+                        pos++;
+                        if (ch == '{')
+                        {
+                            throw new ArgumentException($"Nested {{ in format specification at position {pos}", nameof(format));
+                        }
+                        else if (ch == '}')
+                        {
+                            // end of format specification
+                            pos--;
+                            break;
+                        }
+                    }
+
+                    if (pos != argFormatStart)
+                    {
+                        argFormat = format.Slice(argFormatStart, pos - argFormatStart).ToString();
+                    }
+                }
+
+                if (ch != '}')
+                {
+                    throw new ArgumentException("Unterminated format specification", nameof(format));
+                }
+
+                // skip over the closing brace
+                pos++;
+
+                if (numArgs >= short.MaxValue)
+                {
+                    throw new ArgumentException("Must have less than 32768 arguments", nameof(format));
+                }
+
+                var total = builder.Length - segStart;
+                while (total > short.MaxValue)
+                {
+                    segments.Add(new Segment(short.MaxValue, -1, 0, string.Empty));
+                    total -= short.MaxValue;
+                }
+
+                segments.Add(new Segment((short)total, (short)argIndex, (short)argWidth, argFormat));
+            }
+        }
+
+        private static bool ValidTemplateNameChar(char ch, bool first)
+        {
+            if (first)
+            {
+                return char.IsLetter(ch) || ch == '_';
+            }
+
+            return char.IsLetterOrDigit(ch) || ch == '_';
+        }
+
+        /// <summary>
+        /// A chunk of formatting information.
+        /// </summary>
+        private readonly struct Segment
+        {
+            public Segment(short literalCount, short argIndex, short argWidth, string argFormat)
+            {
+                LiteralCount = literalCount;
+                ArgIndex = argIndex;
+                ArgWidth = argWidth;
+                ArgFormat = argFormat;
+            }
+
+            /// <summary>
+            /// Gets the number of chars of literal text consumed by this segment.
+            /// </summary>
+            public short LiteralCount { get; }
+
+            /// <summary>
+            /// Gets the index of the argument to be formatted, -1 to skip argument formatting.
+            /// </summary>
+            public short ArgIndex { get; }
+
+            /// <summary>
+            /// Gets the width of the formatted value in characters. If this is negative, it indicates to left-justify
+            /// and the field width is then the absolute value.
+            /// </summary>
+            public short ArgWidth { get; }
+
+            /// <summary>
+            /// Gets the custom format string to use when formatting the argument.
+            /// </summary>
+            public string ArgFormat { get; }
+        }
+    }
+}


### PR DESCRIPTION
A follow up PR for: https://github.com/dotnet/runtime/pull/51064

Took parsing logic from https://github.com/geeknoid/FastFormatting/blob/8878f2b829b2ebc023ddabc5b12f584d024d2591/Text.Formatting/CompositeFormat.cs#L204-L486

cc: @geeknoid @eerhardt 

Fixes https://github.com/dotnet/runtime/issues/52226