### PR TITLE
BlockingCollection nullable pragma

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -761,12 +761,7 @@ namespace System.Collections.Concurrent
                 }
             }
 
-#pragma warning disable CS8762
-            // https://github.com/dotnet/runtime/issues/36132
-            // Compiler can't automatically deduce that nullability constraints
-            // for 'item' are satisfied at this exit point.
             return waitForSemaphoreWasSuccessful;
-#pragma warning restore CS8762
         }
 
 


### PR DESCRIPTION
Successfully built libs without `pragma warning disable` locally
If pipeline will pass, contribute to #36132, second pragma is in ConcurrentBag, bit it still can't be removed