### PR TITLE
Fix building tests on Windows ARM64

### DIFF
--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -103,22 +103,20 @@
           Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)**/*"
           Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)%(Identity)')"
           TargetDir="%(RunTimeArtifactsIncludeFolders.Identity)" />
+    </ItemGroup>
 
+    <PropertyGroup>
+      <Crossgen2Dir />
+      <Crossgen2Dir Condition="'$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64'">$(CoreCLRArtifactsPath)x64/crossgen2</Crossgen2Dir>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(Crossgen2Dir)' != ''">
       <RunTimeDependencyCopyLocal
-          Condition="'$(TargetArchitecture)' != 'x64'"
-          Include="$(CoreCLRArtifactsPath)x64/crossgen2/clrjit_*"
+          Include="
+            $(Crossgen2Dir)/clrjit_*;
+            $(Crossgen2Dir)/jitinterface_*;
+            $(Crossgen2Dir)/Microsoft.DiaSymReader.Native.*.dll"
           TargetDir="crossgen2/" />
-
-      <RunTimeDependencyCopyLocal
-          Condition="'$(TargetArchitecture)' != 'x64'"
-          Include="$(CoreCLRArtifactsPath)x64/crossgen2/jitinterface_*"
-          TargetDir="crossgen2/" />
-
-      <RunTimeDependencyCopyLocal
-          Condition="'$(TargetArchitecture)' != 'x64' and '$(TargetOS)' == 'windows'"
-          Include="$(CoreCLRArtifactsPath)x64/crossgen2/Microsoft.DiaSymReader.Native.amd64.dll"
-          TargetDir="crossgen2/" />
-
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm'">
@@ -133,7 +131,7 @@
           Include="@(LibrariesRuntimeFiles)"
           TargetDir="runtimepack/native/"/>
 
-       <RunTimeDependencyCopyLocal
+        <RunTimeDependencyCopyLocal
           Include="$(ArtifactsDir)\TargetingPack\**"
           TargetDir="TargetingPack/"/>
 


### PR DESCRIPTION
When we build the repo on an ARM64 machine, we do not use the x64-hosted cross-architecture Crossgen2.  One of test .targets files would still try to copy `x64/crossgen2/Microsoft.DiaSymReader.Native.amd64.dll` file.  Fix that.