### PR TITLE
Stop harvesting S.Security.Cryptography.Pkcs

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -2,18 +2,17 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Pkcs.csproj">
-      <SupportedFramework>net461;netcoreapp3.0</SupportedFramework>
+      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.csproj" />
-    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="ref/netstandard1.3;runtimes/win/lib/netstandard1.3;lib/netstandard1.3" />
-    <HarvestIncludePaths Include="ref/netstandard2.0" />
-    <HarvestIncludePaths Include="ref/netcoreapp2.1;lib/netcoreapp2.1;runtimes/win/lib/netcoreapp2.1" />
-    <!--
-      Suppress NETStandard.Library collpasing as it add more dependencies then needed in some
-      scenarios like .NET Framework which adds an unecessary amount of package dependencies to download
-    -->
-    <SuppressMetaPackage Include="NETStandard.Library" />
+    <PackageFile Include="buildTransitive\System.Security.Cryptography.Pkcs.targets"
+                 TargetPath="buildTransitive\netcoreapp2.0" />
+    <File Include="$(PlaceholderFile)"
+          TargetPath="buildTransitive\netcoreapp3.0" />
+    <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
+    <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
+    <!-- Disable support check as harvested assets have older assembly versions. TODO: Re-enable after the 6.0 package shipped. -->
+    <SkipSupportCheck>true</SkipSupportCheck>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -11,8 +11,10 @@
           TargetPath="buildTransitive\netcoreapp3.0" />
     <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
     <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
+  </ItemGroup>
+  <PropertyGroup>
     <!-- Disable support check as harvested assets have older assembly versions. TODO: Re-enable after the 6.0 package shipped. -->
     <SkipSupportCheck>true</SkipSupportCheck>
-  </ItemGroup>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Pkcs.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299</SupportedFramework>
+      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.csproj" />
     <PackageFile Include="buildTransitive\System.Security.Cryptography.Pkcs.targets"
@@ -12,9 +12,5 @@
     <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
     <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Disable support check as harvested assets have older assembly versions. TODO: Re-enable after the 6.0 package shipped. -->
-    <SkipSupportCheck>true</SkipSupportCheck>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/buildTransitive/System.Security.Cryptography.Pkcs.targets
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/buildTransitive/System.Security.Cryptography.Pkcs.targets
@@ -1,0 +1,6 @@
+<Project InitialTargets="_ErrorForSystemSecurityCryptographyPkcsOnNetCoreApp20">
+  <Target Name="_ErrorForSystemSecurityCryptographyPkcsOnNetCoreApp20"
+          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
+    <Error Text="System.Security.Cryptography.Pkcs doesn't support netcoreapp2.0. Consider updating your TargetFramework to netcoreapp3.1 or later." />
+  </Target>
+</Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
@@ -1,20 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);netcoreapp3.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);netcoreapp3.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
-    <!-- Currently the netstandard build is locked to the net472 API -->
-    <AssemblyVersion Condition="$(TargetFramework.StartsWith('netstandard'))">4.0.4.0</AssemblyVersion>    
+    <IsPartialFacadeAssembly Condition="'$(TargetFramework)' == 'net461'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Pkcs.cs" />
-    <Compile Include="System.Security.Cryptography.Pkcs.netcoreapp.cs" Condition="!$(TargetFramework.StartsWith('net4'))" />
+    <Compile Include="System.Security.Cryptography.Pkcs.netcoreapp.cs" Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'netstandard2.0'" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Security" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <NoWarn>$(NoWarn);CA5384</NoWarn>
     <Nullable>enable</Nullable>
@@ -12,8 +11,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
     <OmitResources Condition="$(TargetFramework.StartsWith('net4'))">true</OmitResources>
-    <!-- Currently the netstandard build is locked to the net472 API -->
-    <AssemblyVersion Condition="$(TargetFramework.StartsWith('netstandard'))">4.0.4.0</AssemblyVersion>
+    <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
@@ -640,9 +638,6 @@
     <PackageReference Include="System.Buffers"  Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
-    <!-- Ref assembly for netstandard2.0 isn't live built anymore. -->
-    <PackageDownload Include="$(MSBuildProjectName)" Version="[$(SystemSecurityCryptographyPkcsVersion)]" />
-    <ResolvedMatchingContract Include="$(NuGetPackageRoot)$(MSBuildProjectName.ToLowerInvariant())\$(SystemSecurityCryptographyPkcsVersion)\ref\$(TargetFramework)\$(MSBuildProjectName).dll" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith('$(NetCoreAppCurrent)'))">
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />


### PR DESCRIPTION
The removed configurations (netstandard1.3, netcoreapp2.1, net46)
of the touched packages aren't built anymore. Instead
the already built matching binaries from the latest available packages
are redistributed when packaging these libraries.

Dropping these assets as the minimum supported set of platforms are ones
that support netstandard2.0 and are still in-support. As an example,
also dropping the netcoreapp2.1 asset which isn't supported anymore and
adding a target to prevent the package being used for netcoreapp2.x.
For .NET Framework, there's still a net461
configuration present to avoid binding redirect issues.

Contributes to #47530

@ericstj unfortunately there are still errors which I wasn't able to resolve. I might need your help again:

```
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.0/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.1/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/win7-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/win7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/osx.10.11-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/centos.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/debian.8-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/linuxmint.17-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/rhel.7.2-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/ubuntu.14.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/ubuntu.16.04-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/osx.10.12-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/fedora.24-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/opensuse.42.1-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on .NETCoreApp,Version=v2.2/rhel.7-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x86 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x86-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x86-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x64 but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x64-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-x64-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-arm but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-arm but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-arm-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\ref\netstandard2.0-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.packaging\6.0.0-beta.21221.6\build\Packaging.targets(1119,5): error : System.Security.Cryptography.Pkcs should support API version 6.0.0.0 on UAP,Version=v10.0.16299/win10-arm-aot but C:\git\runtime2\artifacts\bin\System.Security.Cryptography.Pkcs\netstandard2.0-windows-Debug\System.Security.Cryptography.Pkcs.dll was found to support 4.0.4.0. [C:\git\runtime2\src\libraries\System.Security.Cryptography.Pkcs\pkg\System.Security.Cryptography.Pkcs.pkgproj]
```