### PR TITLE
JIT: Optimize redundant sign extensions in indexers

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3983,7 +3983,7 @@ protected:
 
     static void impBashVarAddrsToI(GenTree* tree1, GenTree* tree2 = nullptr);
 
-    GenTree* impImplicitIorI4Cast(GenTree* tree, var_types dstTyp);
+    GenTree* impImplicitIorI4Cast(GenTree* tree, var_types dstTyp, bool isUnsigned = false);
 
     GenTree* impImplicitR4orR8Cast(GenTree* tree, var_types dstTyp);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5620,8 +5620,16 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     // Widen 'index' on 64-bit targets
     if (index->TypeGet() != TYP_I_IMPL)
     {
-        // We don't need any casts here since index is known to be never negative at this point.
-        index->ChangeType(TYP_I_IMPL);
+        if (index->OperGet() == GT_CNS_INT)
+        {
+            index->gtType = TYP_I_IMPL;
+        }
+        else
+        {
+            // Mark cast as unsigned since index should never be negative
+            // at this point (handled by GT_ARR_BOUNDS_CHECK)
+            index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
+        }
     }
 #endif // TARGET_64BIT
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5626,7 +5626,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         }
         else
         {
-            // Mark cast as unsigned since index should never be negative
+            // Mark cast as unsigned since index is never negative
             // at this point (handled by GT_ARR_BOUNDS_CHECK)
             index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5620,16 +5620,8 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     // Widen 'index' on 64-bit targets
     if (index->TypeGet() != TYP_I_IMPL)
     {
-        if (index->OperGet() == GT_CNS_INT)
-        {
-            index->gtType = TYP_I_IMPL;
-        }
-        else
-        {
-            // Mark cast as unsigned since index should never be negative
-            // at this point (handled by GT_ARR_BOUNDS_CHECK)
-            index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
-        }
+        // We don't need any casts here since index is known to be never negative at this point.
+        index->ChangeType(TYP_I_IMPL);
     }
 #endif // TARGET_64BIT
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5626,7 +5626,9 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         }
         else
         {
-            index = gtNewCastNode(TYP_I_IMPL, index, false, TYP_I_IMPL);
+            // Mark cast as unsigned since index should never be negative
+            // at this point (handled by GT_ARR_BOUNDS_CHECK)
+            index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
         }
     }
 #endif // TARGET_64BIT


### PR DESCRIPTION
Just a quick fix for the issue noticed by @GrabYourPitchforks - we emit redundant sign-extension movs for indexers, e.g.:
```csharp
int Test(int[] a, int i) => a[i];
```
Codegen:
```asm
G_M40406_IG01:
       sub      rsp, 40
G_M40406_IG02:
       cmp      r8d, dword ptr [rdx+8]
       jae      SHORT G_M40406_IG04
       movsxd   rax, r8d               ;;  <---- 
       mov      eax, dword ptr [rdx+4*rax+16]
G_M40406_IG03:
       add      rsp, 40
       ret      
G_M40406_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 28
```
New codegen: https://www.diffchecker.com/FukMpulc (mov is still there 🤔 but at least without the sign extension)

```
asm.benchmarks.run.windows.x64.checked

Total bytes of base: 2045371
Total bytes of diff: 2037944
Total bytes of delta: -7427 (-0.36% of base)
    diff is an improvement.
```
```
asm.libraries.crossgen.windows.x64.checked.1

Total bytes of base: 4987213
Total bytes of diff: 4970149
Total bytes of delta: -17064 (-0.34% of base)
    diff is an improvement.
```
```
asm.libraries.crossgen2.windows.x64.checked.1

Total bytes of base: 5527650
Total bytes of diff: 5510132
Total bytes of delta: -17518 (-0.32% of base)
    diff is an improvement.
```
```
asm.libraries.pmi.windows.x64.checked

Total bytes of base: 8099472
Total bytes of diff: 8076977
Total bytes of delta: -22495 (-0.28% of base)
    diff is an improvement.
```
```
asm.tests.pmi.windows.x64.checked

Total bytes of base: 2401541
Total bytes of diff: 2393379
Total bytes of delta: -8162 (-0.34% of base)
    diff is an improvement.
```
```
asm.tests_libraries.pmi.windows.x64.checked

Total bytes of base: 9775982
Total bytes of diff: 9748266
Total bytes of delta: -27716 (-0.28% of base)
    diff is an improvement.
```
