### PR TITLE
Remove unnecessary Dispose Override from BackgroundWorker

### DIFF
--- a/src/libraries/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
+++ b/src/libraries/System.ComponentModel.EventBasedAsync/src/System/ComponentModel/BackgroundWorker.cs
@@ -191,9 +191,5 @@ namespace System.ComponentModel
             var e = new RunWorkerCompletedEventArgs(workerResult, error, cancelled);
             _asyncOperation.PostOperationCompleted(_operationCompleted, e);
         }
-
-        protected override void Dispose(bool disposing)
-        {
-        }
     }
 }


### PR DESCRIPTION
As part of #43852 this Dispose was missing documentation, however as this is the same as the Dispose(boolean) of Component base class removing this should cause the documentation to be inherited just like Dispose() and GetService(Type) is.