### PR TITLE
[wasm][debugger][tests] move setting of the unit test locale to code

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -194,13 +194,9 @@ run-browser-tests-%:
 
 run-debugger-tests:
 	if [ ! -z "$(TEST_FILTER)" ]; then \
-		export LC_ALL=en_US.UTF-8; \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) --filter FullyQualifiedName~$(TEST_FILTER); \
-		unset LC_ALL; \
+		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) --filter FullyQualifiedName~$(TEST_FILTER) $(TEST_ARGS); \
 	else \
-		export LC_ALL=en_US.UTF-8; \
 		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) $(TEST_ARGS); \
-		unset LC_ALL; \
 	fi
 
 build-dbg-proxy:

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -76,15 +76,15 @@ namespace DebuggerTests
 
         public DebuggerTestBase(string driver = "debugger-driver.html")
         {
+            // the debugger is working in locale of the debugged application. For example Datetime.ToString()
+            // we want the test to mach it. We are also starting chrome with --lang=en-US
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+
             insp = new Inspector();
             cli = insp.Client;
             scripts = SubscribeToScripts(insp);
 
             startTask = TestHarnessProxy.Start(FindChromePath(), DebuggerTestAppPath, driver);
-
-            // the debugger is working in locale of the debugged application. For example Datetime.ToString()
-            // we want the test to mach it. We are also starting chrome with --lang=en-US
-            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
         }
 
         public virtual async Task InitializeAsync()

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -81,6 +81,10 @@ namespace DebuggerTests
             scripts = SubscribeToScripts(insp);
 
             startTask = TestHarnessProxy.Start(FindChromePath(), DebuggerTestAppPath, driver);
+
+            // the debugger is working in locale of the debugged application. For example Datetime.ToString()
+            // we want the test to mach it. We are also starting chrome with --lang=en-US
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
         }
 
         public virtual async Task InitializeAsync()


### PR DESCRIPTION
Build on windows doesn't depend n Makefile.