### PR TITLE
Fix JsonArray issues with empty array and GetPath()

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -164,6 +164,7 @@ namespace System.Text.Json.Nodes
             }
             else
             {
+                CreateNodes();
                 Debug.Assert(_list != null);
 
                 options ??= JsonSerializerOptions.s_defaultOptions;
@@ -198,7 +199,9 @@ namespace System.Text.Json.Nodes
 
                     foreach (JsonElement element in jElement.EnumerateArray())
                     {
-                        list.Add(JsonNodeConverter.Create(element, Options));
+                        JsonNode? node = JsonNodeConverter.Create(element, Options);
+                        node?.AssignParent(this);
+                        list.Add(node);
                     }
 
                     // Clear since no longer needed.

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
@@ -42,19 +42,20 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Throws<ArgumentNullException>(() => new JsonArray().WriteTo(null));
         }
 
-        [Fact]
-        public static void WriteTo()
+        [Theory]
+        [InlineData("[]")]
+        [InlineData("[42]")]
+        [InlineData("[42,43]")]
+        public static void WriteTo(string json)
         {
-            const string Json = "[42]";
-
-            JsonArray jArray = JsonNode.Parse(Json).AsArray();
+            JsonArray jArray = JsonNode.Parse(json).AsArray();
             var stream = new MemoryStream();
             var writer = new Utf8JsonWriter(stream);
             jArray.WriteTo(writer);
             writer.Flush();
 
-            string json = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(Json, json);
+            string result = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Equal(json, result);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParentPathRootTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParentPathRootTests.cs
@@ -16,18 +16,30 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal("$", node.GetPath());
             Assert.Same(node, node.Root);
 
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$", node.GetPath());
+
             node = new JsonObject();
             Assert.Equal("$", node.GetPath());
             Assert.Same(node, node.Root);
+
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$", node.GetPath());
 
             node = new JsonArray();
             Assert.Equal("$", node.GetPath());
             Assert.Same(node, node.Root);
 
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$", node.GetPath());
+
             node = new JsonObject
             {
                 ["Child"] = 1
             };
+            Assert.Equal("$.Child", node["Child"].GetPath());
+
+            node = JsonValue.Parse(node.ToJsonString());
             Assert.Equal("$.Child", node["Child"].GetPath());
 
             node = new JsonObject
@@ -37,12 +49,18 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal("$.Child[1]", node["Child"][1].GetPath());
             Assert.Same(node, node["Child"][1].Root);
 
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$.Child[1]", node["Child"][1].GetPath());
+
             node = new JsonObject
             {
                 ["Child"] = new JsonArray { 1, 2, 3 }
             };
             Assert.Equal("$.Child[2]", node["Child"][2].GetPath());
             Assert.Same(node, node["Child"][2].Root);
+
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$.Child[2]", node["Child"][2].GetPath());
 
             node = new JsonArray
             {
@@ -53,6 +71,9 @@ namespace System.Text.Json.Nodes.Tests
             };
             Assert.Equal("$[0].Child", node[0]["Child"].GetPath());
             Assert.Same(node, node[0]["Child"].Root);
+
+            node = JsonValue.Parse(node.ToJsonString());
+            Assert.Equal("$[0].Child", node[0]["Child"].GetPath());
         }
 
         [Fact]


### PR DESCRIPTION
Fix issues with the new `JsonArray` type:
- On deserialize of an empty `JsonArray` with "[]" and without touching the array in any way (e.g. calling `Count` or enumerating) a `Debug.Assert` failure or `NullReferenceException` could occur
- The `GetPath` from an item in a `JsonArray` may be "$" in cases after a `Parse()` instead of the proper value such as "$[0]".