### PR TITLE
Reduce loop inversion JitDump output

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6560,7 +6560,7 @@ protected:
 
     static fgWalkResult optInvertCountTreeInfo(GenTree** pTree, fgWalkData* data);
 
-    void optInvertWhileLoop(BasicBlock* block);
+    bool optInvertWhileLoop(BasicBlock* block);
 
 private:
     static bool optIterSmallOverflow(int iterAtExit, var_types incrType);


### PR DESCRIPTION
If it is guaranteed that no IR changes were made, then return an
appropriate Phase status to suppress end phase IR dumps.