### PR TITLE
Fixed issues with caching in the wrong slot

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -481,7 +481,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 if (descriptor == _item)
                 {
-                    return 0;
+                    return Count - 1;
                 }
 
                 if (_items != null)
@@ -489,7 +489,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     int index = _items.IndexOf(descriptor);
                     if (index != -1)
                     {
-                        return index + 1;
+                        return Count - index + 1;
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
@@ -8,11 +8,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     internal static class ServiceCollectionContainerBuilderTestExtensions
     {
-        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderMode mode)
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderMode mode, ServiceProviderOptions options = null)
         {
+            options ??= ServiceProviderOptions.Default;
+
             if (mode == ServiceProviderMode.Default)
             {
-                return services.BuildServiceProvider();
+                return services.BuildServiceProvider(options);
             }
 
             IServiceProviderEngine engine = mode switch
@@ -24,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 _ => throw new NotSupportedException()
             };
 
-            return new ServiceProvider(services, engine, ServiceProviderOptions.Default);
+            return new ServiceProvider(services, engine, options);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTestsWithOptions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTestsWithOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                     // ValidateScopes = true
                 });
             }
-            catch
+            catch (AggregateException)
             {
                 // This is how we "skip" tests that fail on BuildServiceProvider (broken object graphs).
                 // We care mainly about exercising the non-throwing code path so we fallback to the default BuildServiceProvider

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTestsWithOptions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTestsWithOptions.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection.Specification;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    public class ServiceProviderDefaultContainerTestsWithOptions : DependencyInjectionSpecificationTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection collection)
+        {
+            try
+            {
+                return collection.BuildServiceProvider(ServiceProviderMode.Default, new ServiceProviderOptions
+                {
+                    ValidateOnBuild = true,
+                    // Too many tests fail because they try to resolve scoped services from the root
+                    // provider
+                    // ValidateScopes = true
+                });
+            }
+            catch
+            {
+                // This is how we "skip" tests that fail on BuildServiceProvider (broken object graphs).
+                // We care mainly about exercising the non-throwing code path so we fallback to the default BuildServiceProvider
+                return collection.BuildServiceProvider();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- When using ValidateOnBuild we build the callsite for each ServiceDescriptor but using the wrong slot. This didn't matter before but it breaks service overrides.
- Run the spec tests with ValidateOnBuild set to true when it doesn't throw.

```C#
var services = new ServiceCollection();

services.AddTransient<IFoo, Foo1>();
services.AddTransient<IFoo, Foo2>();

var sp = services.BuildServiceProvider(new ServiceProviderOptions
{
    ValidateOnBuild = true
});

Console.WriteLine(sp.GetRequiredService<IFoo>());

interface IFoo { }
class Foo1 : IFoo { }
class Foo2 : IFoo { }
```

This should print Foo2, it was printing Foo1 when ValidateOnBuild was true.

Currently blocking https://github.com/dotnet/aspnetcore/pull/32315