### PR TITLE
Apple Silicon use default XCode version

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -13,12 +13,6 @@
 #
 # ./install-native-dependencies.sh <OS>
 
-if [ "$1" = "OSX" ] && [ "$2" = "arm64" ] && [ "$3" = "azDO" ]; then
-    # On AzDO macOS-10.15 build agents the Xcode currently defaults to Xcode 11.7
-    # Cross compilation for osx-arm64 requires xcode 12.2 or greater
-    sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
-fi
-
 if [ "$1" = "Linux" ]; then
     sudo apt update
     if [ "$?" != "0" ]; then


### PR DESCRIPTION
Current default for vmImage 10.15 is XCode 12.4

Remove pin to Xcode 12.2 for Apple Silicon

See https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md