### PR TITLE
Remove SSE2-specific logic from UTF-16 validation code

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
@@ -165,11 +165,11 @@ namespace System.Text.Unicode.Tests
             processedInput[0] = '\u0080'; // 2-byte UTF-8 sequence
             processedInput[1] = '\u0800'; // 3-byte UTF-8 sequence
             processedInput[2] = '\u0080'; // 2-byte UTF-8 sequence
-            processedInput[3] = '\u0800'; // 3-byte UTF-8 sequence
+            processedInput[3] = '\u8000'; // 3-byte UTF-8 sequence (a negative number, when signed)
             processedInput[4] = '\u0080'; // 2-byte UTF-8 sequence
             processedInput[5] = '\u0800'; // 3-byte UTF-8 sequence
             processedInput[6] = '\u0080'; // 2-byte UTF-8 sequence
-            processedInput[7] = '\u0800'; // 3-byte UTF-8 sequence
+            processedInput[7] = '\u8880'; // 3-byte UTF-8 sequence (a negative number, when signed, with 0x0800 and 0x0080 marker bits also set)
 
             expectedUtf8ByteCount += 12;
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/51830. Specifically, in the following code paths, we're trying to build up a mask of non-ASCII elements. The SSE41 logic sets the `0x0080` bit for all non-ASCII elements, but the SSE2 logic only sets the `0x0080` bit for elements in the range `[0080 .. 7FFF]`.

https://github.com/dotnet/runtime/blob/11c5181e0d1831c86d9014025e01a54e9f3374fa/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs#L119-L132

Normally this would be ok, as the logic later in the method would have noticed the `[8000 .. FFFF]` overflow and manually smeared the relevant bits down to the `0x0080` position. However, the optimization introduced by https://github.com/dotnet/runtime/pull/51671 removed this smear.

### Logic before PR 51671

The smear is in line 143. This forces both the `0x8080` bits to be set if the original unsigned element value is `>= 0x0800`. So even if the original element value was "negative" (`[8000 .. FFFF]`), where _charIsNonAscii_ would be missing its `0x0080` bit set, we'd account for it here.

https://github.com/dotnet/runtime/blob/294a7f9a1b6794d1b467090ae047bc195336aadf/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs#L143-L144

### Logic after PR 51671

The smear is removed, which means that we're only guaranteed to set the `0x8000` bit if the original unsigned element value is `>= 0x0800`. The `0x0080` bit would also be set if the original value happened to have that same bit set, but that's not a solid guarantee. So when we later popcnt, we see only `0x8000` and incorrectly report this as a "1 bit set", when we should've instead seen `0x8080` and reported "2 bits set". Since the popcnt is used to calculate the number of UTF-8 bytes required to represent this data, this results in an undercount in the return value of `UTF8Encoding.GetByteCount`.

https://github.com/dotnet/runtime/blob/a56a142b65b322f276281f039032848bc8e51ac0/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs#L153-L154

### How this PR resolves the issue

This PR simply removes the SSE2-specific logic from this routine. The SSE41-specific logic remains unchanged. This means that no smearing step is required, since the SSE41 code paths already guarantee that the `0x0080` bit will be set for all elements in the range `[0800 .. FFFF]`. This also means that the perf numbers and codegen provided in https://github.com/dotnet/runtime/pull/51671 remain valid for these architectures. If SSE41 instructions are not available, the code will invoke the shared fallback logic, which already handled these cases correctly and was unaffected by the optimizations in PR 51671.

I've also shored up the unit tests to help cover future regressions here. The unit tests pass on my machine both with SSE41 enabled and with the `COMPLUS_ENABLESSE41=0` env var set.

__Note:__ The bad optimization never shipped in any RTM build or preview release. It only ever appeared in nightlies.