### PR TITLE
Reenable48001

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -727,9 +727,6 @@
             <Issue>https://github.com/dotnet/runtime/issues/47294</Issue>
         </ExcludeList>
         <!-- Tracing failures -->
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsvalidation/ThreadPool/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48727</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/48786</Issue>
         </ExcludeList>
@@ -745,12 +742,6 @@
         </ExcludeList>
         <!-- Intermittent failures disable to improve pass rate -->
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/regressions/Dev11/154243/dynamicmethodliveness/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/simple/ParallelCrash/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/simple/ParallelCrashWorkerThreads/*">
             <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/Github/runtime_32848/*">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -730,16 +730,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/48786</Issue>
         </ExcludeList>
-        <!-- Crossgen2 issues -->
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/crossgen2/crossgen2smoke/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48001</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/multifolder/multifolder/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48001</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/FrameworkTests/R2RDumpTests/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48001</Issue>
-        </ExcludeList>
         <!-- Intermittent failures disable to improve pass rate -->
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/regressions/Dev11/154243/dynamicmethodliveness/*">
             <Issue>https://github.com/dotnet/runtime/issues/46365</Issue>


### PR DESCRIPTION
Remove disables from Apple Silicon that are not Apple Silicon specific.
Reenable crossgen2 tests

Fixes #48001