### PR TITLE
Release GCHandle in FSEventStreamContext release callback

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -78,8 +78,8 @@ internal static partial class Interop
         {
             public CFIndex version;
             public IntPtr info;
-            public IntPtr retainFunc;
-            public IntPtr releaseFunc;
+            public IntPtr retain;
+            public IntPtr release;
             public IntPtr copyDescription;
         }
 

--- a/src/libraries/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
@@ -19,8 +19,8 @@ internal static partial class Interop
         {
             public CFIndex version;
             public IntPtr info;
-            public IntPtr retainFunc;
-            public IntPtr releaseFunc;
+            public IntPtr retain;
+            public IntPtr release;
             public IntPtr copyDescription;
         }
 

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -275,9 +275,6 @@ namespace System.IO
 
                     StaticWatcherRunLoopManager.UnscheduleFromRunLoop(eventStream);
                     eventStream.Dispose();
-
-                    Debug.Assert(_gcHandle.IsAllocated);
-                    _gcHandle.Free();
                 }
             }
 
@@ -314,6 +311,7 @@ namespace System.IO
 
                     Interop.EventStream.FSEventStreamContext context = default;
                     context.info = GCHandle.ToIntPtr(_gcHandle);
+                    context.release = (IntPtr)(delegate* unmanaged<IntPtr, void>)&ReleaseCallback;
 
                     // Create the event stream for the path and tell the stream to watch for file system events.
                     SafeEventStreamHandle eventStream = Interop.EventStream.FSEventStreamCreate(
@@ -336,7 +334,10 @@ namespace System.IO
                 finally
                 {
                     if (cleanupGCHandle)
+                    {
+                        Debug.Assert(_gcHandle.Target is RunningInstance);
                         _gcHandle.Free();
+                    }
                     arrPaths?.Dispose();
                     path?.Dispose();
                 }
@@ -371,6 +372,14 @@ namespace System.IO
                         CleanupEventStream();
                     }
                 }
+            }
+
+            [UnmanagedCallersOnly]
+            private static void ReleaseCallback(IntPtr clientCallBackInfo)
+            {
+                GCHandle gcHandle = GCHandle.FromIntPtr(clientCallBackInfo);
+                Debug.Assert(gcHandle.Target is RunningInstance);
+                gcHandle.Free();
             }
 
             [UnmanagedCallersOnly]


### PR DESCRIPTION
The callbacks are sometimes delivered even after the FSEventStream is disposed

Fixes #30056