### PR TITLE
Fix EventPipe shutdown to include last events in session.

### DIFF
--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -611,7 +611,7 @@ write_event (
 	EP_ASSERT (payload != NULL);
 
 	// We can't proceed if tracing is not initialized.
-	ep_return_void_if_nok (ep_volatile_load_eventpipe_state () == EP_STATE_INITIALIZED);
+	ep_return_void_if_nok (ep_volatile_load_eventpipe_state () >= EP_STATE_INITIALIZED);
 
 	// Exit early if the event is not enabled.
 	ep_return_void_if_nok (ep_event_is_enabled (ep_event));
@@ -649,7 +649,7 @@ write_event_2 (
 	EP_ASSERT (payload != NULL);
 
 	// We can't proceed if tracing is not initialized.
-	ep_return_void_if_nok (ep_volatile_load_eventpipe_state () == EP_STATE_INITIALIZED);
+	ep_return_void_if_nok (ep_volatile_load_eventpipe_state () >= EP_STATE_INITIALIZED);
 
 	EventPipeThread *const current_thread = ep_thread_get_or_create ();
 	if (!current_thread) {


### PR DESCRIPTION
Fixing an incorrect state check in write_event, write_event_2 that would prevent events written during disable in ep_shutdown to be included  in session. Since most sessions already closed out at this point this case is mainly hit using the default env based file session, but it will also affect sessions that are running during shutdown since they wouldn't get their rundown events included in session stream.

This is a regression from C++ -> C port of EventPipe library.

//CC @josalem