### PR TITLE
Add [return: NotNullIfNotNull("str")] to SecurityElement.Escape

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
@@ -345,6 +345,7 @@ namespace System.Security
             return c.ToString();
         }
 
+        [return: NotNullIfNotNull("str")]
         public static string? Escape(string? str)
         {
             if (str == null)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10508,6 +10508,7 @@ namespace System.Security
         public string? Attribute(string name) { throw null; }
         public System.Security.SecurityElement Copy() { throw null; }
         public bool Equal([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Security.SecurityElement? other) { throw null; }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("str")]
         public static string? Escape(string? str) { throw null; }
         public static System.Security.SecurityElement? FromString(string xml) { throw null; }
         public static bool IsValidAttributeName([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? name) { throw null; }


### PR DESCRIPTION
This only returns null if str is null