### PR TITLE
Split ComActivator into separate files for supported and not supported

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -109,7 +109,9 @@
 
   <!-- Sources -->
   <ItemGroup>
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivationContextInternal.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComponentActivator.cs" />
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\InMemoryAssemblyLoader.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\IsolatedComponentLoadContext.cs" />
     <Compile Include="$(BclSourcesRoot)\System\__Canon.cs" />
     <Compile Include="$(BclSourcesRoot)\System\ArgIterator.cs" />
@@ -249,13 +251,6 @@
     <Compile Include="$(BclSourcesRoot)\System\WeakReference.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\WeakReference.T.CoreCLR.cs" />
   </ItemGroup>
-  <!-- These classes are only used for FeatureCominterop, but they are referenced by tests
-       in order to allow tests to be built on all platforms, these classes are included for all
-       platforms, but throw PlatformNotSupported() for unsupported platforms -->
-  <ItemGroup>
-    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivator.cs" />
-    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\InMemoryAssemblyLoader.cs" />
-  </ItemGroup>
   <ItemGroup Condition="'$(FeatureComWrappers)' == 'true'">
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\ComWrappers.cs" />
   </ItemGroup>
@@ -272,6 +267,7 @@
     <Compile Include="$(CommonPath)System\Runtime\InteropServices\Variant.cs">
       <Link>Common\System\Runtime\InteropServices\Variant.cs</Link>
     </Compile>
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivator.cs" />
     <Compile Include="$(BclSourcesRoot)\Microsoft\Win32\OAVariantLib.cs" />
     <Compile Include="$(BclSourcesRoot)\System\__ComObject.cs" />
     <Compile Include="$(BclSourcesRoot)\System\OleAutBinder.cs" />
@@ -286,6 +282,9 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\ExpandoToDispatchExMarshaler.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\TypeToTypeInfoMarshaler.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Variant.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCominterop)' != 'true'">
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivator.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="$(BclSourcesRoot)\Interop\Unix\Interop.Libraries.cs" />

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
@@ -17,4 +17,33 @@ namespace Internal.Runtime.InteropServices
         public char* TypeNameBuffer;
         public IntPtr ClassFactoryDest;
     }
+
+    //
+    // Types below are 'public' only to aid in testing of functionality.
+    // They should not be considered publicly consumable.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct ComActivationContext
+    {
+        public Guid ClassId;
+        public Guid InterfaceId;
+        public string AssemblyPath;
+        public string AssemblyName;
+        public string TypeName;
+    }
+
+    [ComImport]
+    [ComVisible(false)]
+    [Guid("00000001-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IClassFactory
+    {
+        void CreateInstance(
+            [MarshalAs(UnmanagedType.Interface)] object? pUnkOuter,
+            ref Guid riid,
+            out IntPtr ppvObject);
+
+        void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock);
+    }
 }

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal.Runtime.InteropServices
+{
+    [StructLayout(LayoutKind.Sequential)]
+    [CLSCompliant(false)]
+    public unsafe struct ComActivationContextInternal
+    {
+        public Guid ClassId;
+        public Guid InterfaceId;
+        public char* AssemblyPathBuffer;
+        public char* AssemblyNameBuffer;
+        public char* TypeNameBuffer;
+        public IntPtr ClassFactoryDest;
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal.Runtime.InteropServices
+{
+    public static class ComActivator
+    {
+        /// <summary>
+        /// Internal entry point for unmanaged COM activation API from native code
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        [CLSCompliant(false)]
+        [UnmanagedCallersOnly]
+        public static unsafe int GetClassFactoryForTypeInternal(ComActivationContextInternal* pCxtInt)
+            => throw new PlatformNotSupportedException();
+
+        /// <summary>
+        /// Internal entry point for registering a managed COM server API from native code
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        [CLSCompliant(false)]
+        [UnmanagedCallersOnly]
+        public static unsafe int RegisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
+            => throw new PlatformNotSupportedException();
+
+        /// <summary>
+        /// Internal entry point for unregistering a managed COM server API from native code
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        [CLSCompliant(false)]
+        [UnmanagedCallersOnly]
+        public static unsafe int UnregisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
+            => throw new PlatformNotSupportedException();
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
@@ -34,5 +34,13 @@ namespace Internal.Runtime.InteropServices
         [UnmanagedCallersOnly]
         public static unsafe int UnregisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
             => throw new PlatformNotSupportedException();
+
+        // Exists here to allow tests to build on any platform.
+        public static object GetClassFactoryForType(ComActivationContext cxt)
+            => throw new PlatformNotSupportedException();
+
+        // Exists here to allow tests to build on any platform.
+        public static void ClassRegistrationScenarioForType(ComActivationContext cxt, bool register)
+            => throw new PlatformNotSupportedException();
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -71,18 +71,6 @@ namespace Internal.Runtime.InteropServices
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    [CLSCompliant(false)]
-    public unsafe struct ComActivationContextInternal
-    {
-        public Guid ClassId;
-        public Guid InterfaceId;
-        public char* AssemblyPathBuffer;
-        public char* AssemblyNameBuffer;
-        public char* TypeNameBuffer;
-        public IntPtr ClassFactoryDest;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
     public struct ComActivationContext
     {
         public Guid ClassId;
@@ -95,7 +83,6 @@ namespace Internal.Runtime.InteropServices
         [CLSCompliant(false)]
         public static unsafe ComActivationContext Create(ref ComActivationContextInternal cxtInt)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -109,20 +96,15 @@ namespace Internal.Runtime.InteropServices
                 AssemblyName = Marshal.PtrToStringUni(new IntPtr(cxtInt.AssemblyNameBuffer))!,
                 TypeName = Marshal.PtrToStringUni(new IntPtr(cxtInt.TypeNameBuffer))!
             };
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
     }
 
     [SupportedOSPlatform("windows")]
     public static class ComActivator
     {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
         // Collection of all ALCs used for COM activation. In the event we want to support
         // unloadable COM server ALCs, this will need to be changed.
         private static readonly Dictionary<string, AssemblyLoadContext> s_assemblyLoadContexts = new Dictionary<string, AssemblyLoadContext>(StringComparer.InvariantCultureIgnoreCase);
-#endif
 
         /// <summary>
         /// Entry point for unmanaged COM activation API from managed code
@@ -131,7 +113,6 @@ namespace Internal.Runtime.InteropServices
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         public static object GetClassFactoryForType(ComActivationContext cxt)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -156,9 +137,6 @@ namespace Internal.Runtime.InteropServices
             }
 
             return new BasicClassFactory(cxt.ClassId, classType);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <summary>
@@ -169,7 +147,6 @@ namespace Internal.Runtime.InteropServices
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         public static void ClassRegistrationScenarioForType(ComActivationContext cxt, bool register)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -255,9 +232,6 @@ namespace Internal.Runtime.InteropServices
                 // Go through all the base types
                 currentType = currentType.BaseType;
             }
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <summary>
@@ -269,7 +243,6 @@ namespace Internal.Runtime.InteropServices
         [UnmanagedCallersOnly]
         public static unsafe int GetClassFactoryForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -302,9 +275,6 @@ $@"{nameof(GetClassFactoryForTypeInternal)} arguments:
             }
 
             return 0;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <summary>
@@ -316,7 +286,6 @@ $@"{nameof(GetClassFactoryForTypeInternal)} arguments:
         [UnmanagedCallersOnly]
         public static unsafe int RegisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -353,9 +322,6 @@ $@"{nameof(RegisterClassForTypeInternal)} arguments:
             }
 
             return 0;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         /// <summary>
@@ -366,7 +332,6 @@ $@"{nameof(RegisterClassForTypeInternal)} arguments:
         [UnmanagedCallersOnly]
         public static unsafe int UnregisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (!Marshal.IsComSupported)
             {
                 throw new NotSupportedException(SR.NotSupported_COM);
@@ -403,38 +368,25 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             }
 
             return 0;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         private static bool IsLoggingEnabled()
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
 #if COM_ACTIVATOR_DEBUG
             return true;
 #else
             return false;
 #endif
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         private static void Log(string fmt, params object[] args)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             // [TODO] Use FrameworkEventSource in release builds
-
             Debug.WriteLine(fmt, args);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         private static Type FindClassType(Guid clsid, string assemblyPath, string assemblyName, string typeName)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             try
             {
                 AssemblyLoadContext alc = GetALC(assemblyPath);
@@ -456,14 +408,10 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
             const int CLASS_E_CLASSNOTAVAILABLE = unchecked((int)0x80040111);
             throw new COMException(string.Empty, CLASS_E_CLASSNOTAVAILABLE);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         private static AssemblyLoadContext GetALC(string assemblyPath)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             AssemblyLoadContext? alc;
 
             lock (s_assemblyLoadContexts)
@@ -476,32 +424,22 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             }
 
             return alc;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         [ComVisible(true)]
         private sealed class BasicClassFactory : IClassFactory
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             private readonly Guid _classId;
             private readonly Type _classType;
-#endif
 
             public BasicClassFactory(Guid clsid, Type classType)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 _classId = clsid;
                 _classType = classType;
-#else
-            throw new PlatformNotSupportedException();
-#endif
             }
 
             public static Type GetValidatedInterfaceType(Type classType, ref Guid riid, object? outer)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 Debug.Assert(classType != null);
                 if (riid == Marshal.IID_IUnknown)
                 {
@@ -526,14 +464,10 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
                 // E_NOINTERFACE
                 throw new InvalidCastException();
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public static IntPtr GetObjectAsInterface(object obj, Type interfaceType)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 // If the requested "interface type" is type object then return as IUnknown
                 if (interfaceType == typeof(object))
                 {
@@ -557,14 +491,10 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 }
 
                 return interfaceMaybe;
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public static object CreateAggregatedObject(object pUnkOuter, object comObject)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 Debug.Assert(pUnkOuter != null && comObject != null);
                 IntPtr outerPtr = Marshal.GetIUnknownForObject(pUnkOuter);
 
@@ -578,9 +508,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                     // Decrement the above 'Marshal.GetIUnknownForObject()'
                     Marshal.Release(outerPtr);
                 }
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void CreateInstance(
@@ -588,7 +515,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 ref Guid riid,
                 out IntPtr ppvObject)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 Type interfaceType = BasicClassFactory.GetValidatedInterfaceType(_classType, ref riid, pUnkOuter);
 
                 object obj = Activator.CreateInstance(_classType)!;
@@ -598,38 +524,25 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 }
 
                 ppvObject = BasicClassFactory.GetObjectAsInterface(obj, interfaceType);
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 // nop
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
         }
 
         [ComVisible(true)]
         private sealed class LicenseClassFactory : IClassFactory2
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             private readonly LicenseInteropProxy _licenseProxy = new LicenseInteropProxy();
             private readonly Guid _classId;
             private readonly Type _classType;
-#endif
 
             public LicenseClassFactory(Guid clsid, Type classType)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 _classId = clsid;
                 _classType = classType;
-#else
-            throw new PlatformNotSupportedException();
-#endif
             }
 
             public void CreateInstance(
@@ -637,25 +550,16 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 ref Guid riid,
                 out IntPtr ppvObject)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 CreateInstanceInner(pUnkOuter, ref riid, key: null, isDesignTime: true, out ppvObject);
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 // nop
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void GetLicInfo(ref LICINFO licInfo)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 _licenseProxy.GetLicInfo(_classType, out bool runtimeKeyAvail, out bool licVerified);
 
                 // The LICINFO is a struct with a DWORD size field and two BOOL fields. Each BOOL
@@ -663,18 +567,11 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 licInfo.cbLicInfo = sizeof(int) + sizeof(int) + sizeof(int);
                 licInfo.fRuntimeKeyAvail = runtimeKeyAvail;
                 licInfo.fLicVerified = licVerified;
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void RequestLicKey(int dwReserved, [MarshalAs(UnmanagedType.BStr)] out string pBstrKey)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 pBstrKey = _licenseProxy.RequestLicKey(_classType);
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             public void CreateInstanceLic(
@@ -684,12 +581,8 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 [MarshalAs(UnmanagedType.BStr)] string bstrKey,
                 out IntPtr ppvObject)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 Debug.Assert(pUnkReserved == null);
                 CreateInstanceInner(pUnkOuter, ref riid, bstrKey, isDesignTime: false, out ppvObject);
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
 
             private void CreateInstanceInner(
@@ -699,7 +592,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 bool isDesignTime,
                 out IntPtr ppvObject)
             {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 Type interfaceType = BasicClassFactory.GetValidatedInterfaceType(_classType, ref riid, pUnkOuter);
 
                 object obj = _licenseProxy.AllocateAndValidateLicense(_classType, key, isDesignTime);
@@ -709,9 +601,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 }
 
                 ppvObject = BasicClassFactory.GetObjectAsInterface(obj, interfaceType);
-#else
-                throw new PlatformNotSupportedException();
-#endif
             }
         }
     }
@@ -724,7 +613,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
     // license context and instantiate the object.
     internal sealed class LicenseInteropProxy
     {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
         private static readonly Type? s_licenseAttrType = Type.GetType("System.ComponentModel.LicenseProviderAttribute, System.ComponentModel.TypeConverter", throwOnError: false);
         private static readonly Type? s_licenseExceptionType = Type.GetType("System.ComponentModel.LicenseException, System.ComponentModel.TypeConverter", throwOnError: false);
 
@@ -750,11 +638,9 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         // RCW Activation
         private object? _licContext;
         private Type? _targetRcwType;
-#endif
 
         public LicenseInteropProxy()
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             Type licManager = Type.GetType("System.ComponentModel.LicenseManager, System.ComponentModel.TypeConverter", throwOnError: true)!;
 
             Type licContext = Type.GetType("System.ComponentModel.LicenseContext, System.ComponentModel.TypeConverter", throwOnError: true)!;
@@ -771,25 +657,17 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
             _licInfoHelper = licManager.GetNestedType("LicInfoHelperLicenseContext", BindingFlags.NonPublic)!;
             _licInfoHelperContains = _licInfoHelper.GetMethod("Contains", BindingFlags.Instance | BindingFlags.Public)!;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // Helper function to create an object from the native side
         public static object Create()
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             return new LicenseInteropProxy();
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // Determine if the type supports licensing
         public static bool HasLicense(Type type)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             // If the attribute type can't be found, then the type
             // definitely doesn't support licensing.
             if (s_licenseAttrType == null)
@@ -798,9 +676,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             }
 
             return type.IsDefined(s_licenseAttrType, inherit: true);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // The CLR invokes this whenever a COM client invokes
@@ -810,7 +685,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         // should only throw in the case of a catastrophic error (stack, memory, etc.)
         public void GetLicInfo(Type type, out bool runtimeKeyAvail, out bool licVerified)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             runtimeKeyAvail = false;
             licVerified = false;
 
@@ -833,16 +707,12 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
             parameters = new object?[] { type.AssemblyQualifiedName };
             runtimeKeyAvail = (bool)_licInfoHelperContains.Invoke(licContext, BindingFlags.DoNotWrapExceptions, binder: null, parameters: parameters, culture: null)!;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // The CLR invokes this whenever a COM client invokes
         // IClassFactory2::RequestLicKey on a managed class.
         public string RequestLicKey(Type type)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             // License will be null, since we passed no instance,
             // however we can still retrieve the "first" license
             // key from the file. This really will only
@@ -872,9 +742,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             }
 
             return licenseKey;
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // The CLR invokes this whenever a COM client invokes
@@ -889,7 +756,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         // license key.
         public object AllocateAndValidateLicense(Type type, string? key, bool isDesignTime)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             object?[] parameters;
             object? licContext;
             if (isDesignTime)
@@ -913,15 +779,11 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 const int CLASS_E_NOTLICENSED = unchecked((int)0x80040112);
                 throw new COMException(exception.Message, CLASS_E_NOTLICENSED);
             }
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // See usage in native RCW code
         public void GetCurrentContextInfo(RuntimeTypeHandle rth, out bool isDesignTime, out IntPtr bstrKey)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             Type targetRcwTypeMaybe = Type.GetTypeFromHandle(rth);
 
             // Types are as follows:
@@ -932,9 +794,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             _targetRcwType = targetRcwTypeMaybe;
             isDesignTime = (bool)parameters[1]!;
             bstrKey = Marshal.StringToBSTR((string)parameters[2]!);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
 
         // The CLR invokes this when instantiating a licensed COM
@@ -943,7 +802,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         // retrieved using RequestLicKey().
         public void SaveKeyInCurrentContext(IntPtr bstrKey)
         {
-#if FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
             if (bstrKey == IntPtr.Zero)
             {
                 return;
@@ -952,9 +810,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             string key = Marshal.PtrToStringBSTR(bstrKey);
             var parameters = new object?[] { _targetRcwType, key };
             _setSavedLicenseKey.Invoke(_licContext, BindingFlags.DoNotWrapExceptions, binder: null, parameters: parameters, culture: null);
-#else
-            throw new PlatformNotSupportedException();
-#endif
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -17,20 +17,6 @@ using System.Runtime.Versioning;
 //
 namespace Internal.Runtime.InteropServices
 {
-    [ComImport]
-    [ComVisible(false)]
-    [Guid("00000001-0000-0000-C000-000000000046")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IClassFactory
-    {
-        void CreateInstance(
-            [MarshalAs(UnmanagedType.Interface)] object? pUnkOuter,
-            ref Guid riid,
-            out IntPtr ppvObject);
-
-        void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock);
-    }
-
     [StructLayout(LayoutKind.Sequential)]
     internal struct LICINFO
     {
@@ -70,15 +56,8 @@ namespace Internal.Runtime.InteropServices
             out IntPtr ppvObject);
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    public struct ComActivationContext
+    public partial struct ComActivationContext
     {
-        public Guid ClassId;
-        public Guid InterfaceId;
-        public string AssemblyPath;
-        public string AssemblyName;
-        public string TypeName;
-
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         [CLSCompliant(false)]
         public static unsafe ComActivationContext Create(ref ComActivationContextInternal cxtInt)

--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -28,7 +28,6 @@
         <FeatureStubsAsIL Condition="'$(Platform)' == 'arm64'">true</FeatureStubsAsIL>
         <FeatureComWrappers>true</FeatureComWrappers>
         <FeatureCominterop>true</FeatureCominterop>
-        <FeatureCominteropUnmanagedActivation>true</FeatureCominteropUnmanagedActivation>
         <FeatureCominteropApartmentSupport>true</FeatureCominteropApartmentSupport>
         <FeatureWin32Registry>true</FeatureWin32Registry>
         <FeatureProfAttach>true</FeatureProfAttach>
@@ -45,7 +44,6 @@
         <DefineConstants Condition="'$(FeatureComWrappers)' == 'true'">$(DefineConstants);FEATURE_COMWRAPPERS</DefineConstants>
         <DefineConstants Condition="'$(FeatureCominterop)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP</DefineConstants>
         <DefineConstants Condition="'$(FeatureCominteropApartmentSupport)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP_APARTMENT_SUPPORT</DefineConstants>
-        <DefineConstants Condition="'$(FeatureCominteropUnmanagedActivation)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP_UNMANAGED_ACTIVATION</DefineConstants>
         <DefineConstants Condition="'$(FeatureManagedEtw)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW</DefineConstants>
         <DefineConstants Condition="'$(FeatureManagedEtwChannels)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW_CHANNELS</DefineConstants>
         <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">$(DefineConstants);FEATURE_PERFTRACING</DefineConstants>


### PR DESCRIPTION
There are really only three functions exposed on `ComActivator`. This puts versions of those that just throw PNSE into a separate file and  removes the sprinkling of `FEATURE_COMINTEROP_UNMANAGED_ACTIVATION` throughout `ComActivator`.

cc @AaronRobinsonMSFT @jkoritzinsky 