### PR TITLE
[wasm] Fix tests failing due to trimming - System.Runtime.Loader

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -69,7 +69,6 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51893", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         public static void LoadAssemblyByPath_ValidUserAssembly()
         {
             var asmName = new AssemblyName(TestAssembly);
@@ -84,7 +83,6 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51893", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         public static void LoadAssemblyByStream_ValidUserAssembly()
         {
             var asmName = new AssemblyName(TestAssembly);

--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml
@@ -2,4 +2,7 @@
   <assembly fullname="LoaderLinkTest.Dynamic" />
   <assembly fullname="ReferencedClassLib" />
   <assembly fullname="ReferencedClassLibNeutralIsSatellite" />
+  <assembly fullname="System.Runtime.Loader.Test.Assembly" />
+  <assembly fullname="System.Runtime.Loader.Test.Assembly2" />
+  <assembly fullname="System.Runtime.Loader.Test.AssemblyNotSupported" />
 </linker>

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -40,4 +40,13 @@
 
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
   </ItemGroup>
+
+  <Target Name="AddTestAssembliesForPublishing" BeforeTargets="PrepareForILLink">
+    <!-- These assemblies are being embedded in the test assembly. But because they are not referenced by the
+         project, they don't get linked, and end up with invalid tokens for references to types in other
+         assemblies. So, explicitly add them for linking -->
+    <ItemGroup>
+      <ManagedAssemblyToLink Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Extension)' == '.dll'" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Test failing with:

```
fail: [FAIL] System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByPath_ValidUserAssembly
info: System.TypeLoadException : Could not resolve type with token 01000014 from typeref (expected class 'System.MulticastDelegate' in assembly 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a')
info:    at System.Reflection.RuntimeModule.GetTypes()
info:    at System.Reflection.Assembly.GetTypes()
info:    at System.Reflection.Assembly.get_DefinedTypes()
info:    at System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByPath_ValidUserAssembly()
info:    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```

This is failing while trying to enumerate the types on a dependent test
assembly - `System.Runtime.Loader.Test.Assembly`. This assembly is
loaded by the test explicitly, into an ALC. But it is loaded from the
assembly's embedded resources.

The main test project(`System.Runtime.Loader.Tests.csproj`) has:
```xml
    <ProjectReference Include="System.Runtime.Loader.Test.Assembly\System.Runtime.Loader.Test.Assembly.csproj"
                      ReferenceOutputAssembly="false"
                      OutputItemType="EmbeddedResource" />
```

- This will cause the referenced project to get built
    - And the assembly(`System.Runtime.Loader.Test.Assembly.dll`) added to `@(EmbeddedResource)`
    - but since we have `ReferenceOutputAssembly=false`, it won't be added
      to the list of references used for compiling the main tests assembly
      (`System.Runtime.Loader.Tests`).
      - but this also means that the test assembly from the referenced
        project does *not* get added to the list of assemblies to be linked.

- The result of all this is that when trimming:
    - the linker has the set of assemblies to trim, edits the
      assemblies, and updates the metadata tokens (type references, for
      example) to be consistent within that set.
    - Since, `*Test.Assembly.dll` was *not* in the above set, it still
      has some old tokens which are no longer valid.
      - and that fails when resolving the tokens in the `*Test.Assembly`
        to assemblies like `System.Runtime`.

- the fix is to add such assemblies to `@(ManagedAssemblyToLink)`, so
  they are included in the linker's set.

Fixes https://github.com/dotnet/runtime/issues/51893