### PR TITLE
Add profiler startup command to the diagnostics command set

### DIFF
--- a/src/coreclr/inc/profilepriv.h
+++ b/src/coreclr/inc/profilepriv.h
@@ -79,6 +79,10 @@ struct ProfControlBlock
     BOOL fGCInProgress;
     BOOL fBaseSystemClassesLoaded;
 
+    BOOL fIsStoredProfilerRegistered;
+    CLSID clsStoredProfilerGuid;
+    SString sStoredProfilerPath;
+
 #ifdef PROF_TEST_ONLY_FORCE_ELT_DATA
     // #TestOnlyELT This implements a test-only (and debug-only) hook that allows a test
     // profiler to ensure enter/leave/tailcall is enabled on startup even though no

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -709,6 +709,11 @@ void EEStartupHelper()
         }
 #endif
 
+#ifdef PROFILING_SUPPORTED
+        // The diagnostics server might register a profiler for delayed startup, indicate here that 
+        // it is not currently set. This will be set to TRUE if a profiler is registered.
+       g_profControlBlock.fIsStoredProfilerRegistered = FALSE;
+#endif // PROFILING_SUPPORTED
 #ifdef FEATURE_PERFTRACING
         DiagnosticServerAdapter::Initialize();
         DiagnosticServerAdapter::PauseForDiagnosticsMonitor();

--- a/src/coreclr/vm/diagnosticserveradapter.h
+++ b/src/coreclr/vm/diagnosticserveradapter.h
@@ -30,6 +30,11 @@ public:
 	{
 		return ds_server_resume_runtime_startup();
 	}
+
+	static bool IsPausedInRuntimeStartup()
+	{
+		return ds_server_is_paused_in_startup();
+	}
 };
 
 #endif // FEATURE_PERFTRACING && !CROSSGEN_COMPILE

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -310,8 +310,9 @@ ds_rt_profiler_startup (DiagnosticsStartupProfilerCommandPayload *payload)
 
 	HRESULT hr = S_OK;
 	EX_TRY {
-		g_profControlBlock.clsStoredProfilerGuid = *(reinterpret_cast<const CLSID *>(ds_startup_profiler_command_payload_get_profiler_guid_cref (payload)));
+		memcpy(&(g_profControlBlock.clsStoredProfilerGuid), reinterpret_cast<const CLSID *>(ds_startup_profiler_command_payload_get_profiler_guid_cref (payload)), sizeof(CLSID));
 		g_profControlBlock.sStoredProfilerPath.Set(reinterpret_cast<LPCWSTR>(ds_startup_profiler_command_payload_get_profiler_path (payload)));
+		g_profControlBlock.fIsStoredProfilerRegistered = TRUE;
 	}
 	EX_CATCH_HRESULT (hr);
 

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -268,11 +268,11 @@ DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR (port_config_array, ds_rt_port_config_array_
 /*
 * DiagnosticsProfiler.
 */
-
-#ifdef FEATURE_PROFAPI_ATTACH_DETACH
+#ifdef PROFILING_SUPPORTED
 #include "profilinghelper.h"
 #include "profilinghelper.inl"
 
+#ifdef FEATURE_PROFAPI_ATTACH_DETACH
 static
 uint32_t
 ds_rt_profiler_attach (DiagnosticsAttachProfilerCommandPayload *payload)
@@ -285,7 +285,7 @@ ds_rt_profiler_attach (DiagnosticsAttachProfilerCommandPayload *payload)
 	// Certain actions are only allowable during attach, and this flag is how we track it.
 	ClrFlsSetThreadType (ThreadType_ProfAPI_Attach);
 
-	HRESULT hr;
+	HRESULT hr = S_OK;
 	EX_TRY {
 		hr = ProfilingAPIUtility::LoadProfilerForAttach (reinterpret_cast<const CLSID *>(ds_attach_profiler_command_payload_get_profiler_guid_cref (payload)),
 			reinterpret_cast<LPCWSTR>(ds_attach_profiler_command_payload_get_profiler_path (payload)),
@@ -301,6 +301,23 @@ ds_rt_profiler_attach (DiagnosticsAttachProfilerCommandPayload *payload)
 	return hr;
 }
 #endif // FEATURE_PROFAPI_ATTACH_DETACH
+
+static
+uint32_t
+ds_rt_profiler_startup (DiagnosticsStartupProfilerCommandPayload *payload)
+{
+	STATIC_CONTRACT_NOTHROW;
+
+	HRESULT hr = S_OK;
+	EX_TRY {
+		g_profControlBlock.clsStoredProfilerGuid = *(reinterpret_cast<const CLSID *>(ds_startup_profiler_command_payload_get_profiler_guid_cref (payload)));
+		g_profControlBlock.sStoredProfilerPath.Set(reinterpret_cast<LPCWSTR>(ds_startup_profiler_command_payload_get_profiler_path (payload)));
+	}
+	EX_CATCH_HRESULT (hr);
+
+	return hr;
+}
+#endif // PROFILING_SUPPORTED
 
 /*
 * DiagnosticServer.

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -235,6 +235,15 @@ ds_rt_profiler_attach (DiagnosticsAttachProfilerCommandPayload *payload)
 	return DS_IPC_E_NOTSUPPORTED;
 }
 
+static
+inline
+uint32_t
+ds_rt_profiler_startup (DiagnosticsStartupProfilerCommandPayload *payload)
+{
+	// TODO: Implement.
+	return DS_IPC_E_NOTSUPPORTED;
+}
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-profiler-protocol.c
+++ b/src/native/eventpipe/ds-profiler-protocol.c
@@ -114,7 +114,6 @@ profiler_protocol_helper_attach_profiler (
 
     if (!ep_rt_is_running ()) {
         ds_ipc_message_send_error (stream, DS_IPC_E_NOT_YET_AVAILABLE);
-        ds_ipc_stream_free (stream);
         ep_raise_error ();
     }
 

--- a/src/native/eventpipe/ds-profiler-protocol.c
+++ b/src/native/eventpipe/ds-profiler-protocol.c
@@ -110,6 +110,7 @@ profiler_protocol_helper_attach_profiler (
 		return false;
 
     bool result = false;
+    DiagnosticsAttachProfilerCommandPayload *payload = NULL;
 
     if (!ep_rt_is_running ()) {
         ds_ipc_message_send_error (stream, DS_IPC_E_NOT_YET_AVAILABLE);
@@ -117,7 +118,6 @@ profiler_protocol_helper_attach_profiler (
         ep_raise_error ();
     }
 
-	DiagnosticsAttachProfilerCommandPayload *payload;
 	payload = (DiagnosticsAttachProfilerCommandPayload *)ds_ipc_message_try_parse_payload (message, attach_profiler_command_try_parse_payload);
 
 	if (!payload) {
@@ -217,13 +217,14 @@ profiler_protocol_helper_startup_profiler (
 	if (!stream)
 		return false;
 
+    bool result = false;
+    DiagnosticsStartupProfilerCommandPayload *payload = NULL;
+
 	if (!ds_server_is_paused_in_startup()) {
 		ds_ipc_message_send_error (stream, DS_IPC_E_INVALIDARG);
 		ep_raise_error ();
 	}		
 
-	bool result = false;
-	DiagnosticsStartupProfilerCommandPayload *payload;
 	payload = (DiagnosticsStartupProfilerCommandPayload *)ds_ipc_message_try_parse_payload (message, startup_profiler_command_try_parse_payload);
 
 	if (!payload) {

--- a/src/native/eventpipe/ds-profiler-protocol.c
+++ b/src/native/eventpipe/ds-profiler-protocol.c
@@ -8,7 +8,7 @@
 #include "ds-profiler-protocol.h"
 #include "ds-rt.h"
 
-#ifdef FEATURE_PROFAPI_ATTACH_DETACH
+#ifdef PROFILING_SUPPORTED
 
 /*
  * Forward declares of all static functions.
@@ -20,8 +20,20 @@ attach_profiler_command_try_parse_payload (
 	uint16_t buffer_len);
 
 static
+uint8_t *
+startup_profiler_command_try_parse_payload (
+	uint8_t *buffer,
+	uint16_t buffer_len);
+
+static
 bool
 profiler_protocol_helper_attach_profiler (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream);
+
+static
+bool
+profiler_protocol_helper_startup_profiler (
 	DiagnosticsIpcMessage *message,
 	DiagnosticsIpcStream *stream);
 
@@ -30,6 +42,8 @@ bool
 profiler_protocol_helper_unknown_command (
 	DiagnosticsIpcMessage *message,
 	DiagnosticsIpcStream *stream);
+
+#ifdef FEATURE_PROFAPI_ATTACH_DETACH
 
 /*
 * DiagnosticsAttachProfilerCommandPayload
@@ -83,22 +97,6 @@ ds_attach_profiler_command_payload_free (DiagnosticsAttachProfilerCommandPayload
 	ep_rt_object_free (payload);
 }
 
-/*
- * DiagnosticsProfilerProtocolHelper.
- */
-
-static
-bool
-profiler_protocol_helper_unknown_command (
-	DiagnosticsIpcMessage *message,
-	DiagnosticsIpcStream *stream)
-{
-	DS_LOG_WARNING_1 ("Received unknown request type (%d)", ds_ipc_header_get_commandset (ds_ipc_message_get_header_ref (message)));
-	ds_ipc_message_send_error (stream, DS_IPC_E_UNKNOWN_COMMAND);
-	ds_ipc_stream_free (stream);
-	return true;
-}
-
 static
 bool
 profiler_protocol_helper_attach_profiler (
@@ -141,6 +139,113 @@ ep_on_error:
 	ep_exit_error_handler ();
 }
 
+#endif // FEATURE_PROFAPI_ATTACH_DETACH
+
+DiagnosticsStartupProfilerCommandPayload *
+ds_startup_profiler_command_payload_alloc (void)
+{
+	return ep_rt_object_alloc (DiagnosticsStartupProfilerCommandPayload);
+}
+
+void
+ds_startup_profiler_command_payload_free (DiagnosticsStartupProfilerCommandPayload *payload)
+{
+	ep_return_void_if_nok (payload != NULL);
+	ep_rt_byte_array_free (payload->incoming_buffer);
+	ep_rt_object_free (payload);
+}
+
+/*
+ * DiagnosticsProfilerProtocolHelper.
+ */
+
+static
+bool
+profiler_protocol_helper_unknown_command (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream)
+{
+	DS_LOG_WARNING_1 ("Received unknown request type (%d)", ds_ipc_header_get_commandset (ds_ipc_message_get_header_ref (message)));
+	ds_ipc_message_send_error (stream, DS_IPC_E_UNKNOWN_COMMAND);
+	ds_ipc_stream_free (stream);
+	return true;
+}
+
+static
+uint8_t *
+startup_profiler_command_try_parse_payload (
+	uint8_t *buffer,
+	uint16_t buffer_len)
+{
+	EP_ASSERT (buffer != NULL);
+
+	uint8_t * buffer_cursor = buffer;
+	uint32_t buffer_cursor_len = buffer_len;
+
+	DiagnosticsStartupProfilerCommandPayload *instance = ds_startup_profiler_command_payload_alloc ();
+	ep_raise_error_if_nok (instance != NULL);
+
+	instance->incoming_buffer = buffer;
+
+	if (!ds_ipc_message_try_parse_value (&buffer_cursor, &buffer_cursor_len, (uint8_t *)&instance->profiler_guid, (uint32_t)EP_ARRAY_SIZE (instance->profiler_guid)) ||
+		!ds_ipc_message_try_parse_string_utf16_t (&buffer_cursor, &buffer_cursor_len, &instance->profiler_path))
+		ep_raise_error ();
+
+ep_on_exit:
+	return (uint8_t *)instance;
+
+ep_on_error:
+	ds_startup_profiler_command_payload_free (instance);
+	instance = NULL;
+	ep_exit_error_handler ();
+}
+
+bool
+profiler_protocol_helper_startup_profiler (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream)
+{
+	EP_ASSERT (message != NULL);
+	EP_ASSERT (stream != NULL);
+
+	if (!stream)
+		return false;
+
+	if (!ds_server_is_paused_in_startup()) {
+		ds_ipc_message_send_error (stream, DS_IPC_E_INVALIDARG);
+		ep_raise_error ();
+	}		
+
+	bool result = false;
+	DiagnosticsStartupProfilerCommandPayload *payload;
+	payload = (DiagnosticsStartupProfilerCommandPayload *)ds_ipc_message_try_parse_payload (message, startup_profiler_command_try_parse_payload);
+
+	if (!payload) {
+		ds_ipc_message_send_error (stream, DS_IPC_E_BAD_ENCODING);
+		ep_raise_error ();
+	}
+
+	ds_ipc_result_t ipc_result;
+	ipc_result = ds_rt_profiler_startup (payload);
+	if (ipc_result != DS_IPC_S_OK) {
+		ds_ipc_message_send_error (stream, ipc_result);
+		ep_raise_error ();
+	} else {
+		ds_ipc_message_send_success (stream, ipc_result);
+	}
+
+	result = true;
+
+ep_on_exit:
+	ds_startup_profiler_command_payload_free (payload);
+	ds_ipc_stream_free (stream);
+	return result;
+
+ep_on_error:
+	EP_ASSERT (!result);
+	ep_exit_error_handler ();
+}
+
 bool
 ds_profiler_protocol_helper_handle_ipc_message (
 	DiagnosticsIpcMessage *message,
@@ -158,10 +263,15 @@ ds_profiler_protocol_helper_handle_ipc_message (
 	}
 
 	switch ((DiagnosticsProfilerCommandId)ds_ipc_header_get_commandid (ds_ipc_message_get_header_ref (message))) {
+#ifdef FEATURE_PROFAPI_ATTACH_DETACH
 	case DS_PROFILER_COMMANDID_ATTACH_PROFILER:
 		result = profiler_protocol_helper_attach_profiler (message, stream);
 		break;
-	default:
+#endif // FEATURE_PROFAPI_ATTACH_DETACH
+	case DS_PROFILER_COMMANDID_STARTUP_PROFILER:
+		result = profiler_protocol_helper_startup_profiler (message, stream);
+		break;
+ 	default:
 		result = profiler_protocol_helper_unknown_command (message, stream);
 		break;
 	}
@@ -173,7 +283,7 @@ ep_on_error:
 	EP_ASSERT (!result);
 	ep_exit_error_handler ();
 }
-#else
+#else // PROFILING_SUPPORTED
 bool
 ds_profiler_protocol_helper_handle_ipc_message (
 	DiagnosticsIpcMessage *message,
@@ -182,13 +292,13 @@ ds_profiler_protocol_helper_handle_ipc_message (
 	EP_ASSERT (message != NULL);
 	EP_ASSERT (stream != NULL);
 
-	DS_LOG_WARNING_0 ("Attach profiler not implemented");
+	DS_LOG_WARNING_0 ("Profiler support not enabled in this runtime");
 	ds_ipc_message_send_error (stream, DS_IPC_E_NOTSUPPORTED);
 	ds_ipc_stream_free (stream);
 
 	return true;
 }
-#endif /* FEATURE_PROFAPI_ATTACH_DETACH */
+#endif // PROFILING_SUPPORTED 
 
 #endif /* !defined(DS_INCLUDE_SOURCE_FILES) || defined(DS_FORCE_INCLUDE_SOURCE_FILES) */
 #endif /* ENABLE_PERFTRACING */

--- a/src/native/eventpipe/ds-profiler-protocol.h
+++ b/src/native/eventpipe/ds-profiler-protocol.h
@@ -51,12 +51,45 @@ DS_DEFINE_GETTER(DiagnosticsAttachProfilerCommandPayload *, attach_profiler_comm
 DS_DEFINE_GETTER(DiagnosticsAttachProfilerCommandPayload *, attach_profiler_command_payload, uint32_t, client_data_len)
 DS_DEFINE_GETTER(DiagnosticsAttachProfilerCommandPayload *, attach_profiler_command_payload, uint8_t *, client_data)
 
-
 DiagnosticsAttachProfilerCommandPayload *
 ds_attach_profiler_command_payload_alloc (void);
 
 void
 ds_attach_profiler_command_payload_free (DiagnosticsAttachProfilerCommandPayload *payload);
+
+
+#if defined(DS_INLINE_GETTER_SETTER) || defined(DS_IMPL_PROFILER_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsStartupProfilerCommandPayload {
+#else
+struct _DiagnosticsStartupProfilerCommandPayload_Internal {
+#endif
+	uint8_t * incoming_buffer;
+
+	// The protocol buffer is defined as:
+	//   CLSID - profiler GUID
+	//   string - profiler path
+	// returns
+	//   ulong - status
+
+	uint8_t profiler_guid [EP_GUID_SIZE];
+	const ep_char16_t *profiler_path;
+};
+
+#if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_PROFILER_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsStartupProfilerCommandPayload {
+	uint8_t _internal [sizeof (struct _DiagnosticsStartupProfilerCommandPayload_Internal)];
+};
+#endif
+
+DS_DEFINE_GETTER_ARRAY_REF(DiagnosticsStartupProfilerCommandPayload *, startup_profiler_command_payload, uint8_t *, const uint8_t *, profiler_guid, profiler_guid [0])
+DS_DEFINE_GETTER(DiagnosticsStartupProfilerCommandPayload *, startup_profiler_command_payload, const ep_char16_t *, profiler_path)
+
+DiagnosticsStartupProfilerCommandPayload *
+ds_startup_profiler_command_payload_alloc (void);
+
+void
+ds_startup_profiler_command_payload_free (DiagnosticsAttachProfilerCommandPayload *payload);
+
 
 /*
  * DiagnosticsProfilerProtocolHelper.

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -135,6 +135,10 @@ static
 uint32_t
 ds_rt_profiler_attach (DiagnosticsAttachProfilerCommandPayload *payload);
 
+static
+uint32_t
+ds_rt_profiler_startup (DiagnosticsStartupProfilerCommandPayload *payload);
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-server.c
+++ b/src/native/eventpipe/ds-server.c
@@ -20,6 +20,7 @@
 static volatile uint32_t _server_shutting_down_state = 0;
 static ep_rt_wait_event_handle_t _server_resume_runtime_startup_event = { 0 };
 static bool _server_disabled = false;
+static volatile bool _is_paused_for_startup = false;
 
 static
 inline
@@ -259,6 +260,7 @@ ds_server_pause_for_diagnostics_monitor (void)
 		EP_ASSERT (ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event));
 		DS_LOG_ALWAYS_0 ("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command.");
 		if (ep_rt_wait_event_wait (&_server_resume_runtime_startup_event, 5000, false) != 0) {
+			_is_paused_for_startup = true;
 			ds_rt_server_log_pause_message ();
 			DS_LOG_ALWAYS_0 ("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command and has waited 5 seconds.");
 			ep_rt_wait_event_wait (&_server_resume_runtime_startup_event, EP_INFINITE_WAIT, false);
@@ -272,8 +274,16 @@ void
 ds_server_resume_runtime_startup (void)
 {
 	ds_ipc_stream_factory_resume_current_port ();
-	if (!ds_ipc_stream_factory_any_suspended_ports () && ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event))
+	if (!ds_ipc_stream_factory_any_suspended_ports () && ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event)) {
 		ep_rt_wait_event_set (&_server_resume_runtime_startup_event);
+		_is_paused_for_startup = false;
+	}
+}
+
+bool
+ds_server_is_paused_in_startup (void)
+{
+	return _is_paused_for_startup;
 }
 
 #endif /* !defined(DS_INCLUDE_SOURCE_FILES) || defined(DS_FORCE_INCLUDE_SOURCE_FILES) */

--- a/src/native/eventpipe/ds-server.c
+++ b/src/native/eventpipe/ds-server.c
@@ -256,11 +256,13 @@ ds_server_shutdown (void)
 void
 ds_server_pause_for_diagnostics_monitor (void)
 {
+    _is_paused_for_startup = true;
+
 	if (ds_ipc_stream_factory_any_suspended_ports ()) {
 		EP_ASSERT (ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event));
 		DS_LOG_ALWAYS_0 ("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command.");
+
 		if (ep_rt_wait_event_wait (&_server_resume_runtime_startup_event, 5000, false) != 0) {
-			_is_paused_for_startup = true;
 			ds_rt_server_log_pause_message ();
 			DS_LOG_ALWAYS_0 ("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command and has waited 5 seconds.");
 			ep_rt_wait_event_wait (&_server_resume_runtime_startup_event, EP_INFINITE_WAIT, false);
@@ -276,8 +278,9 @@ ds_server_resume_runtime_startup (void)
 	ds_ipc_stream_factory_resume_current_port ();
 	if (!ds_ipc_stream_factory_any_suspended_ports () && ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event)) {
 		ep_rt_wait_event_set (&_server_resume_runtime_startup_event);
-		_is_paused_for_startup = false;
 	}
+
+    _is_paused_for_startup = false;
 }
 
 bool

--- a/src/native/eventpipe/ds-server.c
+++ b/src/native/eventpipe/ds-server.c
@@ -278,9 +278,8 @@ ds_server_resume_runtime_startup (void)
 	ds_ipc_stream_factory_resume_current_port ();
 	if (!ds_ipc_stream_factory_any_suspended_ports () && ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event)) {
 		ep_rt_wait_event_set (&_server_resume_runtime_startup_event);
+        _is_paused_for_startup = false;
 	}
-
-    _is_paused_for_startup = false;
 }
 
 bool

--- a/src/native/eventpipe/ds-server.h
+++ b/src/native/eventpipe/ds-server.h
@@ -34,5 +34,8 @@ ds_server_pause_for_diagnostics_monitor (void);
 void
 ds_server_resume_runtime_startup (void);
 
+bool
+ds_server_is_paused_in_startup (void);
+
 #endif /* ENABLE_PERFTRACING */
 #endif /* __DIAGNOSTICS_SERVER_H__ */

--- a/src/native/eventpipe/ds-types.h
+++ b/src/native/eventpipe/ds-types.h
@@ -16,6 +16,7 @@
  */
 
 typedef struct _DiagnosticsAttachProfilerCommandPayload DiagnosticsAttachProfilerCommandPayload;
+typedef struct _DiagnosticsStartupProfilerCommandPayload DiagnosticsStartupProfilerCommandPayload;
 typedef struct _DiagnosticsConnectPort DiagnosticsConnectPort;
 typedef struct _DiagnosticsEnvironmentInfoPayload DiagnosticsEnvironmentInfoPayload;
 typedef struct _DiagnosticsGenerateCoreDumpCommandPayload DiagnosticsGenerateCoreDumpCommandPayload;
@@ -70,6 +71,7 @@ typedef enum {
 typedef enum {
 	DS_PROFILER_COMMANDID_RESERVED = 0x00,
 	DS_PROFILER_COMMANDID_ATTACH_PROFILER = 0x01,
+	DS_PROFILER_COMMANDID_STARTUP_PROFILER = 0x02,
 	// future
 } DiagnosticsProfilerCommandId;
 

--- a/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
+++ b/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Text;

--- a/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
+++ b/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
@@ -49,16 +49,6 @@ namespace Profiler.Tests
             // Send StartupProfiler command
             object ipcMessage = MakeStartupProfilerMessage(profilerGuid, profilerPath);
             SendMessage(_processId, ipcMessage);
-
-            // TODO: the runtime will refuse to resume the runtime if there are any active ports
-            // that haven't resumed the runtime. Since we created this port to send the profiler
-            // command, we have to issue the resume runtime or it will deadlock.
-            // This seems counterintuitive, should probably review that design. I didn't expect
-            // to have to issue the resume runtime message twice.
-            Console.WriteLine("Sending resume runtime message.");
-            // Send ResumeRuntime command
-            ipcMessage = MakeResumeRuntimeMessage();
-            SendMessage(_processId, ipcMessage);
         }
 
         private static object MakeHeader(byte commandSet, byte commandId)

--- a/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
+++ b/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
@@ -26,13 +26,19 @@ namespace Profiler.Tests
 
     }
 
-    internal class DiagnosticsIPCWorkaround
+    public class DiagnosticsIPCWorkaround
     {
         private int _processId;
 
         public DiagnosticsIPCWorkaround(int processId)
         {
             _processId = processId;
+
+            MethodInfo startupProfiler = typeof(DiagnosticsClient).GetMethod("SetStartupProfiler", BindingFlags.Public);
+            if (startupProfiler != null)
+            {
+                throw new Exception("You updated DiagnosticsClient to a version that supports SetStartupProfiler, please remove this nonsense and use the real code.");
+            }
         }
 
         public void SetStartupProfiler(Guid profilerGuid, string profilerPath)

--- a/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
+++ b/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
@@ -34,15 +34,16 @@ namespace Profiler.Tests
         {
             _processId = processId;
 
+        }
+
+        public void SetStartupProfiler(Guid profilerGuid, string profilerPath)
+        {
             MethodInfo startupProfiler = typeof(DiagnosticsClient).GetMethod("SetStartupProfiler", BindingFlags.Public);
             if (startupProfiler != null)
             {
                 throw new Exception("You updated DiagnosticsClient to a version that supports SetStartupProfiler, please remove this nonsense and use the real code.");
             }
-        }
 
-        public void SetStartupProfiler(Guid profilerGuid, string profilerPath)
-        {
             DiagnosticsClient client = new DiagnosticsClient(_processId);
 
             Console.WriteLine("Sending startup profiler message.");            

--- a/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
+++ b/src/tests/profiler/common/DiagnosticsIPCWorkaround.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Reflection;
+using Microsoft.Diagnostics.NETCore.Client;
+
+// This is to work around having to wait for an update to the DiagnosticsClient nuget before adding
+// a test. I really hope this isn't permanent
+// TODO: remove all this code when DiagnosticsClient version is updated...
+namespace Profiler.Tests
+{
+    internal static class BinaryWriterExtensions
+    {
+        public static void WriteString(this BinaryWriter @this, string value)
+        {
+            if (@this == null)
+                throw new ArgumentNullException(nameof(@this));
+
+            @this.Write(value != null ? (value.Length + 1) : 0);
+            if (value != null)
+                @this.Write(Encoding.Unicode.GetBytes(value + '\0'));
+        }
+
+    }
+
+    internal class DiagnosticsIPCWorkaround
+    {
+        private int _processId;
+
+        public DiagnosticsIPCWorkaround(int processId)
+        {
+            _processId = processId;
+        }
+
+        public void SetStartupProfiler(Guid profilerGuid, string profilerPath)
+        {
+            DiagnosticsClient client = new DiagnosticsClient(_processId);
+            
+            // Send StartupProfiler command
+            object ipcMessage = MakeStartupProfilerMessage(profilerGuid, profilerPath);
+            SendMessage(_processId, ipcMessage);
+
+            // Send ResumeRuntime command
+            ipcMessage = MakeResumeRuntimeMessage();
+            SendMessage(_processId, ipcMessage);
+        }
+
+        private static object MakeHeader(byte commandSet, byte commandId)
+        {
+            Type commandEnumType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.DiagnosticsServerCommandSet");
+            object enumCommandSet = Enum.ToObject(commandEnumType, commandSet);
+            Type ipcHeaderType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcHeader");
+            object ipcHeader = Activator.CreateInstance(ipcHeaderType, new object[] { enumCommandSet, commandId });
+            return ipcHeader;
+        }
+
+        private static object MakeMessage(object ipcHeader, byte[] payload)
+        {
+                Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
+                object ipcMessage = Activator.CreateInstance(ipcMessageType, new object[] { ipcHeader, payload });
+                return ipcMessage;
+        }
+
+        private static object MakeStartupProfilerMessage(Guid profilerGuid, string profilerPath)
+        {
+            // public IpcMessage(IpcHeader header, byte[] payload = null)
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(profilerGuid.ToByteArray());
+                writer.WriteString(profilerPath);
+
+                writer.Flush();
+                byte[] payload = stream.ToArray();
+                
+                object ipcHeader = MakeHeader(3, 2);
+                return MakeMessage(ipcHeader, payload);
+            }
+        }
+
+        private static object MakeResumeRuntimeMessage()
+        {
+            object ipcHeader = MakeHeader(4, 1);
+            return MakeMessage(ipcHeader, new byte[0]);
+        }
+
+        private static Type GetPrivateType(string typeName)
+        {
+            return typeof(DiagnosticsClient).Assembly.GetType(typeName);
+        }
+
+        private static void SendMessage(object processId, object message)
+        {
+            Type ipcClientType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcClient");
+            Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
+            MethodInfo clientSendMessage = ipcClientType.GetMethod("SendMessage", new Type[] { typeof(int), ipcMessageType } );
+            clientSendMessage.Invoke(null, new object[] { processId, message });
+        }
+    }
+}

--- a/src/tests/profiler/common/ProfilerControl.cs
+++ b/src/tests/profiler/common/ProfilerControl.cs
@@ -6,28 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.IO;
-using System.Text;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Profiler.Tests
 {
-    // TODO: remove this too when DiagnosticsClient is updated
-    internal static class BinaryWriterExtensions
-    {
-        public static void WriteString(this BinaryWriter @this, string value)
-        {
-            if (@this == null)
-                throw new ArgumentNullException(nameof(@this));
-
-            @this.Write(value != null ? (value.Length + 1) : 0);
-            if (value != null)
-                @this.Write(Encoding.Unicode.GetBytes(value + '\0'));
-        }
-
-    }
-
     /// <summary>
     /// Used by managed profilees to control the profiler
     /// </summary>
@@ -40,59 +25,7 @@ namespace Profiler.Tests
             client.AttachProfiler(TimeSpan.MaxValue, profilerGuid, profilerPath, null);
         }
 
-        private static object MakeHeader(byte commandSet, byte commandId)
-        {
-            Type commandEnumType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.DiagnosticsServerCommandSet");
-            object enumCommandSet = Enum.ToObject(commandEnumType, commandSet);
-            Type ipcHeaderType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcHeader");
-            object ipcHeader = Activator.CreateInstance(ipcHeaderType, new object[] { enumCommandSet, commandId });
-            return ipcHeader;
-        }
-
-        private static object MakeMessage(object ipcHeader, byte[] payload)
-        {
-                Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
-                object ipcMessage = Activator.CreateInstance(ipcMessageType, new object[] { ipcHeader, payload });
-                return ipcMessage;
-        }
-
-        private static object MakeStartupProfilerMessage(Guid profilerGuid, string profilerPath)
-        {
-            // public IpcMessage(IpcHeader header, byte[] payload = null)
-            using (var stream = new MemoryStream())
-            using (var writer = new BinaryWriter(stream))
-            {
-                writer.Write(profilerGuid.ToByteArray());
-                writer.WriteString(profilerPath);
-
-                writer.Flush();
-                byte[] payload = stream.ToArray();
-                
-                object ipcHeader = MakeHeader(3, 2);
-                return MakeMessage(ipcHeader, payload);
-            }
-        }
-
-        private static object MakeResumeRuntimeMessage()
-        {
-            object ipcHeader = MakeHeader(4, 1);
-            return MakeMessage(ipcHeader, new byte[0]);
-        }
-
-        private static Type GetPrivateType(string typeName)
-        {
-            return typeof(DiagnosticsClient).Assembly.GetType(typeName);
-        }
-
-        private static void SendMessage(object processId, object message)
-        {
-            Type ipcClientType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcClient");
-            Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
-            MethodInfo clientSendMessage = ipcClientType.GetMethod("SendMessage", new Type[] { typeof(int), ipcMessageType } );
-            clientSendMessage.Invoke(null, new object[] { processId, message });
-        }
-
-        public static void SetStartupProfilerViaIPC(Guid profilerGuid, string profilerPath, int processId)
+        public static void SetStartupProfilerViaIPC(int processId, Guid profilerGuid, string profilerPath)
         {
             MethodInfo startupProfiler = typeof(DiagnosticsClient).GetMethod("SetStartupProfiler", BindingFlags.Public);
             if (startupProfiler != null)
@@ -103,21 +36,11 @@ namespace Profiler.Tests
                 // client.ResumeRuntime();
             }
 
-            DiagnosticsClient client = new DiagnosticsClient(processId);
-            // TODO: remove all this code when DiagnosticsClient version is updated...
-            // FieldInfo endpoint = typeof(DiagnosticsClient).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance);
-            // object ipcEndpoint = endpoint.GetValue(client);
-            
-            // Send StartupProfiler command
-            object ipcMessage = MakeStartupProfilerMessage(profilerGuid, profilerPath);
-            SendMessage(processId, ipcMessage);
-
-            // Send ResumeRuntime command
-            ipcMessage = MakeResumeRuntimeMessage();
-            SendMessage(processId, ipcMessage);
+            // This is to work around having to wait for an update to the DiagnosticsClient nuget before adding
+            // a test. I really hope this isn't permanent
+            DiagnosticsIPCWorkaround client = new DiagnosticsIPCWorkaround(processId);
+            client.SetStartupProfiler(profilerGuid, profilerPath);
         }
-
-
 
         public static EventPipeSession AttachEventPipeSessionToSelf(IEnumerable<EventPipeProvider> providers)
         {

--- a/src/tests/profiler/common/ProfilerControl.cs
+++ b/src/tests/profiler/common/ProfilerControl.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Diagnostics.NETCore.Client;
+using Tracing.Tests.Common;
 
 namespace Profiler.Tests
 {
@@ -23,23 +25,6 @@ namespace Profiler.Tests
             int processId = Process.GetCurrentProcess().Id;
             DiagnosticsClient client = new DiagnosticsClient(processId);
             client.AttachProfiler(TimeSpan.MaxValue, profilerGuid, profilerPath, null);
-        }
-
-        public static void SetStartupProfilerViaIPC(int processId, Guid profilerGuid, string profilerPath)
-        {
-            MethodInfo startupProfiler = typeof(DiagnosticsClient).GetMethod("SetStartupProfiler", BindingFlags.Public);
-            if (startupProfiler != null)
-            {
-                throw new Exception("You updated DiagnosticsClient to a version that supports SetStartupProfiler, please remove this nonsense and replace it with the calls commented out below.");
-                // DiagnosticsClient client = new DiagnosticsClient(processId);
-                // client.SetStartupProfiler(profilerGuid, profilerPath);
-                // client.ResumeRuntime();
-            }
-
-            // This is to work around having to wait for an update to the DiagnosticsClient nuget before adding
-            // a test. I really hope this isn't permanent
-            DiagnosticsIPCWorkaround client = new DiagnosticsIPCWorkaround(processId);
-            client.SetStartupProfiler(profilerGuid, profilerPath);
         }
 
         public static EventPipeSession AttachEventPipeSessionToSelf(IEnumerable<EventPipeProvider> providers)

--- a/src/tests/profiler/common/ProfilerControl.cs
+++ b/src/tests/profiler/common/ProfilerControl.cs
@@ -7,11 +7,27 @@ using System.Diagnostics;
 using System.Threading;
 using System.IO;
 using System.Text;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Profiler.Tests
 {
+    // TODO: remove this too when DiagnosticsClient is updated
+    internal static class BinaryWriterExtensions
+    {
+        public static void WriteString(this BinaryWriter @this, string value)
+        {
+            if (@this == null)
+                throw new ArgumentNullException(nameof(@this));
+
+            @this.Write(value != null ? (value.Length + 1) : 0);
+            if (value != null)
+                @this.Write(Encoding.Unicode.GetBytes(value + '\0'));
+        }
+
+    }
+
     /// <summary>
     /// Used by managed profilees to control the profiler
     /// </summary>
@@ -24,11 +40,84 @@ namespace Profiler.Tests
             client.AttachProfiler(TimeSpan.MaxValue, profilerGuid, profilerPath, null);
         }
 
+        private static object MakeHeader(byte commandSet, byte commandId)
+        {
+            Type commandEnumType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.DiagnosticsServerCommandSet");
+            object enumCommandSet = Enum.ToObject(commandEnumType, commandSet);
+            Type ipcHeaderType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcHeader");
+            object ipcHeader = Activator.CreateInstance(ipcHeaderType, new object[] { enumCommandSet, commandId });
+            return ipcHeader;
+        }
+
+        private static object MakeMessage(object ipcHeader, byte[] payload)
+        {
+                Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
+                object ipcMessage = Activator.CreateInstance(ipcMessageType, new object[] { ipcHeader, payload });
+                return ipcMessage;
+        }
+
+        private static object MakeStartupProfilerMessage(Guid profilerGuid, string profilerPath)
+        {
+            // public IpcMessage(IpcHeader header, byte[] payload = null)
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(profilerGuid.ToByteArray());
+                writer.WriteString(profilerPath);
+
+                writer.Flush();
+                byte[] payload = stream.ToArray();
+                
+                object ipcHeader = MakeHeader(3, 2);
+                return MakeMessage(ipcHeader, payload);
+            }
+        }
+
+        private static object MakeResumeRuntimeMessage()
+        {
+            object ipcHeader = MakeHeader(4, 1);
+            return MakeMessage(ipcHeader, new byte[0]);
+        }
+
+        private static Type GetPrivateType(string typeName)
+        {
+            return typeof(DiagnosticsClient).Assembly.GetType(typeName);
+        }
+
+        private static void SendMessage(object processId, object message)
+        {
+            Type ipcClientType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcClient");
+            Type ipcMessageType = GetPrivateType("Microsoft.Diagnostics.NETCore.Client.IpcMessage");
+            MethodInfo clientSendMessage = ipcClientType.GetMethod("SendMessage", new Type[] { typeof(int), ipcMessageType } );
+            clientSendMessage.Invoke(null, new object[] { processId, message });
+        }
+
         public static void SetStartupProfilerViaIPC(Guid profilerGuid, string profilerPath, int processId)
         {
+            MethodInfo startupProfiler = typeof(DiagnosticsClient).GetMethod("SetStartupProfiler", BindingFlags.Public);
+            if (startupProfiler != null)
+            {
+                throw new Exception("You updated DiagnosticsClient to a version that supports SetStartupProfiler, please remove this nonsense and replace it with the calls commented out below.");
+                // DiagnosticsClient client = new DiagnosticsClient(processId);
+                // client.SetStartupProfiler(profilerGuid, profilerPath);
+                // client.ResumeRuntime();
+            }
+
             DiagnosticsClient client = new DiagnosticsClient(processId);
-            client.SetStartupProfiler(profilerGuid, profilerPath);
+            // TODO: remove all this code when DiagnosticsClient version is updated...
+            // FieldInfo endpoint = typeof(DiagnosticsClient).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance);
+            // object ipcEndpoint = endpoint.GetValue(client);
+            
+            // Send StartupProfiler command
+            object ipcMessage = MakeStartupProfilerMessage(profilerGuid, profilerPath);
+            SendMessage(processId, ipcMessage);
+
+            // Send ResumeRuntime command
+            ipcMessage = MakeResumeRuntimeMessage();
+            SendMessage(processId, ipcMessage);
         }
+
+
 
         public static EventPipeSession AttachEventPipeSessionToSelf(IEnumerable<EventPipeProvider> providers)
         {

--- a/src/tests/profiler/common/ProfilerControl.cs
+++ b/src/tests/profiler/common/ProfilerControl.cs
@@ -24,6 +24,12 @@ namespace Profiler.Tests
             client.AttachProfiler(TimeSpan.MaxValue, profilerGuid, profilerPath, null);
         }
 
+        public static void SetStartupProfilerViaIPC(Guid profilerGuid, string profilerPath, int processId)
+        {
+            DiagnosticsClient client = new DiagnosticsClient(processId);
+            client.SetStartupProfiler(profilerGuid, profilerPath);
+        }
+
         public static EventPipeSession AttachEventPipeSessionToSelf(IEnumerable<EventPipeProvider> providers)
         {
             int processId = Process.GetCurrentProcess().Id;

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -21,15 +21,12 @@ namespace Profiler.Tests
 
     public class ProfilerTestRunner
     {
-        public delegate void ProcessEventHandler(Process process);
-
-        public static event ProcessEventHandler ProcessLaunched;
-
         public static int Run(string profileePath,
                               string testName,
                               Guid profilerClsid,
                               string profileeArguments = "",
-                              ProfileeOptions profileeOptions = ProfileeOptions.None)
+                              ProfileeOptions profileeOptions = ProfileeOptions.None,
+                              string reverseServerName = null)
         {
             string arguments;
             string program;
@@ -57,6 +54,12 @@ namespace Profiler.Tests
             if (profileeOptions.HasFlag(ProfileeOptions.ReverseDiagnosticsMode))
             {
                 Console.WriteLine("Launching profilee in reverse diagnostics port mode.");
+                if (String.IsNullOrEmpty(reverseServerName))
+                {
+                    throw new ArgumentException();
+                }
+
+                envVars.Add("DOTNET_DiagnosticPorts", reverseServerName);
                 envVars.Add("DOTNET_DefaultDiagnosticPortSuspend", "1");
             }
 
@@ -91,8 +94,6 @@ namespace Profiler.Tests
                 verifier.WriteLine(args.Data);
             };
             process.Start();
-
-            ProcessLaunched?.Invoke(process);
 
             process.BeginOutputReadLine();
 

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -60,7 +60,6 @@ namespace Profiler.Tests
                 }
 
                 envVars.Add("DOTNET_DiagnosticPorts", reverseServerName);
-                envVars.Add("DOTNET_DefaultDiagnosticPortSuspend", "1");
             }
 
             envVars.Add("Profiler_Test_Name", testName);

--- a/src/tests/profiler/common/profiler_common.csproj
+++ b/src/tests/profiler/common/profiler_common.csproj
@@ -10,5 +10,6 @@
     <Compile Include="ProfilerControl.cs" />
     <Compile Include="DiagnosticsIPCWorkaround.cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/common/profiler_common.csproj
+++ b/src/tests/profiler/common/profiler_common.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="ProfilerTestRunner.cs" />
     <Compile Include="ProfilerControl.cs" />
+    <Compile Include="DiagnosticsIPCWorkaround.cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -63,26 +63,10 @@ namespace ReverseStartupTests
                             
                             int processId = (int)advertise.ProcessId;
 
+                            // While we are paused in startup send the profiler startup command
                             string profilerPath = GetProfilerPath();
                             DiagnosticsIPCWorkaround client = new DiagnosticsIPCWorkaround(processId);
                             client.SetStartupProfiler(ReverseStartupProfilerGuid, profilerPath);
-                            // using (MemoryStream memoryStream = new MemoryStream())
-                            // using (BinaryWriter writer = new BinaryWriter(memoryStream))
-                            // {
-                            //     writer.Write(ReverseStartupProfilerGuid.ToByteArray());
-                            //     string profilerPath = GetProfilerPath();
-                            //     Console.WriteLine($"Setting profiler {profilerPath} as startup profiler via diagnostics IPC.");
-                            //     writer.WriteString(profilerPath);
-
-                            //     writer.Flush();
-                            //     byte[] payload = memoryStream.ToArray();
-                                
-                            //     // Profiler startup message
-                            //     IpcMessage profilerMessage = new IpcMessage(0x03,0x02, payload);
-                            //     Console.WriteLine($"Sent startup profiler message: {profilerMessage.ToString()}");
-                            //     IpcMessage profilerResponse = IpcClient.SendMessage(serverStream, profilerMessage);
-                            //     Logger.logger.Log($"Received: {profilerResponse.ToString()}");
-                            // }
 
                             // Resume runtime message
                             IpcMessage resumeMessage = new IpcMessage(0x04,0x01);

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -5,6 +5,7 @@ using Profiler.Tests;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
@@ -55,9 +56,7 @@ namespace ReverseStartupTests
             string profilerPath = Path.Combine(rootPath, profilerName);
 
             Console.WriteLine($"Setting profiler {profilerPath} as startup profiler via diagnostics IPC.");
-            ProfilerControlHelpers.SetStartupProfilerViaIPC(ReleaseOnShutdownGuid, profilerPath, childProcess.Id);
-            
-            return 100;
+            ProfilerControlHelpers.SetStartupProfilerViaIPC(ReverseStartupProfilerGuid, profilerPath, childProcess.Id);
         }
     }
 }

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -26,6 +26,7 @@ namespace ReverseStartupTests
         {
             if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
+                Console.WriteLine("In RunTest, exiting.");
                 return 100;
             }
 
@@ -33,7 +34,7 @@ namespace ReverseStartupTests
             return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                           testName: "ReverseStartup",
                                           profilerClsid: Guid.Empty,
-                                          profileeOptions: ProfileeOptions.NoStartupAttach);
+                                          profileeOptions: ProfileeOptions.NoStartupAttach | ProfileeOptions.ReverseDiagnosticsMode);
         }
 
         public static void AttachProfiler(Process childProcess)
@@ -56,7 +57,7 @@ namespace ReverseStartupTests
             string profilerPath = Path.Combine(rootPath, profilerName);
 
             Console.WriteLine($"Setting profiler {profilerPath} as startup profiler via diagnostics IPC.");
-            ProfilerControlHelpers.SetStartupProfilerViaIPC(ReverseStartupProfilerGuid, profilerPath, childProcess.Id);
+            ProfilerControlHelpers.SetStartupProfilerViaIPC(childProcess.Id, ReverseStartupProfilerGuid, profilerPath);
         }
     }
 }

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -81,6 +81,12 @@ namespace ReverseStartupTests
                 catch (Exception e)
                 {
                     Console.WriteLine($"ReverseServer saw exception {e.Message}");
+                    Console.WriteLine(e.StackTrace);
+
+
+                    Console.WriteLine($"Inner exception {e.InnerException?.Message}");
+                    Console.WriteLine(e.InnerException?.StackTrace);
+                    
                 }
                 finally
                 {

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Profiler.Tests;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+
+namespace EventPipeTests
+{
+    class ReverseStartup
+    {
+        static readonly Guid ReverseStartupProfilerGuid = new Guid("9C1A6E14-2DEC-45CE-9061-F31964D8884D");
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+            {
+                return RunTest();
+            }
+
+            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                          testName: "ReverseStartup",
+                                          profilerClsid: ReverseStartupProfilerGuid,
+                                          profileeOptions: ProfileeOptions.NoStartupAttach);
+        }
+
+        public static int RunTest()
+        {
+            string profilerName;
+            if (TestLibrary.Utilities.IsWindows)
+            {
+                profilerName = "Profiler.dll";
+            }
+            else if (TestLibrary.Utilities.IsLinux)
+            {
+                profilerName = "libProfiler.so";
+            }
+            else
+            {
+                profilerName = "libProfiler.dylib";
+            }
+
+            string rootPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string profilerPath = Path.Combine(rootPath, profilerName);
+
+            _profilerDone = new ManualResetEvent(false);
+            Console.WriteLine($"Attaching profiler {profilerPath} to self.");
+            ProfilerControlHelpers.AttachProfilerToSelf(ReleaseOnShutdownGuid, profilerPath);
+
+            PassCallbackToProfiler(() => _profilerDone.Set());
+            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(5)))
+            {
+                Console.WriteLine("Profiler did not set the callback, test will fail.");
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/tests/profiler/eventpipe/reverse_startup.csproj
+++ b/src/tests/profiler/eventpipe/reverse_startup.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test provides no interesting scenarios for GCStress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
     an infinite event loop in the SocketAsyncEngine on Linux. Since 
     runincontext loads even framework assemblies into the unloadable

--- a/src/tests/profiler/eventpipe/reverse_startup.csproj
+++ b/src/tests/profiler/eventpipe/reverse_startup.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
+    <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/common.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/reverse_startup.csproj
+++ b/src/tests/profiler/eventpipe/reverse_startup.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <Optimize>true</Optimize>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -3,17 +3,18 @@ cmake_minimum_required(VERSION 3.14.5)
 project(Profiler)
 
 set(SOURCES
-    gcbasicprofiler/gcbasicprofiler.cpp
-    gcprofiler/gcprofiler.cpp
-    rejitprofiler/rejitprofiler.cpp
-    rejitprofiler/ilrewriter.cpp
-    rejitprofiler/sigparse.cpp
+    eltprofiler/slowpatheltprofiler.cpp
     eventpipeprofiler/eventpipereadingprofiler.cpp
     eventpipeprofiler/eventpipewritingprofiler.cpp
     eventpipeprofiler/eventpipemetadatareader.cpp
-    metadatagetdispenser/metadatagetdispenser.cpp
+    gcbasicprofiler/gcbasicprofiler.cpp
+    gcprofiler/gcprofiler.cpp
     getappdomainstaticaddress/getappdomainstaticaddress.cpp
-    eltprofiler/slowpatheltprofiler.cpp
+    metadatagetdispenser/metadatagetdispenser.cpp
+    nullprofiler/nullprofiler.cpp
+    rejitprofiler/rejitprofiler.cpp
+    rejitprofiler/ilrewriter.cpp
+    rejitprofiler/sigparse.cpp
     releaseondetach/releaseondetach.cpp
     transitions/transitions.cpp
     profiler.def

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "classfactory.h"
-#include "gcbasicprofiler/gcbasicprofiler.h"
-#include "rejitprofiler/rejitprofiler.h"
+#include "eltprofiler/slowpatheltprofiler.h"
 #include "eventpipeprofiler/eventpipereadingprofiler.h"
 #include "eventpipeprofiler/eventpipewritingprofiler.h"
-#include "metadatagetdispenser/metadatagetdispenser.h"
 #include "getappdomainstaticaddress/getappdomainstaticaddress.h"
-#include "eltprofiler/slowpatheltprofiler.h"
+#include "gcbasicprofiler/gcbasicprofiler.h"
 #include "gcprofiler/gcprofiler.h"
+#include "metadatagetdispenser/metadatagetdispenser.h"
+#include "nullprofiler/nullprofiler.h"
+#include "rejitprofiler/rejitprofiler.h"
 #include "releaseondetach/releaseondetach.h"
 #include "transitions/transitions.h"
 
@@ -69,7 +70,8 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
         new SlowPathELTProfiler(),
         new GCProfiler(),
         new ReleaseOnDetach(),
-        new Transitions()
+        new Transitions(),
+        new NullProfiler()
 		// add new profilers here
 	};
 

--- a/src/tests/profiler/native/nullprofiler/nullprofiler.cpp
+++ b/src/tests/profiler/native/nullprofiler/nullprofiler.cpp
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include "NullProfiler.h"
+#include "nullprofiler.h"
 
 GUID NullProfiler::GetClsid()
 {

--- a/src/tests/profiler/native/nullprofiler/nullprofiler.cpp
+++ b/src/tests/profiler/native/nullprofiler/nullprofiler.cpp
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "NullProfiler.h"
+
+GUID NullProfiler::GetClsid()
+{
+    // {9C1A6E14-2DEC-45CE-9061-F31964D8884D}
+    GUID clsid = { 0x9C1A6E14, 0x2DEC, 0x45CE,{ 0x90, 0x61, 0xF3, 0x19, 0x64, 0xD8, 0x88, 0x4D } };
+    return clsid;
+}
+
+HRESULT NullProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
+{
+    Profiler::Initialize(pICorProfilerInfoUnk);
+
+    // This profiler does nothing, and passes if it is loaded at all
+    printf("PROFILER TEST PASSES\n");
+
+    return S_OK;
+}
+
+HRESULT NullProfiler::Shutdown()
+{
+    Profiler::Shutdown();
+
+    fflush(stdout);
+
+    return S_OK;
+}

--- a/src/tests/profiler/native/nullprofiler/nullprofiler.h
+++ b/src/tests/profiler/native/nullprofiler/nullprofiler.h
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+class NullProfiler : public Profiler
+{
+public:
+    NullProfiler() : Profiler()
+    {
+        
+    }
+
+    virtual GUID GetClsid();
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+};

--- a/src/tests/profiler/native/profiler.cpp
+++ b/src/tests/profiler/native/profiler.cpp
@@ -9,8 +9,8 @@ using std::thread;
 
 Profiler *Profiler::Instance = nullptr;
 
-std::atomic<bool> ShutdownGuard::s_preventHooks = false;
-std::atomic<int> ShutdownGuard::s_hooksInProgress = 0;
+std::atomic<bool> ShutdownGuard::s_preventHooks(false);
+std::atomic<int> ShutdownGuard::s_hooksInProgress(0);
 
 Profiler::Profiler() : refCount(0), pCorProfilerInfo(nullptr)
 {

--- a/src/tests/profiler/native/profiler.cpp
+++ b/src/tests/profiler/native/profiler.cpp
@@ -3,11 +3,18 @@
 
 #include "profiler.h"
 
-std::atomic<bool> ShutdownGuard::s_preventHooks;
-std::atomic<int> ShutdownGuard::s_hooksInProgress;
+#include <thread>
+
+using std::thread;
+
+Profiler *Profiler::Instance = nullptr;
+
+std::atomic<bool> ShutdownGuard::s_preventHooks = false;
+std::atomic<int> ShutdownGuard::s_hooksInProgress = 0;
 
 Profiler::Profiler() : refCount(0), pCorProfilerInfo(nullptr)
 {
+    Profiler::Instance = this;
 }
 
 Profiler::~Profiler()
@@ -759,6 +766,34 @@ String Profiler::GetModuleIDName(ModuleID modId)
     }
 
     return moduleName;
+}
+
+void Profiler::SetCallback(ProfilerCallback cb)
+{
+    assert(cb != NULL);
+    callback = cb;
+    callbackSet.Signal();
+}
+
+void Profiler::NotifyManagedCodeViaCallback()
+{
+    callbackSet.Wait();
+
+    thread callbackThread([&]()
+    {
+        // The destructor will be called from the profiler detach thread, which causes
+        // some crst order asserts if we call back in to managed code. Spin up
+        // a new thread to avoid that.
+        pCorProfilerInfo->InitializeCurrentThread();
+        callback();
+    });
+
+    callbackThread.join();
+}
+
+extern "C" EXPORT void STDMETHODCALLTYPE PassCallbackToProfiler(ProfilerCallback callback)
+{
+    Profiler::Instance->SetCallback(callback);
 }
 
 #ifndef WIN32

--- a/src/tests/profiler/native/profiler.h
+++ b/src/tests/profiler/native/profiler.h
@@ -25,8 +25,11 @@
 #define STRING_LENGTH  256
 #define LONG_LENGTH   1024
 
+typedef void (*ProfilerCallback) (void);
+
 class ShutdownGuard
 {
+
 private:
     static std::atomic<bool> s_preventHooks;
     static std::atomic<int> s_hooksInProgress;
@@ -85,13 +88,19 @@ class Profiler : public ICorProfilerCallback10
 {
 private:
     std::atomic<int> refCount;
+    ProfilerCallback callback;
+    ManualEvent callbackSet;
+    
 
 protected:
     String GetClassIDName(ClassID classId);
     String GetFunctionIDName(FunctionID funcId);
     String GetModuleIDName(ModuleID modId);
+    void NotifyManagedCodeViaCallback();
 
 public:
+    static Profiler *Instance;
+
     ICorProfilerInfo11* pCorProfilerInfo;
 
     Profiler();
@@ -207,4 +216,6 @@ public:
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) override;
     ULONG STDMETHODCALLTYPE AddRef(void) override;
     ULONG STDMETHODCALLTYPE Release(void) override;
+
+    void SetCallback(ProfilerCallback callback);
 };

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.h
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.h
@@ -7,8 +7,6 @@
 
 #include <atomic>
 
-typedef void (*ProfilerCallback) (void);
-
 // This test class is very small and doesn't do much. A repeated problem we had was that 
 // if an ICorProfilerCallback* interface was added the developer would forget to add
 // code to call release on the new interface. This test verifies that it is reclaimed
@@ -20,8 +18,6 @@ typedef void (*ProfilerCallback) (void);
 class ReleaseOnDetach : public Profiler
 {
 public:
-    static ReleaseOnDetach *Instance;
-
     ReleaseOnDetach();
     virtual ~ReleaseOnDetach();
 
@@ -41,6 +37,4 @@ private:
     IMetaDataDispenserEx* _dispenser;
     std::atomic<int> _failures;
     bool _detachSucceeded;
-    ProfilerCallback _callback;
-    ManualEvent _callbackSet;
 };

--- a/src/tests/tracing/eventpipe/common/Reverse.cs
+++ b/src/tests/tracing/eventpipe/common/Reverse.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Tracing.Tests.Common
@@ -40,21 +41,23 @@ namespace Tracing.Tests.Common
         /// <returns> (pid, clrInstanceId) </returns>
         public static IpcAdvertise Parse(Stream stream)
         {
-            var binaryReader = new BinaryReader(stream);
-            var advertise = new IpcAdvertise()
+            using (var binaryReader = new BinaryReader(stream, Encoding.UTF8, true))
             {
-                Magic = binaryReader.ReadBytes(Magic_V1.Length),
-                RuntimeInstanceCookie = new Guid(binaryReader.ReadBytes(16)),
-                ProcessId = binaryReader.ReadUInt64(),
-                Unused = binaryReader.ReadUInt16()
-            };
+                var advertise = new IpcAdvertise()
+                {
+                    Magic = binaryReader.ReadBytes(Magic_V1.Length),
+                    RuntimeInstanceCookie = new Guid(binaryReader.ReadBytes(16)),
+                    ProcessId = binaryReader.ReadUInt64(),
+                    Unused = binaryReader.ReadUInt16()
+                };
 
-            for (int i = 0; i < Magic_V1.Length; i++)
-                if (advertise.Magic[i] != Magic_V1[i])
-                    throw new Exception("Invalid advertise message from client connection");
+                for (int i = 0; i < Magic_V1.Length; i++)
+                    if (advertise.Magic[i] != Magic_V1[i])
+                        throw new Exception("Invalid advertise message from client connection");
 
-            // FUTURE: switch on incoming magic and change if version ever increments
-            return advertise;
+                // FUTURE: switch on incoming magic and change if version ever increments
+                return advertise;
+            }
         }
 
         override public string ToString()


### PR DESCRIPTION
This PR adds the ability for a profiler to register itself as a startup profiler over the diagnostics pipe. The only place where this is legal is in the "reverse server" startup mode, otherwise profilers will have to use the existing attach mechanism.

It doesn't change anything else about profiler startup. When you issue the startup profiler command it stashes the path and guid, then uses them if a profiler isn't registered via the existing startup configuration.

@josalem @noahfalk while testing this I ran in to some issues that were fairly unintuitive (or maybe even bugs). When first writing the test I expected to set up a reverse server, have the runtime connect to it and then be able to issue a startup profiler command and then a resume runtime command on the same session, but the runtime forcibly disconnects the stream after each command. I did not expect that, and would have expected I could issue as many commands as I wanted and then close the connection myself when I was through.

Next I changed the test to start a reverse server, then while sitting with the reverse server stream open I have to spin up another IPC call and do the profiler attach. But then the runtime wouldn't actually resume after sending the resume runtime command, either from the original reverse server stream or the new command stream. After a little debugging I found out that it's because of this check which will not resume the runtime if there are any idle connections around: 
https://github.com/dotnet/runtime/blob/d2fba8fdc44f5ed7a4676c219c626e36a3fa2998/src/native/eventpipe/ds-server.c#L272-L277

In order to resume the runtime I have to issue the resume runtime command via both streams.

It seems like a better user experience if we're going to offer all sorts of functionality over this IPC mechanism to let anyone who opens a stream issue multiple commands. And if we're stuck having to open multiple streams, it would be great if I didn't have to track them and issue resume runtime for every one of them.

CC @shirhatti 