### PR TITLE
Disable cache clearing S.CM.TC test from running in parallel

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ReflectionCachesUpdateHandlerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace System.ComponentModel.Tests
 {
     [SimpleUpdateTest]
+    [Collection("NoParallelTests")] // Clears the cache which disrupts concurrent tests
     public class ReflectionCachesUpdateHandlerTests
     {
         [Fact]
@@ -15,7 +16,7 @@ namespace System.ComponentModel.Tests
             AttributeCollection ac1 = TypeDescriptor.GetAttributes(typeof(ReflectionCachesUpdateHandlerTests));
             AttributeCollection ac2 = TypeDescriptor.GetAttributes(typeof(ReflectionCachesUpdateHandlerTests));
             Assert.Equal(ac1.Count, ac2.Count);
-            Assert.Equal(1, ac1.Count);
+            Assert.Equal(2, ac1.Count);
             Assert.Same(ac1[0], ac2[0]);
 
             MethodInfo beforeUpdate = typeof(TypeDescriptionProvider).Assembly.GetType("System.ComponentModel.ReflectionCachesUpdateHandler", throwOnError: true).GetMethod("BeforeUpdate");

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.ComponentModel.Tests
 {
+    [Collection("NoParallelTests")] // manipulates cache
     public class TypeDescriptorTests
     {
         [Fact]


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/51819

The 1->2 is because it counts the attributes on its own class.