### PR TITLE
Implemented DI of scope provider in LoggerFactory

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/ref/Microsoft.Extensions.Logging.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/ref/Microsoft.Extensions.Logging.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Extensions.Logging
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption, Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Logging.LoggerFactoryOptions> options = null) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption, Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Logging.LoggerFactoryOptions> options = null, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider = null) { }
         public void AddProvider(Microsoft.Extensions.Logging.ILoggerProvider provider) { }
         protected virtual bool CheckDisposed() { throw null; }
         public static Microsoft.Extensions.Logging.ILoggerFactory Create(System.Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Logging
         private volatile bool _disposed;
         private IDisposable _changeTokenRegistration;
         private LoggerFilterOptions _filterOptions;
-        private LoggerFactoryScopeProvider _scopeProvider;
+        private IExternalScopeProvider _scopeProvider;
         private LoggerFactoryOptions _factoryOptions;
 
         /// <summary>
@@ -61,8 +61,21 @@ namespace Microsoft.Extensions.Logging
         /// <param name="providers">The providers to use in producing <see cref="ILogger"/> instances.</param>
         /// <param name="filterOption">The filter option to use.</param>
         /// <param name="options">The <see cref="LoggerFactoryOptions"/>.</param>
-        public LoggerFactory(IEnumerable<ILoggerProvider> providers, IOptionsMonitor<LoggerFilterOptions> filterOption, IOptions<LoggerFactoryOptions> options = null)
+        public LoggerFactory(IEnumerable<ILoggerProvider> providers, IOptionsMonitor<LoggerFilterOptions> filterOption, IOptions<LoggerFactoryOptions> options = null) : this(providers, filterOption, options, null)
         {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="LoggerFactory"/> instance.
+        /// </summary>
+        /// <param name="providers">The providers to use in producing <see cref="ILogger"/> instances.</param>
+        /// <param name="filterOption">The filter option to use.</param>
+        /// <param name="options">The <see cref="LoggerFactoryOptions"/>.</param>
+        /// <param name="scopeProvider">The <see cref="IExternalScopeProvider"/>.</param>
+        public LoggerFactory(IEnumerable<ILoggerProvider> providers, IOptionsMonitor<LoggerFilterOptions> filterOption, IOptions<LoggerFactoryOptions> options = null, IExternalScopeProvider scopeProvider = null)
+        {
+            _scopeProvider = scopeProvider;
+
             _factoryOptions = options == null || options.Value == null ? new LoggerFactoryOptions() : options.Value;
 
             const ActivityTrackingOptions ActivityTrackingOptionsMask = ~(ActivityTrackingOptions.SpanId | ActivityTrackingOptions.TraceId | ActivityTrackingOptions.ParentId |

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggingServiceCollectionExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggingServiceCollectionExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Moq;
 
 namespace Microsoft.Extensions.Logging.Test
 {
@@ -13,6 +14,22 @@ namespace Microsoft.Extensions.Logging.Test
         public void AddLogging_WrapsServiceCollection()
         {
             var services = new ServiceCollection();
+
+            var callbackCalled = false;
+            var loggerBuilder = services.AddLogging(builder =>
+            {
+                callbackCalled = true;
+                Assert.Same(services, builder.Services);
+            });
+            Assert.True(callbackCalled);
+        }
+
+        [Fact]
+        public void AddLogging_InjectScopeProvider()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton(typeof(IExternalScopeProvider), Mock.Of<IExternalScopeProvider>());
 
             var callbackCalled = false;
             var loggerBuilder = services.AddLogging(builder =>


### PR DESCRIPTION
Added LoggerFactory constructor with  IExternalScopeProvider parameter allowing to use injected scope provider implementation. If nothing is provided uses the default implementation as before.

Fix #50590