### PR TITLE
Comment out a false-positive assert that is firing and preventing jit-diffs

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11733,19 +11733,19 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                         regMaskTP regMask;
                         regMask = genRegMask(reg1) | genRegMask(reg2);
 
-                        // TODO-XArch-Bug: https://github.com/dotnet/runtime/issues/51728
-                        // There are various scenarios in which a pointer will be converted to a byref
-                        // If the register allocator decides this conversion occurs "in place" then we'll
-                        // end up with `dstReg == srcReg` and many places in codegen will currently elide
-                        // this from ever reaching emit. This means we will lose track of the GC liveness
-                        // update and the below assert will fail. It's not problematic in practice because
-                        // its a pointer, not an actual byref. However, the fix to actually track the liveness
-                        // for elided same register moves is expensive and fairly expansive.
+// TODO-XArch-Bug: https://github.com/dotnet/runtime/issues/51728
+// There are various scenarios in which a pointer will be converted to a byref
+// If the register allocator decides this conversion occurs "in place" then we'll
+// end up with `dstReg == srcReg` and many places in codegen will currently elide
+// this from ever reaching emit. This means we will lose track of the GC liveness
+// update and the below assert will fail. It's not problematic in practice because
+// its a pointer, not an actual byref. However, the fix to actually track the liveness
+// for elided same register moves is expensive and fairly expansive.
 
-                        // r1/r2 could have been a GCREF as GCREF + int=BYREF
-                        //                            or BYREF+/-int=BYREF
-                        // assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
-                        //        ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+// r1/r2 could have been a GCREF as GCREF + int=BYREF
+//                            or BYREF+/-int=BYREF
+// assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
+//        ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
 #endif
                         // Mark r1 as holding a byref
                         emitGCregLiveUpd(GCT_BYREF, reg1, dst);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11733,10 +11733,19 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                         regMaskTP regMask;
                         regMask = genRegMask(reg1) | genRegMask(reg2);
 
+                        // TODO-XArch-Bug: https://github.com/dotnet/runtime/issues/51728
+                        // There are various scenarios in which a pointer will be converted to a byref
+                        // If the register allocator decides this conversion occurs "in place" then we'll
+                        // end up with `dstReg == srcReg` and many places in codegen will currently elide
+                        // this from ever reaching emit. This means we will lose track of the GC liveness
+                        // update and the below assert will fail. It's not problematic in practice because
+                        // its a pointer, not an actual byref. However, the fix to actually track the liveness
+                        // for elided same register moves is expensive and fairly expansive.
+
                         // r1/r2 could have been a GCREF as GCREF + int=BYREF
                         //                            or BYREF+/-int=BYREF
-                        assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
-                               ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+                        // assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
+                        //        ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
 #endif
                         // Mark r1 as holding a byref
                         emitGCregLiveUpd(GCT_BYREF, reg1, dst);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11733,19 +11733,20 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                         regMaskTP regMask;
                         regMask = genRegMask(reg1) | genRegMask(reg2);
 
-// TODO-XArch-Bug: https://github.com/dotnet/runtime/issues/51728
-// There are various scenarios in which a pointer will be converted to a byref
-// If the register allocator decides this conversion occurs "in place" then we'll
-// end up with `dstReg == srcReg` and many places in codegen will currently elide
-// this from ever reaching emit. This means we will lose track of the GC liveness
-// update and the below assert will fail. It's not problematic in practice because
-// its a pointer, not an actual byref. However, the fix to actually track the liveness
-// for elided same register moves is expensive and fairly expansive.
+                        // TODO-XArch-Bug: https://github.com/dotnet/runtime/issues/51728
+                        // There are various scenarios in which a pointer will be converted to a byref
+                        // If the register allocator decides this conversion occurs "in place" then we'll
+                        // end up with `dstReg == srcReg` and many places in codegen will currently elide
+                        // this from ever reaching emit. This means we will lose track of the GC liveness
+                        // update and the below assert will fail. It's not problematic in practice because
+                        // its a pointer, not an actual byref. However, the fix to actually track the liveness
+                        // for elided same register moves is expensive and fairly expansive.
 
-// r1/r2 could have been a GCREF as GCREF + int=BYREF
-//                            or BYREF+/-int=BYREF
-// assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
-//        ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+                        // r1/r2 could have been a GCREF as GCREF + int=BYREF
+                        //                            or BYREF+/-int=BYREF
+                        // assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
+                        //        ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+                        CLANG_FORMAT_COMMENT_ANCHOR;
 #endif
                         // Mark r1 as holding a byref
                         emitGCregLiveUpd(GCT_BYREF, reg1, dst);


### PR DESCRIPTION
Putting this up as suggested by @AndyAyersMS on Discord.

As per the comment in code and the analysis in https://github.com/dotnet/runtime/issues/51728, we have many scenarios where a `pointer` is converted to a `byref`. These conversions can range from something as simple as `ref *x` to things like `ref T Unsafe.AsRef<T>(void*)` to even `new Span<T>(void*, int)`.

This conversion is correctly tracked and represented in metadata. However, if the `pointer` is `enregistered` and "last use" the register allocator may decide the `byref` will exist in the same register. There are many places in codegen that have logic similar to:
```
if (tgtReg != srcReg)
{
    emit(INS_mov, tgtReg, srcReg);
}
```

Due to how many locations this check exists, it is non trivial to go and fix this to be handled correctly everywhere today. Additionly, for most scenarios, this is a "safe" optimization. However, when that move is for a `pointer<->byref` conversion, eliding this move means that the liveness update will never occur and so asserts such as the one listed will fire due to the mismatch.