### PR TITLE
Stop harvesting S.IO.Pipes.AccessControl

### DIFF
--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -2,13 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Pipes.AccessControl.csproj">
-      <SupportedFramework>$(NetCoreAppCurrent)</SupportedFramework>
+      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
-    <HarvestIncludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" />
-    <HarvestIncludePaths Include="ref/netstandard2.0;lib/netstandard2.0" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.1" />
-    <HarvestIncludePaths Include="ref/net5.0;lib/net5.0;runtimes/win/lib/net5.0" />
     <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
     <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
@@ -65,14 +65,4 @@ namespace System.IO.Pipes
         public void SetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
         public void SetAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
     }
-
-    public static class AnonymousPipeServerStreamAcl
-    {
-        public static System.IO.Pipes.AnonymousPipeServerStream Create(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity) { throw null; }
-    }
-
-    public static class NamedPipeServerStreamAcl
-    {
-        public static System.IO.Pipes.NamedPipeServerStream Create(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity, System.IO.HandleInheritability inheritability = System.IO.HandleInheritability.None, System.IO.Pipes.PipeAccessRights additionalAccessRights = default) { throw null; }
-    }
 }

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
@@ -1,14 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net461</TargetFrameworks>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
+  <PropertyGroup>
+    <IsPartialFacadeAssembly Condition="'$(TargetFramework)' == 'net461'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Pipes.AccessControl.cs" />
+    <Compile Include="System.IO.Pipes.AccessControl.netcoreapp.cs" Condition="'$(TargetFramework)' == 'net5.0'" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
-    <ProjectReference Include="..\..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj" />
-    <ProjectReference Include="..\..\System.IO.Pipes\ref\System.IO.Pipes.csproj" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <Reference Include="netstandard" />
+    <Reference Include="System.IO.Pipes" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.netcoreapp.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.netcoreapp.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.IO.Pipes
+{
+    public static class AnonymousPipeServerStreamAcl
+    {
+        public static System.IO.Pipes.AnonymousPipeServerStream Create(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity) { throw null; }
+    }
+    public static class NamedPipeServerStreamAcl
+    {
+        public static System.IO.Pipes.NamedPipeServerStream Create(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity, System.IO.HandleInheritability inheritability = System.IO.HandleInheritability.None, System.IO.Pipes.PipeAccessRights additionalAccessRights = default) { throw null; }
+    }
+}

--- a/src/libraries/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/Resources/Strings.resx
@@ -57,6 +57,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ArgumentOutOfRange_NeedValidPipeAccessRights" xml:space="preserve">
+    <value>Invalid PipeAccessRights value.</value>
+  </data>
+  <data name="Argument_NonContainerInvalidAnyFlag" xml:space="preserve">
+    <value>This flag may not be set on a pipe.</value>
+  </data>
+  <data name="IO_IO_PipeBroken" xml:space="preserve">
+    <value>Pipe is broken.</value>
+  </data>
   <data name="PlatformNotSupported_AccessControl" xml:space="preserve">
     <value>Access Control List (ACL) APIs are part of resource management on Windows and are not supported on this platform.</value>
   </data>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -10,6 +10,8 @@
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
     <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true' and '$(TargetFramework)' != 'netstandard2.0'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
+    <!-- API Compat will fail for these since we use a fake System.IO.Pipes to forward to. -->
+    <RunApiCompat Condition="'$(IsPartialFacadeAssembly)' == 'true' and '$(TargetFramework)' != '$(NetCoreAppCurrent)-windows'">false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
@@ -30,30 +32,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Reference Include="System.Resources.ResourceManager" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <Reference Include="System.Runtime" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
-    <Reference Include="System.IO.Pipes" Condition="'$(TargetsWindows)' != 'true' or '$(TargetPlatformIdentifier)' == ''" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <!-- THIS IS THE WORST CODE I'VE WRITTEN IN A WHILE. We need to download the 3.1 microsoft.net.core.app.runtime pack for windows
-         as this library depends on an API only exposed in the System.IO.Pipes runtime assembly.
-         We need to come up with a better solution as this adds 30MB to a user's download and breaks sourcebuild. -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[3.1.14]" />
-    <ReferencePath Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\3.1.14\runtimes\win-x64\lib\netcoreapp3.1\System.IO.Pipes.dll" Condition="'$(TargetsWindows)' == 'true'" />
-
-    <Reference Include="System.Resources.ResourceManager" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == '5.0'">
-    <!-- THIS IS THE WORST CODE I'VE WRITTEN IN A WHILE. We need to download the 5.0 microsoft.net.core.app.runtime pack for windows
-         as this library depends on an API only exposed in the System.IO.Pipes runtime assembly.
-         We need to come up with a better solution as this adds 30MB to a user's download and breaks sourcebuild. -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[5.0.5]" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
-    <ReferencePath Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\5.0.5\runtimes\win-x64\lib\net5.0\System.IO.Pipes.dll" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)-windows'">
-    <ProjectReference Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System.IO.Pipes.csproj" SkipUseReferenceAssembly="true" />
+    <!-- Compile against the shipping reference assembly when not targeting Windows. -->
+    <Reference Include="System.IO.Pipes" Condition="'$(TargetsWindows)' != 'true'" />
+    <!-- Compile against the shipping implementation assembly when targeting NetCoreAppCurrent-Windows. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System.IO.Pipes.csproj" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)-windows'" SkipUseReferenceAssembly="true" />
+    <!-- Compile against the non-shipping reference assembly when targeting Windows for older .NETCoreApp tfms. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)System.IO.Pipes\ref\System.IO.Pipes.csproj" Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)-windows' and '$(TargetsWindows)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -1,26 +1,59 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);net5.0-windows;net5.0;netcoreapp3.1-windows;netcoreapp3.1;netstandard2.0-windows;netstandard2.0;net461-windows</TargetFrameworks>
+    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
+
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
-    <OmitResources Condition="'$(TargetsWindows)' == 'true'">true</OmitResources>
-    <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true' and '$(TargetFramework)' != 'netstandard2.0'">true</IsPartialFacadeAssembly>
+    <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
   </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Compile Include="System\IO\PipesAclExtensions.net461.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' and '$(TargetsWindows)' == 'true'">
+    <Compile Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System\IO\Pipes\PipeSecurity.cs" />
+    <Compile Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System\IO\Pipes\PipeAccessRights.cs" />
+    <Compile Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System\IO\Pipes\PipeAccessRule.cs" />
+    <Compile Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System\IO\Pipes\PipeAuditRule.cs" />
+    <Compile Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System\IO\Pipes\PipesAclExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Reference Include="System.Runtime" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
+    <Reference Include="System.IO.Pipes" Condition="'$(TargetsWindows)' != 'true' or '$(TargetPlatformIdentifier)' == ''" />
   </ItemGroup>
-  <!-- Include src projects during restore as TargetsWindows isn't set. -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(MSBuildRestoreSessionId)' != ''">
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <!-- THIS IS THE WORST CODE I'VE WRITTEN IN A WHILE. We need to download the 3.1 microsoft.net.core.app.runtime pack for windows
+         as this library depends on an API only exposed in the System.IO.Pipes runtime assembly.
+         We need to come up with a better solution as this adds 30MB to a user's download and breaks sourcebuild. -->
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[3.1.14]" />
+    <ReferencePath Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\3.1.14\runtimes\win-x64\lib\netcoreapp3.1\System.IO.Pipes.dll" Condition="'$(TargetsWindows)' == 'true'" />
+
+    <Reference Include="System.Resources.ResourceManager" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == '5.0'">
+    <!-- THIS IS THE WORST CODE I'VE WRITTEN IN A WHILE. We need to download the 5.0 microsoft.net.core.app.runtime pack for windows
+         as this library depends on an API only exposed in the System.IO.Pipes runtime assembly.
+         We need to come up with a better solution as this adds 30MB to a user's download and breaks sourcebuild. -->
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[5.0.5]" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
+    <ReferencePath Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\5.0.5\runtimes\win-x64\lib\net5.0\System.IO.Pipes.dll" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)-windows'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.IO.Pipes\src\System.IO.Pipes.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" SkipUseReferenceAssembly="true" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
-    <!-- Referencing the ref project directly as the src project doesn't have a RID less configuration. -->
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj" />
-    <Reference Include="System.IO.Pipes" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.net461.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.net461.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Security.AccessControl;
+
+namespace System.IO.Pipes
+{
+    public static class PipesAclExtensions
+    {
+        public static PipeSecurity GetAccessControl(PipeStream stream)
+        {
+            return stream.GetAccessControl();
+        }
+
+        public static void SetAccessControl(PipeStream stream, PipeSecurity pipeSecurity)
+        {
+            stream.SetAccessControl(pipeSecurity);
+        }
+    }
+}

--- a/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.Internal.cs
+++ b/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.Internal.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.IO.Pipes
+{
+    // The following types are incomplete, meant only to be the target of type forwards
+    public enum PipeAccessRights { }
+    public sealed class PipeAccessRule { }
+    public sealed class PipeAuditRule { }
+    public static class PipesAclExtensions { }
+    public class PipeSecurity { }
+
+#if NET5_0_OR_GREATER
+    public static class AnonymousPipeServerStreamAcl { }
+    public static class NamedPipeServerStreamAcl { }
+#endif
+}

--- a/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.csproj
+++ b/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.csproj
@@ -1,13 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!-- The non NetCoreAppCurrent tfms never ship, they are just used to produce reference assemblies,
+         to expose types for Pipes.AccessControl to forward to. -->
+    <TargetFrameworks>$(NetCoreAppCurrent);net5.0;netcoreapp3.1</TargetFrameworks>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
+  <PropertyGroup>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">4.1.2.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'net5.0'">5.0.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Pipes.cs" />
+    <Compile Include="System.IO.Pipes.Internal.cs" Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Security.Principal\ref\System.Security.Principal.csproj" />
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal\ref\System.Security.Principal.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Security.Principal" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The removed configurations (netstandard1.3, netcoreapp2.1, net46) aren't
built anymore. Instead the already built matching binaries from the
latest available packages are redistributed when packaging these
libraries.

Dropping these assets as the minimum supported set of platforms are ones
that support netstandard2.0 and are still in-support. As an example,
also dropping the netcoreapp2.1 asset which isn't supported anymore and
upgrading it to netcoreapp3.1.. For .NET Framework, there's still a
net461 configuration present to avoid binding redirect issues.

cc @carlossanlop 

Contributes to #47530