### PR TITLE
Fix over-zeroing of destination buffer for zero padding symmetric encryption

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -168,8 +168,8 @@ namespace Internal.Cryptography
                         throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
                     }
 
-                    destination.Slice(0, zeroSize).Clear();
                     block.CopyTo(destination);
+                    destination.Slice(count, padBytes).Clear();
                     return zeroSize;
 
                 default:


### PR DESCRIPTION
This addresses one issue with how zero padding is handled and another theoretical one.

The first is performance. When applying zero padding, we were clearing the entire destination, then copying the plaintext over it. We were zeroing more data than required, the only data that needed to be zeroed is where the zero padding is applied.

The second is in the case of overlapping buffers for the plaintext and ciphertext. However, this cannot happen currently since we always ensure the destination buffer does not overlap the input buffer. If overlapping is permitted in a future change, this would clear the plaintext, not just where padding is required.

Contributes to #2406

------

I'm submitting this separately from the upcoming one-shot PR since that PR is getting fairly large and this is not immediately related to the one-shot APIs, but is adjacent.