### PR TITLE
Refactor `Internal.JitInterface.MemoryHelper`

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2755,7 +2755,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory(ref pEEInfoOut, 0xcc);
+            MemoryHelper.FillStruct(ref pEEInfoOut, 0xcc);
 #endif
 
             int pointerSize = this.PointerSize;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2755,8 +2755,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            fixed (CORINFO_EE_INFO* tmp = &pEEInfoOut)
-                MemoryHelper.FillMemory((byte*)tmp, 0xcc, Marshal.SizeOf<CORINFO_EE_INFO>());
+            MemoryHelper.FillMemory(ref pEEInfoOut, 0xcc);
 #endif
 
             int pointerSize = this.PointerSize;

--- a/src/coreclr/tools/Common/JitInterface/MemoryHelper.cs
+++ b/src/coreclr/tools/Common/JitInterface/MemoryHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace Internal.JitInterface
 {
@@ -10,8 +10,7 @@ namespace Internal.JitInterface
     {
         public static void FillStruct<T>(ref T destination, byte value) where T : unmanaged
         {
-            Span<T> span = MemoryMarshal.CreateSpan(ref destination, 1);
-            MemoryMarshal.AsBytes(span).Fill(value);
+            Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref destination), value, (uint)Unsafe.SizeOf<T>());
         }
     }
 }

--- a/src/coreclr/tools/Common/JitInterface/MemoryHelper.cs
+++ b/src/coreclr/tools/Common/JitInterface/MemoryHelper.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Internal.JitInterface
 {
-    internal static unsafe class MemoryHelper
+    internal static class MemoryHelper
     {
-        public static void FillMemory(byte* dest, byte fill, int count)
+        public static void FillStruct<T>(ref T destination, byte value) where T : unmanaged
         {
-            for (; count > 0; count--)
-            {
-                *dest = fill;
-                dest++;
-            }
+            Span<T> span = MemoryMarshal.CreateSpan(ref destination, 1);
+            MemoryMarshal.AsBytes(span).Fill(value);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -568,8 +568,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            fixed (CORINFO_LOOKUP* tmp = &pLookup)
-                MemoryHelper.FillMemory((byte*)tmp, 0xcc, sizeof(CORINFO_LOOKUP));
+            MemoryHelper.FillMemory(ref pLookup, 0xcc);
 #endif
 
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
@@ -1075,7 +1074,7 @@ namespace Internal.JitInterface
             {
                 _debugVarInfos[i] = vars[i];
             }
-            
+
             // JIT gave the ownership of this to us, so need to free this.
             freeArray(vars);
         }
@@ -1092,7 +1091,7 @@ namespace Internal.JitInterface
             {
                 _debugLocInfos[i] = pMap[i];
             }
-            
+
             // JIT gave the ownership of this to us, so need to free this.
             freeArray(pMap);
         }
@@ -1210,7 +1209,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory((byte*)pResult, 0xcc, Marshal.SizeOf<CORINFO_FIELD_INFO>());
+            MemoryHelper.FillMemory(ref *pResult, 0xcc);
 #endif
 
             Debug.Assert(((int)flags & ((int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET |
@@ -1385,7 +1384,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory((byte*)pResult, 0xcc, Marshal.SizeOf<CORINFO_CALL_INFO>());
+            MemoryHelper.FillMemory(ref *pResult, 0xcc);
 #endif
             pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = false;
 
@@ -2070,8 +2069,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            fixed (CORINFO_GENERICHANDLE_RESULT* tmp = &pResult)
-                MemoryHelper.FillMemory((byte*)tmp, 0xcc, Marshal.SizeOf<CORINFO_GENERICHANDLE_RESULT>());
+            MemoryHelper.FillMemory(ref pResult, 0xcc);
 #endif
 
             bool runtimeLookup = false;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -568,7 +568,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory(ref pLookup, 0xcc);
+            MemoryHelper.FillStruct(ref pLookup, 0xcc);
 #endif
 
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
@@ -1209,7 +1209,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory(ref *pResult, 0xcc);
+            MemoryHelper.FillStruct(ref *pResult, 0xcc);
 #endif
 
             Debug.Assert(((int)flags & ((int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET |
@@ -1384,7 +1384,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory(ref *pResult, 0xcc);
+            MemoryHelper.FillStruct(ref *pResult, 0xcc);
 #endif
             pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = false;
 
@@ -2069,7 +2069,7 @@ namespace Internal.JitInterface
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
             // properly.
-            MemoryHelper.FillMemory(ref pResult, 0xcc);
+            MemoryHelper.FillStruct(ref pResult, 0xcc);
 #endif
 
             bool runtimeLookup = false;


### PR DESCRIPTION
Refactor `Internal.JitInterface.MemoryHelper` to be generic around unmanaged struct types and remove "unsafe" code.

We can eliminate the `count` parameter as `MemoryMarshal.AsBytes` internally gets the size of `T`.