### PR TITLE
Update the loop table after flow graph optimization

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5546,8 +5546,8 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication)
                     if (optimizeJump)
                     {
                         JITDUMP("\nReversing a conditional jump around an unconditional jump (" FMT_BB " -> " FMT_BB
-                                " -> " FMT_BB ")\n",
-                                block->bbNum, bDest->bbNum, bNextJumpDest->bbNum);
+                                ", " FMT_BB " -> " FMT_BB ")\n",
+                                block->bbNum, bDest->bbNum, bNext->bbNum, bNextJumpDest->bbNum);
 
                         //  Reverse the jump condition
                         //
@@ -5585,6 +5585,9 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication)
 
                         /* Mark the block as removed */
                         bNext->bbFlags |= BBF_REMOVED;
+
+                        // Update the loop table if we removed the bottom of a loop, for example.
+                        fgUpdateLoopsAfterCompacting(block, bNext);
 
                         // If this is the first Cold basic block update fgFirstColdBlock
                         if (bNext == fgFirstColdBlock)


### PR DESCRIPTION
In the flow graph optimization that inverts a BBJ_COND
branch over an empty BBJ_ALWAYS block, if the BBJ_ALWAYS
block is the bottom of a loop, we want to update the loop
table with the inverted BBJ_COND as the new bottom.

There are no diffs from this change. In fact, I found it
by getting an assert generating a DOT flow graph dump after
PHASE_OPT_UPDATE_FLOW_GRAPH. It seems reasonable to do this
update, although it's not clear if any subsequent code
currently cares.