### PR TITLE
[wasm][aot] Update disabled tests to track new fixes on `main`

### DIFF
--- a/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
@@ -215,7 +215,6 @@ namespace Tests.System.Net
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50955", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void CopyFromRepeatedlyAndCopyToRepeatedly_Success()
         {
             ReadOnlySpan<byte> source = new byte[] { 1, 2, 3, 4, 5, 6, 7 }.AsSpan();
@@ -245,7 +244,6 @@ namespace Tests.System.Net
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50955", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void CopyFromRepeatedlyAndCopyToRepeatedly_LargeCopies_Success()
         {
             ReadOnlySpan<byte> source = Enumerable.Range(0, 64 * 1024 - 1).Select(x => (byte)x).ToArray().AsSpan();

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
@@ -13,7 +13,6 @@ namespace System.Reflection.Metadata.Decoding.Tests
     public class CustomAttributeDecoderTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51958", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Type assembly name is different on .NET Framework.")]
         public void TestCustomAttributeDecoder()
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
@@ -14,7 +14,6 @@ namespace System.Reflection.Tests
     public static partial class CustomAttributeTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51958", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public static void CustomAttributeTest1()
         {
             Type t = typeof(AttributeHolder1);  // Intentionally not projected. We're reflecting on this (and Invoking it) to get the validation baseline data.

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -652,6 +652,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51673", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         [MemberData(nameof(GetCallingAssembly_TestData))]
         public void GetCallingAssembly(Assembly assembly1, Assembly assembly2, bool expected)
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -253,7 +253,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj" />
 
     <!-- Issue: https://github.com/dotnet/runtime/issues/52384 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Tests.csproj" />
 
     <!-- Issue: https://github.com/dotnet/runtime/issues/50959 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipelines\tests\System.IO.Pipelines.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -240,9 +240,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/50957 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51673 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
-
     <!-- Issue: https://github.com/dotnet/runtime/issues/51680 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -234,9 +234,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/50965 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encodings.Web\tests\System.Text.Encodings.Web.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51037 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections/tests/System.Collections.Tests.csproj" />
-
     <!-- Issue: https://github.com/dotnet/runtime/issues/50957 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -13,7 +13,7 @@
     <TestTrimming Condition="'$(TestTrimming)' == ''">false</TestTrimming>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetsMobile)' == 'true'">
+  <ItemGroup Condition="'$(TargetsMobile)' == 'true' and '$(TargetOS)' != 'Browser'">
     <!-- Microsoft.CodeAnalysis.* assemblies missing in the virtual file system for Browser and the bundle for the mobile platforms -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Tests.csproj" />
   </ItemGroup>
@@ -251,6 +251,12 @@
 
     <!-- Issue: https://github.com/dotnet/runtime/issues/51961 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj" />
+
+    <!-- Issue: https://github.com/dotnet/runtime/issues/52384 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Tests.csproj" />
+
+    <!-- Issue: https://github.com/dotnet/runtime/issues/50959 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipelines\tests\System.IO.Pipelines.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -252,7 +252,7 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/51676 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51960 -->
+    <!-- Issue: https://github.com/dotnet/runtime/issues/52393 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime/tests/System.Runtime.Tests.csproj" />
 
     <!-- Issue: https://github.com/dotnet/runtime/issues/51961 -->


### PR DESCRIPTION
- System.Runtime.Tests failing with a different issue now
  The earlier one (https://github.com/dotnet/runtime/issues/51960) was
  fixed.
  New: https://github.com/dotnet/runtime/issues/52393

- Enable Common.Tests test tracked in https://github.com/dotnet/runtime/issues/50955