### PR TITLE
Annotate System.Diagnostics.Process.MaxWorkingSet/MinWorkingSet props as unsupported on iOS/tvOS

### DIFF
--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -43,8 +43,8 @@ namespace System.Diagnostics
         public System.Diagnostics.ProcessModule? MainModule { get { throw null; } }
         public System.IntPtr MainWindowHandle { get { throw null; } }
         public string MainWindowTitle { get { throw null; } }
-        public System.IntPtr MaxWorkingSet { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] [System.Runtime.Versioning.SupportedOSPlatformAttribute("macos")] [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd")] set { } }
-        public System.IntPtr MinWorkingSet { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] [System.Runtime.Versioning.SupportedOSPlatformAttribute("macos")] [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd")] set { } }
+        public System.IntPtr MaxWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public System.IntPtr MinWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.Diagnostics.ProcessModuleCollection Modules { get { throw null; } }
         [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.NonpagedSystemMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
         public int NonpagedSystemMemorySize { get { throw null; } }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -260,6 +260,8 @@ namespace System.Diagnostics
         /// <remarks>On macOS and FreeBSD, setting the value works only for the current process.</remarks>
         public IntPtr MaxWorkingSet
         {
+            [UnsupportedOSPlatform("ios")]
+            [UnsupportedOSPlatform("tvos")]
             get
             {
                 EnsureWorkingSetLimits();
@@ -280,6 +282,8 @@ namespace System.Diagnostics
         /// <remarks>On macOS and FreeBSD, setting the value works only for the current process.</remarks>
         public IntPtr MinWorkingSet
         {
+            [UnsupportedOSPlatform("ios")]
+            [UnsupportedOSPlatform("tvos")]
             get
             {
                 EnsureWorkingSetLimits();


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/47910

`System.Diagnostics.Process.MaxWorkingSet/MinWorkingSet` properties throw PNSE on iOS/tvOS.
As an example, the test failure below:
```
      <test name="System.Diagnostics.Tests.ProcessTests.MaxWorkingSet_GetNotStarted_ThrowsInvalidOperationException" type="System.Diagnostics.Tests.ProcessTests" method="MaxWorkingSet_GetNotStarted_ThrowsInvalidOperationException" time="0.0027397" result="Fail">
        <failure exception-type="Xunit.Sdk.ThrowsException">
          <message><![CDATA[Assert.Throws() Failure\nExpected: typeof(System.InvalidOperationException)\nActual:   typeof(System.PlatformNotSupportedException): Getting or setting the working set limits on other processes is not supported on this platform.\n---- System.PlatformNotSupportedException : Getting or setting the working set limits on other processes is not supported on this platform.]]></message>
          <stack-trace><![CDATA[   at System.Diagnostics.Process.GetWorkingSetLimits(IntPtr& minWorkingSet, IntPtr& maxWorkingSet) in System.Diagnostics.Process.dll:token 0x600011f+0x12
   at System.Diagnostics.Process.EnsureWorkingSetLimits() in System.Diagnostics.Process.dll:token 0x60000cf+0x8
   at System.Diagnostics.Process.get_MaxWorkingSet() in System.Diagnostics.Process.dll:token 0x600009b+0x0
   at System.Diagnostics.Tests.ProcessTests.<>c__DisplayClass30_0.<MaxWorkingSet_GetNotStarted_ThrowsInvalidOperationException>b__0() in System.Diagnostics.Process.Tests.dll:token 0x60002f8+0x0
----- Inner Stack Trace -----
   at System.Diagnostics.Process.GetWorkingSetLimits(IntPtr& minWorkingSet, IntPtr& maxWorkingSet) in System.Diagnostics.Process.dll:token 0x600011f+0x12
   at System.Diagnostics.Process.EnsureWorkingSetLimits() in System.Diagnostics.Process.dll:token 0x60000cf+0x8
   at System.Diagnostics.Process.get_MaxWorkingSet() in System.Diagnostics.Process.dll:token 0x600009b+0x0
   at System.Diagnostics.Tests.ProcessTests.<>c__DisplayClass30_0.<MaxWorkingSet_GetNotStarted_ThrowsInvalidOperationException>b__0() in System.Diagnostics.Process.Tests.dll:token 0x60002f8+0x0]]></stack-trace>
        </failure>
      </test>
```

