### PR TITLE
[wasm] Bump up the timeout for System.Text.Json to 30mins

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -7,6 +7,7 @@
 
     <!-- these tests depend on the pdb files -->
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
+    <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>


### PR DESCRIPTION
System.Text.Json tests seem to be timing out. This is for *non*-aot
builds, so this should be investigated. This commit will unblock people
though.

Issue: https://github.com/dotnet/runtime/issues/50433