### PR TITLE
Handle null Type in ServiceCacheKey.GetHashCode

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             unchecked
             {
-                return (Type.GetHashCode() * 397) ^ Slot;
+                return ((Type?.GetHashCode() ?? 23) * 397) ^ Slot;
             }
         }
     }


### PR DESCRIPTION
Found in https://github.com/dotnet/runtime/pull/52035#discussion_r623736749
For static ``ServiceCacheKey.Empty`` the Type is null, this would throw a NullReferenceException.
As the library has net461 as a build target, ``HashCode.Combine`` can't be used. I added parenthesis for better readability.
No extra tests were added.
