### PR TITLE
Use Assembly.Load as first option to load TempAssembly.

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -140,6 +140,9 @@ namespace System.Xml.Serialization
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
         [RequiresUnreferencedCode("calls LoadFrom")]
+        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
+            Justification = "Annotating this as dangerous will make the core of the serializer to be marked as not safe, instead " +
+            "this pattern is only dangerous if using sgen only. See https://github.com/dotnet/runtime/issues/50820")]
         internal static Assembly? LoadGeneratedAssembly(Type type, string? defaultNamespace, out XmlSerializerImplementation? contract)
         {
             Assembly? serializer = null;
@@ -224,9 +227,6 @@ namespace System.Xml.Serialization
         }
 
         [RequiresUnreferencedCode("calls LoadFile")]
-        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
-            Justification = "Annotating this as dangerous will make the core of the serializer to be marked as not safe, instead " +
-            "this pattern is only dangerous if using sgen only. See https://github.com/dotnet/runtime/issues/50820")]
         private static Assembly? LoadAssemblyByPath(Type type, string assemblyName)
         {
             Assembly? assembly = null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -227,6 +227,9 @@ namespace System.Xml.Serialization
         }
 
         [RequiresUnreferencedCode("calls LoadFile")]
+        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
+            Justification = "Annotating this as dangerous will make the core of the serializer to be marked as not safe, instead " +
+            "this pattern is only dangerous if using sgen only. See https://github.com/dotnet/runtime/issues/50820")]
         private static Assembly? LoadAssemblyByPath(Type type, string assemblyName)
         {
             Assembly? assembly = null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -161,7 +161,14 @@ namespace System.Xml.Serialization
                 try
                 {
                     serializer = Assembly.Load(name);
-                } catch (FileNotFoundException) { }
+                }
+                catch (Exception e)
+                {
+                    if (e is OutOfMemoryException)
+                    {
+                        throw;
+                    }
+                }
 
                 serializer ??= LoadAssemblyByPath(type, serializerName);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -158,7 +158,11 @@ namespace System.Xml.Serialization
                 name.CodeBase = null;
                 name.CultureInfo = CultureInfo.InvariantCulture;
 
-                serializer = Assembly.Load(name);
+                try
+                {
+                    serializer = Assembly.Load(name);
+                } catch (FileNotFoundException) { }
+
                 serializer ??= LoadAssemblyByPath(type, serializerName);
 
                 if (serializer == null)


### PR DESCRIPTION
Serialization: Use Assembly.Load() as first option for loading TempAssembly.

Years ago, Assembly.Load() was apparently not working correctly for the .Net
Core port of serialization, so a hacky workaround of building a filename and
loading an assembly by filename instead was used. This PR brings back the
Assembly.Load() behavior used in NetFx as the primary option, but keeps
the filename workaround as a backup since it's been in place in .Net Core
[since 2017](https://github.com/dotnet/corefx/commit/eccd13b58c5aa40a459cfb1855ea35d31fe2c0cb).

Fix #1403