### PR TITLE
Revert "Disable regression test 49826 failing after a library refacto…

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -11,9 +11,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_49826/test49826/*">
-            <Issue>https://github.com/dotnet/runtime/issues/51542</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
…ring (#51759)"

This reverts commit 86c113260fd7a998f01b394ef8916039dcc62ec8.

---

Test 49826 can be re-enabled now that the library change that broke it has been reversed - https://github.com/dotnet/runtime/pull/51897.