### PR TITLE
HttpStress: Disable firewall in Windows runs

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -77,6 +77,11 @@ jobs:
     lfs: false
 
   - powershell: |
+      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+    name: disableFirewall
+    displayName: Disable Firewall
+
+  - powershell: |
       $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
       echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
     name: buildRuntime
@@ -103,3 +108,8 @@ jobs:
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 1.1
     condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+
+  - powershell: |
+      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled True
+    name: enableFirewall
+    displayName: Enable Firewall

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -77,11 +77,6 @@ jobs:
     lfs: false
 
   - powershell: |
-      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
-    name: disableFirewall
-    displayName: Disable Firewall
-
-  - powershell: |
       $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
       echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
     name: buildRuntime
@@ -100,6 +95,13 @@ jobs:
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 2.0
     condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+
+    # Firewall is disabled for HTTP 1.1 runs.
+    # See: https://github.com/dotnet/runtime/issues/50854
+  - powershell: |
+      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+    name: disableFirewall
+    displayName: Disable Firewall
 
   - powershell: |
       cd '$(httpStressProject)'


### PR DESCRIPTION
Fixes #50854. The issue seems to be caused by an unknown firewall problem, and from the POV of http stress testing it's a false negative. We need a quick solution to remove this failure type, because the high amount failures renders [our stress test reports](https://dev.azure.com/dnceng/public/_build?definitionId=694&_a=summary) useless. 

Since the build agents do not have a public IP, it seems OK to disable the Windows firewall for the runs.

/cc @MattGal @ViktorHofer