### PR TITLE
Enhancements to MCS dumpMap

### DIFF
--- a/src/coreclr/ToolBox/superpmi/mcs/verbdumpmap.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbdumpmap.cpp
@@ -8,6 +8,7 @@
 #include "verbdumpmap.h"
 #include "verbildump.h"
 #include "spmiutil.h"
+#include "spmidumphelper.h"
 
 // Dump the CSV format header for all the columns we're going to dump.
 void DumpMapHeader()
@@ -37,9 +38,78 @@ void DumpMap(int index, MethodContext* mc)
     printf("\"");
     DumpAttributeToConsoleBare(mc->repGetMethodAttribs(cmi.ftn));
     DumpPrimToConsoleBare(mc, cmi.args.retType, CastHandle(cmi.args.retTypeClass));
-    printf(" %s(", methodName);
+    printf(" %s", methodName);
+
+    // Show class and method generic params, if there are any
+    CORINFO_SIG_INFO sig;
+    mc->repGetMethodSig(cmi.ftn, &sig, nullptr);
+
+    const unsigned classInst = sig.sigInst.classInstCount;
+    if (classInst > 0)
+    {
+        for (unsigned i = 0; i < classInst; i++)
+        {
+            CORINFO_CLASS_HANDLE ci = sig.sigInst.classInst[i];
+            className = mc->repGetClassName(ci);
+
+            printf("%s%s%s%s",
+                i == 0 ? "[" : "",
+                i > 0 ? ", " : "",
+                className,
+                i == classInst - 1 ? "]" : "");
+        }
+    }
+
+    const unsigned methodInst = sig.sigInst.methInstCount;
+    if (methodInst > 0)
+    {
+        for (unsigned i = 0; i < methodInst; i++)
+        {
+            CORINFO_CLASS_HANDLE ci = sig.sigInst.methInst[i];
+            className = mc->repGetClassName(ci);
+
+            printf("%s%s%s%s",
+                i == 0 ? "[" : "",
+                i > 0 ? ", " : "",
+                className,
+                i == methodInst - 1 ? "]" : "");
+        }
+    }
+
+    printf("(");
     DumpSigToConsoleBare(mc, &cmi.args);
-    printf(")\"\n");
+    printf(")\"");
+
+    // Dump the jit flags
+    CORJIT_FLAGS corJitFlags;
+    mc->repGetJitFlags(&corJitFlags, sizeof(corJitFlags));
+    unsigned long long rawFlags = corJitFlags.GetFlagsRaw();
+
+    // Add in the "fake" pgo flags
+    bool hasEdgeProfile = false;
+    bool hasClassProfile = false;
+    bool hasLikelyClass = false;
+    if (mc->hasPgoData(hasEdgeProfile, hasClassProfile, hasLikelyClass))
+    {
+        rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_PGO);
+
+        if (hasEdgeProfile)
+        {
+            rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE);
+        }
+
+        if (hasClassProfile)
+        {
+            rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
+        }
+
+        if (hasLikelyClass)
+        {
+            rawFlags |= 1ULL << (EXTRA_JIT_FLAGS::HAS_LIKELY_CLASS);
+        }
+    }
+
+    printf(", %s\n", SpmiDumpHelper::DumpJitFlags(rawFlags).c_str());
 }
 
 int verbDumpMap::DoWork(const char* nameOfInput)

--- a/src/coreclr/ToolBox/superpmi/mcs/verbdumpmap.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbdumpmap.cpp
@@ -16,7 +16,8 @@ void DumpMapHeader()
     printf("index,");
     // printf("process name,");
     printf("method name,");
-    printf("full signature\n");
+    printf("full signature,");
+    printf("jit flags\n");
 }
 
 void DumpMap(int index, MethodContext* mc)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5652,33 +5652,36 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
         // This call to getClassModule/getModuleAssembly/getAssemblyName fails in crossgen2 due to these
         // APIs being unimplemented. So disable this extra info for pre-jit mode. See
         // https://github.com/dotnet/runtime/issues/48888.
+        //
+        // Ditto for some of the class name queries for generic params.
+        //
         if (!compileFlags->IsSet(JitFlags::JIT_FLAG_PREJIT))
         {
             // Get the assembly name, to aid finding any particular SuperPMI method context function
             (void)info.compCompHnd->getAssemblyName(
                 info.compCompHnd->getModuleAssembly(info.compCompHnd->getClassModule(info.compClassHnd)));
-        }
 
-        // Fetch class names for the method's generic parameters.
-        //
-        CORINFO_SIG_INFO sig;
-        info.compCompHnd->getMethodSig(info.compMethodHnd, &sig, nullptr);
+            // Fetch class names for the method's generic parameters.
+            //
+            CORINFO_SIG_INFO sig;
+            info.compCompHnd->getMethodSig(info.compMethodHnd, &sig, nullptr);
 
-        const unsigned classInst = sig.sigInst.classInstCount;
-        if (classInst > 0)
-        {
-            for (unsigned i = 0; i < classInst; i++)
+            const unsigned classInst = sig.sigInst.classInstCount;
+            if (classInst > 0)
             {
-                eeGetClassName(sig.sigInst.classInst[i]);
+                for (unsigned i = 0; i < classInst; i++)
+                {
+                    eeGetClassName(sig.sigInst.classInst[i]);
+                }
             }
-        }
 
-        const unsigned methodInst = sig.sigInst.methInstCount;
-        if (methodInst > 0)
-        {
-            for (unsigned i = 0; i < methodInst; i++)
+            const unsigned methodInst = sig.sigInst.methInstCount;
+            if (methodInst > 0)
             {
-                eeGetClassName(sig.sigInst.methInst[i]);
+                for (unsigned i = 0; i < methodInst; i++)
+                {
+                    eeGetClassName(sig.sigInst.methInst[i]);
+                }
             }
         }
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5658,6 +5658,29 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
             (void)info.compCompHnd->getAssemblyName(
                 info.compCompHnd->getModuleAssembly(info.compCompHnd->getClassModule(info.compClassHnd)));
         }
+
+        // Fetch class names for the method's generic parameters.
+        //
+        CORINFO_SIG_INFO sig;
+        info.compCompHnd->getMethodSig(info.compMethodHnd, &sig, nullptr);
+
+        const unsigned classInst = sig.sigInst.classInstCount;
+        if (classInst > 0)
+        {
+            for (unsigned i = 0; i < classInst; i++)
+            {
+                eeGetClassName(sig.sigInst.classInst[i]);
+            }
+        }
+
+        const unsigned methodInst = sig.sigInst.methInstCount;
+        if (methodInst > 0)
+        {
+            for (unsigned i = 0; i < methodInst; i++)
+            {
+                eeGetClassName(sig.sigInst.methInst[i]);
+            }
+        }
     }
 #endif // DEBUG
 


### PR DESCRIPTION
I've been trying to correlate methods in SPMI collections with methods
seen in profile data (say perfview). But for generic classes or generic
methods this is not easy.

To make it more feasible, in the "extra query" mode, get the names of
all the generic parameters, and then add these to the class name in MCS's
dumpMap output.

Also dump out the jit flags, so it's easier to find a particular instance
if the method was jitted more than once.