### PR TITLE
Enable binding to non-null IEnumerable properties.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.Configuration
                     instance = CreateInstance(type);
                 }
 
-                // See if its a Dictionary
+                // See if it's a Dictionary
                 Type collectionInterface = FindOpenGenericInterface(typeof(IDictionary<,>), type);
                 if (collectionInterface != null)
                 {
@@ -330,16 +330,31 @@ namespace Microsoft.Extensions.Configuration
                 }
                 else
                 {
-                    // See if its an ICollection
+                    // See if it's an ICollection
                     collectionInterface = FindOpenGenericInterface(typeof(ICollection<>), type);
                     if (collectionInterface != null)
                     {
                         BindCollection(instance, collectionInterface, config, options);
                     }
-                    // Something else
                     else
                     {
-                        BindNonScalar(config, instance, options);
+                        // see if it's an IEnumerable that has been set with a broader collection
+                        collectionInterface = FindOpenGenericInterface(typeof(IEnumerable<>), type);
+
+                        if (collectionInterface != null && instance != null)
+                        {
+                            collectionInterface = FindOpenGenericInterface(typeof(ICollection<>), instance.GetType());
+
+                            if (collectionInterface != null)
+                            {
+                                BindCollection(instance, collectionInterface, config, options);
+                            }
+                        }
+                        // Something else
+                        else
+                        {
+                            BindNonScalar(config, instance, options);
+                        }
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -47,6 +50,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             {
                 get { return null; }
             }
+
+            public IEnumerable<string> InstantiatedCovariantIEnumerable { get; set; } = new List<string>();
         }
 
         public class NestedOptions
@@ -202,6 +207,26 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("DerivedSection", childOptions.DerivedSection.Key);
             Assert.Equal("Section:DerivedSection", childOptions.DerivedSection.Path);
             Assert.Null(options.Section.Value);
+        }
+
+        [Fact]
+        public void CanBindInstantiatedCovariantIEnumerable()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"InstantiatedCovariantIEnumerable:0", "Yo1"},
+                {"InstantiatedCovariantIEnumerable:1", "Yo2"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ComplexOptions>();
+            
+            Assert.Equal(2, options.InstantiatedCovariantIEnumerable.Count());
+            Assert.Equal("Yo1", options.InstantiatedCovariantIEnumerable.ElementAt(0));
+            Assert.Equal("Yo2", options.InstantiatedCovariantIEnumerable.ElementAt(1));
         }
 
         [Fact]


### PR DESCRIPTION
Binding should work for an IEnumerable property instantiated with a collection type.
In the case of IEnumerable, rather than just checking the type of the property,
we also now check the instance type to see if it's `ICollection` based in order
to populate it.

Fix #36390