### PR TITLE
Obsolete the Rijndael and RijndaelManaged classes

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -26,6 +26,11 @@ The acceptance criteria for adding an obsoletion includes:
     * An MSBuild property can be added to the project's first `<PropertyGroup>` to achieve this easily
     * Example: `<IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>`
     * This will need to be specified in both the `src` and `ref` projects
+* If the library contains types that are forwarded within a generated shim
+    * Errors will be received when running `build libs`, with obsoletion errors in `src/libraries/shims/generated` files
+    * This is resolved by adding the obsoletion's diagnostic id to the `<NoWarn>` property for partial facade assemblies
+    * That property is found in `src/libraries/Directory.Build.targets`
+    * Search for the "Ignore Obsolete errors within the generated shims that type-forward types" comment and add the appropriate diagnostic id to the comment and the `<NoWarn>` property (other SYSLIB diagnostics already exist there)
 * Apply the `breaking-change` label to the PR that introduces the obsoletion
     * A bot will automatically apply the `needs-breaking-change-doc-created` label when the `breaking-change` label is detected
 * Follow up with the breaking change process to communicate and document the breaking change
@@ -70,6 +75,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0018`__ | ReflectionOnly loading is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
+|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead. |
 
 ## Analyzer Warnings
 

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -75,7 +75,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0018`__ | ReflectionOnly loading is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
-|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead. |
+|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes instead. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -71,5 +71,8 @@ namespace System
 
         internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";
         internal const string JsonSerializerOptionsIgnoreNullValuesDiagId = "SYSLIB0020";
+
+        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.";
+        internal const string RijndaelDiagId = "SYSLIB0022";
     }
 }

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -72,7 +72,7 @@ namespace System
         internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";
         internal const string JsonSerializerOptionsIgnoreNullValuesDiagId = "SYSLIB0020";
 
-        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.";
+        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.";
         internal const string RijndaelDiagId = "SYSLIB0022";
     }
 }

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -17,8 +17,12 @@
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable;CA1052</NoWarn>
     <!-- Ignore Obsolete errors within the generated shims that type-forward types.
-         SYSLIB0003: Code Access Security (CAS). SYSLIB0004: Constrained Execution Region (CER). SYSLIB0017: Strong name signing. -->
-    <NoWarn Condition="'$(IsPartialFacadeAssembly)' == 'true'">$(NoWarn);SYSLIB0003;SYSLIB0004;SYSLIB0015;SYSLIB0017</NoWarn>
+         SYSLIB0003: Code Access Security (CAS).
+         SYSLIB0004: Constrained Execution Region (CER).
+         SYSLIB0017: Strong name signing.
+         SYSLIB0022: Rijndael types.
+    -->
+    <NoWarn Condition="'$(IsPartialFacadeAssembly)' == 'true'">$(NoWarn);SYSLIB0003;SYSLIB0004;SYSLIB0015;SYSLIB0017;SYSLIB0022</NoWarn>
     <!-- Reset these properties back to blank, since they are defaulted by Microsoft.NET.Sdk -->
     <WarningsAsErrors Condition="'$(WarningsAsErrors)' == 'NU1605'" />
     <!-- Set the documentation output file globally. -->

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -613,7 +613,7 @@ namespace System.Security.Cryptography
         public static byte[] Pbkdf2(string password, byte[] salt, int iterations, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int outputLength) { throw null; }
         public override void Reset() { }
     }
-    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
@@ -623,7 +623,7 @@ namespace System.Security.Cryptography
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
         public static new System.Security.Cryptography.Rijndael? Create(string algName) { throw null; }
     }
-    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -613,6 +613,7 @@ namespace System.Security.Cryptography
         public static byte[] Pbkdf2(string password, byte[] salt, int iterations, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int outputLength) { throw null; }
         public override void Reset() { }
     }
+    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
@@ -622,6 +623,7 @@ namespace System.Security.Cryptography
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
         public static new System.Security.Cryptography.Rijndael? Create(string algName) { throw null; }
     }
+    [System.ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes and AesManaged instead.", DiagnosticId = "SYSLIB0022", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
@@ -13,6 +13,7 @@ namespace Internal.Cryptography
     /// be consistent with the rest of the static Create() methods which return opaque types.
     /// They both have the same implementation.
     /// </summary>
+    [Obsolete(Obsoletions.RijndaelMessage, DiagnosticId = Obsoletions.RijndaelDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     internal sealed class RijndaelImplementation : Rijndael
     {
         private readonly Aes _impl;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -114,6 +114,8 @@
              Link="Internal\Cryptography\UniversalCryptoEncryptor.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs"
              Link="Internal\Cryptography\UniversalCryptoDecryptor.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs"
+             Link="Common\System\Obsoletions.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs"
              Link="Common\System\Memory\PointerMemoryManager.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -119,7 +119,9 @@ namespace System.Security.Cryptography
                 Type HMACSHA256Type = typeof(System.Security.Cryptography.HMACSHA256);
                 Type HMACSHA384Type = typeof(System.Security.Cryptography.HMACSHA384);
                 Type HMACSHA512Type = typeof(System.Security.Cryptography.HMACSHA512);
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
                 Type RijndaelManagedType = typeof(System.Security.Cryptography.RijndaelManaged);
+#pragma warning restore SYSLIB0022
                 Type AesManagedType = typeof(System.Security.Cryptography.AesManaged);
                 Type SHA256DefaultType = typeof(System.Security.Cryptography.SHA256Managed);
                 Type SHA384DefaultType = typeof(System.Security.Cryptography.SHA384Managed);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
@@ -8,6 +8,7 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [Obsolete(Obsoletions.RijndaelMessage, DiagnosticId = Obsoletions.RijndaelDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [UnsupportedOSPlatform("browser")]
     public abstract class Rijndael : SymmetricAlgorithm

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
@@ -7,6 +7,7 @@ using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
+    [Obsolete(Obsoletions.RijndaelMessage, DiagnosticId = Obsoletions.RijndaelDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [UnsupportedOSPlatform("browser")]
     public sealed class RijndaelManaged : Rijndael

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -7,6 +7,8 @@ using System.Text;
 using Test.Cryptography;
 using Xunit;
 
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
+
 namespace System.Security.Cryptography.CryptoConfigTests
 {
     public static class CryptoConfigTests
@@ -425,3 +427,5 @@ namespace System.Security.Cryptography.CryptoConfigTests
         }
     }
 }
+
+#pragma warning restore SYSLIB0022

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Test.Cryptography;
 using Xunit;
 
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
+
 namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 {
     using Rijndael = System.Security.Cryptography.Rijndael;
@@ -462,3 +464,5 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         }
     }
 }
+
+#pragma warning restore SYSLIB0022

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
@@ -99,11 +99,13 @@ namespace System.Security.Cryptography.CryptoConfigTests
 
         [Theory]
         [InlineData("AES", typeof(Aes))]
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
         [InlineData("Rijndael", typeof(Rijndael))]
         [InlineData("System.Security.Cryptography.Rijndael", typeof(Rijndael))]
         [InlineData("http://www.w3.org/2001/04/xmlenc#aes128-cbc", typeof(Rijndael))]
         [InlineData("http://www.w3.org/2001/04/xmlenc#aes192-cbc", typeof(Rijndael))]
         [InlineData("http://www.w3.org/2001/04/xmlenc#aes256-cbc", typeof(Rijndael))]
+#pragma warning restore SYSLIB0022
         [InlineData("3DES", typeof(TripleDES))]
         [InlineData("TripleDES", typeof(TripleDES))]
         [InlineData("System.Security.Cryptography.TripleDES", typeof(TripleDES))]

--- a/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -129,6 +129,7 @@ namespace System.Security.Cryptography.Xml.Tests
             return new Uri("file://" + (path[0] == '/' ? path : '/' + path));
         }
 
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
         /// <summary>
         /// Get specification URL from algorithm implementation
         /// </summary>
@@ -159,6 +160,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
             throw new ArgumentException($"The specified algorithm `{key.GetType().FullName}` is not supported for XML Encryption.");
         }
+#pragma warning restore SYSLIB0022
 
         /// <summary>
         /// Lists functions creating symmetric algorithms


### PR DESCRIPTION
Fixes #46930, marking the `Rijndael` and `RijndaelManaged` classes as obsolete, guiding usage toward `Aes`.