### PR TITLE
Implemented DI of scope provider in LoggerFactory

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Logging
         private volatile bool _disposed;
         private IDisposable _changeTokenRegistration;
         private LoggerFilterOptions _filterOptions;
-        private LoggerFactoryScopeProvider _scopeProvider;
+        private IExternalScopeProvider _scopeProvider;
         private LoggerFactoryOptions _factoryOptions;
 
         /// <summary>
@@ -27,6 +27,15 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         public LoggerFactory() : this(Array.Empty<ILoggerProvider>())
         {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="LoggerFactory"/> instance.
+        /// </summary>
+        /// <param name="scopeProvider">The scope provider to use.</param>
+        internal LoggerFactory(IExternalScopeProvider scopeProvider) : this()
+        {
+            _scopeProvider = scopeProvider;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggingServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggingServiceCollectionExtensions.cs
@@ -38,7 +38,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddOptions();
 
-            services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
+            // Request scope provider to be used. If not provided LoggerLibrary will use a default implementation.
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IExternalScopeProvider scopeProvider = serviceProvider.GetService<IExternalScopeProvider>();
+
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(ILoggerFactory), new LoggerFactory(scopeProvider)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
 
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>>(

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggingServiceCollectionExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggingServiceCollectionExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Moq;
 
 namespace Microsoft.Extensions.Logging.Test
 {
@@ -13,6 +14,22 @@ namespace Microsoft.Extensions.Logging.Test
         public void AddLogging_WrapsServiceCollection()
         {
             var services = new ServiceCollection();
+
+            var callbackCalled = false;
+            var loggerBuilder = services.AddLogging(builder =>
+            {
+                callbackCalled = true;
+                Assert.Same(services, builder.Services);
+            });
+            Assert.True(callbackCalled);
+        }
+
+        [Fact]
+        public void AddLogging_InjectScopeProvider()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton(typeof(IExternalScopeProvider), Mock.Of<IExternalScopeProvider>());
 
             var callbackCalled = false;
             var loggerBuilder = services.AddLogging(builder =>


### PR DESCRIPTION
LoggingServiceCollectionExtensions and LoggerFactory are modified to allow replacing of the default implementation of IExternalScopeProvider with dependency injected version.

Fix #50590