### PR TITLE
StringValues.Count test null first

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -93,13 +93,13 @@ namespace Microsoft.Extensions.Primitives
             {
                 // Take local copy of _values so type checks remain valid even if the StringValues is overwritten in memory
                 object value = _values;
-                if (value is string)
-                {
-                    return 1;
-                }
                 if (value is null)
                 {
                     return 0;
+                }
+                if (value is string)
+                {
+                    return 1;
                 }
                 else
                 {


### PR DESCRIPTION
Trying to cast `is string` and then doing a `is null` later is inefficent when in practice a lot of the values are `default(StringValues)`; so it should do the cheap `null` test first before the cast