### PR TITLE
AssemblyName.ToString() returns an empty string for an empty `Name` property

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -209,7 +209,7 @@ namespace System.Reflection
         {
             get
             {
-                if (this.Name == null || this.Name == string.Empty)
+                if (string.IsNullOrEmpty(this.Name))
                     return string.Empty;
 
                 // Do not call GetPublicKeyToken() here - that latches the result into AssemblyName which isn't a side effect we want.

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -209,10 +209,8 @@ namespace System.Reflection
         {
             get
             {
-                if (this.Name == null)
+                if (this.Name == null || this.Name == string.Empty)
                     return string.Empty;
-                if (this.Name == string.Empty)
-                    throw new System.IO.FileLoadException();
 
                 // Do not call GetPublicKeyToken() here - that latches the result into AssemblyName which isn't a side effect we want.
                 byte[]? pkt = _publicKeyToken ?? ComputePublicKeyToken();

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -634,10 +634,19 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData("Foo")]
         [InlineData("Hi There")]
-        [InlineData("")]
         public void ToStringTest(string name)
         {
             var assemblyName = new AssemblyName(name);
+            Assert.StartsWith(name, assemblyName.ToString());
+            Assert.Equal(assemblyName.FullName, assemblyName.ToString());
+        }
+
+        [Theory]
+        [InlineData("")]
+        public void ToStringEmptyNameTest(string name)
+        {
+            var assemblyName = new AssemblyName("test");
+            assemblyName.Name = name;
             Assert.StartsWith(name, assemblyName.ToString());
             Assert.Equal(assemblyName.FullName, assemblyName.ToString());
         }

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -404,14 +404,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        public void Name_Set_FullName_Invalid()
-        {
-            AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
-            assemblyName.Name = "";
-            Assert.Equal(assemblyName.Name, assemblyName.FullName);
-        }
-
-        [Fact]
         public void Name_CurrentlyExecutingAssembly()
         {
             AssemblyName assemblyName = typeof(AssemblyNameTests).GetTypeInfo().Assembly.GetName();
@@ -641,13 +633,12 @@ namespace System.Reflection.Tests
             Assert.Equal(assemblyName.FullName, assemblyName.ToString());
         }
 
-        [Theory]
-        [InlineData("")]
-        public void ToStringEmptyNameTest(string name)
+        [Fact]
+        public void ToStringEmptyNameTest()
         {
             var assemblyName = new AssemblyName("test");
-            assemblyName.Name = name;
-            Assert.StartsWith(name, assemblyName.ToString());
+            assemblyName.Name = "";
+            Assert.StartsWith(string.Empty, assemblyName.ToString());
             Assert.Equal(assemblyName.FullName, assemblyName.ToString());
         }
 

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -395,6 +395,7 @@ namespace System.Reflection.Tests
         [MemberData(nameof(Names_TestData))]
         [MemberData(nameof(Names_TestDataRequiresEscaping))]
         [InlineData(null, "")]
+        [InlineData("", "")]
         public void Name_Set_FullName(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
@@ -407,7 +408,7 @@ namespace System.Reflection.Tests
         {
             AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
             assemblyName.Name = "";
-            Assert.Throws<FileLoadException>(() => assemblyName.FullName);
+            Assert.Equal(assemblyName.Name, assemblyName.FullName);
         }
 
         [Fact]
@@ -633,6 +634,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData("Foo")]
         [InlineData("Hi There")]
+        [InlineData("")]
         public void ToStringTest(string name)
         {
             var assemblyName = new AssemblyName(name);


### PR DESCRIPTION
This pull request fixes #45420

It removes the *System.IO.FileLoadException* exception in case of calling `AssemblyName.ToString()` with empty `Name` property, making it returning the empty string instead.

---

The implementation of this fix is based on the `FullName` property which now returns the empty string *""* for both `null` and `string.Empty` cases.
(Note that `null` case is left intact).

Unit tests are now enhanced with the empty string for the `Name` property and `ToString()` method.
Also the `FullName` property test is reimplemented so from now on it does not expect it to throw the exception, but ensures that empty `Name` is equal to empty response.