### PR TITLE
Check output size in Expand and DeriveKey in HKDF and throw ArgumentOutOfRangeException when needed

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -363,4 +363,7 @@
   <data name="Cryptography_FeedbackSizeNotSupported" xml:space="preserve">
     <value>The current platform does not support the specified feedback size.</value>
   </data>
+  <data name="Cryptography_OutputLength_OutOfRange" xml:space="preserve">
+    <value>The current platform does not support the specified feedback size.</value>
+  </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
@@ -81,13 +81,16 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="hashAlgorithmName">The hash algorithm used for HMAC operations.</param>
         /// <param name="prk">The pseudorandom key of at least <see cref="HashLength"/> bytes (usually the output from Expand step).</param>
-        /// <param name="outputLength">The length of the output keying material.</param>
+        /// <param name="outputLength">The length of the output keying material that must be larger than 0.</param>
         /// <param name="info">The optional context and application specific information.</param>
         /// <returns>The output keying material.</returns>
         public static byte[] Expand(HashAlgorithmName hashAlgorithmName, byte[] prk, int outputLength, byte[]? info = null)
         {
             if (prk == null)
                 throw new ArgumentNullException(nameof(prk));
+
+            if (outputLength <= 0)
+                throw new ArgumentOutOfRangeException(nameof(outputLength), SR.Cryptography_OutputLength_OutOfRange);
 
             int hashLength = HashLength(hashAlgorithmName);
 
@@ -108,11 +111,14 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="hashAlgorithmName">The hash algorithm used for HMAC operations.</param>
         /// <param name="prk">The pseudorandom key of at least <see cref="HashLength"/> bytes (usually the output from Expand step).</param>
-        /// <param name="output">The destination buffer to receive the output keying material.</param>
+        /// <param name="output">The destination buffer to receive the output keying material with a size of as least 1.</param>
         /// <param name="info">The context and application specific information (can be an empty span).</param>
         public static void Expand(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> prk, Span<byte> output, ReadOnlySpan<byte> info)
         {
             int hashLength = HashLength(hashAlgorithmName);
+
+            if (output.Length == 0)
+                throw new ArgumentOutOfRangeException(nameof(output), SR.Cryptography_OutputLength_OutOfRange);
 
             // Constant comes from section 2.3 (the constraint on L in the Inputs section)
             int maxOkmLength = 255 * hashLength;
@@ -170,7 +176,7 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="hashAlgorithmName">The hash algorithm used for HMAC operations.</param>
         /// <param name="ikm">The input keying material.</param>
-        /// <param name="outputLength">The length of the output keying material.</param>
+        /// <param name="outputLength">The length of the output keying material that must be larger than 0.</param>
         /// <param name="salt">The optional salt value (a non-secret random value). If not provided it defaults to a byte array of <see cref="HashLength"/> zeros.</param>
         /// <param name="info">The optional context and application specific information.</param>
         /// <returns>The output keying material.</returns>
@@ -178,6 +184,9 @@ namespace System.Security.Cryptography
         {
             if (ikm == null)
                 throw new ArgumentNullException(nameof(ikm));
+
+            if (outputLength <= 0)
+                throw new ArgumentOutOfRangeException(nameof(outputLength), SR.Cryptography_OutputLength_OutOfRange);
 
             int hashLength = HashLength(hashAlgorithmName);
             Debug.Assert(hashLength <= 512 / 8, "hashLength is larger than expected, consider increasing this value or using regular allocation");
@@ -202,12 +211,15 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="hashAlgorithmName">The hash algorithm used for HMAC operations.</param>
         /// <param name="ikm">The input keying material.</param>
-        /// <param name="output">The output buffer representing output keying material.</param>
+        /// <param name="output">The output buffer representing output keying material  with a size of as least 1.</param>
         /// <param name="salt">The salt value (a non-secret random value).</param>
         /// <param name="info">The context and application specific information (can be an empty span).</param>
         public static void DeriveKey(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, Span<byte> output, ReadOnlySpan<byte> salt, ReadOnlySpan<byte> info)
         {
             int hashLength = HashLength(hashAlgorithmName);
+
+            if (output.Length == 0)
+                throw new ArgumentOutOfRangeException(nameof(output), SR.Cryptography_OutputLength_OutOfRange);
 
             // Constant comes from section 2.3 (the constraint on L in the Inputs section)
             int maxOkmLength = 255 * hashLength;

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
@@ -439,6 +439,24 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
 
             [Fact]
+            public void Rfc5869ExpandOutputLengthZero()
+            {
+                byte[] prk = new byte[20];
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                    "outputLength",
+                    () => HKDF.Expand(HashAlgorithmName.SHA1, prk, 0, Array.Empty<byte>()));
+            }
+
+            [Fact]
+            public void Rfc5869ExpandOutputLengthLessThanZero()
+            {
+                byte[] prk = new byte[20];
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                    "outputLength",
+                    () => HKDF.Expand(HashAlgorithmName.SHA1, prk, -1, Array.Empty<byte>()));
+            }
+
+            [Fact]
             public void Rfc5869DeriveKeyNullIkm()
             {
                 AssertExtensions.Throws<ArgumentNullException>(
@@ -462,6 +480,24 @@ namespace System.Security.Cryptography.Algorithms.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>(
                     "outputLength",
                     () => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, 8421505, Array.Empty<byte>(), Array.Empty<byte>()));
+            }
+
+            [Fact]
+            public void Rfc5869DeriveOutputLengthZero()
+            {
+                byte[] ikm = new byte[20];
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                    "outputLength",
+                    () => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, 0, Array.Empty<byte>(), Array.Empty<byte>()));
+            }
+
+            [Fact]
+            public void Rfc5869DeriveOutputLengthLessThanZero()
+            {
+                byte[] ikm = new byte[20];
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                    "outputLength",
+                    () => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, -1, Array.Empty<byte>(), Array.Empty<byte>()));
             }
         }
 
@@ -531,6 +567,17 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
 
             [Fact]
+            public void Rfc5869ExpandOutputLengthZero()
+            {
+                byte[] prk = new byte[20];
+                byte[] okm = new byte[0];
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                    "output",
+                    () => HKDF.Expand(HashAlgorithmName.SHA1, prk, okm, Array.Empty<byte>()));
+            }
+
+            [Fact]
             public void Rfc5869DeriveKeySpanOkmMaxSizePlusOne()
             {
                 byte[] ikm = new byte[20];
@@ -546,6 +593,17 @@ namespace System.Security.Cryptography.Algorithms.Tests
                 byte[] ikm = new byte[20];
                 byte[] okm = new byte[8421505];
                 AssertExtensions.Throws<ArgumentException>(
+                    "output",
+                    () => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, okm, Array.Empty<byte>(), Array.Empty<byte>()));
+            }
+
+            [Fact]
+            public void Rfc5869DeriveKeyOutputLengthZero()
+            {
+                byte[] ikm = new byte[20];
+                byte[] okm = new byte[0];
+
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(
                     "output",
                     () => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, okm, Array.Empty<byte>(), Array.Empty<byte>()));
             }


### PR DESCRIPTION
This closes #42229 and closes #42230 

This should add some consistency to these methods and will throw an `ArgumentOutOfRangeException` on `output` and `outputLength` if the values for these are either 0 or less than 0 since an output of 0 doesn't make much sense, and less than 0 isn't possible.

Also added tests to check all of these scenarios. 