### PR TITLE
Dispose of hash handles for Windows 7.

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
@@ -35,19 +35,21 @@ namespace Internal.Cryptography
 
             _hAlgorithm = Interop.BCrypt.BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(hashAlgId, dwFlags, out _hashSize);
 
-            // Win7 won't set hHash, Win8+ will; and both will set _hHash.
+            // Win7 won't set hHash to a valid handle, Win8+ will; and both will set _hHash.
             // So keep hHash trapped in this scope to prevent (mis-)use of it.
             {
-                SafeBCryptHashHandle? hHash = null;
+                SafeBCryptHashHandle hHash;
                 NTSTATUS ntStatus = Interop.BCrypt.BCryptCreateHash(_hAlgorithm, out hHash, IntPtr.Zero, 0, key, key == null ? 0 : key.Length, BCryptCreateHashFlags.BCRYPT_HASH_REUSABLE_FLAG);
                 if (ntStatus == NTSTATUS.STATUS_INVALID_PARAMETER)
                 {
+                    hHash.Dispose();
                     // If we got here, we're running on a downlevel OS (pre-Win8) that doesn't support reusable CNG hash objects. Fall back to creating a
                     // new HASH object each time.
                     ResetHashObject();
                 }
                 else if (ntStatus != NTSTATUS.STATUS_SUCCESS)
                 {
+                    hHash.Dispose();
                     throw Interop.BCrypt.CreateCryptographicException(ntStatus);
                 }
                 else


### PR DESCRIPTION
The handle will never be null, it will be an owned handle that points to nothing. Dispose of it so it doesn't need to get finalized.