### PR TITLE
Fixes issue #51612

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1343,7 +1343,6 @@ _Done:
     compLocallocOptimized |= InlineeCompiler->compLocallocOptimized;
     compQmarkUsed |= InlineeCompiler->compQmarkUsed;
     compUnsafeCastUsed |= InlineeCompiler->compUnsafeCastUsed;
-    compNeedsGSSecurityCookie |= InlineeCompiler->compNeedsGSSecurityCookie;
     compGSReorderStackLayout |= InlineeCompiler->compGSReorderStackLayout;
     compHasBackwardJump |= InlineeCompiler->compHasBackwardJump;
 
@@ -1397,6 +1396,15 @@ _Done:
                 InlineeCompiler->optMethodFlags, optMethodFlags);
     }
 #endif
+
+    // If an inlinee needs GS cookie we need to make sure that the cookie will not be allocated at zero stack offset.
+    // Note that if the root method needs GS cookie then this has already been taken care of.
+    if (!getNeedsGSSecurityCookie() && InlineeCompiler->getNeedsGSSecurityCookie())
+    {
+        setNeedsGSSecurityCookie();
+        const unsigned dummy   = lvaGrabTempWithImplicitUse(false DEBUGARG("GSCookie dummy for inlinee"));
+        lvaTable[dummy].lvType = TYP_INT;
+    }
 
     // If there is non-NULL return, replace the GT_CALL with its return value expression,
     // so later it will be picked up by the GT_RET_EXPR node.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15422,7 +15422,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             if (allocSize <= maxSize)
                             {
                                 const unsigned stackallocAsLocal = lvaGrabTemp(false DEBUGARG("stackallocLocal"));
-                                JITDUMP("Converting stackalloc of %lld bytes to new local V%02u\n", allocSize,
+                                JITDUMP("Converting stackalloc of %zd bytes to new local V%02u\n", allocSize,
                                         stackallocAsLocal);
                                 lvaTable[stackallocAsLocal].lvType           = TYP_BLK;
                                 lvaTable[stackallocAsLocal].lvExactSize      = (unsigned)allocSize;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_51612/Runtime_51612.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_51612/Runtime_51612.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Runtime_51612
+{
+    class Program
+    {
+        struct PassedViaReturnBuffer
+        {
+            public int _0;
+            public int _1;
+        }
+
+        abstract class Base
+        {
+            public unsafe abstract PassedViaReturnBuffer HasEspBasedFrame();
+        }
+
+        class Derived : Base
+        {
+            public Derived(Exception ex)
+            {
+                _ex = ex;
+            }
+
+            readonly Exception _ex;
+
+            public override PassedViaReturnBuffer HasEspBasedFrame()
+            {
+                DoesNotReturn();
+                PassedViaReturnBuffer retBuf;
+                retBuf = RequiresGuardStack();
+                return retBuf;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static unsafe PassedViaReturnBuffer RequiresGuardStack()
+            {
+                int* p = stackalloc int[2];
+
+                p[0] = 1;
+                p[1] = 2;
+
+                PassedViaReturnBuffer retBuf;
+
+                retBuf._0 = p[0];
+                retBuf._1 = p[1];
+
+                return retBuf;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            void DoesNotReturn()
+            {
+                throw _ex;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void AssertsThatGuardStackCookieOffsetIsInvalid(Base x)
+        {
+            x.HasEspBasedFrame();
+        }
+
+        static int Main(string[] args)
+        {
+            try
+            {
+                AssertsThatGuardStackCookieOffsetIsInvalid(new Derived(new Exception()));
+            }
+            catch (Exception ex)
+            {
+                return 100;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_51612/Runtime_51612.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_51612/Runtime_51612.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
<s>First, make sure that the regression test fails in the CI.</s> The added test fails with [Assertion failed 'header->gsCookieOffset != INVALID_GS_COOKIE_OFFSET'](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-52231-merge-f9773c6a0f5d4058ae/JIT.Regression/console.e3dccfd2.log?sv=2019-07-07&se=2021-05-24T18%3A32%3A08Z&sr=c&sp=rl&sig=06o93AfP5N15UwJFyiXAbaWbI6h9uhlE8Q%2FS6cFuesw%3D) as in #51612
