### PR TITLE
[wasm] Turn on verbose emcc output when rebuilding the runtime in local builds

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -50,6 +50,9 @@
       - $(WasmBuildAppAfterThisTarget)      - This target is used as `AfterTargets` for `WasmBuildApp. this
                                               is what triggers the wasm app building. Defaults to `Publish`.
 
+      - $(EmccFlags)                        - This sets the initial emcc flags.
+      - $(EmccVerbose)                      - Set to false to disable verbose emcc output.
+
       Public items:
       - @(WasmExtraFilesToDeploy) - Files to copy to $(WasmAppDir).
                                     (relative path can be set via %(TargetPath) metadata)
@@ -365,6 +368,7 @@
 
     <PropertyGroup>
       <EmccFlags>$(_DefaultEmccFlags) $(EmccFlags)</EmccFlags>
+      <EmccFlags Condition="'$(EmccVerbose)' != 'false'">$(EmccFlags) -v</EmccFlags>
       <EmccFlags Condition="'$(_WasmDevel)' == 'true'">-O0 $(EmccFlags)</EmccFlags>
       <EmccFlags>$(EmccFlags) -s DISABLE_EXCEPTION_CATCHING=0</EmccFlags>
       <EmccFlags Condition="'$(WasmNativeStrip)' == 'false'">$(EmccFlags) -g</EmccFlags>


### PR DESCRIPTION
Turn on verbose If there is a better condition to use let me know.


```
Microsoft (R) Build Engine version 16.11.0-preview-21254-21+e73d08c28 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  bsize -> /Users/lewing/Source/bsize/bin/Debug/net6.0/bsize.dll
  bsize (Blazor output) -> /Users/lewing/Source/bsize/bin/Debug/net6.0/wwwroot
  Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  AOT'ing 32 assemblies
  Compiling native assets with emcc. This may take a while ...
  Compressing Blazor WebAssembly publish artifacts. This may take a while...
  bsize -> /Users/lewing/Source/bsize/bin/Debug/net6.0/publish/
```
to
```
Microsoft (R) Build Engine version 16.11.0-preview-21254-21+e73d08c28 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  bsize -> /Users/lewing/Source/bsize/bin/Debug/net6.0/bsize.dll
  bsize (Blazor output) -> /Users/lewing/Source/bsize/bin/Debug/net6.0/wwwroot
  Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  AOT'ing 32 assemblies
  Compiling native assets with emcc. This may take a while ...
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -DEMSCRIPTEN -fno-inline-functions -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -target wasm32-unknown-emscripten -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=12 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration --sysroot=/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -Xclang -iwithsysroot/include/compat -Xclang -iwithsysroot/include/libc -Xclang -iwithsysroot/lib/libc/musl/arch/emscripten -Xclang -iwithsysroot/local/include -Xclang -iwithsysroot/include/SSE -Xclang -iwithsysroot/include/neon -Xclang -iwithsysroot/lib/compiler-rt/include -Xclang -iwithsysroot/lib/libunwind/include -emit-llvm -DENABLE_METADATA_UPDATE=1 -Oz -v -DENABLE_AOT=1 -DDRIVER_GEN=1 -DLINK_ICALLS=1 -DCORE_BINDINGS -DGEN_PINVOKE=1 -I/Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -g -c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/corebindings.c -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/corebindings.o
  clang version 12.0.0 (/opt/s/w/ir/cache/git/chromium.googlesource.com-external-github.com-llvm-llvm--project 52e240a0721e4120a7143f6f5bab4760d28d48e8)
  Target: wasm32-unknown-emscripten
  Thread model: posix
  InstalledDir: /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin
   (in-process)
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -cc1 -triple wasm32-unknown-emscripten -emit-llvm-bc -emit-llvm-uselists -disable-free -main-file-name corebindings.c -mrelocation-model static -mframe-pointer=none -fno-rounding-math -mconstructor-aliases -target-cpu generic -fvisibility hidden -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -target-linker-version 609 -v -resource-dir /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0 -D EMSCRIPTEN -D __EMSCRIPTEN_major__=2 -D __EMSCRIPTEN_minor__=0 -D __EMSCRIPTEN_tiny__=12 -D _LIBCPP_ABI_VERSION=2 -D unix -D __unix -D __unix__ -D ENABLE_METADATA_UPDATE=1 -D ENABLE_AOT=1 -D DRIVER_GEN=1 -D LINK_ICALLS=1 -D CORE_BINDINGS -D GEN_PINVOKE=1 -I /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -isysroot /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include -Oz -Werror=implicit-function-declaration -fdebug-compilation-dir /Users/lewing/Source/bsize -ferror-limit 19 -fgnuc-version=4.2.1 -fno-inline-functions -vectorize-slp -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -iwithsysroot/include/compat -iwithsysroot/include/libc -iwithsysroot/lib/libc/musl/arch/emscripten -iwithsysroot/local/include -iwithsysroot/include/SSE -iwithsysroot/include/neon -iwithsysroot/lib/compiler-rt/include -iwithsysroot/lib/libunwind/include -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/corebindings.o -x c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/corebindings.c
  clang -cc1 version 12.0.0 based upon LLVM 12.0.0git default target x86_64-apple-darwin19.6.0
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include"
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten"
  #include "..." search starts here:
  #include <...> search starts here:
   /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/compat
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/libc
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libc/musl/arch/emscripten
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/local/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SSE
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/neon
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/compiler-rt/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libunwind/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include
  End of search list.
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -DEMSCRIPTEN -fno-inline-functions -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -target wasm32-unknown-emscripten -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=12 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration --sysroot=/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -Xclang -iwithsysroot/include/compat -Xclang -iwithsysroot/include/libc -Xclang -iwithsysroot/lib/libc/musl/arch/emscripten -Xclang -iwithsysroot/local/include -Xclang -iwithsysroot/include/SSE -Xclang -iwithsysroot/include/neon -Xclang -iwithsysroot/lib/compiler-rt/include -Xclang -iwithsysroot/lib/libunwind/include -emit-llvm -DENABLE_METADATA_UPDATE=1 -Oz -v -DENABLE_AOT=1 -DDRIVER_GEN=1 -DLINK_ICALLS=1 -DCORE_BINDINGS -DGEN_PINVOKE=1 -I/Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -g -c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/driver.c -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/driver.o
  clang version 12.0.0 (/opt/s/w/ir/cache/git/chromium.googlesource.com-external-github.com-llvm-llvm--project 52e240a0721e4120a7143f6f5bab4760d28d48e8)
  Target: wasm32-unknown-emscripten
  Thread model: posix
  InstalledDir: /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin
   (in-process)
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -cc1 -triple wasm32-unknown-emscripten -emit-llvm-bc -emit-llvm-uselists -disable-free -main-file-name driver.c -mrelocation-model static -mframe-pointer=none -fno-rounding-math -mconstructor-aliases -target-cpu generic -fvisibility hidden -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -target-linker-version 609 -v -resource-dir /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0 -D EMSCRIPTEN -D __EMSCRIPTEN_major__=2 -D __EMSCRIPTEN_minor__=0 -D __EMSCRIPTEN_tiny__=12 -D _LIBCPP_ABI_VERSION=2 -D unix -D __unix -D __unix__ -D ENABLE_METADATA_UPDATE=1 -D ENABLE_AOT=1 -D DRIVER_GEN=1 -D LINK_ICALLS=1 -D CORE_BINDINGS -D GEN_PINVOKE=1 -I /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -isysroot /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include -Oz -Werror=implicit-function-declaration -fdebug-compilation-dir /Users/lewing/Source/bsize -ferror-limit 19 -fgnuc-version=4.2.1 -fno-inline-functions -vectorize-slp -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -iwithsysroot/include/compat -iwithsysroot/include/libc -iwithsysroot/lib/libc/musl/arch/emscripten -iwithsysroot/local/include -iwithsysroot/include/SSE -iwithsysroot/include/neon -iwithsysroot/lib/compiler-rt/include -iwithsysroot/lib/libunwind/include -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/driver.o -x c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/driver.c
  clang -cc1 version 12.0.0 based upon LLVM 12.0.0git default target x86_64-apple-darwin19.6.0
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include"
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten"
  #include "..." search starts here:
  #include <...> search starts here:
   /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/compat
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/libc
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libc/musl/arch/emscripten
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/local/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SSE
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/neon
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/compiler-rt/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libunwind/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include
  End of search list.
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -DEMSCRIPTEN -fno-inline-functions -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -target wasm32-unknown-emscripten -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=12 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration --sysroot=/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -Xclang -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -Xclang -iwithsysroot/include/compat -Xclang -iwithsysroot/include/libc -Xclang -iwithsysroot/lib/libc/musl/arch/emscripten -Xclang -iwithsysroot/local/include -Xclang -iwithsysroot/include/SSE -Xclang -iwithsysroot/include/neon -Xclang -iwithsysroot/lib/compiler-rt/include -Xclang -iwithsysroot/lib/libunwind/include -emit-llvm -DENABLE_METADATA_UPDATE=1 -Oz -v -DENABLE_AOT=1 -DDRIVER_GEN=1 -DLINK_ICALLS=1 -DCORE_BINDINGS -DGEN_PINVOKE=1 -I/Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I/Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -g -c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/pinvoke.c -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/pinvoke.o
  clang version 12.0.0 (/opt/s/w/ir/cache/git/chromium.googlesource.com-external-github.com-llvm-llvm--project 52e240a0721e4120a7143f6f5bab4760d28d48e8)
  Target: wasm32-unknown-emscripten
  Thread model: posix
  InstalledDir: /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin
   (in-process)
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/clang" -cc1 -triple wasm32-unknown-emscripten -emit-llvm-bc -emit-llvm-uselists -disable-free -main-file-name pinvoke.c -mrelocation-model static -mframe-pointer=none -fno-rounding-math -mconstructor-aliases -target-cpu generic -fvisibility hidden -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -target-linker-version 609 -v -resource-dir /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0 -D EMSCRIPTEN -D __EMSCRIPTEN_major__=2 -D __EMSCRIPTEN_minor__=0 -D __EMSCRIPTEN_tiny__=12 -D _LIBCPP_ABI_VERSION=2 -D unix -D __unix -D __unix__ -D ENABLE_METADATA_UPDATE=1 -D ENABLE_AOT=1 -D DRIVER_GEN=1 -D LINK_ICALLS=1 -D CORE_BINDINGS -D GEN_PINVOKE=1 -I /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0 -I /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm -isysroot /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten -internal-isystem /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include -Oz -Werror=implicit-function-declaration -fdebug-compilation-dir /Users/lewing/Source/bsize -ferror-limit 19 -fgnuc-version=4.2.1 -fno-inline-functions -vectorize-slp -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL -isystem/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include -iwithsysroot/include/compat -iwithsysroot/include/libc -iwithsysroot/lib/libc/musl/arch/emscripten -iwithsysroot/local/include -iwithsysroot/include/SSE -iwithsysroot/include/neon -iwithsysroot/lib/compiler-rt/include -iwithsysroot/lib/libunwind/include -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/pinvoke.o -x c /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/src/pinvoke.c
  clang -cc1 version 12.0.0 based upon LLVM 12.0.0git default target x86_64-apple-darwin19.6.0
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/include"
  ignoring nonexistent directory "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/wasm32-emscripten"
  #include "..." search starts here:
  #include <...> search starts here:
   /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/mono-2.0
   /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/include/wasm
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SDL
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/compat
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/libc
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libc/musl/arch/emscripten
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/local/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/SSE
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include/neon
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/compiler-rt/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib/libunwind/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/lib/clang/12.0.0/include
   /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/include
  End of search list.
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/wasm-ld" -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Private.CoreLib.dll.bc -L/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/local/lib /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Text.Json.dll.bc -L/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/system/lib /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Text.Encodings.Web.dll.bc -L/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Runtime.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Runtime.CompilerServices.Unsafe.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Private.Uri.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Private.Runtime.InteropServices.JavaScript.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Net.Primitives.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Net.Http.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Net.Http.Json.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Memory.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Linq.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Linq.Expressions.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.ComponentModel.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Collections.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Collections.Immutable.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/System.Collections.Concurrent.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/bsize.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.JSInterop.WebAssembly.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.JSInterop.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Primitives.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Options.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Logging.Abstractions.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Logging.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.DependencyInjection.Abstractions.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.DependencyInjection.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Configuration.Json.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Configuration.Abstractions.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.Extensions.Configuration.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.AspNetCore.Components.WebAssembly.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.AspNetCore.Components.Web.dll.bc /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/Microsoft.AspNetCore.Components.dll.bc /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libicui18n.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libicuuc.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libmono-ee-interp.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libmono-icall-table.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libmono-ilgen.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libmono-profiler-aot.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libmonosgen-2.0.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libSystem.IO.Compression.Native.a /Users/lewing/.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/6.0.0-preview.5.21254.12/runtimes/browser-wasm/native/libSystem.Native.a /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/corebindings.o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/driver.o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/pinvoke.o /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libc.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libcompiler_rt.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libc++.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libc++abi.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libdlmalloc.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libc_rt_wasm.a /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/cache/wasm/libsockets.a -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --allow-undefined --export-table --export putchar --export stackSave --export stackRestore --export stackAlloc --export __wasm_call_ctors --export __errno_location --export malloc --export free --export _ZSt18uncaught_exceptionv --export __cxa_find_matching_catch --export __cxa_is_pointer_type --export __cxa_can_catch --export _get_tzname --export _get_daylight --export _get_timezone --export htonl --export htons --export ntohs --export usleep --export setThrew --export memset --export memalign --export emscripten_main_thread_process_queued_calls -z stack-size=5242880 --initial-memory=536870912 --no-entry --max-memory=2147483648 --global-base=1024
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/wasm-emscripten-finalize" --detect-features --minimize-wasm-changes -g --dyncalls-i64 /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/src/compiler.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/tmposcruo9o.txt
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/wasm-opt" --strip-dwarf --post-emscripten --no-exit-runtime -Oz --low-memory-unused --zero-filled-memory --strip-debug --strip-producers /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -g --mvp-features --enable-mutable-globals
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/tools/acorn-optimizer.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/emscripten_temp_0yglf96t/dotnet.js AJSDCE minifyWhitespace
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/tools/acorn-optimizer.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/tmp9d8d1zr8.js emitDCEGraph noPrint
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/wasm-metadce" --graph-file=/var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/tmp_d1ooiks.txt /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -g --mvp-features --enable-mutable-globals
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/tools/acorn-optimizer.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/tmp4jz46ced.js applyDCEGraphRemovals minifyWhitespace
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/tools/acorn-optimizer.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/emscripten_temp_0yglf96t/dotnet.js.jso.js.jso.js AJSDCE minifyWhitespace
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/bin/wasm-opt" --strip-dwarf --minify-imports-and-exports-and-modules /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -o /Users/lewing/Source/bsize/obj/Debug/net6.0/wasm/dotnet.wasm -g --mvp-features --enable-mutable-globals
   "/usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Node.osx-x64/6.0.0-preview.5.21226.1/tools/bin/node" /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64/6.0.0-preview.5.21226.1/tools/emscripten/tools/acorn-optimizer.js /var/folders/9c/mz6mtrkx0m1449y6k4bfdl4r0000gn/T/tmpv0d4bfo6.js applyImportAndExportNameChanges minifyWhitespace
  Compressing Blazor WebAssembly publish artifacts. This may take a while...
  bsize -> /Users/lewing/Source/bsize/bin/Debug/net6.0/publish/
```