### PR TITLE
[mono] Add a null check to Array.GetRawArrayData (), its needed on pl…

### DIFF
--- a/src/libraries/System.Memory/tests/MemoryMarshal/GetArrayDataReference.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/GetArrayDataReference.cs
@@ -10,7 +10,6 @@ namespace System.SpanTests
     public static partial class MemoryMarshalTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50960", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public static void GetArrayDataReference_NullInput_ThrowsNullRef()
         {
             Assert.Throws<NullReferenceException>(() => MemoryMarshal.GetArrayDataReference((object[])null));

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -766,6 +766,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			return emit_array_generic_access (cfg, fsig, args, TRUE);
 		else if (!strcmp (cmethod->name, "GetRawSzArrayData") || !strcmp (cmethod->name, "GetRawArrayData")) {
 			int dreg = alloc_preg (cfg);
+			MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 			EMIT_NEW_BIALU_IMM (cfg, ins, OP_PADD_IMM, dreg, args [0]->dreg, MONO_STRUCT_OFFSET (MonoArray, vector));
 			return ins;
 		}


### PR DESCRIPTION
…atforms

which use explicit null checks.

Fixes https://github.com/dotnet/runtime/issues/50960.