### PR TITLE
Download Mono AOT workload .nupkg in prepare-artifacts.proj

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -191,7 +191,6 @@
       <!-- RID-specific framework packs. -->
       <RuntimeNupkgFile
         Include="
-          $(DownloadDirectory)**\Microsoft.NET.Sdk.Mono.Toolchain.Manifest.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.Runtime.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.App.Crossgen2.*.nupkg"
@@ -219,6 +218,7 @@
       -->
       <RidAgnosticNupkgToPublishFile
         Include="
+          $(DownloadDirectory)**\Microsoft.NET.Sdk.Mono.Toolchain.Manifest.*.nupkg;
           $(DownloadDirectory)*\$(PublishRidAgnosticPackagesFromPlatform)\**\*.nupkg;
           $(DownloadDirectory)*\*AllConfigurations\**\*.nupkg"
         Exclude="@(RuntimeNupkgFile);@(DownloadedSymbolNupkgFile)" />

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -191,6 +191,7 @@
       <!-- RID-specific framework packs. -->
       <RuntimeNupkgFile
         Include="
+          $(DownloadDirectory)**\Microsoft.NET.Sdk.Mono.Toolchain.Manifest.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.Runtime.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.App.Crossgen2.*.nupkg"


### PR DESCRIPTION
Fixes the official build failure after https://github.com/dotnet/runtime/pull/51327 since the pattern we were using didn't include it.

Note: it sounds wrong to have these in `RuntimeNupkgFile` but I'm sending the PR to unblock the official build, we'll refactor it in a follow-up PR.

Test official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1120630&view=results