### PR TITLE
[MonoVM] Export `mono_profiler_init_*` functions from DSO

### DIFF
--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -341,7 +341,7 @@ runtime_initialized (MonoProfiler *profiler)
 		start_helper_thread ();
 }
 
-MONO_API void
+MONO_API_EXPORT void
 mono_profiler_init_aot (const char *desc);
 
 /**

--- a/src/mono/mono/profiler/coverage.c
+++ b/src/mono/mono/profiler/coverage.c
@@ -1128,7 +1128,7 @@ usage (void)
 	exit (0);
 }
 
-MONO_API void
+MONO_API_EXPORT void
 mono_profiler_init_coverage (const char *desc);
 
 void

--- a/src/mono/mono/profiler/log.c
+++ b/src/mono/mono/profiler/log.c
@@ -4176,7 +4176,7 @@ create_profiler (const char *args, const char *filename, GPtrArray *filters)
 	log_profiler.startup_time = current_time ();
 }
 
-MONO_API void
+MONO_API_EXPORT void
 mono_profiler_init_log (const char *desc);
 
 void

--- a/src/mono/mono/profiler/vtune.c
+++ b/src/mono/mono/profiler/vtune.c
@@ -161,7 +161,7 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 	}
 }
 
-MONO_API void
+MONO_API_EXPORT void
 mono_profiler_init_vtune (const char *desc);
 
 /* the entry point */


### PR DESCRIPTION
Augments: d2dff5d7e2d42437753ce537af1dc3df3a867975

It appears the `MONO_API` macro isn't enough to make symbol
exported by a DSO. `MONO_API_EXPORT` needs to be used instead.