### PR TITLE
GC bookkeeping data structure in-place commit

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8945,6 +8945,8 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         get_card_table_element_layout(start, end, card_table_element_layout);
         size_t alloc_size = card_table_element_layout[total_bookkeeping_elements];
         size_t cb = 0;
+        uint32_t* ct = 0;
+        uint32_t* translated_ct = 0;
 
 #ifdef CARD_BUNDLE
         if (can_use_write_watch_for_card_table())
@@ -8982,7 +8984,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             }
         }
 
-        uint32_t* ct = (uint32_t*)(mem + card_table_element_layout[card_table_element]);
+        ct = (uint32_t*)(mem + card_table_element_layout[card_table_element]);
         card_table_refcount (ct) = 0;
         card_table_lowest_address (ct) = saved_g_lowest_address;
         card_table_highest_address (ct) = saved_g_highest_address;
@@ -9025,7 +9027,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             card_table_mark_array (ct) = NULL;
 #endif //BACKGROUND_GC
 
-        uint32_t* translated_ct = translate_card_table (ct);
+        translated_ct = translate_card_table (ct);
 
         dprintf (GC_TABLE_LOG, ("card table: %Ix(translated: %Ix), seg map: %Ix, mark array: %Ix",
             (size_t)ct, (size_t)translated_ct, (size_t)new_seg_mapping_table, (size_t)card_table_mark_array (ct)));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2297,12 +2297,13 @@ region_allocator global_region_allocator;
 uint8_t*(*initial_regions)[total_generation_count][2] = nullptr;
 size_t      gc_heap::region_count = 0;
 
-uint8_t* bookkeeping_data_structure = nullptr;
-// As long as global_region_allocator.global_region_left_used <= bookkeeping_data_structure_committed
-// no more extra commit to the bookkeeping data structure is necessary.
-// outside of region_lock, bookkeeping_data_structure_committed >= global_region_allocator.global_region_left_used always
-uint8_t* bookkeeping_data_structure_committed = nullptr;
+uint8_t* bookkeeping_data = nullptr;
+uint8_t* bookkeeping_data_committed = nullptr;
+size_t card_table_element_sizes[total_bookkeeping_elements];
+
 #endif //USE_REGIONS
+
+size_t card_table_element_layout[total_bookkeeping_elements + 1];
 
 #ifdef BACKGROUND_GC
 GCEvent     gc_heap::bgc_start_event;
@@ -3574,7 +3575,7 @@ bool region_allocator::init (uint8_t* start, uint8_t* end, size_t alignment, uin
     global_region_left_used = global_region_start;
     global_region_right_used = global_region_end;
 
-    bookkeeping_data_structure_committed = global_region_start;
+    bookkeeping_data_committed = global_region_start;
 
     // Note: I am allocating a map that covers the whole reserved range.
     // We can optimize it to only cover the current heap range.
@@ -3820,7 +3821,7 @@ uint8_t* region_allocator::allocate (uint32_t num_units, allocate_direction dire
     if (alloc)
     {
         total_free_units -= num_units;
-        if ((fn != nullptr) && (global_region_left_used > bookkeeping_data_structure_committed))
+        if ((fn != nullptr) && (global_region_left_used > bookkeeping_data_committed))
         {
             bool speculative_commit_tried = false;
 #ifdef STRESS_REGIONS
@@ -3832,30 +3833,30 @@ uint8_t* region_allocator::allocate (uint32_t num_units, allocate_direction dire
 #endif
             while (true)
             {
-                uint8_t* new_bookkeeping_data_structure_committed = nullptr;
+                uint8_t* new_bookkeeping_data_committed = nullptr;
                 if (speculative_commit_tried)
                 {
-                    new_bookkeeping_data_structure_committed = global_region_left_used;
+                    new_bookkeeping_data_committed = global_region_left_used;
                 }
                 else
                 {
-                    uint64_t committed_size = (uint64_t)(bookkeeping_data_structure_committed - global_region_start);
+                    uint64_t committed_size = (uint64_t)(bookkeeping_data_committed - global_region_start);
                     uint64_t total_size = (uint64_t)(global_region_end - global_region_start);
                     assert (committed_size < total_size);
                     uint64_t new_committed_size = min(committed_size * 2, total_size); // Should not overflow?
                     uint8_t* double_commit = global_region_start + new_committed_size; // Should not overflow?
-                    new_bookkeeping_data_structure_committed = max(double_commit, global_region_left_used);
-                    dprintf (REGIONS_LOG, ("committed_size                           = %llu", committed_size));
-                    dprintf (REGIONS_LOG, ("total_size                               = %llu", total_size));
-                    dprintf (REGIONS_LOG, ("new_committed_size                       = %llu", new_committed_size));
+                    new_bookkeeping_data_committed = max(double_commit, global_region_left_used);
+                    dprintf (REGIONS_LOG, ("committed_size                           = %ld", committed_size));
+                    dprintf (REGIONS_LOG, ("total_size                               = %ld", total_size));
+                    dprintf (REGIONS_LOG, ("new_committed_size                       = %ld", new_committed_size));
                     dprintf (REGIONS_LOG, ("double_commit                            = %p", double_commit));
                 }
-                dprintf (REGIONS_LOG, ("bookkeeping_data_structure_committed     = %p", bookkeeping_data_structure_committed));
-                dprintf (REGIONS_LOG, ("new_bookkeeping_data_structure_committed = %p", new_bookkeeping_data_structure_committed));
+                dprintf (REGIONS_LOG, ("bookkeeping_data_committed     = %p", bookkeeping_data_committed));
+                dprintf (REGIONS_LOG, ("new_bookkeeping_data_committed = %p", new_bookkeeping_data_committed));
 
-                if (fn (bookkeeping_data_structure_committed, new_bookkeeping_data_structure_committed))
+                if (fn (bookkeeping_data_committed, new_bookkeeping_data_committed))
                 {
-                    bookkeeping_data_structure_committed = new_bookkeeping_data_structure_committed;
+                    bookkeeping_data_committed = new_bookkeeping_data_committed;
                     break;
                 }
                 else
@@ -8604,7 +8605,6 @@ void gc_heap::get_card_table_element_sizes (uint8_t* start, uint8_t* end, size_t
 
 void gc_heap::get_card_table_element_layout (uint8_t* start, uint8_t* end, size_t layout[total_bookkeeping_elements + 1])
 {
-    // This code has too many special case, doesn't make sense to change it into a loop
     size_t card_table_element_sizes[total_bookkeeping_elements];
     get_card_table_element_sizes(start, end, card_table_element_sizes);
 
@@ -8622,54 +8622,57 @@ void gc_heap::get_card_table_element_layout (uint8_t* start, uint8_t* end, size_
     }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     layout[seg_mapping_table_element] = align_for_seg_mapping_table (seg_mapping_table_offset_prealign);
-    layout[mark_array_element] = layout[seg_mapping_table_element] + card_table_element_sizes[seg_mapping_table_element];
-    layout[total_bookkeeping_elements] = layout[mark_array_element] + card_table_element_sizes[mark_array_element];
+    layout[mark_array_element] = align_on_page (layout[seg_mapping_table_element] + card_table_element_sizes[seg_mapping_table_element]);
+    layout[total_bookkeeping_elements] = align_on_page (layout[mark_array_element] + card_table_element_sizes[mark_array_element]);
 }
 
 #ifdef USE_REGIONS
 bool gc_heap::inplace_commit_card_table (uint8_t* from, uint8_t* to)
 {
-    dprintf (REGIONS_LOG, ("inplace_commit_card_table(%p, %p), size = %llu", from, to, to - from));
+    dprintf (REGIONS_LOG, ("inplace_commit_card_table(%p, %p), size = %ld", from, to, to - from));
 
     uint8_t* start = g_gc_lowest_address;
     uint8_t* end = g_gc_highest_address;
 
-    size_t offsets[total_bookkeeping_elements + 1];
-    get_card_table_element_layout(start, end, offsets);
-
-    dprintf (REGIONS_LOG, ("layout"));
-    for (int i = card_table_element; i <= total_bookkeeping_elements; i++)
-    {
-        dprintf (REGIONS_LOG, ("%p", bookkeeping_data_structure + offsets[i]));
-    }
-
-    size_t new_sizes[total_bookkeeping_elements];
-    get_card_table_element_sizes (start, to, new_sizes);
-
-    dprintf (REGIONS_LOG, ("new_sizes"));
-    for (int i = card_table_element; i < total_bookkeeping_elements; i++)
-    {
-        dprintf (REGIONS_LOG, ("%llu", new_sizes[i]));
-    }
-
     uint8_t* commit_begins[total_bookkeeping_elements];
     size_t commit_sizes[total_bookkeeping_elements];
+    size_t new_sizes[total_bookkeeping_elements];
 
     bool initial_commit = (from == start);
     bool additional_commit = !initial_commit && (to > from);
 
     if (initial_commit || additional_commit)
     {
-        size_t old_sizes[total_bookkeeping_elements];
+#ifdef DEBUG
+        size_t offsets[total_bookkeeping_elements + 1];
+        get_card_table_element_layout(start, end, offsets);
+
+        dprintf (REGIONS_LOG, ("layout"));
+        for (int i = card_table_element; i <= total_bookkeeping_elements; i++)
+        {
+            assert (offsets[i] == card_table_element_layout[i]);
+            dprintf (REGIONS_LOG, ("%p", bookkeeping_data + card_table_element_layout[i]));
+        }
+#endif
+        get_card_table_element_sizes (start, to, new_sizes);
+#ifdef DEBUG
+        dprintf (REGIONS_LOG, ("new_sizes"));
+        for (int i = card_table_element; i < total_bookkeeping_elements; i++)
+        {
+            dprintf (REGIONS_LOG, ("%ld", new_sizes[i]));
+        }
         if (additional_commit)
         {
-            get_card_table_element_sizes (start, from, old_sizes);
+            size_t current_sizes[total_bookkeeping_elements];
+            get_card_table_element_sizes (start, from, current_sizes);
             dprintf (REGIONS_LOG, ("old_sizes"));
             for (int i = card_table_element; i < total_bookkeeping_elements; i++)
             {
-                dprintf (REGIONS_LOG, ("%llu", old_sizes[i]));
+                assert (current_sizes[i] == card_table_element_sizes[i]);
+                dprintf (REGIONS_LOG, ("%ld", card_table_element_sizes[i]));
             }
         }
+#endif
         for (int i = card_table_element; i <= seg_mapping_table_element; i++)
         {
             uint8_t* required_begin = nullptr;
@@ -8678,21 +8681,30 @@ bool gc_heap::inplace_commit_card_table (uint8_t* from, uint8_t* to)
             uint8_t* commit_end = nullptr;
             if (initial_commit)
             {
-                required_begin = bookkeeping_data_structure + ((i == card_table_element) ? 0 : offsets[i]);
-                required_end = bookkeeping_data_structure + offsets[i] + new_sizes[i];
+                required_begin = bookkeeping_data + ((i == card_table_element) ? 0 : card_table_element_layout[i]);
+                required_end = bookkeeping_data + card_table_element_layout[i] + new_sizes[i];
                 commit_begin = align_lower_page(required_begin);
             }
             else
             {
                 assert (additional_commit);
-                required_begin = bookkeeping_data_structure + offsets[i] + old_sizes[i];
-                required_end = required_begin + new_sizes[i] - old_sizes[i];
+                required_begin = bookkeeping_data + card_table_element_layout[i] + card_table_element_sizes[i];
+                required_end = required_begin + new_sizes[i] - card_table_element_sizes[i];
                 commit_begin = align_on_page(required_begin);
             }
+            assert (required_begin <= required_end);
             commit_end = align_on_page(required_end);
 
-            dprintf (REGIONS_LOG, ("required = [%p, %p), size = %llu", required_begin, required_end, required_end - required_begin));
-            dprintf (REGIONS_LOG, ("commit   = [%p, %p), size = %llu", commit_begin, commit_end, commit_end - commit_begin));
+            if (i != seg_mapping_table_element)
+            {
+                commit_end = min (commit_end, align_lower_page(bookkeeping_data + card_table_element_layout[i + 1]));
+                commit_begin = min (commit_begin, commit_end);
+            }
+            assert (commit_begin <= commit_end);
+            
+
+            dprintf (REGIONS_LOG, ("required = [%p, %p), size = %ld", required_begin, required_end, required_end - required_begin));
+            dprintf (REGIONS_LOG, ("commit   = [%p, %p), size = %ld", commit_begin, commit_end, commit_end - commit_begin));
 
             commit_begins[i] = commit_begin;
             commit_sizes[i] = (size_t)(commit_end - commit_begin);
@@ -8717,7 +8729,14 @@ bool gc_heap::inplace_commit_card_table (uint8_t* from, uint8_t* to)
             }
         }
     }
-    if (failed_commit != -1)
+    if (failed_commit == -1)
+    {
+        for (int i = card_table_element; i < total_bookkeeping_elements; i++)
+        {
+            card_table_element_sizes[i] = new_sizes[i];
+        }
+    }
+    else
     {
         for (int i = card_table_element; i < failed_commit; i++)
         {
@@ -8751,13 +8770,12 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     }
 #endif //CARD_BUNDLE
 
-    size_t offsets[total_bookkeeping_elements + 1];
-    get_card_table_element_layout(start, end, offsets);
+    get_card_table_element_layout(start, end, card_table_element_layout);
 
-    size_t alloc_size = offsets[total_bookkeeping_elements];
+    size_t alloc_size = card_table_element_layout[total_bookkeeping_elements];
     uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size, 0, virtual_reserve_flags);
 #ifdef USE_REGIONS
-    bookkeeping_data_structure = mem;
+    bookkeeping_data = mem;
 #endif //USE_REGIONS
 
     if (!mem)
@@ -8767,7 +8785,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
                  alloc_size, (size_t)mem, (size_t)(mem+alloc_size)));
 
     // mark array will be committed separately (per segment).
-    size_t commit_size = offsets[mark_array_element];
+    size_t commit_size = card_table_element_layout[mark_array_element];
 
 #ifdef USE_REGIONS
     if (!inplace_commit_card_table (g_gc_lowest_address, global_region_allocator.get_left_used_unsafe()))
@@ -8776,7 +8794,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
         GCToOSInterface::VirtualRelease (mem, alloc_size);
         return 0;
     }
-    bookkeeping_data_structure_committed = global_region_allocator.get_left_used_unsafe();
+    bookkeeping_data_committed = global_region_allocator.get_left_used_unsafe();
 #else
     if (!virtual_commit (mem, commit_size, gc_oh_num::none))
     {
@@ -8787,16 +8805,16 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 #endif
 
     // initialize the ref count
-    uint32_t* ct = (uint32_t*)(mem + offsets[card_table_element]);
+    uint32_t* ct = (uint32_t*)(mem + card_table_element_layout[card_table_element]);
     card_table_refcount (ct) = 0;
     card_table_lowest_address (ct) = start;
     card_table_highest_address (ct) = end;
-    card_table_brick_table (ct) = (short*)(mem + offsets[brick_table_element]);
+    card_table_brick_table (ct) = (short*)(mem + card_table_element_layout[brick_table_element]);
     card_table_size (ct) = alloc_size;
     card_table_next (ct) = 0;
 
 #ifdef CARD_BUNDLE
-    card_table_card_bundle_table (ct) = (uint32_t*)(mem + offsets[card_bundle_table_element]);
+    card_table_card_bundle_table (ct) = (uint32_t*)(mem + card_table_element_layout[card_bundle_table_element]);
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     g_gc_card_bundle_table = translate_card_bundle_table(card_table_card_bundle_table(ct), g_gc_lowest_address);
@@ -8806,17 +8824,17 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     if (gc_can_use_concurrent)
     {
-        SoftwareWriteWatch::InitializeUntranslatedTable(mem + offsets[software_write_watch_table_element], start);
+        SoftwareWriteWatch::InitializeUntranslatedTable(mem + card_table_element_layout[software_write_watch_table_element], start);
     }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
-    seg_mapping_table = (seg_mapping*)(mem + offsets[seg_mapping_table_element]);
+    seg_mapping_table = (seg_mapping*)(mem + card_table_element_layout[seg_mapping_table_element]);
     seg_mapping_table = (seg_mapping*)((uint8_t*)seg_mapping_table -
                                         size_seg_mapping_table_of (0, (align_lower_segment (g_gc_lowest_address))));
 
 #ifdef BACKGROUND_GC
     if (gc_can_use_concurrent)
-        card_table_mark_array (ct) = (uint32_t*)(mem + offsets[mark_array_element]);
+        card_table_mark_array (ct) = (uint32_t*)(mem + card_table_element_layout[mark_array_element]);
     else
         card_table_mark_array (ct) = NULL;
 #endif //BACKGROUND_GC

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8574,7 +8574,7 @@ void gc_heap::get_card_table_element_layout (uint8_t* start, uint8_t* end, size_
     for (int element = brick_table_element; element <= total_bookkeeping_elements; element++)
     {
         layout[element] = layout[element - 1] + sizes[element - 1];
-        if (sizes[element] != 0)
+        if ((element != total_bookkeeping_elements) && (sizes[element] != 0))
         {
             layout[element] = ALIGN_UP(layout[element], alignment[element]);
         }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8574,9 +8574,7 @@ void gc_heap::get_card_table_element_layout (uint8_t* start, uint8_t* end, size_
     for (int element = brick_table_element; element <= total_bookkeeping_elements; element++)
     {
         layout[element] = layout[element - 1] + sizes[element - 1];
-#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-        if (element != software_write_watch_table_element || gc_can_use_concurrent)
-#endif //FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+        if (sizes[element] != 0)
         {
             layout[element] = ALIGN_UP(layout[element], alignment[element]);
         }
@@ -8709,11 +8707,8 @@ bool gc_heap::inplace_commit_card_table (uint8_t* from, uint8_t* to)
             assert (required_begin <= required_end);
             commit_end = align_on_page(required_end);
 
-            if (i != seg_mapping_table_element)
-            {
-                commit_end = min (commit_end, align_lower_page(bookkeeping_covered_start + card_table_element_layout[i + 1]));
-                commit_begin = min (commit_begin, commit_end);
-            }
+            commit_end = min (commit_end, align_lower_page(bookkeeping_covered_start + card_table_element_layout[i + 1]));
+            commit_begin = min (commit_begin, commit_end);
             assert (commit_begin <= commit_end);
 
             dprintf (REGIONS_LOG, ("required = [%p, %p), size = %Id", required_begin, required_end, required_end - required_begin));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8942,7 +8942,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         uint32_t* saved_g_card_bundle_table = g_gc_card_bundle_table;
 #endif
-        get_card_table_element_layout(start, end, card_table_element_layout);
+        get_card_table_element_layout(saved_g_lowest_address, saved_g_highest_address, card_table_element_layout);
         size_t alloc_size = card_table_element_layout[total_bookkeeping_elements];
         size_t cb = 0;
         uint32_t* ct = 0;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8801,8 +8801,8 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     }
     bookkeeping_covered_committed = global_region_allocator.get_left_used_unsafe();
 #else
-    // mark array will be committed separately (per segment).
-    size_t commit_size = card_table_element_layout[mark_array_element];
+    // in case of background gc, the mark array will be committed separately (per segment).
+    size_t commit_size = card_table_element_layout[seg_mapping_table_element + 1];
 
     if (!virtual_commit (mem, commit_size, gc_oh_num::none))
     {
@@ -8940,7 +8940,6 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         uint32_t* saved_g_card_bundle_table = g_gc_card_bundle_table;
 #endif
         get_card_table_element_layout(saved_g_lowest_address, saved_g_highest_address, card_table_element_layout);
-        size_t alloc_size = card_table_element_layout[total_bookkeeping_elements];
         size_t cb = 0;
         uint32_t* ct = 0;
         uint32_t* translated_ct = 0;
@@ -8958,6 +8957,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         }
 #endif //CARD_BUNDLE
 
+        size_t alloc_size = card_table_element_layout[total_bookkeeping_elements];
         uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size, 0, virtual_reserve_flags);
 
         if (!mem)
@@ -8970,8 +8970,8 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
                                  alloc_size, (size_t)mem, (size_t)((uint8_t*)mem+alloc_size)));
 
         {
-            // mark array will be committed separately (per segment).
-            size_t commit_size = card_table_element_layout[total_bookkeeping_elements - 1];
+            // in case of background gc, the mark array will be committed separately (per segment).
+            size_t commit_size = card_table_element_layout[seg_mapping_table_element + 1];
 
             if (!virtual_commit (mem, commit_size, gc_oh_num::none))
             {

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1189,8 +1189,12 @@ enum bookkeeping_element
 {
     card_table_element = 0,
     brick_table_element = 1,
+#ifdef CARD_BUNDLE
     card_bundle_table_element = 2,
+#endif
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     software_write_watch_table_element = 3,
+#endif
     seg_mapping_table_element = 4,
     mark_array_element = 5,
     total_bookkeeping_elements = 6

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1185,6 +1185,17 @@ public:
 };
 #endif
 
+enum bookkeeping_element
+{
+    card_table_element = 0,
+    brick_table_element = 1,
+    card_bundle_table_element= 2,
+    software_write_watch_table_element= 3,
+    seg_mapping_table_element= 4,
+    mark_array_element= 5,
+    total_bookkeeping_elements = 6
+};
+
 //class definition of the internal class
 class gc_heap
 {
@@ -1557,6 +1568,17 @@ public:
 
     static
     uint32_t* make_card_table (uint8_t* start, uint8_t* end);
+
+    static
+    void get_card_table_element_layout (uint8_t* start, uint8_t* end, size_t layout[total_bookkeeping_elements + 1]);
+
+    static
+    void get_card_table_element_sizes (uint8_t* start, uint8_t* end, size_t card_table_element_sizes[total_bookkeeping_elements]);
+
+#ifdef USE_REGIONS
+    static
+    bool inplace_commit_card_table(uint8_t* from, uint8_t* to);
+#endif //USE_REGIONS
 
     static
     void set_fgm_result (failure_get_memory f, size_t s, BOOL loh_p);
@@ -5615,6 +5637,8 @@ enum allocate_direction
     allocate_backward = -1,
 };
 
+typedef bool (*region_allocator_callback_fn)(uint8_t*, uint8_t*);
+
 // The big space we reserve for regions is divided into units of region_alignment.
 // 
 // SOH regions are all basic regions, meaning their size is the same as alignment. UOH regions 
@@ -5666,7 +5690,7 @@ private:
     uint8_t* region_address_of (uint32_t* map_index);
     uint32_t* region_map_index_of (uint8_t* address);
 
-    uint8_t* allocate (uint32_t num_units, allocate_direction direction);
+    uint8_t* allocate (uint32_t num_units, allocate_direction direction, region_allocator_callback_fn fn);
     uint8_t* allocate_end (uint32_t num_units, allocate_direction direction);
 
     void enter_spin_lock();
@@ -5704,10 +5728,11 @@ private:
 
 public:
     bool init (uint8_t* start, uint8_t* end, size_t alignment, uint8_t** lowest, uint8_t** highest);
-    bool allocate_region (size_t size, uint8_t** start, uint8_t** end, allocate_direction direction);
-    bool allocate_basic_region (uint8_t** start, uint8_t** end);
-    bool allocate_large_region (uint8_t** start, uint8_t** end, allocate_direction direction, size_t size = 0);
+    bool allocate_region (size_t size, uint8_t** start, uint8_t** end, allocate_direction direction, region_allocator_callback_fn fn);
+    bool allocate_basic_region (uint8_t** start, uint8_t** end, region_allocator_callback_fn fn);
+    bool allocate_large_region (uint8_t** start, uint8_t** end, allocate_direction direction, size_t size, region_allocator_callback_fn fn);
     void delete_region (uint8_t* start);
+    void delete_region_impl (uint8_t* start);
     uint32_t get_va_memory_load()
     {
         return (uint32_t)(((global_region_left_used - global_region_start) + ((global_region_end - global_region_right_used)))* 100.0
@@ -5726,6 +5751,11 @@ public:
         return (region_map_left_end - region_map_left_start);
     }
     void move_highest_free_regions (int64_t n, bool small_region_p, region_free_list to_free_list[count_free_region_kinds]);
+
+    // global_region_left_used can be modified concurrently by allocate and delete
+    // usage of this function must make sure either it is under the region lock or we
+    // are certain that these functions cannot be running concurrently.
+    uint8_t* get_left_used_unsafe() { return global_region_left_used; }
 };
 #endif //USE_REGIONS
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1196,7 +1196,9 @@ enum bookkeeping_element
     software_write_watch_table_element,
 #endif
     seg_mapping_table_element,
+#ifdef BACKGROUND_GC
     mark_array_element,
+#endif
     total_bookkeeping_elements
 };
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1187,17 +1187,17 @@ public:
 
 enum bookkeeping_element
 {
-    card_table_element = 0,
-    brick_table_element = 1,
+    card_table_element,
+    brick_table_element,
 #ifdef CARD_BUNDLE
-    card_bundle_table_element = 2,
+    card_bundle_table_element,
 #endif
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    software_write_watch_table_element = 3,
+    software_write_watch_table_element,
 #endif
-    seg_mapping_table_element = 4,
-    mark_array_element = 5,
-    total_bookkeeping_elements = 6
+    seg_mapping_table_element,
+    mark_array_element,
+    total_bookkeeping_elements
 };
 
 //class definition of the internal class

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4994,6 +4994,9 @@ public:
 protected:
     PER_HEAP
     void update_collection_counts ();
+    
+    PER_HEAP_ISOLATED
+    size_t card_table_element_layout[total_bookkeeping_elements + 1];
 
 #ifdef USE_REGIONS
     PER_HEAP_ISOLATED

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5000,10 +5000,10 @@ protected:
 
 #ifdef USE_REGIONS
     PER_HEAP_ISOLATED
-    uint8_t* bookkeeping_data;
+    uint8_t* bookkeeping_covered_start;
 
     PER_HEAP_ISOLATED
-    uint8_t* bookkeeping_data_committed;
+    uint8_t* bookkeeping_covered_committed;
 
     PER_HEAP_ISOLATED
     size_t bookkeeping_sizes[total_bookkeeping_elements];

--- a/src/coreclr/gc/softwarewritewatch.h
+++ b/src/coreclr/gc/softwarewritewatch.h
@@ -266,11 +266,6 @@ inline size_t SoftwareWriteWatch::GetTableByteSize(void *heapStartAddress, void 
     return tableByteSize;
 }
 
-inline size_t SoftwareWriteWatch::GetTableStartByteOffset(size_t byteSizeBeforeTable)
-{
-    return ALIGN_UP(byteSizeBeforeTable, sizeof(size_t)); // start of the table needs to be aligned to size_t
-}
-
 inline uint8_t *SoftwareWriteWatch::TranslateTableToExcludeHeapStartAddress(uint8_t *table, void *heapStartAddress)
 {
     assert(table != nullptr);


### PR DESCRIPTION
With a fixed reserved range in the `USE_REGIONS` case, we can simplify the logic for managing the GC bookkeeping data structures as we grow the heap by doing so in place.

**Highlights:**
- The code is structured so that the size and layout computation is centralized.
- In the `USE_REGIONS` case, the data structures are committing much less memory than it was.
- In the case of `STRESS_REGIONS`, at random times, the data structure is committed right at the level it needs to stress size computation logic.
- I made sure the arguments to `virtual_commit` are page-aligned.
- In the case of failure to speculatively commit for more memory for the data structure, the code fallbacks to commit less before reporting OOM.

**Lowlights:**
- It doesn't handle `g_mark_list_piece`, it will be done in follow-up PRs.
- We do not change the `g_gc_highest_address` value, it seems unnecessary for the x64 case.