### PR TITLE
Fix error where strings were being tracked on IgnoreCycles

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -316,7 +316,10 @@ namespace System.Text.Json.Serialization
             }
 
             bool ignoreCyclesPopReference = false;
+
             if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
+                // .NET types that are parsed to JSON value types doesn't need to be tracked for cycle detection e.g: string.
+                ConverterStrategy != ConverterStrategy.Value &&
                 !IsValueType && !IsNull(value))
             {
                 Debug.Assert(value != null);
@@ -331,11 +334,9 @@ namespace System.Text.Json.Serialization
 
                 // For boxed reference types: do not push when boxed in order to avoid false positives
                 //   when we run the ContainsReferenceForCycleDetection check for the converter of the unboxed value.
-                if (!CanBePolymorphic)
-                {
-                    resolver.PushReferenceForCycleDetection(value);
-                    ignoreCyclesPopReference = true;
-                }
+                Debug.Assert(!CanBePolymorphic);
+                resolver.PushReferenceForCycleDetection(value);
+                ignoreCyclesPopReference = true;
             }
 
             if (CanBePolymorphic)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -322,7 +322,13 @@ namespace System.Text.Json.Serialization
                 ConverterStrategy != ConverterStrategy.Value &&
                 !IsValueType && !IsNull(value))
             {
+                // Custom (user) converters shall not track references
+                //  it is responsibility of the user to break cycles in case there's any
+                //  if we compare against Preserve, objects don't get preserved when a custom converter exists
+                //  given that the custom converter executes prior to the preserve logic.
+                Debug.Assert(IsInternalConverter);
                 Debug.Assert(value != null);
+
                 ReferenceResolver resolver = state.ReferenceResolver;
 
                 // Write null to break reference cycles.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -318,7 +318,7 @@ namespace System.Text.Json.Serialization
             bool ignoreCyclesPopReference = false;
 
             if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
-                // .NET types that are parsed to JSON value types doesn't need to be tracked for cycle detection e.g: string.
+                // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
                 ConverterStrategy != ConverterStrategy.Value &&
                 !IsValueType && !IsNull(value))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -235,7 +235,10 @@ namespace System.Text.Json.Serialization.Metadata
             T value = Get!(obj);
 
             if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
-                !Converter.IsValueType && value != null &&
+                value != null &&
+                // .NET types that are parsed to JSON value types doesn't need to be tracked for cycle detection e.g: string.
+                // However JsonConverter<object> that uses ConverterStrategy == Value is an exception.
+                (Converter.CanBePolymorphic || (!Converter.IsValueType && ConverterStrategy != ConverterStrategy.Value)) &&
                 state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
             {
                 // If a reference cycle is detected, treat value as null.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -236,7 +236,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
                 value != null &&
-                // .NET types that are parsed to JSON value types doesn't need to be tracked for cycle detection e.g: string.
+                // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
                 // However JsonConverter<object> that uses ConverterStrategy == Value is an exception.
                 (Converter.CanBePolymorphic || (!Converter.IsValueType && ConverterStrategy != ConverterStrategy.Value)) &&
                 state.ReferenceResolver.ContainsReferenceForCycleDetection(value))

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
@@ -345,12 +345,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact] // https://github.com/dotnet/runtime/issues/51837
         public async void IgnoreCycles_StringShouldNotBeIgnored()
         {
+            var stringReference = "John";
+            
             var root = new Person
             {
-                Name = "John",
+                Name = stringReference,
                 Parent = new Person
                 {
-                    Name = "John",
+                    Name = stringReference,
                 }
             };
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51837

We were currently pushing strings to the stack of references because we were only filtering types that were value types in .NET (`Converter.IsValueType`). This PR adds filtering of types that have `ConverterStrategy != ConverterStrategy.Value` since those can be considered as primitive types in JSON cannot cause a loop. 

Keep in mind that `JsonConverter<object>` also defines `ConverterStrategy` as `ConverterStrategy.Value` therefore I have to special case it.