### PR TITLE
Annotate FileStream.Lock/Unlock as unsupported on iOS/tvOS

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -408,11 +408,17 @@ namespace Microsoft.VisualBasic
         public static void Kill(string PathName) { }
         public static string LineInput(int FileNumber) { throw null; }
         public static long Loc(int FileNumber) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Lock(int FileNumber) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Lock(int FileNumber, long Record) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Lock(int FileNumber, long FromRecord, long ToRecord) { }
         public static long LOF(int FileNumber) { throw null; }
         public static void MkDir(string Path) { }
@@ -428,11 +434,17 @@ namespace Microsoft.VisualBasic
         public static Microsoft.VisualBasic.SpcInfo SPC(short Count) { throw null; }
         public static Microsoft.VisualBasic.TabInfo TAB() { throw null; }
         public static Microsoft.VisualBasic.TabInfo TAB(short Column) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Unlock(int FileNumber) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Unlock(int FileNumber, long Record) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public static void Unlock(int FileNumber, long FromRecord, long ToRecord) { }
         public static void Write(int FileNumber, params object[] Output) { }
         public static void WriteLine(int FileNumber, params object[] Output) { }

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6BinaryFile.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6BinaryFile.vb
@@ -26,7 +26,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         ' the implementation of Lock in base class VB6RandomFile does not handle m_lRecordLen=-1
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overloads Overrides Sub Lock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))
@@ -50,7 +52,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         ' see Lock description
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overloads Overrides Sub Unlock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6File.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6File.vb
@@ -603,18 +603,24 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Return m_position
         End Function
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Lock()
             'Lock the whole file, not just the current size of file, since file could change.
             m_file.Lock(0, Int32.MaxValue)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Unlock()
             m_file.Unlock(0, Int32.MaxValue)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Lock(ByVal Record As Long)
             If m_lRecordLen = -1 Then
                 m_file.Lock((Record - 1), 1)
@@ -623,7 +629,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Unlock(ByVal Record As Long)
             If m_lRecordLen = -1 Then
                 m_file.Unlock((Record - 1), 1)
@@ -632,7 +640,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Lock(ByVal RecordStart As Long, ByVal RecordEnd As Long)
             If m_lRecordLen = -1 Then
                 m_file.Lock((RecordStart - 1), (RecordEnd - RecordStart) + 1)
@@ -641,7 +651,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overridable Overloads Sub Unlock(ByVal RecordStart As Long, ByVal RecordEnd As Long)
             If m_lRecordLen = -1 Then
                 m_file.Unlock((RecordStart - 1), (RecordEnd - RecordStart) + 1)

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6RandomFile.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6RandomFile.vb
@@ -122,7 +122,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             CloseTheFile()
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overloads Overrides Sub Lock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))
@@ -137,7 +139,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             m_file.Lock(lStartByte, lLength)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Friend Overloads Overrides Sub Unlock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
@@ -1009,7 +1009,9 @@ Namespace Microsoft.VisualBasic
             End Try
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Function InputString(ByVal FileNumber As Integer, ByVal CharCount As Integer) As String
             Try
                 Dim oFile As VB6File
@@ -1047,37 +1049,49 @@ Namespace Microsoft.VisualBasic
             Return oFile.LineInput()
         End Function
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Lock(ByVal FileNumber As Integer)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock()
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Lock(ByVal FileNumber As Integer, ByVal Record As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock(Record)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Lock(ByVal FileNumber As Integer, ByVal FromRecord As Long, ByVal ToRecord As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock(FromRecord, ToRecord)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Unlock(ByVal FileNumber As Integer)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock()
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Unlock(ByVal FileNumber As Integer, ByVal Record As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock(Record)
         End Sub
 
+        <UnsupportedOSPlatform("ios")>
         <UnsupportedOSPlatform("macos")>
+        <UnsupportedOSPlatform("tvos")>
         Public Sub Unlock(ByVal FileNumber As Integer, ByVal FromRecord As Long, ByVal ToRecord As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock(FromRecord, ToRecord)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -197,7 +197,9 @@ namespace System.IO
         [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual IntPtr Handle => _strategy.Handle;
 
+        [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("macos")]
+        [UnsupportedOSPlatform("tvos")]
         public virtual void Lock(long position, long length)
         {
             if (position < 0 || length < 0)
@@ -212,7 +214,9 @@ namespace System.IO
             _strategy.Lock(position, length);
         }
 
+        [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("macos")]
+        [UnsupportedOSPlatform("tvos")]
         public virtual void Unlock(long position, long length)
         {
             if (position < 0 || length < 0)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7329,7 +7329,9 @@ namespace System.IO
         public override void Flush() { }
         public virtual void Flush(bool flushToDisk) { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public virtual void Lock(long position, long length) { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
@@ -7338,7 +7340,9 @@ namespace System.IO
         public override int ReadByte() { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
         public virtual void Unlock(long position, long length) { }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }


### PR DESCRIPTION
Part of #47910.

`FileStream.Lock/Unlock` methods throw PNSE with `Locking/unlocking file regions is not supported on this platform. Use FileShare on the entire file instead.` message.

An example:
```
<failure exception-type="System.PlatformNotSupportedException">
    <message><![CDATA[System.PlatformNotSupportedException : Locking/unlocking file regions is not supported on this platform. Use FileShare on the entire file instead.]]></message>
    <stack-trace><![CDATA[   at System.IO.Strategies.Net5CompatFileStreamStrategy.Lock(Int64 position, Int64 length) in System.Private.CoreLib.dll:token 0x60055fc+0x5
    at System.IO.FileStream.Lock(Int64 position, Int64 length) in System.Private.CoreLib.dll:token 0x60052ee+0x38
    at System.IO.Tests.FileStream_LockUnlock.NonOverlappingRegions_Success(Int64 fileLength, Int64 firstPosition, Int64 firstLength, Int64 secondPosition, Int64 secondLength) in System.IO.FileSystem.Tests.dll:token 0x60000de+0x3d
    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) in System.Private.CoreLib.dll:token 0x6004a23+0x6a]]></stack-trace>
</failure>
```