### PR TITLE
Skip "reserved device names as path segments" tests on Win10

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -22,7 +22,8 @@ namespace System
         public static bool HasWindowsShell => IsWindows && IsNotWindowsServerCore && IsNotWindowsNanoServer && IsNotWindowsIoTCore;
         public static bool IsWindows7 => IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsWindows8x => IsWindows && GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
-        public static bool IsWindows8xOrLater => IsWindows && new Version((int)GetWindowsVersion(), (int)GetWindowsMinorVersion()) >= new Version(6, 2);
+        public static bool IsWindows8xOrLater => IsWindowsVersionOrLater(6, 2);
+        public static bool IsWindows10OrLater => IsWindowsVersionOrLater(10, 0);
         public static bool IsWindowsNanoServer => IsWindows && (IsNotWindowsIoTCore && GetWindowsInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => IsWindows && GetWindowsInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
         public static int WindowsVersion => IsWindows ? (int)GetWindowsVersion() : -1;
@@ -37,31 +38,24 @@ namespace System
         public static bool IsSoundPlaySupported => IsWindows && IsNotWindowsNanoServer;
 
         // >= Windows 10 Anniversary Update
-        public static bool IsWindows10Version1607OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
+        public static bool IsWindows10Version1607OrGreater => IsWindowsVersionOrLater(10, 0, 14393);
 
-         // >= Windows 10 Creators Update
-        public static bool IsWindows10Version1703OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 15063;
+        // >= Windows 10 Creators Update
+        public static bool IsWindows10Version1703OrGreater => IsWindowsVersionOrLater(10, 0, 15063);
 
         // >= Windows 10 Fall Creators Update
-        public static bool IsWindows10Version1709OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16299;
+        public static bool IsWindows10Version1709OrGreater => IsWindowsVersionOrLater(10, 0, 16299);
 
         // >= Windows 10 April 2018 Update
-        public static bool IsWindows10Version1803OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 17134;
+        public static bool IsWindows10Version1803OrGreater => IsWindowsVersionOrLater(10, 0, 17134);
 
         // >= Windows 10 May 2019 Update (19H1)
-        public static bool IsWindows10Version1903OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 18362;
+        public static bool IsWindows10Version1903OrGreater => IsWindowsVersionOrLater(10, 0, 18362);
 
-        // >= Windows 10 20H1 Update (As of Jan. 2020 yet to be released)
-        // Per https://docs.microsoft.com/en-us/windows-insider/flight-hub/ the first 20H1 build is 18836.
-        public static bool IsWindows10Version2004OrGreater => IsWindows &&
-            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 18836;
+        // >= Windows 10 20H1 Update
+        public static bool IsWindows10Version2004OrGreater => IsWindowsVersionOrLater(10, 0, 19041);
 
-        public static bool IsWindows10Version2004Build19573OrGreater => IsWindows10Version2004OrGreater && GetWindowsBuildNumber() >= 19573;
+        public static bool IsWindows10Version2004Build19573OrGreater => IsWindowsVersionOrLater(10, 0, 19573);
 
         public static bool IsWindowsIoTCore
         {
@@ -178,20 +172,25 @@ namespace System
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
 
-        internal static uint GetWindowsVersion()
+        private static volatile Version s_windowsVersionObject;
+        internal static Version GetWindowsVersionObject()
         {
-            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
-            return osvi.dwMajorVersion;
+            if (s_windowsVersionObject is null)
+            {
+                Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
+                Version newObject = new Version(checked((int)osvi.dwMajorVersion), checked((int)osvi.dwMinorVersion), checked((int)osvi.dwBuildNumber));
+                s_windowsVersionObject = newObject;
+            }
+
+            return s_windowsVersionObject;
         }
-        internal static uint GetWindowsMinorVersion()
+
+        internal static uint GetWindowsVersion() => (uint)GetWindowsVersionObject().Major;
+        internal static uint GetWindowsMinorVersion() => (uint)GetWindowsVersionObject().Minor;
+
+        internal static bool IsWindowsVersionOrLater(int major, int minor, int build = -1)
         {
-            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
-            return osvi.dwMinorVersion;
-        }
-        internal static uint GetWindowsBuildNumber()
-        {
-            Assert.Equal(0, Interop.NtDll.RtlGetVersionEx(out Interop.NtDll.RTL_OSVERSIONINFOEX osvi));
-            return osvi.dwBuildNumber;
+            return IsWindows && GetWindowsVersionObject() >= (build != -1 ? new Version(major, minor, build) : new Version(major, minor));
         }
 
         private static int s_isInAppContainer = -1;

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -414,18 +414,16 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            MemberData(nameof(PathsWithReservedDeviceNames))]
-        [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
+        [ConditionalTheory(nameof(ReservedDeviceNamesAreBlocked))] // device name prefixes
+        [MemberData(nameof(PathsWithReservedDeviceNames))]
         public void PathWithReservedDeviceNameAsPath_ThrowsDirectoryNotFoundException(string path)
         {
             // Throws DirectoryNotFoundException, when the behavior really should be an invalid path
             Assert.Throws<DirectoryNotFoundException>(() => Create(path));
         }
 
-        [ConditionalTheory(nameof(UsingNewNormalization)),
-            MemberData(nameof(ReservedDeviceNames))]
-        [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
+        [ConditionalTheory(nameof(ReservedDeviceNamesAreBlocked), nameof(UsingNewNormalization))] // device name prefixes
+        [MemberData(nameof(ReservedDeviceNames))]
         public void PathWithReservedDeviceNameAsExtendedPath(string path)
         {
             Assert.True(Create(IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, path)).Exists, path);

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -291,10 +291,9 @@ namespace System.IO.Tests
 
         }
 
-        [Theory,
-            MemberData(nameof(PathsWithReservedDeviceNames))]
+        [ConditionalTheory(nameof(ReservedDeviceNamesAreBlocked))] // device names
+        [MemberData(nameof(PathsWithReservedDeviceNames))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows)] // device names
         public void PathWithReservedDeviceNameAsPath_ReturnsFalse(string component)
         {
             Assert.False(Exists(component));

--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -222,10 +222,9 @@ namespace System.IO.Tests
             Assert.False(Exists(component));
         }
 
-        [Theory,
-            MemberData(nameof(PathsWithReservedDeviceNames))]
+        [ConditionalTheory(nameof(ReservedDeviceNamesAreBlocked))] // device names
+        [MemberData(nameof(PathsWithReservedDeviceNames))]
         [OuterLoop]
-        [PlatformSpecific(TestPlatforms.Windows)] // device names
         public void PathWithReservedDeviceNameAsPath_ReturnsFalse(string component)
         {
             Assert.False(Exists(component));

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -20,6 +20,8 @@ namespace System.IO.Tests
 
         public static bool UsingNewNormalization => !PathFeatures.IsUsingLegacyPathNormalization();
 
+        public static bool ReservedDeviceNamesAreBlocked => PlatformDetection.IsWindows && !PlatformDetection.IsWindows10OrLater;
+
         public static TheoryData<string> PathsWithInvalidColons = TestData.PathsWithInvalidColons;
         public static TheoryData<string> PathsWithInvalidCharacters = TestData.PathsWithInvalidCharacters;
         public static TheoryData<char> TrailingCharacters = TestData.TrailingCharacters;

--- a/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -220,7 +220,10 @@ internal static class IOInputs
     }
 
     public static IEnumerable<string> GetReservedDeviceNames()
-    {   // See: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
+    {   // See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+        //
+        // Note - Recent versions of Win10 relax this restriction and allow reserved
+        // device names as filenames.
         yield return "CON";
         yield return "AUX";
         yield return "NUL";


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/20986.

Recent versions of Win10 relax the restriction on creating filesystem objects named `COM1`, `LPT1`, `AUX`, and similar. Some of our tests attempt to create these "illegal" filesystem objects and fail, as they're expecting an exception, but the directory is instead created successfully.

This PR skips all such tests on Win10, since we shouldn't test behavior which is an OS implementation detail subject to change. The tests still run on Win7 and Win8 to ensure that we're throwing friendly exception messages on those platforms.

I also took this opportunity to clean up some of the logic in _PlatformDetection.cs_. The Windows version checks now mostly filter down to a single helper, except where very specific version checks must take place.

There are __no changes to shipping code__ in this PR. This PR only affects unit tests.