### PR TITLE
[tasks] Rename MonoAOTCompiler AotInterp option to LLVMOnlyInterp; add FullInterp

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -31,7 +31,7 @@
       - $(WasmDedup)         - Whenever to dedup generic instances when using AOT. Defaults to true.
 
       - $(WasmProfilers)     - Profilers to use
-      - $(AOTMode)           - Defaults to `AotInterp`
+      - $(AOTMode)           - Defaults to `LLVMOnlyInterp`
       - $(AOTProfilePath)    - profile data file to be used for profile-guided optimization
       - $(InvariantGlobalization)       - Whenever to disable ICU. Defaults to false.
 
@@ -71,7 +71,7 @@
     <WasmStripAOTAssemblies>false</WasmStripAOTAssemblies>
     <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
 
-    <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'AotInterp'">false</WasmStripAOTAssemblies>-->
+    <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'LLVMOnlyInterp'">false</WasmStripAOTAssemblies>-->
     <!--<WasmStripAOTAssemblies Condition="'$(WasmStripAOTAssemblies)' == ''">$(RunAOTCompilation)</WasmStripAOTAssemblies>-->
     <_ExeExt Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">.exe</_ExeExt>
     <WasmUseEMSDK_PATH Condition="'$(WasmUseEMSDK_PATH)' == '' and '$(EMSDK_PATH)' != ''">true</WasmUseEMSDK_PATH>
@@ -107,8 +107,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <!--<AOTMode Condition="'$(AOTMode)' == '' and '$(AOTProfilePath)' != ''">AotInterp</AOTMode>-->
-      <AOTMode Condition="'$(AOTMode)' == ''">AotInterp</AOTMode>
+      <!--<AOTMode Condition="'$(AOTMode)' == '' and '$(AOTProfilePath)' != ''">LLVMOnlyInterp</AOTMode>-->
+      <AOTMode Condition="'$(AOTMode)' == ''">LLVMOnlyInterp</AOTMode>
     </PropertyGroup>
 
     <Error Condition="'$(AOTMode)' == 'llvmonly' and @(_AOT_InternalForceInterpretAssemblies->Count()) > 0"
@@ -165,7 +165,7 @@
   </Target>
 
   <!-- '$(ArchiveTests)' != 'true' is to skip on CI for now -->
-  <Target Name="_WasmStripAOTAssemblies" Condition="'$(RunAOTCompilation)' == 'true' and '$(WasmStripAOTAssemblies)' == 'true' and '$(AOTMode)' != 'AotInterp' and '$(ArchiveTests)' != 'true'">
+  <Target Name="_WasmStripAOTAssemblies" Condition="'$(RunAOTCompilation)' == 'true' and '$(WasmStripAOTAssemblies)' == 'true' and '$(AOTMode)' != 'LLVMOnlyInterp' and '$(ArchiveTests)' != 'true'">
     <PropertyGroup>
       <_WasmStrippedAssembliesPath>$([MSBuild]::NormalizeDirectory($(_WasmIntermediateOutputPath), 'stripped-assemblies'))</_WasmStrippedAssembliesPath>
     </PropertyGroup>

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -297,14 +297,14 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         }
 
         // compute output mode and file names
-        if (parsedAotMode == MonoAotMode.LLVMOnly || parsedAotMode == MonoAotMode.AotInterp)
+        if (parsedAotMode == MonoAotMode.LLVMOnly || parsedAotMode == MonoAotMode.LLVMOnlyInterp)
         {
             aotArgs.Add("llvmonly");
 
             string llvmBitcodeFile = Path.Combine(OutputDir, Path.ChangeExtension(assemblyFilename, ".dll.bc"));
             aotAssembly.SetMetadata("LlvmBitcodeFile", llvmBitcodeFile);
 
-            if (parsedAotMode == MonoAotMode.AotInterp)
+            if (parsedAotMode == MonoAotMode.LLVMOnlyInterp)
             {
                 aotArgs.Add("interp");
             }
@@ -465,7 +465,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                     writer.WriteLine("#define EE_MODE_LLVMONLY 1");
                 }
 
-                if (parsedAotMode == MonoAotMode.AotInterp)
+                if (parsedAotMode == MonoAotMode.LLVMOnlyInterp)
                 {
                     writer.WriteLine("#define EE_MODE_LLVMONLY_INTERP 1");
                 }
@@ -505,7 +505,7 @@ public enum MonoAotMode
     Normal,
     Full,
     LLVMOnly,
-    AotInterp
+    LLVMOnlyInterp
 }
 
 public enum MonoAotOutputType

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -99,9 +99,9 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string? AotModulesTableLanguage { get; set; } = nameof(MonoAotModulesTableLanguage.C);
 
     /// <summary>
-    /// Choose between 'Normal', 'Full', 'LLVMOnly', 'LLVMOnlyInterp'.
+    /// Choose between 'Normal', 'Full', 'FullInterp', 'LLVMOnly', 'LLVMOnlyInterp'.
     /// LLVMOnly means to use only LLVM for FullAOT, AOT result will be a LLVM Bitcode file (the cross-compiler must be built with LLVM support)
-    /// The "interp" options mean generate necessary support to fall back to interpreter if AOT code is not possible for some methods.
+    /// The "interp" options ('LLVMOnlyInterp' and 'FullInterp') mean generate necessary support to fall back to interpreter if AOT code is not possible for some methods.
     /// </summary>
     public string Mode { get; set; } = nameof(MonoAotMode.Normal);
 
@@ -322,9 +322,14 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         }
         else
         {
-            if (parsedAotMode == MonoAotMode.Full)
+            if (parsedAotMode == MonoAotMode.Full || parsedAotMode == MonoAotMode.FullInterp)
             {
                 aotArgs.Add("full");
+            }
+
+            if (parsedAotMode == MonoAotMode.FullInterp)
+            {
+                aotArgs.Add("interp");
             }
 
             if (parsedOutputType == MonoAotOutputType.AsmOnly)
@@ -505,6 +510,7 @@ public enum MonoAotMode
 {
     Normal,
     Full,
+    FullInterp,
     LLVMOnly,
     LLVMOnlyInterp
 }

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -99,8 +99,9 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string? AotModulesTableLanguage { get; set; } = nameof(MonoAotModulesTableLanguage.C);
 
     /// <summary>
-    /// Choose between 'Normal', 'Full', 'LLVMOnly'.
+    /// Choose between 'Normal', 'Full', 'LLVMOnly', 'LLVMOnlyInterp'.
     /// LLVMOnly means to use only LLVM for FullAOT, AOT result will be a LLVM Bitcode file (the cross-compiler must be built with LLVM support)
+    /// The "interp" options mean generate necessary support to fall back to interpreter if AOT code is not possible for some methods.
     /// </summary>
     public string Mode { get; set; } = nameof(MonoAotMode.Normal);
 


### PR DESCRIPTION
The 'LLVMOnlyInterp' options means: use the LLVM AOT backend, and generate the necessary code to allow the runtime to fall back to the interpreter if AOT compilation is not supported for some methods.

The 'FullInterp' options means: use the native mini AOT backend, and generate the necessary code to allow the runtime to fall back to the interpreter if AOT compilation is not supported for some methods.

LLVMOnlyInterp is currently used by WebAssembly AOT.

FullInterp may be used by iOS AOT.