### PR TITLE
Re-enable DNS tests on SLES

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -105,12 +105,6 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
-            if (PlatformDetection.IsSLES)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
-                return;
-            }
-
             IPHostEntry entry = Dns.GetHostByName("");
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.
@@ -121,12 +115,6 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
-            if (PlatformDetection.IsSLES)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
-                return;
-            }
-
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -27,12 +27,6 @@ namespace System.Net.NameResolution.Tests
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntry_HostString_Ok(string hostName)
         {
-            if (PlatformDetection.IsSLES)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
-                return;
-            }
-
             try
             {
                 await TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
@@ -77,20 +71,11 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
-        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName)
-        {
-            if (PlatformDetection.IsSLES)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
-                return;
-            }
-
+        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName) =>
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
-        }
 
         [Fact]
         public async Task Dns_GetHostEntryAsync_IPString_Ok() =>


### PR DESCRIPTION
Fixes #48751

The tests were failing due to infra on SLES, which is now fixed. We can re-enable the tests.