### PR TITLE
Print R2RDump Statistics in the Output File Instead of Console

### DIFF
--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -561,13 +561,55 @@ namespace R2RDump
                     Count = group.Count()
                 }).OrderByDescending(x => x.Count);
 
-            _writer.WriteLine($"                      Fixup | Count");
+            /* Runtime Repo GH Issue #49249:
+             *
+             * In order to format the fixup counts results table, we need to
+             * know beforehand the size of each column. */
+
+            int longestFixupKind = 0;
+            int sortedFixupCountsTotal = sortedFixupCounts.Sum(x => x.Count);
+
+            /* First, we look at all the Fixup Kinds that will be printed. We
+             * then store the length of the longest one's name. */
+
             foreach (var fixupAndCount in sortedFixupCounts)
             {
-                _writer.WriteLine($"{fixupAndCount.FixupKind, 27} | {fixupAndCount.Count, 5}");
+                int kindLength = fixupAndCount.FixupKind.ToString().Length;
+
+                if (kindLength > longestFixupKind)
+                    longestFixupKind = kindLength;
             }
-            _writer.WriteLine("-----------------------------------");
-            _writer.WriteLine($"                      Total | {sortedFixupCounts.Sum(x => x.Count), 5}");
+
+            /* The padding is calculated in the two following lines:
+             *
+             * Fixup: Length of the longest Fixup Kind name, as explained above.
+             * Count: Since a total is always bigger than its operands, we set
+             *        the padding to the total's number of digits.
+             *
+             * The reason we are using 'Max()' here is because in the case of only
+             * getting values shorter than 5 digits (Length of "Fixup" and "Count"),
+             * the formatting could be messed up. The likelyhood of this happening
+             * is apparently 0%, but better safe than sorry.
+             */
+
+            int fixupPadding = Math.Max(longestFixupKind, 5);
+            int countPadding = Math.Max(sortedFixupCountsTotal.ToString().Length, 5);
+
+            _writer.WriteLine(
+                $"{"Fixup".PadLeft(fixupPadding)} | {"Count".PadLeft(countPadding)}"
+            );
+            foreach (var fixupAndCount in sortedFixupCounts)
+            {
+                _writer.WriteLine(
+                    $"{fixupAndCount.FixupKind.ToString().PadLeft(fixupPadding)} | {fixupAndCount.Count.ToString().PadLeft(countPadding)}"
+                );
+            }
+
+            // The +3 in this divider is to account for the " | " table division.
+            _writer.WriteLine(new string('-', fixupPadding + countPadding + 3));
+            _writer.WriteLine(
+                $"{"Total".PadLeft(fixupPadding)} | {sortedFixupCountsTotal.ToString().PadLeft(countPadding)}"
+            );
             SkipLine();
         }
     }

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -564,36 +564,32 @@ namespace R2RDump
             /* Runtime Repo GH Issue #49249:
              *
              * In order to format the fixup counts results table, we need to
-             * know beforehand the size of each column. */
+             * know beforehand the size of each column. The padding is calculated
+             * as follows:
+             *
+             * Fixup: Length of the longest Fixup Kind name.
+             * Count: Since a total is always bigger than its operands, we set
+             *        the padding to the total's number of digits.
+             *
+             * The reason we want them to be at least 5, is because in the case of only
+             * getting values shorter than 5 digits (Length of "Fixup" and "Count"),
+             * the formatting could be messed up. The likelyhood of this happening
+             * is apparently 0%, but better safe than sorry. */
 
-            int longestFixupKind = 0;
+            int fixupPadding = 5;
             int sortedFixupCountsTotal = sortedFixupCounts.Sum(x => x.Count);
+            int countPadding = Math.Max(sortedFixupCountsTotal.ToString().Length, 5);
 
-            /* First, we look at all the Fixup Kinds that will be printed. We
+            /* We look at all the Fixup Kinds that will be printed. We
              * then store the length of the longest one's name. */
 
             foreach (var fixupAndCount in sortedFixupCounts)
             {
                 int kindLength = fixupAndCount.FixupKind.ToString().Length;
 
-                if (kindLength > longestFixupKind)
-                    longestFixupKind = kindLength;
+                if (kindLength > fixupPadding)
+                    fixupPadding = kindLength;
             }
-
-            /* The padding is calculated in the two following lines:
-             *
-             * Fixup: Length of the longest Fixup Kind name, as explained above.
-             * Count: Since a total is always bigger than its operands, we set
-             *        the padding to the total's number of digits.
-             *
-             * The reason we are using 'Max()' here is because in the case of only
-             * getting values shorter than 5 digits (Length of "Fixup" and "Count"),
-             * the formatting could be messed up. The likelyhood of this happening
-             * is apparently 0%, but better safe than sorry.
-             */
-
-            int fixupPadding = Math.Max(longestFixupKind, 5);
-            int countPadding = Math.Max(sortedFixupCountsTotal.ToString().Length, 5);
 
             _writer.WriteLine(
                 $"{"Fixup".PadLeft(fixupPadding)} | {"Count".PadLeft(countPadding)}"

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -561,13 +561,13 @@ namespace R2RDump
                     Count = group.Count()
                 }).OrderByDescending(x => x.Count);
 
-            Console.WriteLine($"                      Fixup | Count");
+            _writer.WriteLine($"                      Fixup | Count");
             foreach (var fixupAndCount in sortedFixupCounts)
             {
-                Console.WriteLine($"{fixupAndCount.FixupKind, 27} | {fixupAndCount.Count, 5}");
+                _writer.WriteLine($"{fixupAndCount.FixupKind, 27} | {fixupAndCount.Count, 5}");
             }
-            Console.WriteLine("-----------------------------------");
-            Console.WriteLine($"                      Total | {sortedFixupCounts.Sum(x => x.Count), 5}");
+            _writer.WriteLine("-----------------------------------");
+            _writer.WriteLine($"                      Total | {sortedFixupCounts.Sum(x => x.Count), 5}");
             SkipLine();
         }
     }


### PR DESCRIPTION
This PR fixes #49249. When running `R2RDump.exe/dll`, the Fixup count statistics were shown in the console at the end. The intended behavior was to add them at the end of the resulting `--out` file instead.

This PR addresses this issue, and adds a little useful feature. Instead of hardcoding the table's format, its padding is now generated from the contents that will be printed in it. This allows it to always display properly, regardless of the fields and numbers stored, and therefore is now a self-maintaining component.

Before this change:
```text
=========== Eager fixup counts across all methods ===========
                      Fixup | Count
         Verify_FieldOffset | 655074
                 TypeHandle | 243894
          Verify_TypeLayout | 122611
               StringHandle | 106559
           MethodDictionary |  5465
      IndirectPInvokeTarget |  1007
             TypeDictionary |   950
Check_InstructionSetSupport |   736
               MethodHandle |   277
              PInvokeTarget |    88
       MethodEntry_DefToken |    12
                FieldHandle |     8
-----------------------------------
                      Total | 1136681
=============================================================
```

After this change:
```text
=========== Eager fixup counts across all methods ===========
                      Fixup |   Count
         Verify_FieldOffset |  655074
                 TypeHandle |  243894
          Verify_TypeLayout |  122611
               StringHandle |  106559
           MethodDictionary |    5465
      IndirectPInvokeTarget |    1007
             TypeDictionary |     950
Check_InstructionSetSupport |     736
               MethodHandle |     277
              PInvokeTarget |      88
       MethodEntry_DefToken |      12
                FieldHandle |       8
-------------------------------------
                      Total | 1136681
=============================================================
```
