### PR TITLE
use AssertExtensions.SequenceEqual in a few places

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -373,7 +373,7 @@ namespace System.Net.Sockets.Tests
             sender.Send(new byte[] { 42 });
 
             (_, byte[] recvBuffer) = await acceptTask;
-            Assert.Equal(new byte[] { 42 }, recvBuffer);
+            AssertExtensions.SequenceEqual(new byte[] { 42 }, recvBuffer);
         }
     }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -705,7 +705,7 @@ namespace System.Net.Sockets.Tests
                             bytesReceived += sock.Receive(contentActual, bytesReceived, bytesExpected-bytesReceived, SocketFlags.None);
                         }
                         Assert.Equal(bytesExpected, bytesReceived);
-                        Assert.Equal(contentExpected, contentActual);
+                        AssertExtensions.SequenceEqual(contentExpected, contentActual);
                     }
                 }
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -471,7 +471,7 @@ namespace System.Net.Sockets.Tests
                         Assert.Equal(5000000, receivedTotal);
                         if (GuaranteedSendOrdering)
                         {
-                            Assert.Equal(sendData, receiveBuffer);
+                            AssertExtensions.SequenceEqual(sendData, receiveBuffer);
                         }
                     }
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
@@ -240,10 +240,10 @@ namespace System.Net.Sockets.Tests
                 var tcs = new TaskCompletionSource();
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
 
-                var receiveBufer = new byte[600];
-                receiveBufer[0] = data[499] = 0;
+                var receiveBuffer = new byte[600];
+                receiveBuffer[0] = data[499] = 0;
 
-                args.SetBuffer(receiveBufer, 0, receiveBufer.Length);
+                args.SetBuffer(receiveBuffer, 0, receiveBuffer.Length);
                 args.Completed += delegate { tcs.SetResult(); };
 
                 // First peek at the message.
@@ -253,9 +253,9 @@ namespace System.Net.Sockets.Tests
                     await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                 }
                 Assert.Equal(SocketFlags.None, args.SocketFlags);
-                Assert.Equal(1, receiveBufer[0]);
-                Assert.Equal(1, receiveBufer[499]);
-                receiveBufer[0] = receiveBufer[499] = 0;
+                Assert.Equal(1, receiveBuffer[0]);
+                Assert.Equal(1, receiveBuffer[499]);
+                receiveBuffer[0] = receiveBuffer[499] = 0;
 
                 // Now, we should be able to get same message again.
                 tcs = new TaskCompletionSource();
@@ -265,19 +265,19 @@ namespace System.Net.Sockets.Tests
                     await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                 }
                 Assert.Equal(SocketFlags.None, args.SocketFlags);
-                Assert.Equal(1, receiveBufer[0]);
-                Assert.Equal(1, receiveBufer[499]);
-                receiveBufer[0] = receiveBufer[499] = 0;
+                Assert.Equal(1, receiveBuffer[0]);
+                Assert.Equal(1, receiveBuffer[499]);
+                receiveBuffer[0] = receiveBuffer[499] = 0;
 
                 // Set buffer smaller than message.
                 tcs = new TaskCompletionSource();
-                args.SetBuffer(receiveBufer, 0, 100);
+                args.SetBuffer(receiveBuffer, 0, 100);
                 if (receiver.ReceiveAsync(args))
                 {
                     await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                 }
                 Assert.Equal(SocketFlags.Truncated, args.SocketFlags);
-                Assert.Equal(2, receiveBufer[0]);
+                Assert.Equal(2, receiveBuffer[0]);
 
                 // There should be no more data.
                 Assert.Equal(0, receiver.Available);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -577,18 +577,13 @@ namespace System.Net.Sockets.Tests
                     client.Shutdown(SocketShutdown.Both);
                 }
 
-                Assert.True(
-                    accepted.WaitOne(TestSettings.PassingTestTimeout), "Test completed in allotted time");
+                Assert.True(accepted.WaitOne(TestSettings.PassingTestTimeout), "Test completed in allotted time");
 
-                Assert.Equal(
-                    SocketError.Success, acceptArgs.SocketError);
+                Assert.Equal(SocketError.Success, acceptArgs.SocketError);
 
-                Assert.Equal(
-                    acceptBufferDataSize, acceptArgs.BytesTransferred);
+                Assert.Equal(acceptBufferDataSize, acceptArgs.BytesTransferred);
 
-                Assert.Equal(
-                    new ArraySegment<byte>(sendBuffer),
-                    new ArraySegment<byte>(acceptArgs.Buffer, 0, acceptArgs.BytesTransferred));
+                AssertExtensions.SequenceEqual(sendBuffer, acceptArgs.Buffer.AsSpan().Slice(0, acceptArgs.BytesTransferred));
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -295,7 +295,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 Assert.Equal(writeBuffer.Length, readData.Length);
-                Assert.Equal(writeBuffer, readData.ToArray());
+                AssertExtensions.SequenceEqual(writeBuffer, readData.ToArray());
             }
             finally
             {
@@ -345,7 +345,7 @@ namespace System.Net.Sockets.Tests
                 }
                 await TestSettings.WhenAllOrAnyFailedWithTimeout(writes.Concat(reads).ToArray());
 
-                Assert.Equal(sendData.OrderBy(i => i), receiveData.OrderBy(i => i));
+                AssertExtensions.SequenceEqual(sendData.OrderBy(i => i).ToArray(), receiveData.OrderBy(i => i).ToArray());
             }
         }
 
@@ -383,7 +383,7 @@ namespace System.Net.Sockets.Tests
 
                 await TestSettings.WhenAllOrAnyFailedWithTimeout(writes.Concat(reads).ToArray());
 
-                Assert.Equal(sendData, receiveData);
+                AssertExtensions.SequenceEqual(sendData, receiveData);
             }
         }
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/51480

Use AssertExtensions.SequenceEqual in a few places in the System.Net.Sockets tests.
Also some minor style/spelling cleanup.

@antonfirsov 