### PR TITLE
Update the SDK to 6.0 Preview 3

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -15,6 +15,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Enable NuGet static graph evaluation to optimize incremental restore -->
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <!-- Suppress analyzer and linker warnings as these are tests -->
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -36,6 +36,8 @@
 
   <PropertyGroup Condition="'$(EnableAggressiveTrimming)' == 'true'">
     <PublishTrimmed>true</PublishTrimmed>
+    <!-- Suppress linker warnings as these are tests -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.2.21155.3",
+    "version": "6.0.100-preview.3.21202.5",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.2.21155.3"
+    "dotnet": "6.0.100-preview.3.21202.5"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -644,12 +644,6 @@
 			<method signature="System.Void .ctor()" />
 		</type>
 
-    <!-- Used by metadata update -->
-    <!-- TODO: Remove this and add a debugger-libs command to invoke updates, see https://github.com/dotnet/runtime/issues/48458 -->
-		<type fullname="System.Reflection.Metadata.AssemblyExtensions">
-			<method name="ApplyUpdateSdb" />
-		</type>
-
 		<type fullname="System.ValueType">
 			<!-- https://github.com/dotnet/runtime/issues/47909 -->
 			<method signature="System.Void .ctor()" />


### PR DESCRIPTION
Updating the minimum and target version of the SDK to 6.0 Preview 3.

Contributes to https://github.com/dotnet/runtime/issues/51716