### PR TITLE
JIT: more general value class devirtualization

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21009,118 +21009,105 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
 
         if (unboxedEntryMethod != nullptr)
         {
-            bool didOptimize = false;
-            bool canOptimize = false;
+            bool optimizedTheBox = false;
 
             // If the 'this' object is a local box, see if we can revise things
             // to not require boxing.
             //
-            if (thisObj->IsBoxedValue())
+            if (thisObj->IsBoxedValue() && !isExplicitTailCall)
             {
-                if (isExplicitTailCall)
+                // Since the call is the only consumer of the box, we know the box can't escape
+                // since it is being passed an interior pointer.
+                //
+                // So, revise the box to simply create a local copy, use the address of that copy
+                // as the this pointer, and update the entry point to the unboxed entry.
+                //
+                // Ideally, we then inline the boxed method and and if it turns out not to modify
+                // the copy, we can undo the copy too.
+                if (requiresInstMethodTableArg)
                 {
-                    // We won't optimize away boxes that feed explicit tail calls, as ensuring
-                    // we get the right tail call info is tricky (we'd need to pass an updated
-                    // sig and resolved token back to some callers).
+                    // Perform a trial box removal and ask for the type handle tree that fed the box.
                     //
-                    canOptimize = false;
-                }
-                else
-                {
-                    // Since the call is the only consumer of the box, we know the box can't escape
-                    // since it is being passed an interior pointer.
-                    //
-                    // So, revise the box to simply create a local copy, use the address of that copy
-                    // as the this pointer, and update the entry point to the unboxed entry.
-                    //
-                    // Ideally, we then inline the boxed method and and if it turns out not to modify
-                    // the copy, we can undo the copy too.
-                    if (requiresInstMethodTableArg)
+                    JITDUMP("Unboxed entry needs method table arg...\n");
+                    GenTree* methodTableArg = gtTryRemoveBoxUpstreamEffects(thisObj, BR_DONT_REMOVE_WANT_TYPE_HANDLE);
+
+                    if (methodTableArg != nullptr)
                     {
-                        // Perform a trial box removal and ask for the type handle tree that fed the box.
+                        // If that worked, turn the box into a copy to a local var
                         //
-                        JITDUMP("Unboxed entry needs method table arg...\n");
-                        GenTree* methodTableArg =
-                            gtTryRemoveBoxUpstreamEffects(thisObj, BR_DONT_REMOVE_WANT_TYPE_HANDLE);
-
-                        if (methodTableArg != nullptr)
-                        {
-                            // If that worked, turn the box into a copy to a local var
-                            //
-                            JITDUMP("Found suitable method table arg tree [%06u]\n", dspTreeID(methodTableArg));
-                            GenTree* localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
-
-                            if (localCopyThis != nullptr)
-                            {
-                                // Pass the local var as this and the type handle as a new arg
-                                //
-                                JITDUMP("Success! invoking unboxed entry point on local copy, and passing method table "
-                                        "arg\n");
-                                call->gtCallThisArg = gtNewCallArgs(localCopyThis);
-                                call->gtCallMoreFlags |= GTF_CALL_M_UNBOXED;
-
-                                // Prepend for R2L arg passing or empty L2R passing
-                                // Append for non-empty L2R
-                                //
-                                if ((Target::g_tgtArgOrder == Target::ARG_ORDER_R2L) || (call->gtCallArgs == nullptr))
-                                {
-                                    call->gtCallArgs = gtPrependNewCallArg(methodTableArg, call->gtCallArgs);
-                                }
-                                else
-                                {
-                                    GenTreeCall::Use* beforeArg = call->gtCallArgs;
-                                    while (beforeArg->GetNext() != nullptr)
-                                    {
-                                        beforeArg = beforeArg->GetNext();
-                                    }
-
-                                    beforeArg->SetNext(gtNewCallArgs(methodTableArg));
-                                }
-
-                                call->gtCallMethHnd = unboxedEntryMethod;
-                                derivedMethod       = unboxedEntryMethod;
-
-                                // Method attributes will differ because unboxed entry point is shared
-                                //
-                                const DWORD unboxedMethodAttribs =
-                                    info.compCompHnd->getMethodAttribs(unboxedEntryMethod);
-                                JITDUMP("Updating method attribs from 0x%08x to 0x%08x\n", derivedMethodAttribs,
-                                        unboxedMethodAttribs);
-                                derivedMethodAttribs = unboxedMethodAttribs;
-                                didOptimize          = true;
-                            }
-                            else
-                            {
-                                JITDUMP("Sorry, failed to undo the box -- can't convert to local copy\n");
-                            }
-                        }
-                        else
-                        {
-                            JITDUMP("Sorry, failed to undo the box -- can't find method table arg\n");
-                        }
-                    }
-                    else
-                    {
-                        JITDUMP("Found unboxed entry point, trying to simplify box to a local copy\n");
+                        JITDUMP("Found suitable method table arg tree [%06u]\n", dspTreeID(methodTableArg));
                         GenTree* localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
 
                         if (localCopyThis != nullptr)
                         {
-                            JITDUMP("Success! invoking unboxed entry point on local copy\n");
+                            // Pass the local var as this and the type handle as a new arg
+                            //
+                            JITDUMP(
+                                "Success! invoking unboxed entry point on local copy, and passing method table arg\n");
                             call->gtCallThisArg = gtNewCallArgs(localCopyThis);
-                            call->gtCallMethHnd = unboxedEntryMethod;
                             call->gtCallMoreFlags |= GTF_CALL_M_UNBOXED;
-                            derivedMethod = unboxedEntryMethod;
-                            didOptimize   = true;
+
+                            // Prepend for R2L arg passing or empty L2R passing
+                            // Append for non-empty L2R
+                            //
+                            if ((Target::g_tgtArgOrder == Target::ARG_ORDER_R2L) || (call->gtCallArgs == nullptr))
+                            {
+                                call->gtCallArgs = gtPrependNewCallArg(methodTableArg, call->gtCallArgs);
+                            }
+                            else
+                            {
+                                GenTreeCall::Use* beforeArg = call->gtCallArgs;
+                                while (beforeArg->GetNext() != nullptr)
+                                {
+                                    beforeArg = beforeArg->GetNext();
+                                }
+
+                                beforeArg->SetNext(gtNewCallArgs(methodTableArg));
+                            }
+
+                            call->gtCallMethHnd = unboxedEntryMethod;
+                            derivedMethod       = unboxedEntryMethod;
+
+                            // Method attributes will differ because unboxed entry point is shared
+                            //
+                            const DWORD unboxedMethodAttribs = info.compCompHnd->getMethodAttribs(unboxedEntryMethod);
+                            JITDUMP("Updating method attribs from 0x%08x to 0x%08x\n", derivedMethodAttribs,
+                                    unboxedMethodAttribs);
+                            derivedMethodAttribs = unboxedMethodAttribs;
+                            optimizedTheBox      = true;
                         }
                         else
                         {
-                            JITDUMP("Sorry, failed to undo the box\n");
+                            JITDUMP("Sorry, failed to undo the box -- can't convert to local copy\n");
                         }
+                    }
+                    else
+                    {
+                        JITDUMP("Sorry, failed to undo the box -- can't find method table arg\n");
+                    }
+                }
+                else
+                {
+                    JITDUMP("Found unboxed entry point, trying to simplify box to a local copy\n");
+                    GenTree* localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
+
+                    if (localCopyThis != nullptr)
+                    {
+                        JITDUMP("Success! invoking unboxed entry point on local copy\n");
+                        call->gtCallThisArg = gtNewCallArgs(localCopyThis);
+                        call->gtCallMethHnd = unboxedEntryMethod;
+                        call->gtCallMoreFlags |= GTF_CALL_M_UNBOXED;
+                        derivedMethod = unboxedEntryMethod;
+
+                        optimizedTheBox = true;
+                    }
+                    else
+                    {
+                        JITDUMP("Sorry, failed to undo the box\n");
                     }
                 }
 
-                if (didOptimize)
+                if (optimizedTheBox)
                 {
 
 #if FEATURE_TAILCALL_OPT
@@ -21137,7 +21124,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                 }
             }
 
-            if (canOptimize && !didOptimize)
+            if (!optimizedTheBox)
             {
                 // If we get here, we have a boxed value class that either wasn't boxed
                 // locally, or was boxed locally but we were unable to remove the box for

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21230,17 +21230,13 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         *pExactContextHandle = MAKE_CLASSCONTEXT(derivedClass);
     }
 
-// To update info for explicit tail calls and ready to run,
-// we also need to create a resolved token.
-
 #ifdef FEATURE_READYTORUN_COMPILER
-    const bool needResolvedToken = isExplicitTailCall || opts.IsReadyToRun();
-#else
-    const bool needResolvedToken = isExplicitTailCall;
-#endif
-
-    if (needResolvedToken)
+    if (opts.IsReadyToRun())
     {
+        // For R2R, getCallInfo triggers bookkeeping on the zap
+        // side so we need to call it here.
+        //
+        // First, cons up a suitable resolved token.
         CORINFO_RESOLVED_TOKEN derivedResolvedToken = {};
 
         derivedResolvedToken.tokenScope   = info.compCompHnd->getMethodModule(derivedMethod);
@@ -21250,36 +21246,16 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         derivedResolvedToken.hClass       = derivedClass;
         derivedResolvedToken.hMethod      = derivedMethod;
 
-        // If this call is an explicit tail call, update the tail call info.
-        //
-        if (isExplicitTailCall)
-        {
-            TailCallSiteInfo* const tailCallInfo = call->tailCallInfo;
-            assert(tailCallInfo != nullptr);
-            CORINFO_SIG_INFO sig;
-            info.compCompHnd->getMethodSig(derivedMethod, &sig);
-            tailCallInfo->SetCall(&sig, &derivedResolvedToken);
-        }
+        // Look up the new call info.
+        CORINFO_CALL_INFO derivedCallInfo;
+        eeGetCallInfo(&derivedResolvedToken, nullptr, addVerifyFlag(CORINFO_CALLINFO_ALLOWINSTPARAM), &derivedCallInfo);
 
-#ifdef FEATURE_READYTORUN_COMPILER
-        if (opts.IsReadyToRun())
-        {
-            // For R2R, getCallInfo triggers bookkeeping on the zap
-            // side so we need to call it here.
-            //
-            // Look up the new call info.
-            CORINFO_CALL_INFO derivedCallInfo;
-            eeGetCallInfo(&derivedResolvedToken, nullptr, addVerifyFlag(CORINFO_CALLINFO_ALLOWINSTPARAM),
-                          &derivedCallInfo);
-
-            // Update the call.
-            //
-            call->gtCallMoreFlags &= ~GTF_CALL_M_VIRTSTUB_REL_INDIRECT;
-            call->gtCallMoreFlags &= ~GTF_CALL_M_R2R_REL_INDIRECT;
-            call->setEntryPoint(derivedCallInfo.codePointerLookup.constLookup);
-        }
-#endif // FEATURE_READYTORUN_COMPILER
+        // Update the call.
+        call->gtCallMoreFlags &= ~GTF_CALL_M_VIRTSTUB_REL_INDIRECT;
+        call->gtCallMoreFlags &= ~GTF_CALL_M_R2R_REL_INDIRECT;
+        call->setEntryPoint(derivedCallInfo.codePointerLookup.constLookup);
     }
+#endif // FEATURE_READYTORUN_COMPILER
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -517,6 +517,7 @@ private:
                     compiler->dspTreeID(origCall), currBlock->bbNum);
 
             // We currently need inline candidate info to guarded devirt.
+            //
             if (!origCall->IsInlineCandidate())
             {
                 JITDUMP("*** %s Bailing on [%06u] -- not an inline candidate\n", Name(), compiler->dspTreeID(origCall));
@@ -748,11 +749,25 @@ private:
             // Then invoke impDevirtualizeCall to actually
             // transform the call for us. It should succeed.... as we have
             // now provided an exact typed this.
-            CORINFO_METHOD_HANDLE  methodHnd              = inlineInfo->methInfo.ftn;
-            unsigned               methodFlags            = inlineInfo->methAttr;
-            CORINFO_CONTEXT_HANDLE context                = inlineInfo->exactContextHnd;
-            const bool             isLateDevirtualization = true;
-            bool explicitTailCall = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
+            //
+            CORINFO_METHOD_HANDLE  methodHnd   = inlineInfo->methInfo.ftn;
+            unsigned               methodFlags = inlineInfo->methAttr;
+            CORINFO_CONTEXT_HANDLE context     = inlineInfo->exactContextHnd;
+
+            // If we have a boxed value class the inline info might reflect the properties of the unboxed
+            // entry. For devirtualization we need these to reflect the boxed entry.
+            //
+            // The devirtualizer will update these back, if it can figure how to invoke the unboxed entry.
+            //
+            CORINFO_METHOD_HANDLE unboxedMethodHnd = inlineInfo->guardedMethodUnboxedEntryHandle;
+            if (unboxedMethodHnd != nullptr)
+            {
+                methodHnd   = inlineInfo->guardedMethodHandle;
+                methodFlags = compiler->info.compCompHnd->getMethodAttribs(methodHnd);
+            }
+
+            const bool isLateDevirtualization = true;
+            const bool explicitTailCall       = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
             compiler->impDevirtualizeCall(call, &methodHnd, &methodFlags, &context, nullptr, isLateDevirtualization,
                                           explicitTailCall);
 
@@ -761,38 +776,64 @@ private:
             // up here.
             assert(!call->IsVirtual());
 
-            // Re-establish this call as an inline candidate.
-            //
-            GenTree* oldRetExpr              = inlineInfo->retExpr;
-            inlineInfo->clsHandle            = compiler->info.compCompHnd->getMethodClass(methodHnd);
-            inlineInfo->exactContextHnd      = context;
-            inlineInfo->preexistingSpillTemp = returnTemp;
-            call->gtInlineCandidateInfo      = inlineInfo;
-
-            // Add the call.
-            compiler->fgNewStmtAtEnd(thenBlock, call);
-
-            // If there was a ret expr for this call, we need to create a new one
-            // and append it just after the call.
-            //
-            // Note the original GT_RET_EXPR is sitting at the join point of the
-            // guarded expansion and for non-void calls, and now refers to a temp local;
-            // we set all this up in FixupRetExpr().
-            if (oldRetExpr != nullptr)
+            // If the devirtualizer was unable to transform the call to invoke the unboxed entry, the inline info
+            // we've set up is invalid. We won't be able to inline anyways...
+            if ((unboxedMethodHnd != nullptr) && (methodHnd != unboxedMethodHnd))
             {
-                GenTree* retExpr = compiler->gtNewInlineCandidateReturnExpr(call, call->TypeGet(), thenBlock->bbFlags);
-                inlineInfo->retExpr = retExpr;
+                // Demote this call to a non-inline candidate
+                //
+                JITDUMP("Devirtualization was unable to use the unboxed entry; so marking call (to boxed entry) as not "
+                        "inlineable\n");
+
+                call->gtFlags &= ~GTF_CALL_INLINE_CANDIDATE;
+                call->gtInlineCandidateInfo = nullptr;
 
                 if (returnTemp != BAD_VAR_NUM)
                 {
-                    retExpr = compiler->gtNewTempAssign(returnTemp, retExpr);
+                    GenTree* const assign = compiler->gtNewTempAssign(returnTemp, call);
+                    compiler->fgNewStmtAtEnd(thenBlock, assign);
                 }
                 else
                 {
-                    // We should always have a return temp if we return results by value
-                    assert(origCall->TypeGet() == TYP_VOID);
+                    compiler->fgNewStmtAtEnd(thenBlock, call);
                 }
-                compiler->fgNewStmtAtEnd(thenBlock, retExpr);
+            }
+            else
+            {
+                // Add the call.
+                //
+                compiler->fgNewStmtAtEnd(thenBlock, call);
+
+                // Re-establish this call as an inline candidate.
+                //
+                GenTree* oldRetExpr              = inlineInfo->retExpr;
+                inlineInfo->clsHandle            = compiler->info.compCompHnd->getMethodClass(methodHnd);
+                inlineInfo->exactContextHnd      = context;
+                inlineInfo->preexistingSpillTemp = returnTemp;
+                call->gtInlineCandidateInfo      = inlineInfo;
+
+                // If there was a ret expr for this call, we need to create a new one
+                // and append it just after the call.
+                //
+                // Note the original GT_RET_EXPR has been bashed to a temp.
+                // we set all this up in FixupRetExpr().
+                if (oldRetExpr != nullptr)
+                {
+                    GenTree* retExpr =
+                        compiler->gtNewInlineCandidateReturnExpr(call, call->TypeGet(), thenBlock->bbFlags);
+                    inlineInfo->retExpr = retExpr;
+
+                    if (returnTemp != BAD_VAR_NUM)
+                    {
+                        retExpr = compiler->gtNewTempAssign(returnTemp, retExpr);
+                    }
+                    else
+                    {
+                        // We should always have a return temp if we return results by value
+                        assert(origCall->TypeGet() == TYP_VOID);
+                    }
+                    compiler->fgNewStmtAtEnd(thenBlock, retExpr);
+                }
             }
         }
 

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -529,7 +529,9 @@ struct GuardedDevirtualizationCandidateInfo : ClassProfileCandidateInfo
 {
     CORINFO_CLASS_HANDLE  guardedClassHandle;
     CORINFO_METHOD_HANDLE guardedMethodHandle;
+    CORINFO_METHOD_HANDLE guardedMethodUnboxedEntryHandle;
     unsigned              likelihood;
+    bool                  requiresInstMethodTableArg;
 };
 
 // InlineCandidateInfo provides basic information about a particular


### PR DESCRIPTION
When devirtualization knows that the `this` object is a boxed value class,
it now attempts to update the call to invoke the unboxed entry (when there
is one).

This extends an existing optimization that worked on calls where the box was
local and only fed the call. We now handle calls that dispatch on boxed value
classes more generally,  even if their creation is not local or is local but
in a form the existing opt could not handle.

These new cases either come from failed local box removal opts (say multi-use
boxes) or from guarded devirtualization.

The "boxed" entry for value class methods is an un-inlineable VM stub. This
transformation effectively inlinines the stub and unblocks inlining of the
underlying method.