### PR TITLE
Some cleanup of `var_types` - related functions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3579,7 +3579,7 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* t
     // force the fromType to unsigned if GT_UNSIGNED flag is set
     if (tree->IsUnsigned())
     {
-        fromType = genUnsignedType(fromType);
+        fromType = varTypeToUnsigned(fromType);
     }
 
     // If we have a cast involving floating point types, then bail.

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1467,7 +1467,7 @@ void CodeGen::genIntToFloatCast(GenTree* treeNode)
     // force the srcType to unsigned if GT_UNSIGNED flag is set
     if (treeNode->gtFlags & GTF_UNSIGNED)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     // We only expect a srcType whose size is EA_4BYTE.

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3356,7 +3356,7 @@ void CodeGen::genIntToFloatCast(GenTree* treeNode)
     // force the srcType to unsigned if GT_UNSIGNED flag is set
     if (treeNode->gtFlags & GTF_UNSIGNED)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     // We should never see a srcType whose size is neither EA_4BYTE or EA_8BYTE

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6415,7 +6415,7 @@ void CodeGen::genIntToFloatCast(GenTree* treeNode)
     // force the srcType to unsigned if GT_UNSIGNED flag is set
     if (treeNode->gtFlags & GTF_UNSIGNED)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     noway_assert(!varTypeIsGC(srcType));

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -124,7 +124,7 @@ var_types genActualType(var_types type);
 var_types genUnsignedType(var_types type);
 var_types genSignedType(var_types type);
 
-unsigned ReinterpretHexAsDecimal(unsigned);
+unsigned ReinterpretHexAsDecimal(unsigned in);
 
 /*****************************************************************************/
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -121,7 +121,6 @@ unsigned genLog2(unsigned value);
 unsigned genLog2(unsigned __int64 value);
 
 var_types genActualType(var_types type);
-var_types genUnsignedType(var_types type);
 var_types genSignedType(var_types type);
 
 unsigned ReinterpretHexAsDecimal(unsigned in);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -121,7 +121,6 @@ unsigned genLog2(unsigned value);
 unsigned genLog2(unsigned __int64 value);
 
 var_types genActualType(var_types type);
-var_types genSignedType(var_types type);
 
 unsigned ReinterpretHexAsDecimal(unsigned in);
 
@@ -5116,7 +5115,7 @@ public:
         else
         {
             assert(elemTyp != TYP_STRUCT);
-            elemTyp = varTypeUnsignedToSigned(elemTyp);
+            elemTyp = varTypeToSigned(elemTyp);
             return CORINFO_CLASS_HANDLE(size_t(elemTyp) << 1 | 0x1);
         }
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -120,8 +120,6 @@ void* __cdecl operator new(size_t n, void* p, const jitstd::placement_t& syntax_
 unsigned genLog2(unsigned value);
 unsigned genLog2(unsigned __int64 value);
 
-var_types genActualType(var_types type);
-
 unsigned ReinterpretHexAsDecimal(unsigned in);
 
 /*****************************************************************************/

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -615,28 +615,6 @@ inline var_types genActualType(var_types type)
     return (var_types)genActualTypes[type];
 }
 
-/*****************************************************************************/
-
-inline var_types genSignedType(var_types type)
-{
-    /* Force non-small unsigned type into corresponding signed type */
-    /* Note that we leave the small types alone */
-
-    switch (type)
-    {
-        case TYP_UINT:
-            type = TYP_INT;
-            break;
-        case TYP_ULONG:
-            type = TYP_LONG;
-            break;
-        default:
-            break;
-    }
-
-    return type;
-}
-
 /*****************************************************************************
  *  Can this type be passed as a parameter in a register?
  */

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -604,15 +604,16 @@ inline unsigned genTypeStSz(var_types type)
 
 extern const BYTE genActualTypes[TYP_COUNT];
 
-inline var_types genActualType(var_types type)
+template <class T>
+inline var_types genActualType(T value)
 {
     /* Spot check to make certain the table is in synch with the enum */
-
     assert(genActualTypes[TYP_DOUBLE] == TYP_DOUBLE);
     assert(genActualTypes[TYP_REF] == TYP_REF);
 
-    assert((unsigned)type < sizeof(genActualTypes));
-    return (var_types)genActualTypes[type];
+    assert((unsigned)TypeGet(value) < sizeof(genActualTypes));
+
+    return (var_types)genActualTypes[TypeGet(value)];
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -617,33 +617,6 @@ inline var_types genActualType(var_types type)
 
 /*****************************************************************************/
 
-inline var_types genUnsignedType(var_types type)
-{
-    /* Force signed types into corresponding unsigned type */
-
-    switch (type)
-    {
-        case TYP_BYTE:
-            type = TYP_UBYTE;
-            break;
-        case TYP_SHORT:
-            type = TYP_USHORT;
-            break;
-        case TYP_INT:
-            type = TYP_UINT;
-            break;
-        case TYP_LONG:
-            type = TYP_ULONG;
-            break;
-        default:
-            break;
-    }
-
-    return type;
-}
-
-/*****************************************************************************/
-
 inline var_types genSignedType(var_types type)
 {
     /* Force non-small unsigned type into corresponding signed type */

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -569,11 +569,11 @@ inline bool genSmallTypeCanRepresentValue(var_types type, ssize_t value)
 extern const BYTE genTypeSizes[TYP_COUNT];
 
 template <class T>
-inline unsigned genTypeSize(T type)
+inline unsigned genTypeSize(T value)
 {
-    assert((unsigned)TypeGet(type) < _countof(genTypeSizes));
+    assert((unsigned)TypeGet(value) < _countof(genTypeSizes));
 
-    return genTypeSizes[TypeGet(type)];
+    return genTypeSizes[TypeGet(value)];
 }
 
 /*****************************************************************************
@@ -584,11 +584,12 @@ inline unsigned genTypeSize(T type)
 
 extern const BYTE genTypeStSzs[TYP_COUNT];
 
-inline unsigned genTypeStSz(var_types type)
+template <class T>
+inline unsigned genTypeStSz(T value)
 {
-    assert((unsigned)type < _countof(genTypeStSzs));
+    assert((unsigned)TypeGet(value) < _countof(genTypeStSzs));
 
-    return genTypeStSzs[type];
+    return genTypeStSzs[TypeGet(value)];
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -539,7 +539,7 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
 
     if ((cast->gtFlags & GTF_UNSIGNED) != 0)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     bool skipDecomposition = false;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11628,7 +11628,7 @@ void Compiler::gtDispTree(GenTree*     tree,
             /* if GTF_UNSIGNED is set then force fromType to an unsigned type */
             if (tree->gtFlags & GTF_UNSIGNED)
             {
-                fromType = genUnsignedType(fromType);
+                fromType = varTypeToUnsigned(fromType);
             }
 
             if (finalType != toType)

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -609,7 +609,7 @@ void Lowering::LowerCast(GenTree* tree)
     // force the srcType to unsigned if GT_UNSIGNED flag is set
     if (tree->gtFlags & GTF_UNSIGNED)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     // We should never see the following casts as they are expected to be lowered
@@ -4179,7 +4179,7 @@ void Lowering::ContainCheckCast(GenTreeCast* node)
     // force the srcType to unsigned if GT_UNSIGNED flag is set
     if (node->gtFlags & GTF_UNSIGNED)
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
     }
 
     if (!node->gtOverflow() && (varTypeIsFloating(castToType) || varTypeIsFloating(srcType)))

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -307,7 +307,7 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
     // U8 -> R4   = U8 -> R8 -> R4
     else if (tree->IsUnsigned() && varTypeIsFloating(dstType))
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
 
         if (srcType == TYP_ULONG)
         {
@@ -337,7 +337,7 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
     // Do we have to do two step U4/8 -> R4/8 ?
     else if (tree->IsUnsigned() && varTypeIsFloating(dstType))
     {
-        srcType = genUnsignedType(srcType);
+        srcType = varTypeToUnsigned(srcType);
 
         if (srcType == TYP_ULONG)
         {
@@ -588,7 +588,7 @@ OPTIMIZECAST:
                     srcType = genActualType(srcType);
                 }
 
-                srcType = genUnsignedType(srcType);
+                srcType = varTypeToUnsigned(srcType);
             }
 
             if (srcType == dstType)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6145,7 +6145,12 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
 
                 if (doit && (dstSize <= genTypeSize(tree->gtType)))
                 {
-                    tree->gtType = genSignedType(dstt);
+                    if (!varTypeIsSmall(dstt))
+                    {
+                        dstt = varTypeToSigned(dstt);
+                    }
+
+                    tree->gtType = dstt;
                     tree->SetVNs(vnpNarrow);
 
                     /* Make sure we don't mess up the variable type */
@@ -6196,7 +6201,10 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
 
                     if (doit)
                     {
-                        dstt = genSignedType(dstt);
+                        if (!varTypeIsSmall(dstt))
+                        {
+                            dstt = varTypeToSigned(dstt);
+                        }
 
                         if ((oprSize == dstSize) &&
                             ((varTypeIsUnsigned(dstt) == varTypeIsUnsigned(oprt)) || !varTypeIsSmall(dstt)))

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -145,29 +145,25 @@ inline var_types varTypeUnsignedToSigned(var_types vt)
     }
 }
 
-// If "vt" is a signed integral type, returns the corresponding unsigned integral type, otherwise
-// return "vt".
-inline var_types varTypeSignedToUnsigned(var_types vt)
+// If "vt" represents a signed integral type, returns the corresponding unsigned integral type,
+// otherwise returns the original type.
+template <class T>
+inline var_types varTypeToUnsigned(T vt)
 {
-    if (varTypeIsSigned(vt))
+    // Force signed types into corresponding unsigned type.
+    var_types type = TypeGet(vt);
+    switch (type)
     {
-        switch (vt)
-        {
-            case TYP_BYTE:
-                return TYP_UBYTE;
-            case TYP_SHORT:
-                return TYP_USHORT;
-            case TYP_INT:
-                return TYP_UINT;
-            case TYP_LONG:
-                return TYP_ULONG;
-            default:
-                unreached();
-        }
-    }
-    else
-    {
-        return vt;
+        case TYP_BYTE:
+            return TYP_UBYTE;
+        case TYP_SHORT:
+            return TYP_USHORT;
+        case TYP_INT:
+            return TYP_UINT;
+        case TYP_LONG:
+            return TYP_ULONG;
+        default:
+            return type;
     }
 }
 

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -118,13 +118,15 @@ inline bool varTypeIsSigned(T vt)
     return varTypeIsIntegralOrI(vt) && !varTypeIsUnsigned(vt);
 }
 
-// If "vt" is an unsigned integral type, returns the corresponding signed integral type, otherwise
-// return "vt".
-inline var_types varTypeUnsignedToSigned(var_types vt)
+// If "vt" represents an unsigned integral type, returns the corresponding signed integral type,
+// otherwise returns the original type.
+template <class T>
+inline var_types varTypeToSigned(T vt)
 {
-    if (varTypeIsUnsigned(vt))
+    var_types type = TypeGet(vt);
+    if (varTypeIsUnsigned(type))
     {
-        switch (vt)
+        switch (type)
         {
             case TYP_BOOL:
             case TYP_UBYTE:
@@ -139,10 +141,8 @@ inline var_types varTypeUnsignedToSigned(var_types vt)
                 unreached();
         }
     }
-    else
-    {
-        return vt;
-    }
+
+    return type;
 }
 
 // If "vt" represents a signed integral type, returns the corresponding unsigned integral type,


### PR DESCRIPTION
1\) Renamed `genUnsignedType` to `varTypeToUnsigned` to conform to the existing
naming convention, moved its definition from "compiler.hpp" to "vartype.h",
made it a templated function like all the other `varType*` functions.
Deleted the equivalent but unused `varTypeSignedToUnsigned`.

2\) `genSignedType` had confusing semantics where it only returned the actual
signed type for `TYP_UINT` and `TYP_ULONG`. Deleted the function and made
the callsites explicitly request that behavior.
Also renamed `varTypeUnsignedToSigned` to `varTypeToSigned` for parity
with `varTypeToUnsigned` and made it a templated function.

3\) Made `genActualType` and `genTypeStSz` templated functions.

The actual significant change here is making `genActualType` templated for ease of use, but I noticed some related oddities and so fixed them up as well.

Semantics of all callsites have been preserved. This is a no-diff change as expected.