### PR TITLE
Improve flow graph DOT dump: conditional display, block ID

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -702,7 +702,7 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
     printf("\n");
 }
 
-const char* BasicBlock::dspToString(int blockNumPadding /* = 2*/)
+const char* BasicBlock::dspToString(int blockNumPadding /* = 0 */)
 {
     static char buffers[3][64]; // static array of 3 to allow 3 concurrent calls in one printf()
     static int  nextBufferIndex = 0;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1032,6 +1032,8 @@ struct BasicBlock : private LIR::Range
     // in the BB list with that stamp (in this field); then we can tell if (e.g.) predecessors are
     // still in the BB list by whether they have the same stamp (with high probability).
     unsigned bbTraversalStamp;
+
+    // bbID is a unique block identifier number that does not change: it does not get renumbered, like bbNum.
     unsigned bbID;
 #endif // DEBUG
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -211,6 +211,8 @@ CONFIG_INTEGER(JitDumpFgLoops, W("JitDumpFgLoops"), 0) // 0 == no loop regions; 
 CONFIG_INTEGER(JitDumpFgConstrained, W("JitDumpFgConstrained"), 1) // 0 == don't constrain to mostly linear layout;
                                                                    // non-zero == force mostly lexical block
                                                                    // linear layout
+CONFIG_INTEGER(JitDumpFgBlockID, W("JitDumpFgBlockID"), 0) // 0 == display block with bbNum; 1 == display with both
+                                                           // bbNum and bbID
 
 CONFIG_STRING(JitLateDisasmTo, W("JITLateDisasmTo"))
 CONFIG_STRING(JitRange, W("JitRange"))


### PR DESCRIPTION
1. For conditional blocks, display a small summary of the branch taken path
of the block (namely, the JTRUE condition). This is currently very limited,
but could be expanded to additional cases as it proves useful (but it needs
to be very compact; you're expected to consult the JitDump for more details).
2. Optionally display both the bbNum and bbID as the block label. This makes
it easier to see which blocks remained the same through renames if comparing
flow graph displays from different phases. This is enabled by setting
`COMPlus_JitDumpFgBlockID=1`.