### PR TITLE
Arm64: Use zero register wherever possible

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1580,6 +1580,12 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     }
 #endif // FEATURE_SIMD
 
+#ifdef TARGET_ARM64
+    if (IsContainableImmed(storeLoc, op1))
+    {
+        MakeSrcContained(storeLoc, op1);
+    }
+#else
     // If the source is a containable immediate, make it contained, unless it is
     // an int-size or larger store of zero to memory, because we can generate smaller code
     // by zeroing a register and then storing it.
@@ -1588,7 +1594,6 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     {
         MakeSrcContained(storeLoc, op1);
     }
-#ifdef TARGET_ARM
     else if (op1->OperGet() == GT_LONG)
     {
         MakeSrcContained(storeLoc, op1);


### PR DESCRIPTION
While investigating https://github.com/dotnet/runtime/issues/41704 I noticed that we do not use zero register often, but instead move `#0` to a register and then use that register. This minor PR fixes that issue (thanks to @echesakov for cross checking the fix). For Arm64, we would just mark such node as contained and then, wherever that value is used, code generation already handles the cases for `0` immediate by emitting `REG_ZR`.