### PR TITLE
Improve loop cloning throughput

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7427,7 +7427,7 @@ public:
     bool optIdentifyLoopOptInfo(unsigned loopNum, LoopCloneContext* context);
     static fgWalkPreFn optCanOptimizeByLoopCloningVisitor;
     fgWalkResult optCanOptimizeByLoopCloning(GenTree* tree, LoopCloneVisitorInfo* info);
-    void optObtainLoopCloningOpts(LoopCloneContext* context);
+    bool optObtainLoopCloningOpts(LoopCloneContext* context);
     bool optIsLoopClonable(unsigned loopInd);
 
     bool optLoopCloningEnabled();


### PR DESCRIPTION
1. Cloning was rebuilding reachability and dominators after every
cloned loop. This is unnecessary; only rebuild it once, after all
the loops in the function are cloned.
2. Early out if we don't detect any clonable loops.

No asm diffs

Fixes #52480