### PR TITLE
Some cleanup around PInvokeStaticSigInfo

### DIFF
--- a/src/coreclr/vm/binder.cpp
+++ b/src/coreclr/vm/binder.cpp
@@ -1038,8 +1038,7 @@ void CoreLibBinder::CheckExtended()
         else
         if (pMD->IsNDirect())
         {
-            PInvokeStaticSigInfo sigInfo;
-            NDirect::PopulateNDirectMethodDesc((NDirectMethodDesc *)pMD, &sigInfo);
+            NDirect::PopulateNDirectMethodDesc((NDirectMethodDesc *)pMD);
 
             if (pMD->IsQCall())
             {

--- a/src/coreclr/vm/classcompat.cpp
+++ b/src/coreclr/vm/classcompat.cpp
@@ -3311,7 +3311,7 @@ HRESULT MethodTableBuilder::FindMethodDeclarationForMethodImpl(
             IfFailRet(pMDInternalImport->GetNameAndSigOfMemberRef(tkMethod, &pSig, &cSig, &szMember));
 
             if (isCallConv(
-                MetaSig::GetCallingConvention(NULL, Signature(pSig, cSig)),
+                MetaSig::GetCallingConvention(Signature(pSig, cSig)),
                 IMAGE_CEE_CS_CALLCONV_FIELD))
             {
                 return VLDTR_E_MR_BADCALLINGCONV;

--- a/src/coreclr/vm/compile.cpp
+++ b/src/coreclr/vm/compile.cpp
@@ -5736,7 +5736,7 @@ void CEEPreloader::GenerateMethodStubs(
         {
             NDirectMethodDesc* pNMD = (NDirectMethodDesc*)pMD;
             PInvokeStaticSigInfo sigInfo;
-            NDirect::PopulateNDirectMethodDesc(pNMD, &sigInfo);
+            NDirect::InitializeSigInfoAndPopulateNDirectMethodDesc(pNMD, &sigInfo);
             pStubMD = NDirect::GetILStubMethodDesc((NDirectMethodDesc*)pMD, &sigInfo, dwNGenStubFlags);
         }
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2607,7 +2607,7 @@ void PInvokeStaticSigInfo::PreInit(MethodDesc* pMD)
 }
 
 PInvokeStaticSigInfo::PInvokeStaticSigInfo(
-    MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName)
+    _In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName)
 {
     STANDARD_VM_CONTRACT;
 
@@ -2712,7 +2712,7 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(
     ReportErrors();
 }
 
-void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Out_ LPCUTF8 *ppLibName, _Out_ LPCUTF8 *ppEntryPointName)
+void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *ppLibName, _Outptr_opt_ LPCUTF8 *ppEntryPointName)
 {
     CONTRACTL
     {
@@ -4173,6 +4173,13 @@ namespace
 {
     void PopulateNDirectMethodDescImpl(_Inout_ NDirectMethodDesc* pNMD, _In_ const PInvokeStaticSigInfo& sigInfo, _In_z_ LPCUTF8 libName, _In_z_ LPCUTF8 entryPointName)
     {
+        CONTRACTL
+        {
+            STANDARD_VM_CHECK;
+            PRECONDITION(pNMD != NULL);
+        }
+        CONTRACTL_END;
+
         WORD ndirectflags = 0;
         if (pNMD->MethodDesc::IsVarArg())
             ndirectflags |= NDirectMethodDesc::kVarArgs;

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -305,12 +305,12 @@ public:
 
     PInvokeStaticSigInfo(MethodDesc* pMdDelegate, ThrowOnError throwOnError = THROW_ON_ERROR);
 
-    PInvokeStaticSigInfo(_In_ MethodDesc* pMD, _Out_opt_ LPCUTF8 *pLibName, _Out_opt_ LPCUTF8 *pEntryPointName);
+    PInvokeStaticSigInfo(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
 
 private:
     void ReportErrors();
     void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
-    void DllImportInit(_In_ MethodDesc* pMD, _Out_opt_ LPCUTF8 *pLibName, _Out_opt_ LPCUTF8 *pEntryPointName);
+    void DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);
     void PreInit(MethodDesc* pMD);
     void SetError(WORD error) { if (!m_error) m_error = error; }

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -15,10 +15,10 @@ struct PInvokeStaticSigInfo;
 struct StubSigDesc
 {
 public:
-    StubSigDesc(MethodDesc * pMD, PInvokeStaticSigInfo* pSigInfo = NULL);
-    StubSigDesc(MethodDesc*  pMD, Signature sig, Module* m_pModule);
-    StubSigDesc(MethodTable* pMT, Signature sig, Module* m_pModule);
-    StubSigDesc(std::nullptr_t, Signature sig, Module* m_pModule);
+    StubSigDesc(MethodDesc* pMD);
+    StubSigDesc(MethodDesc*  pMD, const Signature& sig, Module* m_pModule);
+    StubSigDesc(MethodTable* pMT, const Signature& sig, Module* m_pModule);
+    StubSigDesc(const Signature& sig, Module* m_pModule);
 
     MethodDesc        *m_pMD;
     MethodTable       *m_pMT;
@@ -305,12 +305,12 @@ public:
 
     PInvokeStaticSigInfo(MethodDesc* pMdDelegate, ThrowOnError throwOnError = THROW_ON_ERROR);
 
-    PInvokeStaticSigInfo(MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName);
+    PInvokeStaticSigInfo(_In_ MethodDesc* pMD, _Out_opt_ LPCUTF8 *pLibName, _Out_opt_ LPCUTF8 *pEntryPointName);
 
 private:
     void ReportErrors();
     void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
-    void DllImportInit(MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName);
+    void DllImportInit(_In_ MethodDesc* pMD, _Out_opt_ LPCUTF8 *pLibName, _Out_opt_ LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);
     void PreInit(MethodDesc* pMD);
     void SetError(WORD error) { if (!m_error) m_error = error; }
@@ -341,13 +341,13 @@ public: // getters
                (GetBestFitMapping() ? NDIRECTSTUB_FL_BESTFIT : 0) |
                (IsDelegateInterop() ? NDIRECTSTUB_FL_DELEGATE : 0);
     }
-    Module* GetModule() { LIMITED_METHOD_CONTRACT; return m_pModule; }
+    Module* GetModule() const { LIMITED_METHOD_CONTRACT; return m_pModule; }
     BOOL IsStatic() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_STATIC; }
     BOOL GetThrowOnUnmappableChar() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR; }
     BOOL GetBestFitMapping() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_BEST_FIT; }
     BOOL IsDelegateInterop() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP; }
     CorInfoCallConvExtension GetCallConv() const { LIMITED_METHOD_CONTRACT; return m_callConv; }
-    Signature GetSignature() { LIMITED_METHOD_CONTRACT; return m_sig; }
+    Signature GetSignature() const { LIMITED_METHOD_CONTRACT; return m_sig; }
     CorNativeLinkType GetCharSet() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkType)((m_wFlags & COR_NATIVE_LINK_TYPE_MASK) >> COR_NATIVE_LINK_TYPE_SHIFT); }
     CorNativeLinkFlags GetLinkFlags() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkFlags)((m_wFlags & COR_NATIVE_LINK_FLAGS_MASK) >> COR_NATIVE_LINK_FLAGS_SHIFT); }
 

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -71,7 +71,9 @@ public:
         _In_opt_ PCCOR_SIGNATURE pSig = NULL,
         _In_opt_ Module* pModule = NULL,
         _In_ bool unmanagedCallersOnlyRequiresMarshalling = true);
-    static void PopulateNDirectMethodDesc(NDirectMethodDesc* pNMD, PInvokeStaticSigInfo* pSigInfo);
+
+    static void PopulateNDirectMethodDesc(_Inout_ NDirectMethodDesc* pNMD);
+    static void InitializeSigInfoAndPopulateNDirectMethodDesc(_Inout_ NDirectMethodDesc* pNMD, _Inout_ PInvokeStaticSigInfo* pSigInfo);
 
     static MethodDesc* CreateCLRToNativeILStub(
                     StubSigDesc*             pSigDesc,
@@ -325,7 +327,7 @@ public:
                (IsDelegateInterop() ? NDIRECTSTUB_FL_DELEGATE : 0);
     }
     Module* GetModule() { LIMITED_METHOD_CONTRACT; return m_pModule; }
-    BOOL IsStatic() { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_STATIC; }
+    BOOL IsStatic() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_STATIC; }
     void SetIsStatic (BOOL isStatic)
     {
         LIMITED_METHOD_CONTRACT;
@@ -334,7 +336,7 @@ public:
         else
             m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_STATIC;
     }
-    BOOL GetThrowOnUnmappableChar() { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR; }
+    BOOL GetThrowOnUnmappableChar() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR; }
     void SetThrowOnUnmappableChar (BOOL throwOnUnmappableChar)
     {
         LIMITED_METHOD_CONTRACT;
@@ -343,7 +345,7 @@ public:
         else
             m_wFlags &= ~PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR;
     }
-    BOOL GetBestFitMapping() { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_BEST_FIT; }
+    BOOL GetBestFitMapping() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_BEST_FIT; }
     void SetBestFitMapping (BOOL bestFit)
     {
         LIMITED_METHOD_CONTRACT;
@@ -352,7 +354,7 @@ public:
         else
             m_wFlags &= ~PINVOKE_STATIC_SIGINFO_BEST_FIT;
     }
-    BOOL IsDelegateInterop() { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP; }
+    BOOL IsDelegateInterop() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP; }
     void SetIsDelegateInterop (BOOL delegateInterop)
     {
         LIMITED_METHOD_CONTRACT;
@@ -361,7 +363,7 @@ public:
         else
             m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
     }
-    CorInfoCallConvExtension GetCallConv() { LIMITED_METHOD_CONTRACT; return m_callConv; }
+    CorInfoCallConvExtension GetCallConv() const { LIMITED_METHOD_CONTRACT; return m_callConv; }
     Signature GetSignature() { LIMITED_METHOD_CONTRACT; return m_sig; }
 
 private:
@@ -388,8 +390,8 @@ private:
     WORD m_wFlags;
 
   public:
-    CorNativeLinkType GetCharSet() { LIMITED_METHOD_CONTRACT; return (CorNativeLinkType)((m_wFlags & COR_NATIVE_LINK_TYPE_MASK) >> COR_NATIVE_LINK_TYPE_SHIFT); }
-    CorNativeLinkFlags GetLinkFlags() { LIMITED_METHOD_CONTRACT; return (CorNativeLinkFlags)((m_wFlags & COR_NATIVE_LINK_FLAGS_MASK) >> COR_NATIVE_LINK_FLAGS_SHIFT); }
+    CorNativeLinkType GetCharSet() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkType)((m_wFlags & COR_NATIVE_LINK_TYPE_MASK) >> COR_NATIVE_LINK_TYPE_SHIFT); }
+    CorNativeLinkFlags GetLinkFlags() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkFlags)((m_wFlags & COR_NATIVE_LINK_FLAGS_MASK) >> COR_NATIVE_LINK_FLAGS_SHIFT); }
     void SetCharSet(CorNativeLinkType linktype)
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -307,10 +307,8 @@ public:
 
     PInvokeStaticSigInfo(MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName);
 
-public:
-    void ReportErrors();
-
 private:
+    void ReportErrors();
     void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
     void DllImportInit(MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);
@@ -318,60 +316,7 @@ private:
     void SetError(WORD error) { if (!m_error) m_error = error; }
     void BestGuessNDirectDefaults(MethodDesc* pMD);
 
-public:
-    DWORD GetStubFlags()
-    {
-        WRAPPER_NO_CONTRACT;
-        return (GetThrowOnUnmappableChar() ? NDIRECTSTUB_FL_THROWONUNMAPPABLECHAR : 0) |
-               (GetBestFitMapping() ? NDIRECTSTUB_FL_BESTFIT : 0) |
-               (IsDelegateInterop() ? NDIRECTSTUB_FL_DELEGATE : 0);
-    }
-    Module* GetModule() { LIMITED_METHOD_CONTRACT; return m_pModule; }
-    BOOL IsStatic() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_STATIC; }
-    void SetIsStatic (BOOL isStatic)
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (isStatic)
-            m_wFlags |= PINVOKE_STATIC_SIGINFO_IS_STATIC;
-        else
-            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_STATIC;
-    }
-    BOOL GetThrowOnUnmappableChar() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR; }
-    void SetThrowOnUnmappableChar (BOOL throwOnUnmappableChar)
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (throwOnUnmappableChar)
-            m_wFlags |= PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR;
-        else
-            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR;
-    }
-    BOOL GetBestFitMapping() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_BEST_FIT; }
-    void SetBestFitMapping (BOOL bestFit)
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (bestFit)
-            m_wFlags |= PINVOKE_STATIC_SIGINFO_BEST_FIT;
-        else
-            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_BEST_FIT;
-    }
-    BOOL IsDelegateInterop() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP; }
-    void SetIsDelegateInterop (BOOL delegateInterop)
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (delegateInterop)
-            m_wFlags |= PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
-        else
-            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
-    }
-    CorInfoCallConvExtension GetCallConv() const { LIMITED_METHOD_CONTRACT; return m_callConv; }
-    Signature GetSignature() { LIMITED_METHOD_CONTRACT; return m_sig; }
-
 private:
-    Module* m_pModule;
-    Signature m_sig;
-    CorInfoCallConvExtension m_callConv;
-    WORD m_error;
-
     enum
     {
         PINVOKE_STATIC_SIGINFO_IS_STATIC = 0x0001,
@@ -387,11 +332,58 @@ private:
     };
     #define COR_NATIVE_LINK_TYPE_SHIFT 3 // Keep in synch with above mask
     #define COR_NATIVE_LINK_FLAGS_SHIFT 6  // Keep in synch with above mask
-    WORD m_wFlags;
 
-  public:
+public: // getters
+    DWORD GetStubFlags() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return (GetThrowOnUnmappableChar() ? NDIRECTSTUB_FL_THROWONUNMAPPABLECHAR : 0) |
+               (GetBestFitMapping() ? NDIRECTSTUB_FL_BESTFIT : 0) |
+               (IsDelegateInterop() ? NDIRECTSTUB_FL_DELEGATE : 0);
+    }
+    Module* GetModule() { LIMITED_METHOD_CONTRACT; return m_pModule; }
+    BOOL IsStatic() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_STATIC; }
+    BOOL GetThrowOnUnmappableChar() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR; }
+    BOOL GetBestFitMapping() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_BEST_FIT; }
+    BOOL IsDelegateInterop() const { LIMITED_METHOD_CONTRACT; return m_wFlags & PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP; }
+    CorInfoCallConvExtension GetCallConv() const { LIMITED_METHOD_CONTRACT; return m_callConv; }
+    Signature GetSignature() { LIMITED_METHOD_CONTRACT; return m_sig; }
     CorNativeLinkType GetCharSet() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkType)((m_wFlags & COR_NATIVE_LINK_TYPE_MASK) >> COR_NATIVE_LINK_TYPE_SHIFT); }
     CorNativeLinkFlags GetLinkFlags() const { LIMITED_METHOD_CONTRACT; return (CorNativeLinkFlags)((m_wFlags & COR_NATIVE_LINK_FLAGS_MASK) >> COR_NATIVE_LINK_FLAGS_SHIFT); }
+
+private: // setters
+    void SetIsStatic(BOOL isStatic)
+    {
+        LIMITED_METHOD_CONTRACT;
+        if (isStatic)
+            m_wFlags |= PINVOKE_STATIC_SIGINFO_IS_STATIC;
+        else
+            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_STATIC;
+    }
+    void SetThrowOnUnmappableChar(BOOL throwOnUnmappableChar)
+    {
+        LIMITED_METHOD_CONTRACT;
+        if (throwOnUnmappableChar)
+            m_wFlags |= PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR;
+        else
+            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_THROW_ON_UNMAPPABLE_CHAR;
+    }
+    void SetBestFitMapping(BOOL bestFit)
+    {
+        LIMITED_METHOD_CONTRACT;
+        if (bestFit)
+            m_wFlags |= PINVOKE_STATIC_SIGINFO_BEST_FIT;
+        else
+            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_BEST_FIT;
+    }
+    void SetIsDelegateInterop(BOOL delegateInterop)
+    {
+        LIMITED_METHOD_CONTRACT;
+        if (delegateInterop)
+            m_wFlags |= PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
+        else
+            m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
+    }
     void SetCharSet(CorNativeLinkType linktype)
     {
         LIMITED_METHOD_CONTRACT;
@@ -410,6 +402,13 @@ private:
         // Then set the given value
         m_wFlags |= (linkflags << COR_NATIVE_LINK_FLAGS_SHIFT);
     }
+
+private:
+    Module* m_pModule;
+    Signature m_sig;
+    CorInfoCallConvExtension m_callConv;
+    WORD m_error;
+    WORD m_wFlags;
 };
 
 

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1261,7 +1261,7 @@ void TransitionFrame::PromoteCallerStack(promote_func* fn, ScanContext* sc)
     }
 
     //If not "vararg" calling convention, assume "default" calling convention
-    if (!MetaSig::IsVarArg(pFunction->GetModule(), callSignature))
+    if (!MetaSig::IsVarArg(callSignature))
     {
         SigTypeContext typeContext(pFunction);
         PCCOR_SIGNATURE pSig;
@@ -2064,7 +2064,7 @@ bool CheckGCRefMapEqual(PTR_BYTE pGCRefMap, MethodDesc* pMD, bool isDispatchCell
 #ifdef _DEBUG
     GCRefMapBuilder gcRefMapNew;
     ComputeCallRefMap(pMD, &gcRefMapNew, isDispatchCell);
-    
+
     DWORD dwFinalLength;
     PVOID pBlob = gcRefMapNew.GetBlob(&dwFinalLength);
 

--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -338,7 +338,7 @@ void MemberLoader::GetDescFromMemberRef(Module * pModule,
     IfFailThrow(pInternalImport->GetNameAndSigOfMemberRef(MemberRef, &pSig, &cSig, &szMember));
 
     BOOL fIsField = isCallConv(
-        MetaSig::GetCallingConvention(pModule, Signature(pSig, cSig)),
+        MetaSig::GetCallingConvention(Signature(pSig, cSig)),
         IMAGE_CEE_CS_CALLCONV_FIELD);
 
     if (fIsField)
@@ -462,7 +462,7 @@ MethodDesc * MemberLoader::GetMethodDescFromMemberRefAndType(Module * pModule,
 
     IfFailThrow(pInternalImport->GetNameAndSigOfMemberRef(MemberRef, &pSig, &cSig, &szMember));
 
-    _ASSERTE(!isCallConv(MetaSig::GetCallingConvention(pModule, Signature(pSig, cSig)), IMAGE_CEE_CS_CALLCONV_FIELD));
+    _ASSERTE(!isCallConv(MetaSig::GetCallingConvention(Signature(pSig, cSig)), IMAGE_CEE_CS_CALLCONV_FIELD));
 
     // For array method signatures, the caller's signature contains "actual" types whereas the callee's signature has
     // formals (ELEMENT_TYPE_VAR 0 wherever the element type of the array occurs). So we need to pass in a substitution
@@ -532,7 +532,7 @@ FieldDesc * MemberLoader::GetFieldDescFromMemberRefAndType(Module * pModule,
 
     IfFailThrow(pInternalImport->GetNameAndSigOfMemberRef(MemberRef, &pSig, &cSig, &szMember));
 
-    _ASSERTE(isCallConv(MetaSig::GetCallingConvention(pModule, Signature(pSig, cSig)), IMAGE_CEE_CS_CALLCONV_FIELD));
+    _ASSERTE(isCallConv(MetaSig::GetCallingConvention(Signature(pSig, cSig)), IMAGE_CEE_CS_CALLCONV_FIELD));
 
     FieldDesc * pFD = MemberLoader::FindField(pMT, szMember, pSig, cSig, pModule);
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2581,8 +2581,7 @@ void MethodDesc::Save(DataImage *image)
     {
         EX_TRY
         {
-            PInvokeStaticSigInfo sigInfo;
-            NDirect::PopulateNDirectMethodDesc((NDirectMethodDesc*)this, &sigInfo);
+            NDirect::PopulateNDirectMethodDesc((NDirectMethodDesc*)this);
         }
         EX_CATCH
         {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1140,7 +1140,7 @@ BOOL MethodDesc::IsVarArg()
 
     Signature signature = GetSignature();
     _ASSERTE(!signature.IsEmpty());
-    return MetaSig::IsVarArg(GetModule(), signature);
+    return MetaSig::IsVarArg(signature);
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2557,7 +2557,7 @@ HRESULT MethodTableBuilder::FindMethodDeclarationForMethodImpl(
             IfFailRet(pMDInternalImport->GetNameAndSigOfMemberRef(pToken, &pSig, &cSig, &szMember));
 
             if (isCallConv(
-                MetaSig::GetCallingConvention(GetModule(), Signature(pSig, cSig)),
+                MetaSig::GetCallingConvention(Signature(pSig, cSig)),
                 IMAGE_CEE_CS_CALLCONV_FIELD))
             {
                 return VLDTR_E_MR_BADCALLINGCONV;
@@ -5008,7 +5008,7 @@ MethodTableBuilder::ValidateMethods()
                 pMemberSignature = it.GetSig(&cMemberSignature);
             }
 
-            if (MetaSig::IsVarArg(pModule, Signature(pMemberSignature, cMemberSignature)))
+            if (MetaSig::IsVarArg(Signature(pMemberSignature, cMemberSignature)))
             {
                 BuildMethodTableThrowException(BFA_GENCODE_NOT_BE_VARARG);
             }

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -683,7 +683,6 @@ class MetaSig
         // defines in cor.h) - throws.
         //----------------------------------------------------------
         static BYTE GetCallingConvention(
-            Module          *pModule,
             const Signature &signature)
         {
             CONTRACTL
@@ -710,7 +709,6 @@ class MetaSig
         //----------------------------------------------------------
         __checkReturn
         static HRESULT GetCallingConvention_NoThrow(
-            Module          *pModule,
             const Signature &signature,
             BYTE            *pbCallingConvention)
         {
@@ -798,7 +796,7 @@ class MetaSig
         //----------------------------------------------------------
         // Is vararg?
         //----------------------------------------------------------
-        static BOOL IsVarArg(Module *pModule, const Signature &signature)
+        static BOOL IsVarArg(const Signature &signature)
         {
             CONTRACTL
             {
@@ -812,7 +810,7 @@ class MetaSig
             HRESULT hr;
             BYTE    nCallingConvention;
 
-            hr = GetCallingConvention_NoThrow(pModule, signature, &nCallingConvention);
+            hr = GetCallingConvention_NoThrow(signature, &nCallingConvention);
             if (FAILED(hr))
             {   // Invalid signatures are not VarArg
                 return FALSE;


### PR DESCRIPTION
- Trying to make it a little clearer how `PInvokeStaticSigInfo` gets created/used
- Remove unused parameter in `MetaSig::GetCallingConvention`

cc @AaronRobinsonMSFT @jkoritzinsky 