### PR TITLE
Optimize System.HexConverter.IsHexChar on 64 bits

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -292,36 +292,27 @@ namespace System
         {
             if (sizeof(IntPtr) == 8)
             {
-                // Same logic as BitHelper.HasLookupFlag in Microsoft.Toolkit.HighPerformance.
-                // First, the input value is scaled down by '0' (48), which is the offset used
-                // to populate the bitmask. This avoids wasting 48 bits set to 0 at the start of
-                // the mask, and lets all the necessary range (from '0' to 'f' to fit in 64 bits).
-                // We then do a range check (the clt.un comparison will push 0/1, so the bool will
-                // be normalized) and use the result to compute a bitwise flag of either 0xFFFFFFFF
-                // if the input is accepted, or all 0 otherwise. The target bit is then extracted,
-                // (the mask has a 1 bit for "0123456789ABCDEFabcdef" chars left shifted by '0')
-                // and this value is combined with the previous mask. This is done so that
-                // if the shift was performed with a value that was too high, which has an
-                // undefined behavior and could produce a non-0 value, the mask will reset
-                // the final value anyway. This result is then unchecked-cast to a byte (as
-                // it is guaranteed to always be either 1 or 0), and than to a bool to return.
-                // We only use this logic on 64-bit systems, as using 64 bit values would otherwise
-                // be much slower than just using the lookup table anyway (no hardware support).
                 // This code path, when used, has no branches and doesn't depend on cache hits,
                 // so it's faster and does not vary in speed depending on input data distribution.
-                // It also gets JITted to just a constant when the input is a constant as well.
-                int i = c - '0';
-                bool isInRange = (uint)i < 64u;
-                byte byteFlag = *(byte*)&isInRange;
-                int
-                    negativeFlag = byteFlag - 1,
-                    mask = ~negativeFlag,
-                    shift = unchecked((int)((35465847073801215UL >> i) & 1)),
-                    and = shift & mask;
-                byte result = unchecked((byte)and);
-                bool valid = *(bool*)&result;
+                // We only use this logic on 64-bit systems, as using 64 bit values would otherwise
+                // be much slower than just using the lookup table anyway (no hardware support).
+                // The magic constant 18428868213665201664 is a 64 bit value containing 1s at the
+                // indices corresponding to all the valid hex characters (ie. "0123456789ABCDEFabcdef")
+                // minus 48 (ie. '0'), and backwards (so from the most significant bit and downwards).
+                // The offset of 48 for each bit is necessary so that the entire range fits in 64 bits.
+                // First, we subtract '0' to the input digit (after casting to uint to account for any
+                // negative inputs). Note that even if this subtraction underflows, this happens before
+                // the result is zero-extended to ulong, meaning that `i` will always have upper 32 bits
+                // equal to 0. We then left shift the constant with this offset, and apply a bitmask that
+                // has the highest bit set (the sign bit) if and only if `c` is in the ['0', '0' + 64) range.
+                // Then we only need to check whether this final result is less than 0: this will only be
+                // the case if both `i` was in fact the index of a set bit in the magic constant, and also
+                // `c` was in the allowed range (this ensures that false positive bit shifts are ignored).
+                ulong i = (uint)c - '0';
+                ulong shift = 18428868213665201664UL << (int)i;
+                ulong mask = i - 64;
 
-                return valid;
+                return (long)(shift & mask) < 0 ? true : false;
             }
 
             return FromChar(c) != 0xFF;

--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -288,9 +288,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsHexChar(int c)
+        public static bool IsHexChar(int c)
         {
-            if (sizeof(IntPtr) == 8)
+            if (IntPtr.Size == 8)
             {
                 // This code path, when used, has no branches and doesn't depend on cache hits,
                 // so it's faster and does not vary in speed depending on input data distribution.


### PR DESCRIPTION
## Overview

This PR adds a fast path to `System.HexConverter.IsHexChar(int)` on 64 bit systems, which has:

- No branches (down from 2 conditional + 1 unconditional)
- Smaller codegen (66 bytes ---> 35 bytes)
- No memory accesses (so the speed is no longer affected by cache state)

The change is a specialized version of what I used in [`BitHelper.HasLookupFlag`](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/529624cf1af8f034bed9c4f9927d0e0d62f1a6db/Microsoft.Toolkit.HighPerformance/Helpers/BitHelper.cs#L332) in the `Microsoft.Toolkit.HighPerformance` package, and just uses bit trickery to make the code branchless and read the lookup value from a constant value and not from memory.

## Codegen diff

<details>
    <summary><b>Before (click to expand):</b></summary>
<br/>

```asm
; Method IsHexCharFast.HexConverter2:IsHexChar_OG(int):bool
G_M3768_IG01:
       sub      rsp, 40
						;; bbWeight=1    PerfScore 0.25

G_M3768_IG02:
       cmp      ecx, 256
       jge      SHORT G_M3768_IG04
						;; bbWeight=1    PerfScore 1.25

G_M3768_IG03:
       cmp      ecx, 256
       jae      SHORT G_M3768_IG07
       movsxd   rax, ecx
       mov      rdx, 0xD1FFAB1E
       movzx    rax, byte  ptr [rax+rdx]
       jmp      SHORT G_M3768_IG05
						;; bbWeight=0.50 PerfScore 2.88

G_M3768_IG04:
       mov      eax, 255
						;; bbWeight=0.50 PerfScore 0.12

G_M3768_IG05:
       cmp      eax, 255
       setne    al
       movzx    rax, al
						;; bbWeight=1    PerfScore 1.50

G_M3768_IG06:
       add      rsp, 40
       ret      
						;; bbWeight=1    PerfScore 1.25

G_M3768_IG07:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
						;; bbWeight=0    PerfScore 0.00
; Total bytes of code: 66
```
</details>

<details>
    <summary><b>After (click to expand):</b></summary>
<br/>

```asm
; Method IsHexCharFast.HexConverter2:IsHexChar(int):bool
G_M2063_IG01:
						;; bbWeight=1    PerfScore 0.00

G_M2063_IG02:
       add      ecx, -48
       lea      rax, [rcx-64]
       mov      rdx, 0xD1FFAB1E
       shl      rdx, cl
       and      rax, rdx
       jl       SHORT G_M2063_IG05
						;; bbWeight=1    PerfScore 4.25

G_M2063_IG03:
       xor      eax, eax
						;; bbWeight=0.50 PerfScore 0.12

G_M2063_IG04:
       ret      
						;; bbWeight=0.50 PerfScore 0.50

G_M2063_IG05:
       mov      eax, 1
						;; bbWeight=0.50 PerfScore 0.12

G_M2063_IG06:
       ret      
						;; bbWeight=0.50 PerfScore 0.50
; Total bytes of code: 34
```
</details>

Additionally, the new version can also be JITted to just a constant, if the input is a constant.
That is, if you call `IsHexChar` with an input constant like `'A'`, you get this JIT diff:

<details>
    <summary><b>Before (click to expand):</b></summary>
<br/>

```asm
; Method IsHexCharFast.HexConverter2:Check_Constant_OG():bool
G_M36347_IG01:
						;; bbWeight=1    PerfScore 0.00

G_M36347_IG02:
       mov      rax, 0xD1FFAB1E
       movzx    rax, byte  ptr [rax]
       cmp      eax, 255
       setne    al
       movzx    rax, al
						;; bbWeight=1    PerfScore 3.75

G_M36347_IG03:
       ret      
						;; bbWeight=1    PerfScore 1.00
; Total bytes of code: 25
```
</details>

<details>
    <summary><b>After (click to expand):</b></summary>
<br/>

```asm
; Method IsHexCharFast.HexConverter2:Check_Constant_NEW():bool
G_M50831_IG01:
						;; bbWeight=1    PerfScore 0.00

G_M50831_IG02:
       mov      eax, 1
						;; bbWeight=1    PerfScore 0.25

G_M50831_IG03:
       ret      
						;; bbWeight=1    PerfScore 1.00
; Total bytes of code: 6
```
</details>

## Benchmark

I've put together a small test benchmark which you can find [here](https://gist.github.com/Sergio0694/52a8b2269fd95da35fd2370cd86487d1).

|                   Method |     Mean |     Error |    StdDev | Ratio | Code Size |
|------------------------- |---------:|----------:|----------:|------:|----------:|
|      IsHexChar_OG_Random | 9.230 us | 0.0508 us | 0.0475 us |  1.00 |      72 B |
|     IsHexChar_NEW_Random | **4.406 us** | 0.0331 us | 0.0309 us |  0.48 |      62 B |
|                          |          |           |           |       |           |
|  IsHexChar_OG_AlwaysTrue | 2.934 us | 0.0183 us | 0.0172 us |  1.00 |      72 B |
| IsHexChar_NEW_AlwaysTrue | **2.947 us** | 0.0199 us | 0.0186 us |  1.00 |      62 B |

The new version is about 2x faster over random data in this test. When the input is always valid and the branch predictor can be more effective in the original implementation, this test shows the new version is still on par, but a couple notes:

- This benchmark is not representative of real world data since the method is just constantly being invoked in a loop, so the original version will just do cache hits every single time, which gives it an advantage here.
- Even not taking this into consideration, the new version is just generally not dependent on input data and always produces consistent performance in all cases (which I would argue is better even with performance being the same in this test)

## JIT diff

Currently work in progress, I'm not having luck with the runtime tooling today... 😄
Opened the PR in the meantime to have the CI run on it at least.