### PR TITLE
Remove redundant enums

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -28,8 +28,6 @@ namespace Internal.TypeSystem
         ByValArray = 0x1e,
         SysInt = 0x1f,
         SysUInt = 0x20,
-        Int = 0x1f,
-        UInt = 0x20,
         Func = 0x26,
         AsAny = 0x28,
         Array = 0x2a,


### PR DESCRIPTION
I cannot find any reference to these declarations in the repo
Also seems to be they have name which does not make sense.
What's purpose Int name has over SysInt and can only raise confusion with I4