### PR TITLE
Adding Infrastructure and post build step to run the linker on our OOB assemblies

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.Configuration.Binder, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue(System.Type,System.String,System.String,System.Object@,System.Exception@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.CreateInstance(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue(System.Type,System.String,System.String,System.Object@,System.Exception@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.BindCollection(System.Object,System.Type,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Configuration.BinderOptions)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.BindDictionary(System.Object,System.Type,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Configuration.BinderOptions)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.CreateInstance(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Configuration.ConfigurationBinder.GetAllProperties(System.Type)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateOpenGeneric(Microsoft.Extensions.DependencyInjection.ServiceDescriptor,System.Type,Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteChain,System.Int32,System.Boolean)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.Hosting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">F:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.options</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_0`1.{ValidateOnStart}b__0(Microsoft.Extensions.DependencyInjection.ValidatorOptions,Microsoft.Extensions.Options.IOptionsMonitor{`0})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.{ValidateOnStart}b__1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.ValidateOnStart``1(Microsoft.Extensions.Options.OptionsBuilder{``0})</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
@@ -11,13 +11,13 @@
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_0`1.{ValidateOnStart}b__0(Microsoft.Extensions.DependencyInjection.ValidatorOptions,Microsoft.Extensions.Options.IOptionsMonitor{`0})</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_0`1.&lt;ValidateOnStart&gt;b__0(Microsoft.Extensions.DependencyInjection.ValidatorOptions,Microsoft.Extensions.Options.IOptionsMonitor{`0})</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.{ValidateOnStart}b__1</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.&lt;ValidateOnStart&gt;b__1</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/Microsoft.Extensions.Http/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Http/src/ILLink/ILLink.Suppressions.xml
@@ -5,13 +5,13 @@
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass10_0`1.{AddTypedClientCore}b__0(System.IServiceProvider)</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass10_0`1.&lt;AddTypedClientCore&gt;b__0(System.IServiceProvider)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass12_0`2.{AddTypedClientCore}b__0(System.IServiceProvider)</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass12_0`2.&lt;AddTypedClientCore&gt;b__0(System.IServiceProvider)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/Microsoft.Extensions.Http/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Http/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass10_0`1.{AddTypedClientCore}b__0(System.IServiceProvider)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.&lt;&gt;c__DisplayClass12_0`2.{AddTypedClientCore}b__0(System.IServiceProvider)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.Logging.EventSource, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.ActivityJsonStart(System.Int32,System.Int32,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.ActivityJsonStop(System.Int32,System.Int32,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.ActivityStart(System.Int32,System.Int32,System.String,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.ActivityStop(System.Int32,System.Int32,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.FormattedMessage(Microsoft.Extensions.Logging.LogLevel,System.Int32,System.String,System.Int32,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.Message(Microsoft.Extensions.Logging.LogLevel,System.Int32,System.String,System.Int32,System.String,Microsoft.Extensions.Logging.EventSource.ExceptionInfo,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Logging.EventSource.LoggingEventSource.MessageJson(Microsoft.Extensions.Logging.LogLevel,System.Int32,System.String,System.Int32,System.String,System.String,System.String,System.String)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.Extensions.Options.DataAnnotations, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.Options.DataAnnotationValidateOptions`1.Validate(System.String,`0)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.CodeDom/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.CodeDom/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.CodeDom, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CodeDomProvider.GetConverter(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerResults.get_CompiledAssembly</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerInfo.get_CodeDomProviderType</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerInfo.get_IsCodeDomProviderTypeValid</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CodeDomProvider.GetConverter(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerInfo.CreateProvider</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerInfo.CreateProvider</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.CodeDom.Compiler.CompilerInfo.CreateProvider(System.Collections.Generic.IDictionary{System.String,System.String})</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.ComponentModel.Composition.Registration/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.ComponentModel.Composition.Registration/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.ComponentModel.Composition.Registration, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Registration.PartBuilder.BuildConstructorAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Registration.PartBuilder.BuildDefaultConstructorAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Registration.PartBuilder.BuildPropertyAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Registration.PartBuilder.BuildPropertyAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.ComponentModel.Composition/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.ComponentModel.Composition/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,323 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.AssemblyCatalog.get_InnerCatalog</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.AssemblyCatalog.LoadAssembly(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Primitives.ComposablePartCatalog.get_Parts</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.CompositionServices.AdjustSpecifiedTypeIdentityType(System.Type,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ExportFactoryCreator.CreateStronglyTypedExportFactoryOfT``1(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ExportFactoryCreator.CreateStronglyTypedExportFactoryOfTM``2(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericServices.CreateTypeSpecialization(System.Type,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericSpecializationPartCreationInfo.&lt;&gt;c__DisplayClass13_0.{#ctor}b__0</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.CreateSemiStronglyTypedLazyFactory(System.Type,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.CreateStronglyTypedLazyFactory(System.Type,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ExportFactoryCreator.CreateStronglyTypedExportFactoryFactory(System.Type,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2065</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.MetadataViewGenerator.#cctor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Internal.ReflectionInvoke.SafeCreateInstance(System.Type,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Internal.ReflectionServices.&lt;&gt;c.{GetAllProperties}b__7_0(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.AttributedModel.AttributedPartCreationInfo.SelectPartConstructor(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ContractNameServices.GetTypeIdentity(System.Type,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.IsDictionaryConstructorViewType(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericServices.CanSpecialize(System.Type,System.Reflection.GenericParameterAttributes)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.CompositionServices.TryExportMetadataForMember(System.Reflection.MemberInfo,System.Collections.Generic.IDictionary{System.String,System.Object}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.MetadataViewGenerator.GetMetadataViewFactory(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericSpecializationPartCreationInfo.BuildMembersTable(System.Collections.Generic.List{System.ComponentModel.Composition.ReflectionModel.LazyMemberInfo})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericSpecializationPartCreationInfo.GetConstructor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ImportingMember.GetNormalizedCollection(System.Type,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ReflectionPartCreationInfo.GetConstructor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.CatalogReflectionContextAttribute.CreateReflectionContext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ExportFactoryCreator.CreateStronglyTypedExportFactoryOfT``1(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.ExportFactoryCreator.CreateStronglyTypedExportFactoryOfTM``2(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Internal.ReflectionServices.&lt;GetDeclaredFields&gt;d__11.MoveNext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Internal.ReflectionServices.&lt;GetDeclaredMethods&gt;d__9.MoveNext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.AttributedModel.AttributedPartCreationInfo.&lt;GetDeclaredOnlyImportMembers&gt;d__40.MoveNext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.AttributedModel.AttributedPartCreationInfo.&lt;GetExportMembers&gt;d__34.MoveNext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Internal.LazyServices.GetNotNullValue``1(System.Lazy{``0},System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.CreateStronglyTypedLazyOfT``1(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.CreateStronglyTypedLazyOfTM``2(System.ComponentModel.Composition.Primitives.Export)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.DisposableLazy`1.#ctor(System.Func{`0},System.IDisposable,System.Threading.LazyThreadSafetyMode)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.ExportServices.DisposableLazy`2.#ctor(System.Func{`0},`1,System.IDisposable,System.Threading.LazyThreadSafetyMode)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.CompositionContainer.ReleaseExport``1(System.Lazy{``0})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.CompositionContainer.ReleaseExports``1(System.Collections.Generic.IEnumerable{System.Lazy{``0}})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.CompositionContainer.ReleaseExports``2(System.Collections.Generic.IEnumerable{System.Lazy{``0,``1}})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExport``1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExport``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExport``2</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExport``2(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExportCore``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExportCore``2(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExports``1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExports``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExports``2</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExports``2(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExportsCore``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Composition.Hosting.ExportProvider.GetExportsCore``2(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">type</property>
+      <property name="Target">T:System.ComponentModel.Composition.ExportServices.DisposableLazy`1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">type</property>
+      <property name="Target">T:System.ComponentModel.Composition.ExportServices.DisposableLazy`2</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.ComponentModel.Composition/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.ComponentModel.Composition/src/ILLink/ILLink.Suppressions.xml
@@ -47,7 +47,7 @@
       <argument>ILLink</argument>
       <argument>IL2055</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericSpecializationPartCreationInfo.&lt;&gt;c__DisplayClass13_0.{#ctor}b__0</property>
+      <property name="Target">M:System.ComponentModel.Composition.ReflectionModel.GenericSpecializationPartCreationInfo.&lt;&gt;c__DisplayClass13_0.&lt;#ctor&gt;b__0</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -83,7 +83,7 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Internal.ReflectionServices.&lt;&gt;c.{GetAllProperties}b__7_0(System.Type)</property>
+      <property name="Target">M:Microsoft.Internal.ReflectionServices.&lt;&gt;c.&lt;GetAllProperties&gt;b__7_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.ComponentModel.TypeConverter, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Design.DesigntimeLicenseContextSerializer.DeserializeUsingBinaryFormatter(System.ComponentModel.Design.DesigntimeLicenseContextSerializer.StreamWrapper,System.String,System.ComponentModel.Design.RuntimeLicenseContext)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ComponentModel.Design.DesigntimeLicenseContextSerializer.SerializeWithBinaryFormatter(System.IO.Stream,System.String,System.ComponentModel.Design.DesigntimeLicenseContext)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Composition.Convention/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Composition.Convention/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Composition.Convention, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildOnImportsSatisfiedNotification(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildPropertyAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildConstructorAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildDefaultConstructorAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildOnImportsSatisfiedNotification(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Convention.PartConventionBuilder.BuildPropertyAttributes(System.Type,System.Collections.Generic.List{System.Tuple{System.Object,System.Collections.Generic.List{System.Attribute}}}@)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Composition.Hosting/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Composition.Hosting/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Composition.Hosting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.ExportFactory.ExportFactoryExportDescriptorProvider.GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.ExportFactory.ExportFactoryWithMetadataExportDescriptorProvider.GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.ImportMany.ImportManyExportDescriptorProvider.GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Metadata.MetadataViewProvider.GetMetadataViewProvider``1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2090</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Metadata.MetadataViewProvider.GetMetadataViewProvider``1</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`1.{GetLazyDefinitions}b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`1.{GetLazyDefinitions}b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`2.{GetLazyDefinitions}b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2091</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`2.{GetLazyDefinitions}b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Composition.Hosting/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Composition.Hosting/src/ILLink/ILLink.Suppressions.xml
@@ -47,25 +47,25 @@
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`1.{GetLazyDefinitions}b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`1.&lt;GetLazyDefinitions&gt;b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`1.{GetLazyDefinitions}b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`1.&lt;GetLazyDefinitions&gt;b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`2.{GetLazyDefinitions}b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_0`2.&lt;GetLazyDefinitions&gt;b__0(System.Composition.Hosting.Core.CompositionDependency)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`2.{GetLazyDefinitions}b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
+      <property name="Target">M:System.Composition.Hosting.Providers.Lazy.LazyWithMetadataExportDescriptorProvider.&lt;&gt;c__DisplayClass2_2`2.&lt;GetLazyDefinitions&gt;b__3(System.Composition.Hosting.Core.LifetimeContext,System.Composition.Hosting.Core.CompositionOperation)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Composition.TypedParts/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Composition.TypedParts/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Composition.TypedParts, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.Hosting.ContainerConfiguration.&lt;&gt;c.{WithAssemblies}b__16_0(System.Reflection.Assembly)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.ActivationFeatures.PropertyInjectionFeature.#cctor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPart.#cctor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredInstanceExport.CloseGenericExport(System.Reflection.TypeInfo,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPart.TryCloseGenericPart(System.Type[],System.Composition.TypedParts.Discovery.DiscoveredPart@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPropertyExport.CloseGenericExport(System.Reflection.TypeInfo,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.ActivationFeatures.OnImportsSatisfiedFeature.RewriteActivator(System.Reflection.TypeInfo,System.Composition.Hosting.Core.CompositeActivator,System.Collections.Generic.IDictionary{System.String,System.Object},System.Collections.Generic.IEnumerable{System.Composition.Hosting.Core.CompositionDependency})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.ActivationFeatures.PropertyInjectionFeature.GetDependencies(System.Reflection.TypeInfo,System.Composition.Hosting.Core.DependencyAccessor)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPropertyExport.CloseGenericExport(System.Reflection.TypeInfo,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPart.GetConstructorInfoFromGenericType(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.CompositionContextExtensions.SatisfyImportsInternal(System.Composition.CompositionContext,System.Object,System.Composition.Convention.AttributedModelProvider)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPart.GetConstructorInfoFromGenericType(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.ContractHelpers.GetImportInfo(System.Type,System.Object[],System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.TypeInspector.&lt;DiscoverPropertyExports&gt;d__7.MoveNext</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.TypeInspector.ReadMetadataAttribute(System.Attribute,System.Collections.Generic.IDictionary{System.String,System.Object})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Composition.TypedParts.Discovery.DiscoveredPart.&lt;GetPartActivatorDependencies&gt;d__18.MoveNext</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Composition.TypedParts/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Composition.TypedParts/src/ILLink/ILLink.Suppressions.xml
@@ -5,7 +5,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Composition.Hosting.ContainerConfiguration.&lt;&gt;c.{WithAssemblies}b__16_0(System.Reflection.Assembly)</property>
+      <property name="Target">M:System.Composition.Hosting.ContainerConfiguration.&lt;&gt;c.&lt;WithAssemblies&gt;b__16_0(System.Reflection.Assembly)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Configuration.ConfigurationManager, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ApplicationSettingsBase.CreateSetting(System.Reflection.PropertyInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ConfigurationProperty.CreateConverter</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.InfiniteTimeSpanConverter.#cctor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.ConvertObjectToString(System.Object,System.Type,System.Configuration.SettingsSerializeAs,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.Deserialize</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.GetObjectFromString(System.Type,System.Configuration.SettingsSerializeAs,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.SerializePropertyValue</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.GetImplicitType(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ApplicationSettingsBase.CreateSetting(System.Reflection.PropertyInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ApplicationSettingsBase.get_Initializer</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ConfigurationErrorsException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.Internal.InternalConfigHost.System#Configuration#Internal#IInternalConfigHost#GetConfigType(System.String,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.GetImplicitType(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.GetType(System.String,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.ConvertObjectToString(System.Object,System.Type,System.Configuration.SettingsSerializeAs,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.GetObjectFromString(System.Type,System.Configuration.SettingsSerializeAs,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.CreateInstance(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ConfigurationElement.CreatePropertyBagFromType(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.GetConstructor(System.Type,System.Type,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ApplicationSettingsBase.CreateSetting(System.Reflection.PropertyInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ConfigurationProperty.CreateConverter</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.TypeUtil.CreateInstance``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ApplicationSettingsBase.EnsureInitialized</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.ConfigurationElement.Dump(System.IO.TextWriter)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.SettingsPropertyValue.Deserialize</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Configuration.CallbackValidatorAttribute.get_ValidatorInstance</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Data.Odbc/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Data.Odbc/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Data.Odbc, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Interop.Odbc.SQLSetConnectAttrW(System.Data.Odbc.OdbcConnectionHandle,System.Data.Odbc.ODBC32.SQL_ATTR,System.Transactions.IDtcTransaction,System.Int32)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Data.OleDb/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Data.OleDb/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Data.OleDb, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Data.Common.UnsafeNativeMethods.GetErrorInfo(System.Int32,System.Data.Common.UnsafeNativeMethods.IErrorInfo@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Data.OleDb.OleDbEnumerator.GetEnumeratorFromType(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Data.OleDb.OleDbConnectionInternal.CreateInstanceDataLinks</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.DirectoryServices.AccountManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.AccountManagement.UnsafeNativeMethods.IntADsOpenObject(System.String,System.String,System.String,System.Int32,System.Guid@,System.Object@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.AccountManagement.ADStoreCtx.BuildExtensionPropertyList(System.Collections.Hashtable,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.AccountManagement.Principal.MakePrincipal(System.DirectoryServices.AccountManagement.PrincipalContext,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.AccountManagement.FilterFactory.CreateFilter(System.String)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.DirectoryServices/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.DirectoryServices/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.DirectoryServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.Interop.UnsafeNativeMethods.IntADsOpenObject(System.String,System.String,System.String,System.Int32,System.Guid@,System.Object@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.DirectoryEntry.Invoke(System.String,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.DirectoryEntry.InvokeGet(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.DirectoryServices.DirectoryEntry.InvokeSet(System.String,System.Object[])</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Drawing.Common/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Drawing.Common/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.BitmapSelector.DoesAssemblyHaveCustomAttribute(System.Reflection.Assembly,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.FontConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.FontConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext,System.Object,System.Attribute[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.ImageConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext,System.Object,System.Attribute[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.Printing.MarginsConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.Printing.MarginsConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.FontConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext,System.Object,System.Attribute[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.ImageConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext,System.Object,System.Attribute[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.Icon.OleCreatePictureIndirect(System.Drawing.Icon.PICTDESC,System.Guid@,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipCreateBitmapFromStream(Interop.Ole32.IStream,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipCreateBitmapFromStreamICM(Interop.Ole32.IStream,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipCreateMetafileFromStream(Interop.Ole32.IStream,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipGetMetafileHeaderFromStream(Interop.Ole32.IStream,System.IntPtr)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipLoadImageFromStream(Interop.Ole32.IStream,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipLoadImageFromStreamICM(Interop.Ole32.IStream,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipRecordMetafileStream(Interop.Ole32.IStream,System.IntPtr,System.Drawing.Imaging.EmfType,System.Drawing.RectangleF@,System.Drawing.Imaging.MetafileFrameUnit,System.String,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipRecordMetafileStream(Interop.Ole32.IStream,System.IntPtr,System.Drawing.Imaging.EmfType,System.IntPtr,System.Drawing.Imaging.MetafileFrameUnit,System.String,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipRecordMetafileStreamI(Interop.Ole32.IStream,System.IntPtr,System.Drawing.Imaging.EmfType,System.Drawing.Rectangle@,System.Drawing.Imaging.MetafileFrameUnit,System.String,System.IntPtr@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Drawing.SafeNativeMethods.Gdip.GdipSaveImageToStream(System.Runtime.InteropServices.HandleRef,Interop.Ole32.IStream,System.Guid@,System.Runtime.InteropServices.HandleRef)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Management/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Management/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Management, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Management.ManagementClassGenerator.InitializeCodeGenerator(System.Management.CodeLanguage)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Interop.Ole32.CoMarshalInterface(System.Runtime.InteropServices.ComTypes.IStream,System.Guid,System.IntPtr,System.UInt32,System.IntPtr,System.UInt32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Interop.Ole32.CoUnmarshalInterface(System.Runtime.InteropServices.ComTypes.IStream,System.Guid)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Interop.Ole32.CreateStreamOnHGlobal(System.IntPtr,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2050</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Interop.Ole32.GetHGlobalFromStream(System.Runtime.InteropServices.ComTypes.IStream)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Management.ManagementClassGenerator.ProcessNamespaceAndClassName</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Management.MTAHelper.CreateInMTA(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Management.ManagementClassGenerator.InitializeCodeGenerator(System.Management.CodeLanguage)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Management.MTAHelper.WorkerThread</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Memory.Data/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Memory.Data/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Memory.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.#ctor(System.Object,System.Text.Json.JsonSerializerOptions,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2087</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.FromObjectAsJson``1(``0,System.Text.Json.JsonSerializerOptions)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2087</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.ToObjectFromJson``1(System.Text.Json.JsonSerializerOptions)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Memory.Data/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Memory.Data/src/ILLink/ILLink.Suppressions.xml
@@ -3,6 +3,24 @@
   <assembly fullname="System.Memory.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.#ctor(System.Object,System.Text.Json.JsonSerializerOptions,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.FromObjectAsJson``1(``0,System.Text.Json.JsonSerializerOptions)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.BinaryData.ToObjectFromJson``1(System.Text.Json.JsonSerializerOptions)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
       <argument>IL2067</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.BinaryData.#ctor(System.Object,System.Text.Json.JsonSerializerOptions,System.Type)</property>

--- a/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Private.DataContractSerialization, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.ClassDataContract.get_UnadaptedClassType</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.SurrogateDataContract.GetUninitializedObject(System.Type)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Reflection.Context/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Reflection.Context/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,455 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Reflection.Context, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetExportedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetReferencedAssemblies</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.LoadModule(System.String,System.Byte[],System.Byte[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingConstructorInfo.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingMethodInfo.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.FindTypes(System.Reflection.TypeFilter,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetField(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveField(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveMember(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveMethod(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveSignature(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveString(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveType(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.CreateInstance(System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetExportedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetReferencedAssemblies</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.LoadModule(System.String,System.Byte[],System.Byte[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingConstructorInfo.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingMethodInfo.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.FindTypes(System.Reflection.TypeFilter,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetField(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveField(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveMember(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveMethod(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveSignature(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveString(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingModule.ResolveType(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.MakeGenericType(System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingAssembly.CreateInstance(System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingMethodInfo.MakeGenericMethod(System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetConstructors(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetDefaultMembers</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetEvents</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetEvents(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMembers(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetNestedTypes(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetProperties(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetPropertyImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2085</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Projection.ProjectingType.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2085</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Projection.ProjectingType.GetMembers(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetConstructorImpl(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetConstructors(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetDefaultMembers</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetEvent(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetEvents</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetEvents(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetField(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMembers(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetNestedType(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetNestedTypes(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetProperties(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.GetPropertyImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Context.Delegation.DelegatingType.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,377 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Reflection.MetadataLoadContext, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetExportedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.CreateInstance(System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.get_DefinedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.get_ExportedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetExportedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetForwardedTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetReferencedAssemblies</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.LoadModule(System.String,System.Byte[],System.Byte[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoConstructor.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoMethod.GetMethodBody</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetField(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetType(System.String,System.Boolean,System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.GetTypes</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveField(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveMember(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveMethod(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveSignature(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveString(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoModule.ResolveType(System.Int32,System.Type[],System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.SignatureTypeExtensions.TryMakeGenericType(System.Type,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2055</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Assignability.IsAssignableFrom(System.Type,System.Type,System.Reflection.TypeLoading.CoreTypes)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.ConstructorPolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.EventPolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.FieldPolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.MethodPolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.NestedTypePolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.Runtime.BindingFlagSupport.PropertyPolicies.GetDeclaredMembers(System.Reflection.TypeInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.CustomAttributeHelpers.ToCustomAttributeNamedArgument(System.Type,System.String,System.Type,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeHelpers.ToApiForm(System.Reflection.Metadata.CustomAttributeNamedArgument{System.Reflection.TypeLoading.RoType},System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoAssembly.AddPublicNestedTypes(System.Type,System.Collections.Generic.List{System.Type})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.MetadataLoadContext.TryGetConstructor(System.Reflection.TypeLoading.CoreType,System.Reflection.TypeLoading.CoreType[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeData.ComputeConstructor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Ecma.EcmaModule.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Ecma.EcmaModule.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2085</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetDefaultMembers</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2085</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.InternalGetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetConstructorImpl(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetConstructors(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetDefaultMembers</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetEvent(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetEvents(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetField(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetFields(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMember(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMembers(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMethodImpl(System.String,System.Int32,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetMethods(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetNestedType(System.String,System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetNestedTypes(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetProperties(System.Reflection.BindingFlags)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.GetPropertyImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2094</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.RoType.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2096</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Reflection.TypeLoading.Helpers.LoadTypeFromAssemblyQualifiedName(System.String,System.Reflection.TypeLoading.RoAssembly,System.Boolean,System.Boolean)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Resources.Extensions/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Resources.Extensions/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Resources.Extensions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.DeserializingResourceReader.DeserializeObject(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.DeserializingResourceReader.ReadBinaryFormattedObject</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.PreserializedResourceWriter.AddResource(System.String,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.DeserializingResourceReader.UndoTruncatedTypeNameSerializationBinder.BindToType(System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2062</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.PreserializedResourceWriter.AddResource(System.String,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.Extensions.DeserializingResourceReader.DeserializeObject(System.Int32)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Security.Cryptography.Xml/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Security.Cryptography.Xml/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Security.Cryptography.Xml, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.CryptoHelpers.CreateFromName``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.DSASignatureDescription.CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.DSASignatureDescription.CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.RSAPKCS1SignatureDescription.CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.RSAPKCS1SignatureDescription.CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.SignedXml.CheckSignedInfo(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.SignedXml.ComputeSignature</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.DSASignatureDescription.CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.DSASignatureDescription.CreateDigest</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.DSASignatureDescription.CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.RSAPKCS1SignatureDescription.CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.RSAPKCS1SignatureDescription.CreateDigest</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2046</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.RSAPKCS1SignatureDescription.CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2057</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.Xml.SignedXml.CheckSignedInfo(System.Security.Cryptography.AsymmetricAlgorithm)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.ServiceModel.Syndication/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.ServiceModel.Syndication/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.ServiceModel.Syndication, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtension.#ctor(System.Object,System.Xml.Serialization.XmlSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtension.ExtensionDataWriter.ComputeOuterNameAndNs(System.String@,System.String@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtension.ExtensionDataWriter.WriteTo(System.Xml.XmlWriter)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtension.GetObject``1(System.Runtime.Serialization.XmlObjectSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtension.GetObject``1(System.Xml.Serialization.XmlSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationElementExtensionCollection.Add(System.Object,System.Xml.Serialization.XmlSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.XmlSyndicationContent.ReadContent``1(System.Runtime.Serialization.XmlObjectSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.XmlSyndicationContent.ReadContent``1(System.Xml.Serialization.XmlSerializer)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationFeedFormatter.CreateFeedInstance(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2067</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.SyndicationItemFormatter.CreateItemInstance(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.AtomPub10CategoriesDocumentFormatter.CreateInlineCategoriesDocument</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.AtomPub10CategoriesDocumentFormatter.CreateReferencedCategoriesDocument</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2077</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.ServiceModel.Syndication.AtomPub10ServiceDocumentFormatter.CreateDocumentInstance</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Speech/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Speech/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Speech, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.GetTypeForRule(System.Reflection.Assembly,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.Init(System.String,System.Byte[],System.Byte[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.Synthesis.VoiceSynthesis.GetSsmlEngine(System.Speech.Synthesis.VoiceInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.Create(System.String,System.String,System.String,System.Uri@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadGrammarFromAssembly(System.Reflection.Assembly,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadLocalizedGrammarFromType(System.Type,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.RecognizedPhrase.GetTypeForRule(System.Reflection.Assembly,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.GetRuleInstance(System.String,System.String,System.Reflection.MethodInfo@,System.Speech.Recognition.Grammar@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.Init(System.String,System.Byte[],System.Byte[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.Synthesis.VoiceSynthesis.GetSsmlEngine(System.Speech.Synthesis.VoiceInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadGrammarFromAssembly(System.Reflection.Assembly,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadLocalizedGrammarFromType(System.Type,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2058</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.RecognizedPhrase.GetRuleInstance(System.Speech.Recognition.Grammar,System.String,System.String,System.Reflection.MethodInfo@,System.Speech.Recognition.Grammar@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2065</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadGrammarFromAssembly(System.Reflection.Assembly,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2065</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.LoadLocalizedGrammarFromType(System.Type,System.Object[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.ParseValue(System.Type,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.MatchInitParameters(System.Type,System.String,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.ParseValue(System.Type,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.ObjectTokens.ObjectToken.CreateObjectFromToken``1(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.MethodInfo(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.Grammar.RunOnInit(System.Boolean)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Recognition.RecognizedPhrase.TryExecuteOnRecognition(System.Speech.Recognition.Grammar,System.Speech.Recognition.RecognitionResult,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.MatchInitParameters(System.String,System.String,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.OnInit(System.String,System.Object[],System.String,System.Exception@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2080</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.SrgsCompiler.AppDomainGrammarProxy.OnRecognition(System.String,System.Object[],System.Exception@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2087</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Speech.Internal.StreamMarshaler.ReadArray``1(``0[],System.Int32)</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -16,8 +16,9 @@
       <!-- suppress warnings with the following codes:
            IL2009: Could not find method A in type B specified in resource C
            IL2025: Duplicate preserve of A in B
+           IL2007: Could not resolve assembly A. OOB assemblies now have Suppression xmls too, so we need to suppress this error as the sharedframework won't contain these assemblies.
       -->
-      <LinkerNoWarn>IL2009;IL2025</LinkerNoWarn>
+      <LinkerNoWarn>IL2009;IL2025;IL2007</LinkerNoWarn>
       <!-- https://github.com/dotnet/runtime/issues/40336 - need to also suppress the following on non-Windows:
            IL2008: Could not find type A specified in resource B
            and on 32-bit builds:

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -138,5 +138,16 @@
                              RootAttributes="@(FrameworkListRootAttribute)" />
   </Target>
 
+  <Target Name="ILLinkTrimOOBLibraries"
+          AfterTargets="GenerateRuntimeListFile"
+          DependsOnTargets="SetCommonILLinkArgs"
+          Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <Message Importance="High" Text="Trimming $(PackageRID) OOB assemblies with ILLinker..." />
+    <MSBuild Targets="Restore;Publish"
+             Projects="$(MSBuildThisFileDirectory)trimming\trimming.csproj"
+             Properties="$(TraversalGlobalProperties);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+  </Target> 
+
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.SharedFramework.Sdk" />
 </Project>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -142,10 +142,14 @@
           AfterTargets="GenerateRuntimeListFile"
           DependsOnTargets="SetCommonILLinkArgs"
           Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
-    <Message Importance="High" Text="Trimming $(PackageRID) OOB assemblies with ILLinker..." />
-    <MSBuild Targets="Restore;Publish"
+    <MSBuild Targets="Restore"
              Projects="$(MSBuildThisFileDirectory)trimming\trimming.csproj"
              Properties="$(TraversalGlobalProperties);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+
+    <Message Importance="High" Text="Trimming $(PackageRID) OOB assemblies with ILLinker..." />
+    <MSBuild Targets="Publish"
+             Projects="$(MSBuildThisFileDirectory)trimming\trimming.csproj"
+             Properties="$(TraversalGlobalProperties)" />
   </Target> 
 
   <Import Project="$(RepositoryEngineeringDir)illink.targets" />

--- a/src/libraries/trimming/Program.cs
+++ b/src/libraries/trimming/Program.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace trimming
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/libraries/trimming/trimming.csproj
+++ b/src/libraries/trimming/trimming.csproj
@@ -1,81 +1,83 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
+
+    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <PublishTrimmed>true</PublishTrimmed>
+    <UseAppHost>true</UseAppHost>
+
+    <TrimmerDefaultAction>link</TrimmerDefaultAction>
+    <TrimMode>link</TrimMode>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude packaging wrapper projects that don't produce a library -->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Extensions.HostFactoryResolver\src\*.csproj" />
+    <ProjectExclusions Include="$(LibrariesProjectRoot)System.Composition\src\*.csproj" />
+    <!--Exclude projects that don't have a net6.0 compatible configuration-->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)System.Private.Runtime.InteropServices.JavaScript\src\*.csproj" />
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Diagnostics.Tracing.EventSource.Redist\src\*.csproj" />
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.IO.Redist\src\*.csproj" />
+    <!--Exclude Microsoft.NETCore.* assemblies-->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Platforms\src\*.csproj" />
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Targets\src\*.csproj" />
+    <!--Exclude single Tests project that doesn't follow default naming conventions of the repo-->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Specification.Tests\src\*.csproj" />
+    <!--Exclude Source Generators-->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.XmlSerializer.Generator\src\*.csproj" />
+    <!--Exclude Common Project-->
+    <ProjectExclusions Include="$(LibrariesProjectRoot)Common\src\*.csproj" />
+
+
+    <Compile Include="Program.cs" />
+    <_allSrc Include="$(LibrariesProjectRoot)*\src\*.csproj"
+             Exclude="@(ProjectExclusions)" />
+    <NonNetCoreAppProject Include="@(_allSrc)"
+                          Exclude="@(NetCoreAppLibrary->'%(Identity)\src\%(Identity).csproj')" />
+  </ItemGroup>
+
+  <Target Name="AddSuppressionsForLinker"
+          BeforeTargets="PrepareForILLink">
+    <!-- Add Suppression xmls -->
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
-
-        <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
-        <PublishTrimmed>true</PublishTrimmed>
-        <UseAppHost>true</UseAppHost>
-
-        <TrimmerDefaultAction>link</TrimmerDefaultAction>
-        <TrimMode>link</TrimMode>
-        <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+      <ProjectILLinkSuppressionsFile>src\ILLink\ILLink.Suppressions</ProjectILLinkSuppressionsFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <!--Exclude projects that don't have a net6.0 compatible configuration-->
-        <ProjectExclusions Include="$(LibrariesProjectRoot)System.Private.Runtime.InteropServices.JavaScript\src\*.csproj" />
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Diagnostics.Tracing.EventSource.Redist\src\*.csproj" />
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.IO.Redist\src\*.csproj" />
-        <!--Exclude Microsoft.NETCore.* assemblies-->
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Platforms\src\*.csproj" />
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Targets\src\*.csproj" />
-        <!--Exclude single Tests project that doesn't follow default naming conventions of the repo-->
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Specification.Tests\src\*.csproj" />
-        <!--Exclude Source Generators-->
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.XmlSerializer.Generator\src\*.csproj" />
-        <!--Exclude Common Project-->
-        <ProjectExclusions Include="$(LibrariesProjectRoot)Common\src\*.csproj" />
+      <!-- Include suppression XML files bin-placed in earlier per-library linker run. -->
+      <_SuppressionsXmls Include="$(ILLinkTrimAssemblySuppressionsXmlsDir)*.xml" />
 
-
-        <Compile Include="Program.cs" />
-        <_allSrc Include="$(LibrariesProjectRoot)*\src\*.csproj"
-                 Exclude="@(ProjectExclusions)" />
-        <NonNetCoreAppProject Include="@(_allSrc)"
-                              Exclude="@(NetCoreAppLibrary->'%(Identity)\src\%(Identity).csproj')" />
+      <!-- Collate CoreLib suppression XML files not bin-placed in earlier per-library linker run. CoreLib doesn't use bin-place logic. -->
+      <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared.xml" />
+      <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.LibraryBuild.xml" />
+      <_SuppressionsXmls Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\$(ProjectILLinkSuppressionsFile).LibraryBuild.xml" />
     </ItemGroup>
 
-    <Target Name="AddSuppressionsForLinker"
-            BeforeTargets="PrepareForILLink">
-        <!-- Add Suppression xmls -->
-        <PropertyGroup>
-           <ProjectILLinkSuppressionsFile>src\ILLink\ILLink.Suppressions</ProjectILLinkSuppressionsFile>
-        </PropertyGroup>
+    <PropertyGroup>
+      <_ExtraTrimmerArgs Condition="'@(_SuppressionsXmls)' != ''">$(_ExtraTrimmerArgs) --link-attributes &quot;@(_SuppressionsXmls->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</_ExtraTrimmerArgs>
+    </PropertyGroup>
+  </Target>
 
-        <ItemGroup>
-          <!-- Include suppression XML files bin-placed in earlier per-library linker run. -->
-          <_SuppressionsXmls Include="$(ILLinkTrimAssemblySuppressionsXmlsDir)*.xml" />
+  <ItemGroup>
+    <ProjectReference Include="@(NonNetCoreAppProject)" />
+    <TrimmerRootAssembly Include="@(NonNetCoreAppProject -> '%(FileName)')" />
+  </ItemGroup>
 
-          <!-- Collate CoreLib suppression XML files not bin-placed in earlier per-library linker run. CoreLib doesn't use bin-place logic. -->
-          <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared.xml" />
-          <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.LibraryBuild.xml" />
-          <_SuppressionsXmls Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\$(ProjectILLinkSuppressionsFile).LibraryBuild.xml" />
-        </ItemGroup>
-
-        <PropertyGroup>
-          <_ExtraTrimmerArgs Condition="'@(_SuppressionsXmls)' != ''">$(_ExtraTrimmerArgs) --link-attributes &quot;@(_SuppressionsXmls->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</_ExtraTrimmerArgs>
-          <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --generate-warning-suppressions xml</_ExtraTrimmerArgs>
-        </PropertyGroup>
-    </Target>
-
+  <Target Name="AddP2PsToCopyLocal" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
-        <ProjectReference Include="@(NonNetCoreAppProject)" />
-        <TrimmerRootAssembly Include="@(NonNetCoreAppProject -> '%(FileName)')" />
+      <ReferenceCopyLocalPaths Include="%(_ResolvedProjectReferencePaths.Identity)" PostprocessAssembly="true" TrimMode="link" />
     </ItemGroup>
+  </Target>
 
-    <Target Name="AddP2PsToCopyLocal" AfterTargets="ResolveAssemblyReferences">
-        <ItemGroup>
-            <ReferenceCopyLocalPaths Include="%(_ResolvedProjectReferencePaths.Identity)" PostprocessAssembly="true" TrimMode="link" />
-        </ItemGroup>
-    </Target>
+  <Target Name="RemoveUnusedArcadePackageReferences" BeforeTargets="CollectPackageReferences">
+    <ItemGroup>
+      <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+      <PackageReference Remove="Microsoft.SourceLink.AzureRepos.Git" />
+    </ItemGroup>
+  </Target>
 
-    <Target Name="RemoveUnusedArcadePackageReferences" BeforeTargets="CollectPackageReferences">
-        <ItemGroup>
-            <PackageReference Remove="Microsoft.SourceLink.GitHub" />
-            <PackageReference Remove="Microsoft.SourceLink.AzureRepos.Git" />
-        </ItemGroup>
-    </Target>
-
-    <Import Project="$(RepositoryEngineeringDir)illink.targets" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 </Project>

--- a/src/libraries/trimming/trimming.csproj
+++ b/src/libraries/trimming/trimming.csproj
@@ -1,0 +1,81 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
+
+        <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+        <PublishTrimmed>true</PublishTrimmed>
+        <UseAppHost>true</UseAppHost>
+
+        <TrimmerDefaultAction>link</TrimmerDefaultAction>
+        <TrimMode>link</TrimMode>
+        <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!--Exclude projects that don't have a net6.0 compatible configuration-->
+        <ProjectExclusions Include="$(LibrariesProjectRoot)System.Private.Runtime.InteropServices.JavaScript\src\*.csproj" />
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Diagnostics.Tracing.EventSource.Redist\src\*.csproj" />
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.IO.Redist\src\*.csproj" />
+        <!--Exclude Microsoft.NETCore.* assemblies-->
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Platforms\src\*.csproj" />
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.NETCore.Targets\src\*.csproj" />
+        <!--Exclude single Tests project that doesn't follow default naming conventions of the repo-->
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Specification.Tests\src\*.csproj" />
+        <!--Exclude Source Generators-->
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Microsoft.XmlSerializer.Generator\src\*.csproj" />
+        <!--Exclude Common Project-->
+        <ProjectExclusions Include="$(LibrariesProjectRoot)Common\src\*.csproj" />
+
+
+        <Compile Include="Program.cs" />
+        <_allSrc Include="$(LibrariesProjectRoot)*\src\*.csproj"
+                 Exclude="@(ProjectExclusions)" />
+        <NonNetCoreAppProject Include="@(_allSrc)"
+                              Exclude="@(NetCoreAppLibrary->'%(Identity)\src\%(Identity).csproj')" />
+    </ItemGroup>
+
+    <Target Name="AddSuppressionsForLinker"
+            BeforeTargets="PrepareForILLink">
+        <!-- Add Suppression xmls -->
+        <PropertyGroup>
+           <ProjectILLinkSuppressionsFile>src\ILLink\ILLink.Suppressions</ProjectILLinkSuppressionsFile>
+        </PropertyGroup>
+
+        <ItemGroup>
+          <!-- Include suppression XML files bin-placed in earlier per-library linker run. -->
+          <_SuppressionsXmls Include="$(ILLinkTrimAssemblySuppressionsXmlsDir)*.xml" />
+
+          <!-- Collate CoreLib suppression XML files not bin-placed in earlier per-library linker run. CoreLib doesn't use bin-place logic. -->
+          <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared.xml" />
+          <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.LibraryBuild.xml" />
+          <_SuppressionsXmls Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\$(ProjectILLinkSuppressionsFile).LibraryBuild.xml" />
+        </ItemGroup>
+
+        <PropertyGroup>
+          <_ExtraTrimmerArgs Condition="'@(_SuppressionsXmls)' != ''">$(_ExtraTrimmerArgs) --link-attributes &quot;@(_SuppressionsXmls->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</_ExtraTrimmerArgs>
+          <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --generate-warning-suppressions xml</_ExtraTrimmerArgs>
+        </PropertyGroup>
+    </Target>
+
+    <ItemGroup>
+        <ProjectReference Include="@(NonNetCoreAppProject)" />
+        <TrimmerRootAssembly Include="@(NonNetCoreAppProject -> '%(FileName)')" />
+    </ItemGroup>
+
+    <Target Name="AddP2PsToCopyLocal" AfterTargets="ResolveAssemblyReferences">
+        <ItemGroup>
+            <ReferenceCopyLocalPaths Include="%(_ResolvedProjectReferencePaths.Identity)" PostprocessAssembly="true" TrimMode="link" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="RemoveUnusedArcadePackageReferences" BeforeTargets="CollectPackageReferences">
+        <ItemGroup>
+            <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+            <PackageReference Remove="Microsoft.SourceLink.AzureRepos.Git" />
+        </ItemGroup>
+    </Target>
+
+    <Import Project="$(RepositoryEngineeringDir)illink.targets" />
+</Project>


### PR DESCRIPTION
cc: @eerhardt @sbomer @krwq @vitek-karas @ViktorHofer 

fixes https://github.com/dotnet/runtime/issues/48488

This is mostly ready for review except that I'm still hitting https://github.com/mono/linker/issues/1416 and trying to find the best way to suppress these warnings which for now are causing the build to fail. That means this PR isn't ready to go in, but sending it out for now to get initial feedback on the infrastructure.

This approach is mostly following the advise we are giving library devs here: https://github.com/dotnet/docs/blob/main/docs/core/deploying/prepare-libraries-for-trimming.md. We are only adding a few additional targets that are accounting for the fact that we have a slightly complex build system, but other than that this is mostly following the guidance on those docs provided by @sbomer 