### PR TITLE
Dispose of hash provider in HMACCommon

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
@@ -99,10 +99,12 @@ namespace Internal.Cryptography
 
         public void Dispose(bool disposing)
         {
-            if (disposing && _hMacProvider != null)
+            if (disposing)
             {
-                _hMacProvider.Dispose(true);
+                _hMacProvider?.Dispose(true);
                 _hMacProvider = null!;
+                _lazyHashProvider?.Dispose(true);
+                _lazyHashProvider = null;
             }
         }
 


### PR DESCRIPTION
Explicitly dispose of the `_lazyHashProvider` so that it does not leave the underlying hash handle in the finalization queue.

Contributes to #52041