### PR TITLE
Improve loop inversion

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6516,7 +6516,7 @@ protected:
     // loop nested in "loopInd" that shares the same head as "loopInd".
     void optUpdateLoopHead(unsigned loopInd, BasicBlock* from, BasicBlock* to);
 
-    void optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap);
+    void optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, const bool updatePreds = false);
 
     // Marks the containsCall information to "lnum" and any parent loops.
     void AddContainsCallAllContainingLoops(unsigned lnum);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4424,8 +4424,8 @@ void Compiler::optInvertWhileLoop(BasicBlock* block)
     bool foundCondTree = false;
 
     // Create a new block after `block` to put the copied condition code.
-    block->bbJumpKind = BBJ_NONE;
-    block->bbJumpDest = nullptr;
+    block->bbJumpKind    = BBJ_NONE;
+    block->bbJumpDest    = nullptr;
     BasicBlock* bNewCond = fgNewBBafter(BBJ_COND, block, /*extendRegion*/ true);
 
     // Clone each statement in bTest and append to bNewCond.
@@ -4497,14 +4497,14 @@ void Compiler::optInvertWhileLoop(BasicBlock* block)
     // (and create spaghetti code) if we get it wrong.
 
     BlockToBlockMap blockMap(getAllocator(CMK_LoopOpt));
-    bool blockMapInitialized = false;
+    bool            blockMapInitialized = false;
 
     unsigned loopFirstNum  = bNewCond->bbNext->bbNum;
     unsigned loopBottomNum = bTest->bbNum;
     for (flowList* pred = bTest->bbPreds; pred != nullptr; pred = pred->flNext)
     {
         BasicBlock* predBlock = pred->getBlock();
-        unsigned bNum = predBlock->bbNum;
+        unsigned    bNum      = predBlock->bbNum;
         if ((loopFirstNum <= bNum) && (bNum <= loopBottomNum))
         {
             // Looks like the predecessor is from within the potential loop; skip it.
@@ -4518,8 +4518,8 @@ void Compiler::optInvertWhileLoop(BasicBlock* block)
         }
 
         // Redirect the predecessor to the new block.
-        JITDUMP("Redirecting " FMT_BB " -> " FMT_BB " to " FMT_BB " -> " FMT_BB,
-            predBlock->bbNum, bTest->bbNum, predBlock->bbNum, bNewCond->bbNum);
+        JITDUMP("Redirecting " FMT_BB " -> " FMT_BB " to " FMT_BB " -> " FMT_BB, predBlock->bbNum, bTest->bbNum,
+                predBlock->bbNum, bNewCond->bbNum);
         optRedirectBlock(predBlock, &blockMap, /*updatePreds*/ true);
     }
 


### PR DESCRIPTION
When doing loop inversion, we duplicate the condition block to the
top of the loop to create a fall-through zero trip test. Improve
this by redirecting all incoming branches to the condition block
that appear to be coming from outside the potential loop body
to branch to the new duplicated condition block. This improves the
ability of the loop recognizer to find loops, whereas before we
would reject the loops as "multi-entry".

There are good diffs where more loops are detected, leading to
better optimization and more loop alignment.