### PR TITLE
Fix: FileSystemEntry.Attributes property is not correct on Unix

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -44,7 +44,7 @@ namespace System.IO.Enumeration
             // symlink or a directory.
             if (isUnknown)
             {
-                isSymlink = entry._status.IsSymbolicLink(entry.FullPath);
+                isSymlink = entry.IsSymbolicLink;
                 isDirectory = entry._status.IsDirectory(entry.FullPath);
             }
             // Same idea as the directory check, just repeated for (and tweaked due to the

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -47,12 +47,11 @@ namespace System.IO.Enumeration
                 isSymlink = entry._status.IsSymbolicLink(entry.FullPath);
                 isDirectory = entry._status.IsDirectory(entry.FullPath);
             }
-
             // Same idea as the directory check, just repeated for (and tweaked due to the
             // nature of) symlinks.
             // Whether we had the dirent structure or not, we treat a symlink to a directory as a directory,
             // so we need to reflect that in our isDirectory variable.
-            if (isSymlink)
+            else if (isSymlink)
             {
                 isDirectory = entry._status.IsDirectory(entry.FullPath);
             }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -63,10 +63,6 @@ namespace System.IO.Enumeration
                 attributes |= FileAttributes.ReparsePoint;
             if (isDirectory)
                 attributes |= FileAttributes.Directory;
-            if ((directoryEntry.NameLength > 0 && directoryEntry.Name[0] == '.') || entry._status.HasHiddenFlag) // soft retrieval
-                attributes |= FileAttributes.Hidden;
-            if (entry._status.HasReadOnlyFlag) // soft retrieval
-                attributes |= FileAttributes.ReadOnly;
 
             return attributes;
         }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -45,15 +45,15 @@ namespace System.IO.Enumeration
             // directory.
             if (isSymlink || isUnknown)
             {
-                // DT_LNK: stat to it to see if we can resolve it to a directory
-                entry._status.TryRefreshSymbolicLinkCache(entry.FullPath);
-                isDirectory = entry._status.HasDirectoryFlag;
+                // DT_LNK and DT_UNKNOWN: stat to it to see if we can resolve it to a directory
+                isDirectory = entry._status.IsDirectory(entry.FullPath);
             }
 
+            // Same idea as the directory check, just repeated for (and tweaked due to the
+            // nature of) symlinks.
             if (isUnknown)
             {
-                entry._status.TryRefreshFileCache(entry.FullPath);
-                isSymlink = entry._status.HasSymbolicLinkFlag;
+                isSymlink = entry._status.IsSymbolicLink(entry.FullPath);
             }
 
             entry._status.InitiallyDirectory = isDirectory;
@@ -63,10 +63,9 @@ namespace System.IO.Enumeration
                 attributes |= FileAttributes.ReparsePoint;
             if (isDirectory)
                 attributes |= FileAttributes.Directory;
-            if ((directoryEntry.NameLength > 0 && directoryEntry.Name[0] == '.') ||
-                (entry._status.IsFileCacheInitialized && entry._status.HasHiddenFlag)) // soft retrieval
+            if ((directoryEntry.NameLength > 0 && directoryEntry.Name[0] == '.') || entry._status.HasHiddenFlag) // soft retrieval
                 attributes |= FileAttributes.Hidden;
-            if (entry._status.IsFileCacheInitialized && entry._status.HasReadOnlyFlag) // soft retrieval
+            if (entry._status.HasReadOnlyFlag) // soft retrieval
                 attributes |= FileAttributes.ReadOnly;
 
             return attributes;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -115,8 +115,6 @@ namespace System.IO.Enumeration
                             ref entry, _entry, _currentPath, _rootDirectory, _originalRootDirectory, new Span<char>(_pathBuffer));
                         bool isDirectory = (attributes & FileAttributes.Directory) != 0;
                         bool isSymlink = (attributes & FileAttributes.ReparsePoint) != 0;
-                        bool isHidden = (attributes & FileAttributes.Hidden) != 0;
-                        bool isReadOnly = (attributes & FileAttributes.ReadOnly) != 0;
 
                         bool isSpecialDirectory = false;
                         if (isDirectory)
@@ -137,8 +135,8 @@ namespace System.IO.Enumeration
                             // initialized yet and we could not soft-retrieve the attributes in Initialize
                             if ((ShouldSkip(FileAttributes.Directory) && isDirectory) ||
                                 (ShouldSkip(FileAttributes.ReparsePoint) && isSymlink) ||
-                                (ShouldSkip(FileAttributes.Hidden) && (isHidden || entry.IsHidden)) ||
-                                (ShouldSkip(FileAttributes.ReadOnly) && (isReadOnly || entry.IsReadOnly)))
+                                (ShouldSkip(FileAttributes.Hidden) && entry.IsHidden) ||
+                                (ShouldSkip(FileAttributes.ReadOnly) && entry.IsReadOnly))
                             {
                                 continue;
                             }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -114,6 +114,9 @@ namespace System.IO.Enumeration
                         FileAttributes attributes = FileSystemEntry.Initialize(
                             ref entry, _entry, _currentPath, _rootDirectory, _originalRootDirectory, new Span<char>(_pathBuffer));
                         bool isDirectory = (attributes & FileAttributes.Directory) != 0;
+                        bool isSymlink = (attributes & FileAttributes.ReparsePoint) != 0;
+                        bool isHidden = (attributes & FileAttributes.Hidden) != 0;
+                        bool isReadOnly = (attributes & FileAttributes.ReadOnly) != 0;
 
                         bool isSpecialDirectory = false;
                         if (isDirectory)
@@ -130,13 +133,12 @@ namespace System.IO.Enumeration
 
                         if (!isSpecialDirectory && _options.AttributesToSkip != 0)
                         {
-                            if ((_options.AttributesToSkip & FileAttributes.ReadOnly) != 0)
-                            {
-                                // ReadOnly is the only attribute that requires hitting entry.Attributes (which hits the disk)
-                                attributes = entry.Attributes;
-                            }
-
-                            if ((_options.AttributesToSkip & attributes) != 0)
+                            // IsSymbolicLink, IsHidden and IsReadOnly will hit the disk if
+                            // caches had not been initialized yet and we could not soft-retrieve the attributes in Initialize
+                            if ((ShouldSkip(FileAttributes.Directory) && isDirectory) ||
+                                (ShouldSkip(FileAttributes.ReparsePoint) && (isSymlink || entry.IsSymbolicLink)) ||
+                                (ShouldSkip(FileAttributes.Hidden) && (isHidden || entry.IsHidden)) ||
+                                (ShouldSkip(FileAttributes.ReadOnly) && (isReadOnly || entry.IsReadOnly)))
                             {
                                 continue;
                             }
@@ -161,6 +163,8 @@ namespace System.IO.Enumeration
                     } while (true);
                 }
             }
+
+            bool ShouldSkip(FileAttributes attributeToSkip) => (_options.AttributesToSkip & attributeToSkip) != 0;
         }
 
         private unsafe void FindNextEntry()

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -133,7 +133,7 @@ namespace System.IO.Enumeration
 
                         if (!isSpecialDirectory && _options.AttributesToSkip != 0)
                         {
-                            // IsSymbolicLink, IsHidden and IsReadOnly will hit the disk if
+                            // entry.IsSymbolicLink, entry.IsHidden and entry.IsReadOnly will hit the disk if
                             // caches had not been initialized yet and we could not soft-retrieve the attributes in Initialize
                             if ((ShouldSkip(FileAttributes.Directory) && isDirectory) ||
                                 (ShouldSkip(FileAttributes.ReparsePoint) && (isSymlink || entry.IsSymbolicLink)) ||

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Unix.cs
@@ -133,10 +133,10 @@ namespace System.IO.Enumeration
 
                         if (!isSpecialDirectory && _options.AttributesToSkip != 0)
                         {
-                            // entry.IsSymbolicLink, entry.IsHidden and entry.IsReadOnly will hit the disk if
-                            // caches had not been initialized yet and we could not soft-retrieve the attributes in Initialize
+                            // entry.IsHidden and entry.IsReadOnly will hit the disk if the caches had not been
+                            // initialized yet and we could not soft-retrieve the attributes in Initialize
                             if ((ShouldSkip(FileAttributes.Directory) && isDirectory) ||
-                                (ShouldSkip(FileAttributes.ReparsePoint) && (isSymlink || entry.IsSymbolicLink)) ||
+                                (ShouldSkip(FileAttributes.ReparsePoint) && isSymlink) ||
                                 (ShouldSkip(FileAttributes.Hidden) && (isHidden || entry.IsHidden)) ||
                                 (ShouldSkip(FileAttributes.ReadOnly) && (isReadOnly || entry.IsReadOnly)))
                             {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -52,14 +52,8 @@ namespace System.IO
         // Ideally, use this if Refresh has been successfully called at least once.
         // But since it is also used for soft retrieval during FileSystemEntry initialization,
         // we return false early if the cache has not been initialized
-        internal bool HasHiddenFlag
-        {
-            get
-            {
-                return IsFileCacheInitialized &&
-                       (_fileCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
-            }
-        }
+        internal bool HasHiddenFlag => IsFileCacheInitialized &&
+            (_fileCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
 
         // Checks if the main path (without following symlinks) has the read-only attribute set
         // Ideally, use this if Refresh has been successfully called at least once.

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.IO
@@ -9,88 +10,188 @@ namespace System.IO
     {
         private const int NanosecondsPerTick = 100;
 
-        // The last cached stat information about the file
-        private Interop.Sys.FileStatus _fileStatus;
+        // The last cached lstat information about the file
+        private Interop.Sys.FileStatus _fileCache;
 
-        // -1 if _fileStatus isn't initialized, 0 if _fileStatus was initialized with no
-        // errors, or the errno error code.
-        private int _fileStatusInitialized;
+        // -1: if the file cache isn't initialized - Refresh should always change this value
+        //  0: if the file cache was initialized with no errors
+        // Positive number: the error code returned by the lstat call
+        private int _initializedFileCache;
+
+        // The last cached stat information about the file
+        // Refresh only collects this if lstat determines the path is a symbolic link
+        private Interop.Sys.FileStatus _symlinkCache;
+
+        // -1: if the symlink cache isn't initialized - Refresh only changes this value if lstat determines the path is a symbolic link
+        // 0: if the symlink cache was initialized with no errors
+        // Positive number: the error code returned by the stat call
+        private int _initializedSymlinkCache;
 
         // We track intent of creation to know whether or not we want to (1) create a
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
-        internal bool InitiallyDirectory { get; private set; }
+        // Set to true during initialization when the DirectoryEntry's INodeType describes a directory
+        internal bool InitiallyDirectory { get; set; }
 
         // Is a directory as of the last refresh
-        internal bool _isDirectory;
+        // Its value can come from either the main path or the symbolic link path
+        private bool _isDirectory;
 
         // Exists as of the last refresh
         private bool _exists;
 
-        internal static void Initialize(
-            ref FileStatus status,
-            bool isDirectory)
+        internal bool IsFileCacheInitialized => _initializedFileCache == 0;
+        internal bool IsSymlinkCacheInitialized => _initializedSymlinkCache == 0;
+
+        internal bool AreCachesInitialized =>
+            // The file cache should always be successfully refreshed
+            _initializedFileCache == 0 &&
+            // The symbolic link cache only gets refreshed when the path is detected
+            // to be a symlink, so -1 is also acceptable
+            _initializedSymlinkCache <= 0;
+
+        // Check if the main path (without following symlinks) has the hidden attribute set
+        // Only use this if Refresh has been successfully called at least once
+        internal bool HasHiddenFlag
         {
-            status.InitiallyDirectory = isDirectory;
-            status._fileStatusInitialized = -1;
+            get
+            {
+                Debug.Assert(IsFileCacheInitialized);
+                return (_fileCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
+            }
         }
 
-        internal void Invalidate() => _fileStatusInitialized = -1;
+        // Checks if the main path (without following symlinks) has the read-only attribute set
+        // Only use this if Refresh has been successfully called at least once
+        internal bool HasReadOnlyFlag
+        {
+            get
+            {
+                Debug.Assert(IsFileCacheInitialized);
+#if TARGET_BROWSER
+                const Interop.Sys.Permissions readBit = Interop.Sys.Permissions.S_IRUSR;
+                const Interop.Sys.Permissions writeBit = Interop.Sys.Permissions.S_IWUSR;
+#else
+                Interop.Sys.Permissions readBit, writeBit;
+
+                if (_fileCache.Uid == Interop.Sys.GetEUid())
+                {
+                    // User effectively owns the file
+                    readBit = Interop.Sys.Permissions.S_IRUSR;
+                    writeBit = Interop.Sys.Permissions.S_IWUSR;
+                }
+                else if (_fileCache.Gid == Interop.Sys.GetEGid())
+                {
+                    // User belongs to a group that effectively owns the file
+                    readBit = Interop.Sys.Permissions.S_IRGRP;
+                    writeBit = Interop.Sys.Permissions.S_IWGRP;
+                }
+                else
+                {
+                    // Others permissions
+                    readBit = Interop.Sys.Permissions.S_IROTH;
+                    writeBit = Interop.Sys.Permissions.S_IWOTH;
+                }
+#endif
+
+                return ((_fileCache.Mode & (int)readBit) != 0 && // has read permission
+                    (_fileCache.Mode & (int)writeBit) == 0);     // but not write permission
+            }
+        }
+
+        // Checks if the main path is a symbolic link
+        // Only call if Refresh has been successfully called at least once
+        internal bool HasSymbolicLinkFlag
+        {
+            get
+            {
+                Debug.Assert(IsFileCacheInitialized);
+                return (_fileCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
+            }
+        }
+
+        // Checks if any of the caches has the directory attribute set
+        // Only call if Refresh has been successfully called at least once
+        internal bool HasDirectoryFlag
+        {
+            get
+            {
+                Debug.Assert(IsFileCacheInitialized || IsSymlinkCacheInitialized);
+                if (IsSymlinkCacheInitialized)
+                {
+                    return CacheHasDirectoryFlag(_symlinkCache);
+                }
+                else if (IsFileCacheInitialized)
+                {
+                    return CacheHasDirectoryFlag(_fileCache);
+                }
+
+                return false;
+            }
+        }
+
+        // Checks if the specified cache (lstat=_fileCache, stat=_symlinkCache) has the directory attribute set
+        // Only call if Refresh has been successfully called at least once, and you're
+        // certain the passed-in cache was successfully retrieved
+        private bool CacheHasDirectoryFlag(Interop.Sys.FileStatus cache) => (cache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+
+        internal static void Initialize(ref FileStatus status, bool initiallyDirectory)
+        {
+            status.InitiallyDirectory = initiallyDirectory;
+            status.InvalidateCaches();
+        }
+
+        // Sets the cache initialization flags to -1, which means the caches are now uninitialized
+        internal void InvalidateCaches()
+        {
+            _initializedFileCache = -1;
+            _initializedSymlinkCache = -1;
+        }
 
         internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
-#if TARGET_BROWSER
-            const Interop.Sys.Permissions readBit = Interop.Sys.Permissions.S_IRUSR;
-            const Interop.Sys.Permissions writeBit = Interop.Sys.Permissions.S_IWUSR;
-#else
-            Interop.Sys.Permissions readBit, writeBit;
+            EnsureCachesInitialized(path, continueOnError);
+            return HasReadOnlyFlag;
+        }
 
-            if (_fileStatus.Uid == Interop.Sys.GetEUid())
-            {
-                // User effectively owns the file
-                readBit = Interop.Sys.Permissions.S_IRUSR;
-                writeBit = Interop.Sys.Permissions.S_IWUSR;
-            }
-            else if (_fileStatus.Gid == Interop.Sys.GetEGid())
-            {
-                // User belongs to a group that effectively owns the file
-                readBit = Interop.Sys.Permissions.S_IRGRP;
-                writeBit = Interop.Sys.Permissions.S_IWGRP;
-            }
-            else
-            {
-                // Others permissions
-                readBit = Interop.Sys.Permissions.S_IROTH;
-                writeBit = Interop.Sys.Permissions.S_IWOTH;
-            }
-#endif
+        internal bool IsHidden(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureCachesInitialized(path, continueOnError);
+            return HasHiddenFlag;
+        }
 
-            return ((_fileStatus.Mode & (int)readBit) != 0 && // has read permission
-                (_fileStatus.Mode & (int)writeBit) == 0);     // but not write permission
+        // Returns true if the path points to a directory, or if the path is a symbolic link
+        // that points to a directory
+        internal bool IsDirectory(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureCachesInitialized(path, continueOnError);
+            return _isDirectory;
+        }
+
+        internal bool IsSymbolicLink(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureCachesInitialized(path, continueOnError);
+            return HasSymbolicLinkFlag;
         }
 
         public FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
         {
-            // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
-
-            EnsureStatInitialized(path);
+            EnsureCachesInitialized(path);
 
             if (!_exists)
                 return (FileAttributes)(-1);
 
             FileAttributes attributes = default;
 
-            if (IsReadOnly(path))
+            if (HasReadOnlyFlag)
                 attributes |= FileAttributes.ReadOnly;
 
-            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
+            if (HasSymbolicLinkFlag)
                 attributes |= FileAttributes.ReparsePoint;
 
-            if (_isDirectory)
+            if (_isDirectory) // Refresh caches this
                 attributes |= FileAttributes.Directory;
 
-            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
-            if (fileName.Length > 0 && (fileName[0] == '.' || (_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN))
+            if (fileName.Length > 0 && (fileName[0] == '.' || HasHiddenFlag))
                 attributes |= FileAttributes.Hidden;
 
             return attributes != default ? attributes : FileAttributes.Normal;
@@ -113,34 +214,28 @@ namespace System.IO
                 throw new ArgumentException(SR.Arg_InvalidFileAttrs, "Attributes");
             }
 
-            EnsureStatInitialized(path);
+            EnsureCachesInitialized(path);
 
             if (!_exists)
                 FileSystemInfo.ThrowNotFound(path);
 
             if (Interop.Sys.CanSetHiddenFlag)
             {
-                if ((attributes & FileAttributes.Hidden) != 0)
+                if ((attributes & FileAttributes.Hidden) != 0 && (_fileCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == 0)
                 {
-                    if ((_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == 0)
-                    {
-                        // If Hidden flag is set and cached file status does not have the flag set then set it
-                        Interop.CheckIo(Interop.Sys.LChflags(path, (_fileStatus.UserFlags | (uint)Interop.Sys.UserFlags.UF_HIDDEN)), path, InitiallyDirectory);
-                    }
+                    // If Hidden flag is set and cached file status does not have the flag set then set it
+                    Interop.CheckIo(Interop.Sys.LChflags(path, (_fileCache.UserFlags | (uint)Interop.Sys.UserFlags.UF_HIDDEN)), path, InitiallyDirectory);
                 }
-                else
+                else if (HasHiddenFlag)
                 {
-                    if ((_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN)
-                    {
-                        // If Hidden flag is not set and cached file status does have the flag set then remove it
-                        Interop.CheckIo(Interop.Sys.LChflags(path, (_fileStatus.UserFlags & ~(uint)Interop.Sys.UserFlags.UF_HIDDEN)), path, InitiallyDirectory);
-                    }
+                    // If Hidden flag is not set and cached file status does have the flag set then remove it
+                    Interop.CheckIo(Interop.Sys.LChflags(path, (_fileCache.UserFlags & ~(uint)Interop.Sys.UserFlags.UF_HIDDEN)), path, InitiallyDirectory);
                 }
             }
 
             // The only thing we can reasonably change is whether the file object is readonly by changing permissions.
 
-            int newMode = _fileStatus.Mode;
+            int newMode = _fileCache.Mode;
             if ((attributes & FileAttributes.ReadOnly) != 0)
             {
                 // Take away all write permissions from user/group/everyone
@@ -153,37 +248,35 @@ namespace System.IO
             }
 
             // Change the permissions on the file
-            if (newMode != _fileStatus.Mode)
+            if (newMode != _fileCache.Mode)
             {
                 Interop.CheckIo(Interop.Sys.ChMod(path, newMode), path, InitiallyDirectory);
             }
 
-            _fileStatusInitialized = -1;
+            _initializedFileCache = -1;
         }
 
         internal bool GetExists(ReadOnlySpan<char> path)
         {
-            if (_fileStatusInitialized == -1)
-                Refresh(path);
-
+            EnsureCachesInitialized(path, continueOnError: true);
             return _exists && InitiallyDirectory == _isDirectory;
         }
 
         internal DateTimeOffset GetCreationTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
                 return DateTimeOffset.FromFileTime(0);
 
-            if ((_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0)
-                return UnixTimeToDateTimeOffset(_fileStatus.BirthTime, _fileStatus.BirthTimeNsec);
+            if ((_fileCache.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0)
+                return UnixTimeToDateTimeOffset(_fileCache.BirthTime, _fileCache.BirthTimeNsec);
 
             // fall back to the oldest time we have in between change and modify time
-            if (_fileStatus.MTime < _fileStatus.CTime ||
-                (_fileStatus.MTime == _fileStatus.CTime && _fileStatus.MTimeNsec < _fileStatus.CTimeNsec))
-                return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
+            if (_fileCache.MTime < _fileCache.CTime ||
+                (_fileCache.MTime == _fileCache.CTime && _fileCache.MTimeNsec < _fileCache.CTimeNsec))
+                return UnixTimeToDateTimeOffset(_fileCache.MTime, _fileCache.MTimeNsec);
 
-            return UnixTimeToDateTimeOffset(_fileStatus.CTime, _fileStatus.CTimeNsec);
+            return UnixTimeToDateTimeOffset(_fileCache.CTime, _fileCache.CTimeNsec);
         }
 
         internal void SetCreationTime(string path, DateTimeOffset time)
@@ -202,20 +295,20 @@ namespace System.IO
 
         internal DateTimeOffset GetLastAccessTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
                 return DateTimeOffset.FromFileTime(0);
-            return UnixTimeToDateTimeOffset(_fileStatus.ATime, _fileStatus.ATimeNsec);
+            return UnixTimeToDateTimeOffset(_fileCache.ATime, _fileCache.ATimeNsec);
         }
 
         internal void SetLastAccessTime(string path, DateTimeOffset time) => SetAccessOrWriteTime(path, time, isAccessTime: true);
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
                 return DateTimeOffset.FromFileTime(0);
-            return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
+            return UnixTimeToDateTimeOffset(_fileCache.MTime, _fileCache.MTimeNsec);
         }
 
         internal void SetLastWriteTime(string path, DateTimeOffset time) => SetAccessOrWriteTime(path, time, isAccessTime: false);
@@ -228,8 +321,8 @@ namespace System.IO
         private unsafe void SetAccessOrWriteTime(string path, DateTimeOffset time, bool isAccessTime)
         {
             // force a refresh so that we have an up-to-date times for values not being overwritten
-            _fileStatusInitialized = -1;
-            EnsureStatInitialized(path);
+            _initializedFileCache = -1;
+            EnsureCachesInitialized(path);
 
             // we use utimes()/utimensat() to set the accessTime and writeTime
             Interop.Sys.TimeSpec* buf = stackalloc Interop.Sys.TimeSpec[2];
@@ -250,87 +343,128 @@ namespace System.IO
             {
                 buf[0].TvSec = seconds;
                 buf[0].TvNsec = nanoseconds;
-                buf[1].TvSec = _fileStatus.MTime;
-                buf[1].TvNsec = _fileStatus.MTimeNsec;
+                buf[1].TvSec = _fileCache.MTime;
+                buf[1].TvNsec = _fileCache.MTimeNsec;
             }
             else
             {
-                buf[0].TvSec = _fileStatus.ATime;
-                buf[0].TvNsec = _fileStatus.ATimeNsec;
+                buf[0].TvSec = _fileCache.ATime;
+                buf[0].TvNsec = _fileCache.ATimeNsec;
                 buf[1].TvSec = seconds;
                 buf[1].TvNsec = nanoseconds;
             }
 #endif
             Interop.CheckIo(Interop.Sys.UTimensat(path, buf), path, InitiallyDirectory);
-            _fileStatusInitialized = -1;
+            _initializedFileCache = -1;
         }
 
         internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
-            return _fileStatus.Size;
+            EnsureCachesInitialized(path, continueOnError);
+            return _fileCache.Size;
         }
 
-        public void Refresh(ReadOnlySpan<char> path)
+        // Tries to refresh the lstat cache (_fileCache) and, if the file is pointing to a symbolic link, then also the stat cache (_symlinkCache)
+        // This method should not throw. Instead, we store the results, and we will throw when the user attempts to access any of the properties when there was a failure
+        public void RefreshCaches(ReadOnlySpan<char> path)
         {
-            // This should not throw, instead we store the result so that we can throw it
-            // when someone actually accesses a property.
-
-            // Use lstat to get the details on the object, without following symlinks.
-            // If it is a symlink, then subsequently get details on the target of the symlink,
-            // storing those results separately.  We only report failure if the initial
-            // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
             _isDirectory = false;
             path = Path.TrimEndingDirectorySeparator(path);
 
-            int result = Interop.Sys.LStat(path, out _fileStatus);
-            if (result < 0)
+            // Retrieve the file cache (lstat) to get the details on the object, without following symlinks.
+            // If it is a symlink, then subsequently get details on the target of the symlink,
+            // storing those results separately.  We only report failure if the initial
+            // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
+            if (!TryRefreshFileCache(path))
+            {
+                _exists = false;
+                return;
+            }
+
+            // Do an initial check in case the main path is pointing to a directory
+            _isDirectory = CacheHasDirectoryFlag(_fileCache);
+
+            // We also need to check if the main path is a symbolic link,
+            // in which case, we retrieve the symbolic link data
+            if (!_isDirectory && HasSymbolicLinkFlag && TryRefreshSymbolicLinkCache(path))
+            {
+                // and check again if the symlink path is a directory
+                _isDirectory = CacheHasDirectoryFlag(_symlinkCache);
+            }
+
+            _exists = true;
+        }
+
+        // Checks if the file cache is set to -1 and refreshes it's value.
+        // Optionally, if the symlink cache is set to -1 and the file cache determined the path is pointing to a symbolic link, this cache is also refreshed.
+        // If stat or lstat failed, and continueOnError is set to true, this method will throw.
+        internal void EnsureCachesInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            if (!AreCachesInitialized)
+            {
+                RefreshCaches(path);
+
+                if (!continueOnError)
+                {
+                    ThrowOnCacheInitializationError(path);
+                }
+            }
+        }
+
+        // Throws if any of the caches has an error number saved in it
+        private void ThrowOnCacheInitializationError(ReadOnlySpan<char> path)
+        {
+            int errno = 0;
+
+            // Lstat should always be initialized by Refresh
+            if (_initializedFileCache != 0)
+            {
+                errno = _initializedFileCache;
+            }
+            // Stat is optionally initialized when Refresh detects object is a symbolic link
+            else if (_initializedSymlinkCache != 0 && _initializedSymlinkCache != -1)
+            {
+                errno = _initializedSymlinkCache;
+            }
+
+            if (errno != 0)
+            {
+                InvalidateCaches();
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
+            }
+        }
+
+        internal bool TryRefreshFileCache(ReadOnlySpan<char> path, bool verify = true) =>
+            VerifyStatCall(Interop.Sys.LStat(path, out _fileCache), out _initializedFileCache);
+
+        internal bool TryRefreshSymbolicLinkCache(ReadOnlySpan<char> path, bool verify = true) =>
+            VerifyStatCall(Interop.Sys.Stat(path, out _symlinkCache), out _initializedSymlinkCache);
+
+        // Receives the return value of a stat or lstat call.
+        // If the call is unsuccessful, sets the initialized parameter to a positive number representing the last error info.
+        // If the call is successful, sets the initialized parameter to zero.
+        // The method returns true if the initialized parameter is set to zero, false otherwise.
+        private bool VerifyStatCall(int returnValue, out int initialized)
+        {
+            initialized = 0;
+
+            // Both stat and lstat return -1 on error, 0 on success
+            if (returnValue < 0)
             {
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
 
                 // This should never set the error if the file can't be found.
                 // (see the Windows refresh passing returnErrorOnNotFound: false).
-                if (errorInfo.Error == Interop.Error.ENOENT
-                    || errorInfo.Error == Interop.Error.ENOTDIR)
+                if (errorInfo.Error != Interop.Error.ENOENT && // A component of the path does not exist, or path is an empty string
+                    errorInfo.Error != Interop.Error.ENOTDIR)  // A component of the path prefix of path is not a directory
                 {
-                    _fileStatusInitialized = 0;
-                    _exists = false;
+                    // Expect a positive integer
+                    initialized = errorInfo.RawErrno;
                 }
-                else
-                {
-                    _fileStatusInitialized = errorInfo.RawErrno;
-                }
-                return;
+                return false;
             }
 
-            _exists = true;
-
-            // IMPORTANT: Is directory logic must match the logic in FileSystemEntry
-            _isDirectory = (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-
-            // If we're a symlink, attempt to check the target to see if it is a directory
-            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK &&
-                Interop.Sys.Stat(path, out Interop.Sys.FileStatus targetStatus) >= 0)
-            {
-                _isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-            }
-
-            _fileStatusInitialized = 0;
-        }
-
-        internal void EnsureStatInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
-        {
-            if (_fileStatusInitialized == -1)
-            {
-                Refresh(path);
-            }
-
-            if (_fileStatusInitialized != 0 && !continueOnError)
-            {
-                int errno = _fileStatusInitialized;
-                _fileStatusInitialized = -1;
-                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
-            }
+            return true;
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -153,11 +153,13 @@ namespace System.IO
             return HasReadOnlyFlag;
         }
 
-        internal bool IsHidden(ReadOnlySpan<char> path, bool continueOnError = false)
+        internal bool IsHidden(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName, bool continueOnError = false)
         {
             EnsureCachesInitialized(path, continueOnError);
-            return HasHiddenFlag;
+            return IsNameHidden(fileName) || HasHiddenFlag;
         }
+
+        internal bool IsNameHidden(ReadOnlySpan<char> fileName) => fileName.Length > 0 && fileName[0] == '.';
 
         // Returns true if the path points to a directory, or if the path is a symbolic link
         // that points to a directory
@@ -191,7 +193,7 @@ namespace System.IO
             if (_isDirectory) // Refresh caches this
                 attributes |= FileAttributes.Directory;
 
-            if (fileName.Length > 0 && (fileName[0] == '.' || HasHiddenFlag))
+            if (IsNameHidden(fileName) || HasHiddenFlag)
                 attributes |= FileAttributes.Hidden;
 
             return attributes != default ? attributes : FileAttributes.Normal;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -73,36 +73,23 @@ namespace System.IO
 #else
                 Interop.Sys.Permissions readBit, writeBit;
 
-                if (_euid == null)
-                {
-                    _euid = Interop.Sys.GetEUid();
-                }
-
-                if (_fileCache.Uid == _euid)
+                if (_fileCache.Uid == (_euid ??= Interop.Sys.GetEUid()))
                 {
                     // User effectively owns the file
                     readBit = Interop.Sys.Permissions.S_IRUSR;
                     writeBit = Interop.Sys.Permissions.S_IWUSR;
                 }
+                else if (_fileCache.Gid == (_egid ??= Interop.Sys.GetEGid()))
+                {
+                    // User belongs to a group that effectively owns the file
+                    readBit = Interop.Sys.Permissions.S_IRGRP;
+                    writeBit = Interop.Sys.Permissions.S_IWGRP;
+                }
                 else
                 {
-                    if (_egid == null)
-                    {
-                        _egid = Interop.Sys.GetEGid();
-                    }
-
-                    if (_fileCache.Gid == _egid)
-                    {
-                        // User belongs to a group that effectively owns the file
-                        readBit = Interop.Sys.Permissions.S_IRGRP;
-                        writeBit = Interop.Sys.Permissions.S_IWGRP;
-                    }
-                    else
-                    {
-                        // Others permissions
-                        readBit = Interop.Sys.Permissions.S_IROTH;
-                        writeBit = Interop.Sys.Permissions.S_IWOTH;
-                    }
+                    // Others permissions
+                    readBit = Interop.Sys.Permissions.S_IROTH;
+                    writeBit = Interop.Sys.Permissions.S_IWOTH;
                 }
 #endif
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -401,17 +401,14 @@ namespace System.IO
         // If stat or lstat failed, and continueOnError is set to true, this method will throw.
         internal void EnsureCachesInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            // The file cache should always be successfully refreshed (0)
-            // The symbolic link cache only gets refreshed when the path is detected
-            // to be a symlink, so -1 (meaning 'uninitialized') is also acceptable
-            if (_initializedFileCache != 0 || _initializedSymlinkCache > 0)
+            if (_initializedFileCache == -1)
             {
                 RefreshCaches(path);
+            }
 
-                if (!continueOnError)
-                {
-                    ThrowOnCacheInitializationError(path);
-                }
+            if (!continueOnError)
+            {
+                ThrowOnCacheInitializationError(path);
             }
         }
 
@@ -464,6 +461,7 @@ namespace System.IO
                 {
                     // Expect a positive integer
                     initialized = errorInfo.RawErrno;
+                    Debug.Assert(initialized > 0);
                 }
                 return false;
             }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -122,17 +122,6 @@ namespace System.IO
             }
         }
 
-        // Checks if the specified cache (lstat=_fileCache, stat=_symlinkCache) has the directory attribute set
-        // Only call if Refresh has been successfully called at least once, and you're
-        // certain the passed-in cache was successfully retrieved
-        private bool CacheHasDirectoryFlag(Interop.Sys.FileStatus cache) => (cache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-
-        internal static void Initialize(ref FileStatus status, bool initiallyDirectory)
-        {
-            status.InitiallyDirectory = initiallyDirectory;
-            status.InvalidateCaches();
-        }
-
         // Sets the cache initialization flags to -1, which means the caches are now uninitialized
         internal void InvalidateCaches()
         {
@@ -399,6 +388,12 @@ namespace System.IO
 #endif
 
             _exists = true;
+
+            // Checks if the specified cache (lstat=_fileCache, stat=_symlinkCache) has the directory attribute set
+            // Only call if Refresh has been successfully called at least once, and you're
+            // certain the passed-in cache was successfully retrieved
+            static bool CacheHasDirectoryFlag(Interop.Sys.FileStatus cache) =>
+                (cache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
         }
 
         // Checks if the file cache is set to -1 and refreshes it's value.

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -50,24 +50,26 @@ namespace System.IO
             _initializedSymlinkCache <= 0;
 
         // Check if the main path (without following symlinks) has the hidden attribute set
-        // Only use this if Refresh has been successfully called at least once
+        // Ideally, use this if Refresh has been successfully called at least once.
+        // But since it is also used for soft retrieval during FileSystemEntry initialization,
+        // we return false early if the cache has not been initialized
         internal bool HasHiddenFlag
         {
             get
             {
-                Debug.Assert(IsFileCacheInitialized);
                 return IsFileCacheInitialized &&
                        (_fileCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
             }
         }
 
         // Checks if the main path (without following symlinks) has the read-only attribute set
-        // Only use this if Refresh has been successfully called at least once
+        // Ideally, use this if Refresh has been successfully called at least once.
+        // But since it is also used for soft retrieval during FileSystemEntry initialization,
+        // we return false early if the cache has not been initialized
         internal bool HasReadOnlyFlag
         {
             get
             {
-                Debug.Assert(IsFileCacheInitialized);
                 if (!IsFileCacheInitialized)
                 {
                     return false;
@@ -105,33 +107,12 @@ namespace System.IO
 
         // Checks if the main path is a symbolic link
         // Only call if Refresh has been successfully called at least once
-        internal bool HasSymbolicLinkFlag
+        private bool HasSymbolicLinkFlag
         {
             get
             {
                 Debug.Assert(IsFileCacheInitialized);
-                return IsFileCacheInitialized &&
-                       (_fileCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
-            }
-        }
-
-        // Checks if any of the caches has the directory attribute set
-        // Only call if Refresh has been successfully called at least once
-        internal bool HasDirectoryFlag
-        {
-            get
-            {
-                Debug.Assert(IsFileCacheInitialized || IsSymlinkCacheInitialized);
-                if (IsSymlinkCacheInitialized)
-                {
-                    return CacheHasDirectoryFlag(_symlinkCache);
-                }
-                else if (IsFileCacheInitialized)
-                {
-                    return CacheHasDirectoryFlag(_fileCache);
-                }
-
-                return false;
+                return (_fileCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -162,8 +162,13 @@ namespace System.IO
 
         internal bool IsHidden(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName, bool continueOnError = false)
         {
+            // Avoid disk hit first
+            if (IsNameHidden(fileName))
+            {
+                return true;
+            }
             EnsureCachesInitialized(path, continueOnError);
-            return IsNameHidden(fileName) || HasHiddenFlag;
+            return HasHiddenFlag;
         }
 
         internal bool IsNameHidden(ReadOnlySpan<char> fileName) => fileName.Length > 0 && fileName[0] == '.';

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -46,15 +46,7 @@ namespace System.IO
         private uint? _egid;
 #endif
 
-        private bool IsFileCacheInitialized    => _initializedFileCache == 0;
-        private bool IsSymlinkCacheInitialized => _initializedSymlinkCache == 0;
-
-        private bool AreCachesInitialized =>
-            // The file cache should always be successfully refreshed
-            _initializedFileCache == 0 &&
-            // The symbolic link cache only gets refreshed when the path is detected
-            // to be a symlink, so -1 is also acceptable
-            _initializedSymlinkCache <= 0;
+        private bool IsFileCacheInitialized => _initializedFileCache == 0;
 
         // Check if the main path (without following symlinks) has the hidden attribute set
         // Ideally, use this if Refresh has been successfully called at least once.
@@ -420,7 +412,10 @@ namespace System.IO
         // If stat or lstat failed, and continueOnError is set to true, this method will throw.
         internal void EnsureCachesInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            if (!AreCachesInitialized)
+            // The file cache should always be successfully refreshed (0)
+            // The symbolic link cache only gets refreshed when the path is detected
+            // to be a symlink, so -1 (meaning 'uninitialized') is also acceptable
+            if (_initializedFileCache != 0 || _initializedSymlinkCache > 0)
             {
                 RefreshCaches(path);
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -11,7 +11,8 @@ namespace System.IO
 
         protected FileSystemInfo()
         {
-            FileStatus.Initialize(ref _fileStatus, this is DirectoryInfo);
+            _fileStatus.InitiallyDirectory = this is DirectoryInfo;
+            _fileStatus.InvalidateCaches();
         }
 
         internal static FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -14,7 +14,7 @@ namespace System.IO
             FileStatus.Initialize(ref _fileStatus, this is DirectoryInfo);
         }
 
-        internal static unsafe FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)
+        internal static FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)
         {
             FileSystemInfo info = fileStatus.InitiallyDirectory
                 ? (FileSystemInfo)new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true)
@@ -26,12 +26,12 @@ namespace System.IO
             return info;
         }
 
-        internal void Invalidate() => _fileStatus.Invalidate();
+        internal void Invalidate() => _fileStatus.InvalidateCaches();
 
         internal unsafe void Init(ref FileStatus fileStatus)
         {
             _fileStatus = fileStatus;
-            _fileStatus.EnsureStatInitialized(FullPath);
+            _fileStatus.EnsureCachesInitialized(FullPath);
         }
 
         public FileAttributes Attributes
@@ -62,7 +62,7 @@ namespace System.IO
 
         internal long LengthCore => _fileStatus.GetLength(FullPath);
 
-        public void Refresh() => _fileStatus.Refresh(FullPath);
+        public void Refresh() => _fileStatus.RefreshCaches(FullPath);
 
         internal static void ThrowNotFound(string path)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37301

New attempt - this time without a perf regression. Changes in this PR:

- Caching the `stat` and `lstat` results inside `FileStatus`.
- Collection of information is the same between `FileSystemEntry` and `FileStatus`.
- The `Hidden` and `ReadOnly` flags are now being collected when expected, and made sure they are collected lazily, to avoid the perf regression on enumeration when not required.
- `System.IO.FileSystem unit tests passed locally, pending checking all results from CI.

cc @isazonov @mklement0 @jozkee @adamsitnik @jeffhandley 

I collected perf results for the `System.IO.Tests.Perf_Directory` benchmarks four times, before and after my changes, because IO benchmarks tend to yield not-so-stable results. I wanted to make sure the results stayed under a close margin of error: 

Command:

```
/home/carlos/.dotnet/dotnet run \
    --project /home/carlos/performance/src/benchmarks/micro/MicroBenchmarks.csproj
    -c Release -f net6.0 \
    --artifacts /home/carlos/perf_together \
    --coreRun \
        /home/carlos/runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun \
        /home/carlos/runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun \
    --cli /home/carlos/.dotnet/dotnet \
    --statisticalTest 3ms \
    --filter System.IO.Tests.Perf_Directory*
```

<details>
<summary>Result 1</summary>

|                         Method |        Job |                                                                                                Toolchain | UnrollFactor | depth |           Mean |        Error |       StdDev |         Median |            Min |            Max | Ratio | MannWhitney(3ms) | RatioSD |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------- |--------------------------------------------------------------------------------------------------------- |------------- |------ |---------------:|-------------:|-------------:|---------------:|---------------:|---------------:|------:|----------------- |--------:|---------:|--------:|------:|----------:|
|                CreateDirectory | Job-VQFCFU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    20,786.0 ns |    909.50 ns |  1,047.38 ns |    20,665.0 ns |    19,000.0 ns |    23,180.0 ns |  1.03 |             Same |    0.07 |        - |       - |     - |     497 B |
|                CreateDirectory | Job-YTPACX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    20,123.0 ns |    687.54 ns |    791.77 ns |    19,840.0 ns |    19,020.0 ns |    21,580.0 ns |  1.00 |             Base |    0.00 |        - |       - |     - |     377 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|            GetCurrentDirectory | Job-ZALFUF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       615.0 ns |      6.28 ns |      5.87 ns |       615.5 ns |       598.7 ns |       623.2 ns |  1.01 |             Same |    0.03 |   0.0442 |       - |     - |     288 B |
|            GetCurrentDirectory | Job-KVFFMU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       606.8 ns |     14.38 ns |     16.56 ns |       605.7 ns |       557.5 ns |       632.4 ns |  1.00 |             Base |    0.00 |   0.0440 |       - |     - |     288 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                         Exists | Job-ZALFUF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       622.9 ns |     10.46 ns |      9.78 ns |       624.7 ns |       608.5 ns |       637.6 ns |  1.02 |             Same |    0.02 |        - |       - |     - |         - |
|                         Exists | Job-KVFFMU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       610.9 ns |      4.02 ns |      3.76 ns |       611.2 ns |       601.5 ns |       616.3 ns |  1.00 |             Base |    0.00 |        - |       - |     - |         - |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                 EnumerateFiles | Job-ZALFUF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,436,529.1 ns | 32,055.46 ns | 29,984.70 ns | 3,447,346.9 ns | 3,380,712.5 ns | 3,471,143.8 ns |  1.02 |             Same |    0.01 | 125.0000 |       - |     - | 872,324 B |
|                 EnumerateFiles | Job-KVFFMU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,361,367.6 ns | 34,994.73 ns | 31,021.91 ns | 3,346,721.9 ns | 3,328,408.8 ns | 3,430,447.5 ns |  1.00 |             Base |    0.00 | 137.5000 |       - |     - | 872,321 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-ZALFUF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   366,592.8 ns |  4,279.96 ns |  3,573.96 ns |   366,223.7 ns |   361,246.7 ns |   372,439.2 ns |  1.00 |             Same |    0.02 |   1.4535 |       - |     - |   9,553 B |
| RecursiveCreateDeleteDirectory | Job-KVFFMU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   366,512.9 ns |  6,944.90 ns |  6,156.47 ns |   365,293.6 ns |   357,992.4 ns |   378,678.6 ns |  1.00 |             Base |    0.00 |        - |       - |     - |   8,113 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-ZALFUF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,011,570.2 ns | 30,733.07 ns | 27,244.06 ns | 4,013,036.3 ns | 3,969,929.0 ns | 4,059,991.9 ns |  1.01 |             Same |    0.01 |  32.2581 | 16.1290 |     - | 249,588 B |
| RecursiveCreateDeleteDirectory | Job-KVFFMU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 3,957,395.1 ns | 45,248.32 ns | 37,784.40 ns | 3,959,139.7 ns | 3,891,123.8 ns | 4,021,439.7 ns |  1.00 |             Base |    0.00 |  31.7460 | 15.8730 |     - | 237,357 B |

</details>

<details>
<summary>Result 2</summary>

|                         Method |        Job |                                                                                                Toolchain | UnrollFactor | depth |           Mean |        Error |       StdDev |         Median |            Min |            Max | Ratio | MannWhitney(3ms) | RatioSD |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------- |--------------------------------------------------------------------------------------------------------- |------------- |------ |---------------:|-------------:|-------------:|---------------:|---------------:|---------------:|------:|----------------- |--------:|---------:|--------:|------:|----------:|
|                CreateDirectory | Job-NAOXHK |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    19,783.3 ns |    791.01 ns |    846.38 ns |    19,410.0 ns |    18,770.0 ns |    21,480.0 ns |  0.95 |             Same |    0.11 |        - |       - |     - |     497 B |
|                CreateDirectory | Job-SUNLMH | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    21,055.6 ns |  2,350.29 ns |  2,514.79 ns |    20,135.0 ns |    18,760.0 ns |    26,970.0 ns |  1.00 |             Base |    0.00 |        - |       - |     - |     377 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|            GetCurrentDirectory | Job-AIHZTX |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       603.1 ns |      7.41 ns |      6.93 ns |       602.6 ns |       586.8 ns |       615.6 ns |  1.00 |             Same |    0.01 |   0.0457 |       - |     - |     288 B |
|            GetCurrentDirectory | Job-HOTEOR | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       600.8 ns |      2.30 ns |      2.15 ns |       600.4 ns |       597.4 ns |       604.4 ns |  1.00 |             Base |    0.00 |   0.0436 |       - |     - |     288 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                         Exists | Job-AIHZTX |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       614.7 ns |      5.18 ns |      4.60 ns |       614.4 ns |       609.7 ns |       623.1 ns |  1.01 |             Same |    0.01 |        - |       - |     - |         - |
|                         Exists | Job-HOTEOR | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       611.0 ns |      4.58 ns |      4.06 ns |       609.4 ns |       604.1 ns |       618.4 ns |  1.00 |             Base |    0.00 |        - |       - |     - |         - |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                 EnumerateFiles | Job-AIHZTX |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,441,360.7 ns | 26,152.90 ns | 23,183.86 ns | 3,438,537.5 ns | 3,398,874.2 ns | 3,485,755.5 ns |  1.03 |             Same |    0.01 | 125.0000 |       - |     - | 872,323 B |
|                 EnumerateFiles | Job-HOTEOR | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,332,139.2 ns | 25,884.69 ns | 24,212.56 ns | 3,331,166.2 ns | 3,300,743.8 ns | 3,363,672.5 ns |  1.00 |             Base |    0.00 | 137.5000 |       - |     - | 872,322 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-AIHZTX |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   367,497.6 ns |  4,021.55 ns |  3,565.00 ns |   366,880.6 ns |   361,300.4 ns |   374,970.8 ns |  1.01 |             Same |    0.01 |   1.4620 |       - |     - |   9,554 B |
| RecursiveCreateDeleteDirectory | Job-HOTEOR | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   364,194.4 ns |  4,306.78 ns |  3,596.36 ns |   364,351.7 ns |   359,269.8 ns |   369,916.0 ns |  1.00 |             Base |    0.00 |        - |       - |     - |   8,113 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-AIHZTX |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,007,709.4 ns | 39,706.47 ns | 33,156.70 ns | 4,011,190.5 ns | 3,937,668.3 ns | 4,054,766.7 ns |  1.00 |             Same |    0.01 |  31.7460 | 15.8730 |     - | 249,587 B |
| RecursiveCreateDeleteDirectory | Job-HOTEOR | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,002,334.2 ns | 34,737.30 ns | 30,793.71 ns | 3,997,458.9 ns | 3,952,767.7 ns | 4,060,111.3 ns |  1.00 |             Base |    0.00 |  32.2581 | 16.1290 |     - | 237,357 B |

</details>

<details>
<summary>Result 3</summary>

|                         Method |        Job |                                                                                                Toolchain | UnrollFactor | depth |           Mean |        Error |       StdDev |         Median |            Min |            Max | Ratio | MannWhitney(3ms) | RatioSD |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------- |--------------------------------------------------------------------------------------------------------- |------------- |------ |---------------:|-------------:|-------------:|---------------:|---------------:|---------------:|------:|----------------- |--------:|---------:|--------:|------:|----------:|
|                CreateDirectory | Job-PDEYFB |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    20,425.8 ns |  1,504.72 ns |  1,672.50 ns |    19,930.0 ns |    18,730.0 ns |    24,170.0 ns |  0.99 |             Same |    0.10 |        - |       - |     - |     497 B |
|                CreateDirectory | Job-OWNBSX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    20,690.5 ns |  1,000.45 ns |  1,112.00 ns |    20,760.0 ns |    18,990.0 ns |    22,770.0 ns |  1.00 |             Base |    0.00 |        - |       - |     - |     377 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|            GetCurrentDirectory | Job-MLRFUU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       609.1 ns |      8.71 ns |      8.15 ns |       610.9 ns |       593.9 ns |       623.5 ns |  1.00 |             Same |    0.02 |   0.0452 |       - |     - |     288 B |
|            GetCurrentDirectory | Job-ZSPQVX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       606.5 ns |      7.70 ns |      7.21 ns |       606.4 ns |       591.4 ns |       616.1 ns |  1.00 |             Base |    0.00 |   0.0459 |       - |     - |     288 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                         Exists | Job-MLRFUU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       620.7 ns |      1.91 ns |      1.78 ns |       620.0 ns |       618.4 ns |       624.1 ns |  1.00 |             Same |    0.01 |        - |       - |     - |         - |
|                         Exists | Job-ZSPQVX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       621.7 ns |      4.35 ns |      4.07 ns |       623.0 ns |       613.1 ns |       625.9 ns |  1.00 |             Base |    0.00 |        - |       - |     - |         - |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                 EnumerateFiles | Job-MLRFUU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,492,924.1 ns | 31,351.68 ns | 29,326.38 ns | 3,489,420.3 ns | 3,446,018.8 ns | 3,538,670.3 ns |  1.03 |             Same |    0.01 | 125.0000 |       - |     - | 872,324 B |
|                 EnumerateFiles | Job-ZSPQVX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,391,640.5 ns | 33,177.29 ns | 31,034.06 ns | 3,391,781.2 ns | 3,344,562.5 ns | 3,461,081.2 ns |  1.00 |             Base |    0.00 | 137.5000 |       - |     - | 872,321 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-MLRFUU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   419,711.6 ns | 27,996.69 ns | 32,241.03 ns |   429,124.8 ns |   361,567.1 ns |   468,078.5 ns |  1.18 |             Same |    0.05 |        - |       - |     - |   9,553 B |
| RecursiveCreateDeleteDirectory | Job-ZSPQVX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   366,426.2 ns |  6,737.50 ns |  5,260.20 ns |   365,630.5 ns |   360,113.6 ns |   380,890.1 ns |  1.00 |             Base |    0.00 |        - |       - |     - |   8,113 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-MLRFUU |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,012,941.6 ns | 50,257.57 ns | 44,552.02 ns | 4,006,118.5 ns | 3,955,548.4 ns | 4,093,054.8 ns |  1.00 |             Same |    0.01 |  32.2581 | 16.1290 |     - | 249,588 B |
| RecursiveCreateDeleteDirectory | Job-ZSPQVX | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,031,409.2 ns | 39,659.96 ns | 35,157.52 ns | 4,019,719.4 ns | 3,995,309.7 ns | 4,119,485.5 ns |  1.00 |             Base |    0.00 |  32.2581 | 16.1290 |     - | 237,348 B |

</details>

<details>
<summary>Result 4</summary>

|                         Method |        Job |                                                                                                Toolchain | UnrollFactor | depth |           Mean |        Error |       StdDev |         Median |            Min |            Max | Ratio | MannWhitney(3ms) | RatioSD |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------- |--------------------------------------------------------------------------------------------------------- |------------- |------ |---------------:|-------------:|-------------:|---------------:|---------------:|---------------:|------:|----------------- |--------:|---------:|--------:|------:|----------:|
|                CreateDirectory | Job-ODAKGD |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    21,361.1 ns |  2,064.33 ns |  2,294.49 ns |    20,610.0 ns |    19,150.0 ns |    27,150.0 ns |  1.04 |             Same |    0.13 |        - |       - |     - |     497 B |
|                CreateDirectory | Job-OVXERW | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |            1 |     ? |    20,603.2 ns |  1,332.69 ns |  1,481.28 ns |    20,030.0 ns |    19,060.0 ns |    24,150.0 ns |  1.00 |             Base |    0.00 |        - |       - |     - |     377 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|            GetCurrentDirectory | Job-FNVICF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       596.2 ns |      8.61 ns |      8.05 ns |       597.1 ns |       581.3 ns |       607.6 ns |  1.00 |             Same |    0.02 |   0.0435 |       - |     - |     288 B |
|            GetCurrentDirectory | Job-MXCTDU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       597.5 ns |     10.43 ns |      9.25 ns |       597.7 ns |       584.1 ns |       616.2 ns |  1.00 |             Base |    0.00 |   0.0452 |       - |     - |     288 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                         Exists | Job-FNVICF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       618.3 ns |      5.64 ns |      5.28 ns |       617.5 ns |       611.5 ns |       630.4 ns |  0.99 |             Same |    0.01 |        - |       - |     - |         - |
|                         Exists | Job-MXCTDU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? |       623.7 ns |      3.24 ns |      3.04 ns |       624.3 ns |       619.3 ns |       628.6 ns |  1.00 |             Base |    0.00 |        - |       - |     - |         - |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
|                 EnumerateFiles | Job-FNVICF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,393,408.9 ns | 32,024.75 ns | 29,955.97 ns | 3,396,978.8 ns | 3,329,993.8 ns | 3,436,910.0 ns |  1.02 |             Same |    0.01 | 137.5000 |       - |     - | 872,322 B |
|                 EnumerateFiles | Job-MXCTDU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |     ? | 3,337,261.2 ns | 45,611.81 ns | 42,665.32 ns | 3,348,791.2 ns | 3,274,133.8 ns | 3,411,288.8 ns |  1.00 |             Base |    0.00 | 137.5000 |       - |     - | 872,321 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-FNVICF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   364,870.1 ns |  4,342.78 ns |  3,626.42 ns |   365,444.7 ns |   356,443.9 ns |   368,413.9 ns |  1.00 |             Same |    0.01 |   1.4599 |       - |     - |   9,554 B |
| RecursiveCreateDeleteDirectory | Job-MXCTDU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |    10 |   363,824.3 ns |  3,982.08 ns |  3,530.01 ns |   364,590.2 ns |   356,500.9 ns |   370,426.6 ns |  1.00 |             Base |    0.00 |        - |       - |     - |   8,113 B |
|                                |            |                                                                                                          |              |       |                |              |              |                |                |                |       |                  |         |          |         |       |           |
| RecursiveCreateDeleteDirectory | Job-FNVICF |      /runtime/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,005,961.7 ns | 43,158.49 ns | 38,258.88 ns | 4,002,134.2 ns | 3,939,368.3 ns | 4,092,201.7 ns |  1.00 |             Same |    0.01 |  33.3333 | 16.6667 |     - | 249,588 B |
| RecursiveCreateDeleteDirectory | Job-MXCTDU | /runtime_base/artifacts/bin/testhost/net6.0-Linux-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun |           16 |   100 | 4,016,106.9 ns | 55,378.57 ns | 43,235.95 ns | 4,016,171.0 ns | 3,941,038.7 ns | 4,079,680.6 ns |  1.00 |             Base |    0.00 |  32.2581 | 16.1290 |     - | 237,357 B |

</details>