### PR TITLE
 Make PInvokeStaticSigInfo always report errors

### DIFF
--- a/src/coreclr/vm/callconvbuilder.hpp
+++ b/src/coreclr/vm/callconvbuilder.hpp
@@ -85,7 +85,7 @@ namespace CallConv
     //
     // Returns:
     //   true  - No errors
-    //   false - Invalid (more than one calling convention specified)
+    //   false - Not specified or invalid (more than one calling convention specified)
     //-------------------------------------------------------------------------
     bool TryGetCallingConventionFromUnmanagedCallersOnly(_In_ MethodDesc* pMD, _Out_ CorInfoCallConvExtension* callConv);
 }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2702,7 +2702,7 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(_In_ MethodDesc* pMD)
 
 ErrExit:
     if (FAILED(hr))
-        ReportError(IDS_EE_NDIRECT_BADNATL);
+        ThrowError(IDS_EE_NDIRECT_BADNATL);
 }
 
 PInvokeStaticSigInfo::PInvokeStaticSigInfo(
@@ -2760,7 +2760,7 @@ void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCU
     {
         if (FAILED(pInternalImport->GetModuleRefProps(modref, ppLibName)))
         {
-            ReportError(IDS_CLASSLOAD_BADFORMAT);
+            ThrowError(IDS_CLASSLOAD_BADFORMAT);
         }
     }
 
@@ -2808,7 +2808,7 @@ void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCU
     }
 
     if (FAILED(RemapLinkType(nlt, &nlt)))
-        ReportError(IDS_EE_NDIRECT_BADNATL);
+        ThrowError(IDS_EE_NDIRECT_BADNATL);
 
     SetCharSet(nlt);
 }
@@ -2931,7 +2931,7 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
     if (FAILED(hr))
     {
         // Use an error message specific to P/Invokes or UnmanagedFunction for bad format.
-        ReportError(hr == COR_E_BADIMAGEFORMAT ? IDS_EE_NDIRECT_BADNATL : errorResID);
+        ThrowError(hr == COR_E_BADIMAGEFORMAT ? IDS_EE_NDIRECT_BADNATL : errorResID);
     }
 
     CorInfoCallConvExtension sigCallConv = builder.GetCurrentCallConv();
@@ -2941,7 +2941,7 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
     // If no calling convention is provided, then use the default calling convention for the platform.
 
     if (callConv != CallConvWinApiSentinel && sigCallConv != CallConvWinApiSentinel && callConv != sigCallConv)
-        ReportError(IDS_EE_NDIRECT_BADNATL_CALLCONV);
+        ThrowError(IDS_EE_NDIRECT_BADNATL_CALLCONV);
 
     if (callConv == CallConvWinApiSentinel && sigCallConv == CallConvWinApiSentinel)
         m_callConv = GetDefaultCallConv(bIsVarArg);
@@ -2951,23 +2951,23 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
         m_callConv = sigCallConv;
 
     if (bIsVarArg && m_callConv != CorInfoCallConvExtension::C)
-        ReportError(IDS_EE_NDIRECT_BADNATL_VARARGS_CALLCONV);
+        ThrowError(IDS_EE_NDIRECT_BADNATL_VARARGS_CALLCONV);
 
     _ASSERTE(m_callConv != CallConvWinApiSentinel);
 }
 
-void PInvokeStaticSigInfo::ReportError(WORD error)
+void PInvokeStaticSigInfo::ThrowError(WORD errorResourceID)
 {
     CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(error != 0);
+        PRECONDITION(errorResourceID != 0);
     }
     CONTRACTL_END;
 
-    COMPlusThrow(kTypeLoadException, error);
+    COMPlusThrow(kTypeLoadException, errorResourceID);
 }
 
 CorInfoCallConvExtension NDirect::GetCallingConvention_IgnoreErrors(_In_ MethodDesc* pMD)
@@ -2980,7 +2980,7 @@ CorInfoCallConvExtension NDirect::GetCallingConvention_IgnoreErrors(_In_ MethodD
     }
     CONTRACTL_END;
 
-    // This method explicitly does not check that any calling convention specified through
+    // This method intentionally does not check that any calling convention specified through
     // attributes match that in the signature. We just return once a non-sentinel calling
     // convention is found.
     CorInfoCallConvExtension callConv;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2584,7 +2584,6 @@ void PInvokeStaticSigInfo::PreInit(Module* pModule, MethodTable * pMT)
     SetThrowOnUnmappableChar (FALSE);
     SetLinkFlags (nlfNone);
     SetCharSet (nltAnsi);
-    m_error = 0;
 
     // assembly/type level m_bestFit & m_bThrowOnUnmappableChar
     BOOL bBestFit;
@@ -2626,14 +2625,17 @@ void PInvokeStaticSigInfo::PreInit(MethodDesc* pMD)
 PInvokeStaticSigInfo::PInvokeStaticSigInfo(
     _In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName)
 {
-    STANDARD_VM_CONTRACT;
+    CONTRACTL
+    {
+        STANDARD_VM_CHECK;
+        PRECONDITION(CheckPointer(pMD));
+    }
+    CONTRACTL_END;
 
     DllImportInit(pMD, pLibName, pEntryPointName);
-
-    ReportErrors();
 }
 
-PInvokeStaticSigInfo::PInvokeStaticSigInfo(MethodDesc* pMD, ThrowOnError throwOnError)
+PInvokeStaticSigInfo::PInvokeStaticSigInfo(_In_ MethodDesc* pMD)
 {
     CONTRACTL
     {
@@ -2658,11 +2660,11 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(MethodDesc* pMD, ThrowOnError throwOn
     // System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute
     BYTE* pData = NULL;
     LONG cData = 0;
+    CorInfoCallConvExtension callConv = CallConvWinApiSentinel;
+
     hr = pMT->GetCustomAttribute(
         WellKnownAttribute::UnmanagedFunctionPointer, (const VOID **)(&pData), (ULONG *)&cData);
-    IfFailThrow(hr);
-
-    CorInfoCallConvExtension callConv = CallConvWinApiSentinel;
+    IfFailGo(hr);
     if (cData != 0)
     {
         CustomAttributeParser ca(pData, cData);
@@ -2700,14 +2702,11 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(MethodDesc* pMD, ThrowOnError throwOn
 
 ErrExit:
     if (FAILED(hr))
-        SetError(IDS_EE_NDIRECT_BADNATL);
-
-    if (throwOnError)
-        ReportErrors();
+        ReportError(IDS_EE_NDIRECT_BADNATL);
 }
 
 PInvokeStaticSigInfo::PInvokeStaticSigInfo(
-    Signature sig, Module* pModule)
+    _In_ const Signature& sig, _In_ Module* pModule)
 {
     CONTRACTL
     {
@@ -2721,8 +2720,6 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(
     m_sig = sig;
     SetIsStatic(!(MetaSig::GetCallingConvention(sig) & IMAGE_CEE_CS_CALLCONV_HASTHIS));
     InitCallConv(CallConvWinApiSentinel, FALSE);
-
-    ReportErrors();
 }
 
 void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *ppLibName, _Outptr_opt_ LPCUTF8 *ppEntryPointName)
@@ -2750,16 +2747,6 @@ void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCU
     mdModuleRef modref = mdModuleRefNil;
     if (FAILED(pInternalImport->GetPinvokeMap(pMD->GetMemberDef(), (DWORD*)&mappingFlags, ppEntryPointName, &modref)))
     {
-#if !defined(CROSSGEN_COMPILE) // IJW
-        // The guessing heuristic has been broken with NGen for a long time since we stopped loading
-        // images at NGen time using full LoadLibrary. The DLL references are not resolved correctly
-        // without full LoadLibrary.
-        //
-        // Disable the heuristic consistently during NGen so that it does not kick in by accident.
-        if (!IsCompilationProcess())
-            BestGuessNDirectDefaults(pMD);
-#endif
-
         InitCallConv(CallConvWinApiSentinel, pMD->IsVarArg());
         return;
     }
@@ -2773,8 +2760,7 @@ void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCU
     {
         if (FAILED(pInternalImport->GetModuleRefProps(modref, ppLibName)))
         {
-            SetError(IDS_CLASSLOAD_BADFORMAT);
-            return;
+            ReportError(IDS_CLASSLOAD_BADFORMAT);
         }
     }
 
@@ -2821,14 +2807,10 @@ void PInvokeStaticSigInfo::DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCU
             break;
     }
 
-    if (SUCCEEDED(RemapLinkType(nlt, &nlt)))
-    {
-        SetCharSet(nlt);
-    }
-    else
-    {
-        SetError(IDS_EE_NDIRECT_BADNATL);
-    }
+    if (FAILED(RemapLinkType(nlt, &nlt)))
+        ReportError(IDS_EE_NDIRECT_BADNATL);
+
+    SetCharSet(nlt);
 }
 
 #if !defined(CROSSGEN_COMPILE) // IJW
@@ -2932,43 +2914,6 @@ DWORD STDMETHODCALLTYPE FalseGetLastError()
     return GetThread()->m_dwLastError;
 }
 
-void PInvokeStaticSigInfo::BestGuessNDirectDefaults(MethodDesc* pMD)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    if (!pMD->IsNDirect())
-        return;
-
-    NDirectMethodDesc* pMDD = (NDirectMethodDesc*)pMD;
-
-    if (!pMDD->IsEarlyBound())
-        return;
-
-    LPVOID pTarget = NULL;
-
-    // NOTE: If we get inside this block, and this is a call to GetLastError,
-    //  then InitEarlyBoundNDirectTarget has not been run yet.
-    if (pMDD->NDirectTargetIsImportThunk())
-    {
-        // Get the unmanaged callsite.
-        pTarget = (LPVOID)pMDD->GetModule()->GetInternalPInvokeTarget(pMDD->GetRVA());
-
-        // If this is a call to GetLastError, then we haven't overwritten m_pNativeNDirectTarget yet.
-        if (HeuristicDoesThisLookLikeAGetLastErrorCall((LPBYTE)pTarget))
-            pTarget = (BYTE*)FalseGetLastError;
-    }
-    else
-    {
-        pTarget = pMDD->GetNativeNDirectTarget();
-    }
-}
-
 #endif // !CROSSGEN_COMPILE
 
 CorInfoCallConvExtension GetDefaultCallConv(BOOL bIsVarArg)
@@ -2985,8 +2930,8 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
     HRESULT hr = CallConv::TryGetUnmanagedCallingConventionFromModOpt(GetScopeHandle(m_pModule), m_sig.GetRawSig(), m_sig.GetRawSigLen(), &builder, &errorResID);
     if (FAILED(hr))
     {
-        // Set an error message specific to P/Invokes or UnmanagedFunction for bad format.
-        SetError(hr == COR_E_BADIMAGEFORMAT ? IDS_EE_NDIRECT_BADNATL : errorResID);
+        // Use an error message specific to P/Invokes or UnmanagedFunction for bad format.
+        ReportError(hr == COR_E_BADIMAGEFORMAT ? IDS_EE_NDIRECT_BADNATL : errorResID);
     }
 
     CorInfoCallConvExtension sigCallConv = builder.GetCurrentCallConv();
@@ -2996,7 +2941,7 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
     // If no calling convention is provided, then use the default calling convention for the platform.
 
     if (callConv != CallConvWinApiSentinel && sigCallConv != CallConvWinApiSentinel && callConv != sigCallConv)
-        SetError(IDS_EE_NDIRECT_BADNATL_CALLCONV);
+        ReportError(IDS_EE_NDIRECT_BADNATL_CALLCONV);
 
     if (callConv == CallConvWinApiSentinel && sigCallConv == CallConvWinApiSentinel)
         m_callConv = GetDefaultCallConv(bIsVarArg);
@@ -3006,23 +2951,23 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
         m_callConv = sigCallConv;
 
     if (bIsVarArg && m_callConv != CorInfoCallConvExtension::C)
-        SetError(IDS_EE_NDIRECT_BADNATL_VARARGS_CALLCONV);
+        ReportError(IDS_EE_NDIRECT_BADNATL_VARARGS_CALLCONV);
 
     _ASSERTE(m_callConv != CallConvWinApiSentinel);
 }
 
-void PInvokeStaticSigInfo::ReportErrors()
+void PInvokeStaticSigInfo::ReportError(WORD error)
 {
     CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(error != 0);
     }
     CONTRACTL_END;
 
-    if (m_error != 0)
-        COMPlusThrow(kTypeLoadException, m_error);
+    COMPlusThrow(kTypeLoadException, error);
 }
 
 CorInfoCallConvExtension NDirect::GetCallingConvention_IgnoreErrors(_In_ MethodDesc* pMD)
@@ -3036,7 +2981,7 @@ CorInfoCallConvExtension NDirect::GetCallingConvention_IgnoreErrors(_In_ MethodD
     CONTRACTL_END;
 
     // This method explicitly does not check that any calling convention specified through
-    // attributes match that in the signature, so we just return once a non-sentinel calling
+    // attributes match that in the signature. We just return once a non-sentinel calling
     // convention is found.
     CorInfoCallConvExtension callConv;
     MethodTable* pMT = pMD->GetMethodTable();
@@ -3045,8 +2990,7 @@ CorInfoCallConvExtension NDirect::GetCallingConvention_IgnoreErrors(_In_ MethodD
         // System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute
         BYTE* pData = NULL;
         LONG cData = 0;
-        HRESULT hr = pMT->GetCustomAttribute(
-            WellKnownAttribute::UnmanagedFunctionPointer, (const VOID **)(&pData), (ULONG *)&cData);
+        HRESULT hr = pMT->GetCustomAttribute(WellKnownAttribute::UnmanagedFunctionPointer, (const VOID **)(&pData), (ULONG *)&cData);
         if (hr == S_OK)
         {
             _ASSERTE(cData > 0);
@@ -4242,7 +4186,7 @@ static void CreateNDirectStubAccessMetadata(
 
 namespace
 {
-    void PopulateNDirectMethodDescImpl(_Inout_ NDirectMethodDesc* pNMD, _In_ const PInvokeStaticSigInfo& sigInfo, _In_z_ LPCUTF8 libName, _In_z_ LPCUTF8 entryPointName)
+    void PopulateNDirectMethodDescImpl(_Inout_ NDirectMethodDesc* pNMD, _In_ const PInvokeStaticSigInfo& sigInfo, _In_opt_z_ LPCUTF8 libName, _In_opt_z_ LPCUTF8 entryPointName)
     {
         CONTRACTL
         {

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -56,6 +56,15 @@ public:
 class NDirect
 {
 public:
+    // Get the calling convention for a method by checking:
+    //   - For delegates: UnmanagedFunctionPointer attribute
+    //   - For non-delegates: P/Invoke metadata
+    //   - Any modopts encoded in the method signature
+    // If no calling convention is specified, the default calling convention is returned
+    // This function ignores any errors when reading attributes/metadata, treating them as
+    // if no calling convention was specified through that mechanism.
+    static CorInfoCallConvExtension GetCallingConvention_IgnoreErrors(_In_ MethodDesc* pMD);
+
     //---------------------------------------------------------
     // Does a class or method have a NAT_L CustomAttribute?
     //

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -305,25 +305,20 @@ enum ETW_IL_STUB_FLAGS
 struct PInvokeStaticSigInfo
 {
 public:
-    enum ThrowOnError { THROW_ON_ERROR = TRUE, NO_THROW_ON_ERROR = FALSE };
-
-public:
     PInvokeStaticSigInfo() { LIMITED_METHOD_CONTRACT; }
 
-    PInvokeStaticSigInfo(Signature sig, Module* pModule);
+    PInvokeStaticSigInfo(_In_ const Signature& sig, _In_ Module* pModule);
 
-    PInvokeStaticSigInfo(MethodDesc* pMdDelegate, ThrowOnError throwOnError = THROW_ON_ERROR);
+    PInvokeStaticSigInfo(_In_ MethodDesc* pMdDelegate);
 
     PInvokeStaticSigInfo(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
 
 private:
-    void ReportErrors();
+    void ReportError(WORD error);
     void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
     void DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);
     void PreInit(MethodDesc* pMD);
-    void SetError(WORD error) { if (!m_error) m_error = error; }
-    void BestGuessNDirectDefaults(MethodDesc* pMD);
 
 private:
     enum
@@ -416,7 +411,6 @@ private:
     Module* m_pModule;
     Signature m_sig;
     CorInfoCallConvExtension m_callConv;
-    WORD m_error;
     WORD m_wFlags;
 };
 

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -314,7 +314,7 @@ public:
     PInvokeStaticSigInfo(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
 
 private:
-    void ReportError(WORD error);
+    void ThrowError(WORD errorResourceID);
     void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
     void DllImportInit(_In_ MethodDesc* pMD, _Outptr_opt_ LPCUTF8 *pLibName, _Outptr_opt_ LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9954,8 +9954,7 @@ namespace
                     *pSuppressGCTransition = pMD->ShouldSuppressGCTransition();
                 }
 
-                PInvokeStaticSigInfo sigInfo(pMD, PInvokeStaticSigInfo::NO_THROW_ON_ERROR);
-                return sigInfo.GetCallConv();
+                return NDirect::GetCallingConvention_IgnoreErrors(pMD);
             }
             else
             {


### PR DESCRIPTION
We had one usage of `PInvokeStaticSigInfo` that specified to not report errors. The only thing it actually wanted was the calling convention, not all the other information parsed by that class.

This creates a separate function specifically for getting only the calling convention for a p/invoke or delegate without throwing on errors, so that `PInvokeStaticSigInfo` does not need to always track errors and avoid throwing.

cc @AaronRobinsonMSFT @jkoritzinsky 