### PR TITLE
Make RandomNumberGenerator.Create return a singleton

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
@@ -7,15 +7,6 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class RandomNumberGeneratorImplementation
     {
-        // a singleton which always calls into a thread-safe implementation
-        // and whose Dispose method no-ops
-        internal static readonly RandomNumberGeneratorImplementation s_singleton = new RandomNumberGeneratorImplementation();
-
-        // private ctor used only by singleton
-        private RandomNumberGeneratorImplementation()
-        {
-        }
-
         private static unsafe void GetBytes(byte* pbBuffer, int count)
         {
             Debug.Assert(count > 0);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs
@@ -7,6 +7,15 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class RandomNumberGeneratorImplementation
     {
+        // a singleton which always calls into a thread-safe implementation
+        // and whose Dispose method no-ops
+        internal static readonly RandomNumberGeneratorImplementation s_singleton = new RandomNumberGeneratorImplementation();
+
+        // private ctor used only by singleton
+        private RandomNumberGeneratorImplementation()
+        {
+        }
+
         private static unsafe void GetBytes(byte* pbBuffer, int count)
         {
             Debug.Assert(count > 0);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs
@@ -7,6 +7,15 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class RandomNumberGeneratorImplementation : RandomNumberGenerator
     {
+        // a singleton which always calls into a thread-safe implementation
+        // and whose Dispose method no-ops
+        internal static readonly RandomNumberGeneratorImplementation s_singleton = new RandomNumberGeneratorImplementation();
+
+        // private ctor used only by singleton
+        private RandomNumberGeneratorImplementation()
+        {
+        }
+
         // As long as each implementation can provide a static GetBytes(ref byte buf, int length)
         // they can share this one implementation of FillSpan.
         internal static unsafe void FillSpan(Span<byte> data)

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -12,10 +12,7 @@ namespace System.Security.Cryptography
     {
         protected RandomNumberGenerator() { }
 
-        public static RandomNumberGenerator Create()
-        {
-            return new RandomNumberGeneratorImplementation();
-        }
+        public static RandomNumberGenerator Create() => RandomNumberGeneratorImplementation.s_singleton;
 
         [UnsupportedOSPlatform("browser")]
         [RequiresUnreferencedCode(CryptoConfig.CreateFromNameUnreferencedCodeMessage)]

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -12,6 +12,30 @@ namespace System.Security.Cryptography.RNG.Tests
 {
     public class RandomNumberGeneratorTests
     {
+        [Fact]
+        public static void Create_ReturnsSingleton()
+        {
+            RandomNumberGenerator rng1 = RandomNumberGenerator.Create();
+            RandomNumberGenerator rng2 = RandomNumberGenerator.Create();
+
+            Assert.Same(rng1, rng2);
+        }
+
+        [Fact]
+        public static void Singleton_NoopsDispose()
+        {
+            byte[] random = new byte[1024];
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(random);
+            RandomDataGenerator.VerifyRandomDistribution(random);
+            rng.Dispose(); // should no-op if called once
+
+            random = new byte[1024];
+            rng.GetBytes(random); // should still work even after earlier Dispose call
+            RandomDataGenerator.VerifyRandomDistribution(random);
+            rng.Dispose(); // should no-op if called twice
+        }
+
         [Theory]
         [InlineData(2048)]
         [InlineData(65536)]


### PR DESCRIPTION
Inspired by https://github.com/dotnet/runtime/issues/40169 and https://github.com/dotnet/runtime/pull/52373. This makes the implementation of `RandomNumberGenerator.Create()` return a singleton instance. So apps which need to call `RandomNumberGenerator.Create()` instead of using the static accelerator APIs can still take advantage of a non-allocating factory.

Attempting to dispose of the returned singleton instance will no-op. The implementation of `RandomNumberGenerator.Create(string)` is _not_ changed. Using that API will continue to go through the normal `CryptoConfig` activation code paths.

/cc @jeffhandley