### PR TITLE
Disable ComDisabled tests on Mono

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/ComDisabled/System.Runtime.InteropServices.ComDisabled.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComDisabled/System.Runtime.InteropServices.ComDisabled.Tests.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
-    <TestRuntime>true</TestRuntime>    
-    <!-- COM tests are currently only supported only in windows -->
-    <IgnoreForCI Condition="'$(TargetOS)' != 'Windows'">true</IgnoreForCI>
+    <TestRuntime>true</TestRuntime>
+    <!-- COM tests are currently only supported only in Windows on coreclr -->
+    <IgnoreForCI Condition="'$(TargetOS)' != 'Windows' or '$(RuntimeFlavor)' != 'CoreCLR'">true</IgnoreForCI>
   </PropertyGroup>
-  <ItemGroup>    
+  <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\Marshal\MarshalComDisabledTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Mono doesn't have built-in COM support, so we shouldn't be running these.