### PR TITLE
Apple Silicon enable R2R CI testing

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -18,6 +18,7 @@ jobs:
     - Linux_arm
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x86
     - windows_x64
@@ -45,6 +46,7 @@ jobs:
     - Linux_arm
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x86
     - windows_x64

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -17,6 +17,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64
@@ -42,6 +43,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -33,6 +33,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - windows_x86
     - windows_x64
     jobParameters:

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -17,6 +17,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64
@@ -45,6 +46,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - OSX_x64
     - windows_x86
     - windows_x64
@@ -73,6 +75,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64
@@ -110,6 +113,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - windows_x86
     - windows_x64
     jobParameters:
@@ -196,4 +200,20 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
       targetos: Linux
+      targetarch: arm64
+
+# test target osx-arm64
+# verify that cross architecture targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - OSX_arm64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: OSX
       targetarch: arm64

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -17,6 +17,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64
@@ -42,6 +43,7 @@ jobs:
     platforms:
     - Linux_x64
     - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
     - windows_arm64

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -16,6 +16,9 @@ jobs:
     buildConfig: checked
     platformGroup: gcstress
     platforms:
+    # It is too early to include OSX_arm64 in platform group gcstress
+    # Adding it here will enable it also
+    - OSX_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: r2r-extra
@@ -35,6 +38,10 @@ jobs:
     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
     buildConfig: checked
     platformGroup: gcstress # r2r-extra testGroup runs gcstress0xf scenario
+    platforms:
+    # It is too early to include OSX_arm64 in platform group gcstress
+    # Adding it here will enable it also
+    - OSX_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -18,6 +18,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - windows_arm
     - windows_arm64
     - windows_x64
@@ -44,6 +45,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - windows_arm
     - windows_arm64
     - windows_x64


### PR DESCRIPTION
This enables R2R testing on Apple Silicon.
It also enables the R2R stress testing in R2R-extra

/cc @mangod9 