### PR TITLE
HTTP/3 test fixes

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -781,28 +781,30 @@ namespace System.Net.Http
                         authority = authority ?? _originAuthority;
                     }
 
-                    if (authority != null)
+                    if (authority == null)
                     {
-                        if (IsAltSvcBlocked(authority))
-                        {
-                            throw GetVersionException(request, 3);
-                        }
-
-                        Http3Connection connection = await GetHttp3ConnectionAsync(request, authority, cancellationToken).ConfigureAwait(false);
-                        HttpResponseMessage response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
-
-                        // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
-                        // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
-                        // In this case, we blocklist the authority and retry the request at the origin.
-                        if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
-                        {
-                            response.Dispose();
-                            BlocklistAuthority(connection.Authority);
-                            continue;
-                        }
-
-                        return response;
+                        break;
                     }
+
+                    if (IsAltSvcBlocked(authority))
+                    {
+                        throw GetVersionException(request, 3);
+                    }
+
+                    Http3Connection connection = await GetHttp3ConnectionAsync(request, authority, cancellationToken).ConfigureAwait(false);
+                    HttpResponseMessage response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
+
+                    // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
+                    // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
+                    // In this case, we blocklist the authority and retry the request at the origin.
+                    if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
+                    {
+                        response.Dispose();
+                        BlocklistAuthority(connection.Authority);
+                        continue;
+                    }
+
+                    return response;
                 }
             }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -33,6 +33,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
                 socketsHttpHandler.QuicImplementationProvider = quicImplementationProvider;
+                socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
             }
 
             return handler;

--- a/src/libraries/System.Net.Quic/readme.md
+++ b/src/libraries/System.Net.Quic/readme.md
@@ -1,7 +1,7 @@
 # MsQuic
 
 `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), Microsoft, cross-platform, native implementation of the [QUIC](https://datatracker.ietf.org/wg/quic/about/) protocol.
-Currently, `System.Net.Quic` depends on [**msquic@7b31e149a9d1ed7a6850e8253ba3d0af707150e5**](https://github.com/microsoft/msquic/commit/7b31e149a9d1ed7a6850e8253ba3d0af707150e5) revision.
+Currently, `System.Net.Quic` depends on [**msquic@2084736032ec917f1819802caa515e61a6d3dd9a**](https://github.com/microsoft/msquic/commit/2084736032ec917f1819802caa515e61a6d3dd9a) revision.
 
 ## Usage
 
@@ -23,10 +23,10 @@ Prerequisites:
 
 Run inside the msquic directory (for **Debug** build with logging on):
 ```bash
-# build msquic in debug with logging and stub tls
+# build msquic in debug with logging
 rm -rf build
 mkdir build
-cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS=stub
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=on
 cd build
 cmake --build . --config Debug
 


### PR DESCRIPTION
Fixed working with cert validation after https://github.com/dotnet/runtime/pull/51015 cc: @wfurt 
Fixed infinite loop in `TrySendUsingHttp3Async` for version upgrade (policy = higher) and when h3 authority hasn't been announced yet via Alt-Svc after https://github.com/dotnet/runtime/pull/51454 cc: @geoffkizer 
Updated msquic revision in readme, it works with the newest version without any changes.