### PR TITLE
[tests] Fix integer rounding error in GetTestFileName

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -104,7 +104,7 @@ namespace System.IO
                     // Take a chunk out of the middle as perhaps it's the least interesting part of the name
                     int halfMemberNameLength = (int)Math.Floor((double)memberName.Length / 2);
                     int halfExcessLength = (int)Math.Floor((double)excessLength / 2);
-                    memberName = memberName.Substring(0, halfMemberNameLength - halfExcessLength) + "..." + memberName.Substring(halfMemberNameLength + halfExcessLength + 1);
+                    memberName = memberName.Substring(0, halfMemberNameLength - halfExcessLength) + "..." + memberName.Substring(halfMemberNameLength + halfExcessLength);
 
                     testFileName = GenerateTestFileName(index, memberName, lineNumber);
                     testFilePath = Path.Combine(TestDirectory, testFileName);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -102,7 +102,9 @@ namespace System.IO
                 if (excessLength < memberName.Length + "...".Length)
                 {
                     // Take a chunk out of the middle as perhaps it's the least interesting part of the name
-                    memberName = memberName.Substring(0, memberName.Length / 2 - excessLength / 2) + "..." + memberName.Substring(memberName.Length / 2 + excessLength / 2);
+                    int halfMemberNameLength = (int)Math.Floor((double)memberName.Length / 2);
+                    int halfExcessLength = (int)Math.Floor((double)excessLength / 2);
+                    memberName = memberName.Substring(0, halfMemberNameLength - halfExcessLength) + "..." + memberName.Substring(halfMemberNameLength + halfExcessLength + 1);
 
                     testFileName = GenerateTestFileName(index, memberName, lineNumber);
                     testFilePath = Path.Combine(TestDirectory, testFileName);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -103,7 +103,7 @@ namespace System.IO
                 {
                     // Take a chunk out of the middle as perhaps it's the least interesting part of the name
                     int halfMemberNameLength = (int)Math.Floor((double)memberName.Length / 2);
-                    int halfExcessLength = (int)Math.Floor((double)excessLength / 2);
+                    int halfExcessLength = (int)Math.Ceiling((double)excessLength / 2);
                     memberName = memberName.Substring(0, halfMemberNameLength - halfExcessLength) + "..." + memberName.Substring(halfMemberNameLength + halfExcessLength);
 
                     testFileName = GenerateTestFileName(index, memberName, lineNumber);


### PR DESCRIPTION
Fixes #52257

There seemed to be an integer rounding error when getting a portion of the test file name. Using the suggestion https://github.com/dotnet/runtime/issues/52257#issuecomment-832163922 led to the tests running to completion with no crashes or hangs.