### PR TITLE
[json tests] Fix CRLF vs LF issues

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
@@ -741,7 +741,7 @@ namespace System.Text.Json
 
         public static void AssertContentsAgainstJsonNet(string expectedValue, string value, bool skipSpecialRules)
         {
-            Assert.Equal(expectedValue.NormalizeToJsonNetFormat(skipSpecialRules), value.NormalizeToJsonNetFormat(skipSpecialRules));
+            Assert.Equal(expectedValue.NormalizeToJsonNetFormat(skipSpecialRules), value.NormalizeToJsonNetFormat(skipSpecialRules), ignoreLineEndingDifferences: true);
         }
 
         public static void AssertContentsNotEqualAgainstJsonNet(string expectedValue, string value, bool skipSpecialRules)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -101,7 +101,7 @@ namespace System.Text.Json.Tests
   ""One"",
   ""II"",
   ""3""
-]", json);
+]", json, ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.cs
@@ -568,7 +568,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Same(john, jane.Spouse);
             Assert.Same(jane, john.Spouse);
 
-            Assert.Equal(json, JsonSerializer.Serialize(people, options));
+            Assert.Equal(json, JsonSerializer.Serialize(people, options), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -619,7 +619,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Same(firstListOfPeople[0].Spouse, secondListOfPeople[0].Spouse);
             Assert.Same(firstListOfPeople[1].Spouse, secondListOfPeople[1].Spouse);
 
-            Assert.Equal(json, JsonSerializer.Serialize(secondListOfPeople, options));
+            Assert.Equal(json, JsonSerializer.Serialize(secondListOfPeople, options), ignoreLineEndingDifferences: true);
         }
 
         internal class PresistentGuidReferenceHandler : ReferenceHandler

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/WriteValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/WriteValueTests.cs
@@ -350,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
                     {
                         JsonSerializer.Serialize(writer, input, type, options);
                     }
-                    Assert.Equal(expected, Encoding.UTF8.GetString(stream.ToArray()));
+                    Assert.Equal(expected, Encoding.UTF8.GetString(stream.ToArray()), ignoreLineEndingDifferences: true);
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/52106

When running `System.Text.Json.Tests` on windows targeting `Browser`,
the line ending differs between host and target systems. Compensate for
that by using `Assert.Equal(..., ignoreLineEndingDifferences: true)`.

The `Browser` Environment.NewLine is `\n`, while windows use `\r\n`.
https://github.com/dotnet/runtime/blob/5bd0edfe860e41bdfd690d3743e730594307292e/src/libraries/System.Private.CoreLib/src/System/Environment.UnixOrBrowser.cs#L51