### PR TITLE
Update the exception thrown to be more useful

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
@@ -30,10 +30,15 @@ namespace System.Security.Cryptography
                 foreach (AsnEncodedData asn in values)
                 {
                     if (asn.Oid is null)
+                    {
                         throw new ArgumentException(SR.Argument_InvalidOidValue, nameof(values));
+                    }
 
-                    if (!string.Equals(asn.Oid!.Value, oid.Value, StringComparison.Ordinal))
+
+                    if (!string.Equals(asn.Oid.Value, oid.Value, StringComparison.Ordinal))
+                    {
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_WrongOidInAsnCollection, oid.Value, asn.Oid.Value));
+                    }
                 }
                 Values = values;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
@@ -34,7 +34,6 @@ namespace System.Security.Cryptography
                         throw new ArgumentException(SR.Argument_InvalidOidValue, nameof(values));
                     }
 
-
                     if (!string.Equals(asn.Oid.Value, oid.Value, StringComparison.Ordinal))
                     {
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_WrongOidInAsnCollection, oid.Value, asn.Oid.Value));

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
@@ -29,6 +29,9 @@ namespace System.Security.Cryptography
             {
                 foreach (AsnEncodedData asn in values)
                 {
+                    if (asn.Oid is null)
+                        throw new ArgumentException(SR.Argument_InvalidOidValue, nameof(values));
+
                     if (!string.Equals(asn.Oid!.Value, oid.Value, StringComparison.Ordinal))
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_WrongOidInAsnCollection, oid.Value, asn.Oid.Value));
                 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -537,6 +537,23 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        public static void CryptographicAttributeObjectAsnOidNull()
+        {
+            var oid = new Oid(Oids.Sha1);
+#if NETCOREAPP
+            AssertExtensions.Throws<ArgumentException>("values", () =>
+            {
+                var _ = new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
+            });
+#else
+            Assert.Throws<NullReferenceException>(() =>
+            {
+                var _ = new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
+            });
+#endif
+        }
+
+        [Fact]
         public static void CryptographicAttributeObjectPassNullValuesToCtor()
         {
             Oid oid = new Oid(Oids.DocumentDescription);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -543,12 +543,12 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 #if NETCOREAPP
             AssertExtensions.Throws<ArgumentException>("values", () =>
             {
-                var _ = new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
+                new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
             });
 #else
             Assert.Throws<NullReferenceException>(() =>
             {
-                var _ = new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
+                new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
             });
 #endif
         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -540,17 +540,12 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static void CryptographicAttributeObjectAsnOidNull()
         {
             var oid = new Oid(Oids.Sha1);
-#if NETCOREAPP
-            AssertExtensions.Throws<ArgumentException>("values", () =>
+            var asnEncodedData = new AsnEncodedData(new byte[] { 1, 2, 3 });
+
+            AssertExtensions.Throws<ArgumentException, NullReferenceException>("values", () =>
             {
-                new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
+                new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(asnEncodedData));
             });
-#else
-            Assert.Throws<NullReferenceException>(() =>
-            {
-                new CryptographicAttributeObject(oid, new AsnEncodedDataCollection(new AsnEncodedData(new byte[] { 1, 2, 3 })));
-            });
-#endif
         }
 
         [Fact]


### PR DESCRIPTION
This closes #44070 by simply checking that `asn.Oid` is null, and if it is it throws a more relevant exception.

This also adds a test to check and see that if this value is null, the correct exception is thrown (with also a different exception value for .NET Framework since this will not change the outcome of the .NET Framework libraries.