### PR TITLE
increase timeout for websocket compression tests

### DIFF
--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -20,7 +20,7 @@ namespace System.Net.WebSockets.Tests
         {
             if (!Debugger.IsAttached)
             {
-                _cancellation = new CancellationTokenSource(30);
+                _cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             }
         }
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -20,7 +20,7 @@ namespace System.Net.WebSockets.Tests
         {
             if (!Debugger.IsAttached)
             {
-                _cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                _cancellation = new CancellationTokenSource(30);
             }
         }
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -421,6 +421,12 @@ namespace System.Net.WebSockets.Tests
         [MemberData(nameof(SupportedWindowBits))]
         public async Task PayloadShouldHaveSimilarSizeWhenSplitIntoSegments(int windowBits)
         {
+            if (PlatformDetection.IsArmOrArm64Process && (windowBits == 14 || windowBits == 15))
+            {
+                // https://github.com/dotnet/runtime/issues/52031
+                return;
+            }
+
             MemoryStream stream = new();
             using WebSocket client = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions
             {


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/52031

This test is failing all the time. In such a situation we should disable or fix it immediately. 

I don't know why it is timing out, but we should be able to quickly see if it is indeed hanging rather than just slow.