### PR TITLE
Fix crash in mono_resolve_patch_target_ext when method is NULL.

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1429,11 +1429,11 @@ mono_resolve_patch_target_ext (MonoMemoryManager *mem_manager, MonoMethod *metho
 		if (method && method->dynamic) {
 			jump_table = (void **)mono_code_manager_reserve (mono_dynamic_code_hash_lookup (method)->code_mp, sizeof (gpointer) * patch_info->data.table->table_size);
 		} else {
-			MonoMemoryManager *mem_manager = m_method_get_mem_manager (method);
+			MonoMemoryManager *method_mem_manager = method ? m_method_get_mem_manager (method) : mem_manager;
 			if (mono_aot_only) {
-				jump_table = (void **)mono_mem_manager_alloc (mem_manager, sizeof (gpointer) * patch_info->data.table->table_size);
+				jump_table = (void **)mono_mem_manager_alloc (method_mem_manager, sizeof (gpointer) * patch_info->data.table->table_size);
 			} else {
-				jump_table = (void **)mono_mem_manager_code_reserve (mem_manager, sizeof (gpointer) * patch_info->data.table->table_size);
+				jump_table = (void **)mono_mem_manager_code_reserve (method_mem_manager, sizeof (gpointer) * patch_info->data.table->table_size);
 			}
 		}
 


### PR DESCRIPTION
Method can be NULL when resolving patch targets in AOT module:

```
coreclr.dll!m_method_get_mem_manager(_MonoMethod * method) Line 1600    C
coreclr.dll!mono_resolve_patch_target_ext(_MonoMemoryManager * mem_manager, _MonoMethod * method, unsigned char * code, MonoJumpInfo * patch_info, int run_cctors, _MonoErrorInternal * error) Line 1432    C
coreclr.dll!mono_resolve_patch_target(_MonoMethod * method, unsigned char * code, MonoJumpInfo * patch_info, int run_cctors, _MonoErrorInternal * error) Line 1683    C
coreclr.dll!init_method(MonoAotModule * amodule, void * info, unsigned int method_index, _MonoMethod * method, _MonoClass * init_class, _MonoErrorInternal * error) Line 4575    C
coreclr.dll!load_method(MonoAotModule * amodule, _MonoImage * image, _MonoMethod * method, unsigned int token, int method_index, _MonoErrorInternal * error) Line 4165    C
coreclr.dll!mono_aot_get_method_from_token(_MonoImage * image, unsigned int token, _MonoErrorInternal * error) Line 4883    C
coreclr.dll!mono_aot_trampoline(__int64 * regs, unsigned char * code, unsigned char * token_info, unsigned char * tramp) Line 886    C
0000023b8d930b56()    Unknown
System.Private.CoreLib.dll.dll!System.Diagnostics.Tracing.ManifestBuilder:StartEvent()    C#
```

This PR handles case and fall-backs to passed in memory manager in cases where method is NULL.

Issue introduced by https://github.com/dotnet/runtime/commit/7ea91b742cc1646bd1611749a8179fba2fcdc3af.