### PR TITLE
Gracefully stop host if hosted service stops the application during startup

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         private readonly HostOptions _options;
         private readonly IHostEnvironment _hostEnvironment;
         private readonly PhysicalFileProvider _defaultProvider;
-        private readonly ICollection<IHostedService> _hostedServices = new List<IHostedService>();
+        private readonly List<IHostedService> _hostedServices = new List<IHostedService>();
 
         public Host(IServiceProvider services,
                     IHostEnvironment hostEnvironment,

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Extensions.Hosting.Internal
 
             foreach (IHostedService hostedService in _hostedServices)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // Fire IHostedService.Start
                 await hostedService.StartAsync(combinedCancellationToken).ConfigureAwait(false);
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -116,11 +116,11 @@ namespace Microsoft.Extensions.Hosting.Internal
                 IList<Exception> exceptions = new List<Exception>();
                 if (_hostedServices.Count > 0) // Started?
                 {
-                    foreach (IHostedService hostedService in _hostedServices.Reverse())
+                    for (int i = _hostedServices.Count - 1; i >= 0; i--)
                     {
                         try
                         {
-                            await hostedService.StopAsync(token).ConfigureAwait(false);
+                            await _hostedServices[i].StopAsync(token).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 if (_applicationLifetime.ApplicationStopping.IsCancellationRequested)
                 {
+                    _logger.StartAborted();
                     return;
                 }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 _applicationLifetime.StopApplication();
 
                 IList<Exception> exceptions = new List<Exception>();
-                if (_hostedServices.Count != 0) // Started?
+                if (_hostedServices.Count > 0) // Started?
                 {
                     foreach (IHostedService hostedService in _hostedServices.Reverse())
                     {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -97,5 +97,16 @@ namespace Microsoft.Extensions.Hosting.Internal
                     message: SR.BackgroundServiceExceptionStoppedHost);
             }
         }
+
+        public static void StartAborted(this ILogger logger)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogWarning(
+                    eventId: LoggerEventIds.StartAborted,
+                    message: "Host is stopping before completely started. Note that some hosted services may not have been started."
+                );
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/LoggerEventIds.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/LoggerEventIds.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         public static readonly EventId ApplicationStoppedException = new EventId(8, nameof(ApplicationStoppedException));
         public static readonly EventId BackgroundServiceFaulted = new EventId(9, nameof(BackgroundServiceFaulted));
         public static readonly EventId BackgroundServiceStoppingHost = new EventId(10, nameof(BackgroundServiceStoppingHost));
+        public static readonly EventId StartAborted = new EventId(11, nameof(StartAborted));
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -630,6 +630,30 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         [Fact]
+        public async Task HostDoesNotStartHostedServiceIfCancellationIsRequested()
+        {
+            var firstHostedService = new Mock<IHostedService>();
+            var secondHostedService = new Mock<IHostedService>();
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            firstHostedService
+                .Setup(s => s.StartAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => cancellationTokenSource.Cancel());
+
+            using var host = CreateBuilder()
+                .ConfigureServices((_, services) =>
+                {
+                    services.AddSingleton(_ => firstHostedService.Object);
+                    services.AddSingleton(_ => secondHostedService.Object);
+                })
+                .Build();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => host.StartAsync(cancellationTokenSource.Token));
+            firstHostedService.Verify(s => s.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+            secondHostedService.Verify(s => s.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task WebHostStopAsyncUsesDefaultTimeoutIfNoTokenProvided()
         {
             var service = new Mock<IHostedService>();


### PR DESCRIPTION
This PR closes #51613 by introducing the following behavior when starting `IHostedService` from the `Host`:

1. Before starting each hosted service, check  `IHostApplicationLifetime` to see if the application has been instructed to stop and if so abort the start sequence.
2. If the application is not instructed to stop, check the provided `CancellationToken` to see if the caller has requested cancellation and if so throws `OperationCanceledException`.