### PR TITLE
Fix infinite loop in DeflateStream.ReadAsync when read buffer is empty

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -606,6 +606,19 @@ namespace System.IO.Compression
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Read_EmptyBuffer(bool useAsync)
+        {
+            using (var decompressor = CreateStream(new MemoryStream(new byte[1]), CompressionMode.Decompress))
+            {
+                var data = new byte[1] { 42 };
+                Assert.Equal(0, useAsync ? decompressor.ReadAsync(data, 0, 0).Result : decompressor.Read(data, 0, 0));
+                Assert.Equal(42, data[0]);
+            }
+        }
+
+        [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
         public void CopyToAsync_ArgumentValidation(CompressionMode mode)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -465,6 +465,11 @@ namespace System.IO.Compression
                         _inflater.SetInput(_buffer, 0, bytesRead);
                     }
 
+                    if (buffer.Length == 0)
+                    {
+                        return 0;
+                    }
+
                     // Finish inflating any bytes in the input buffer
                     int inflatedBytes = 0, bytesReadIteration = -1;
                     while (inflatedBytes < buffer.Length && bytesReadIteration != 0)


### PR DESCRIPTION
Fixes #52009 for the release/5.0 branch as the related issue is already fixed in the `main` branch after an heavy refactoring including breaking changes.

# Description

Fix infinite loop in DeflateStream.ReadAsync when read buffer is empty.

# Customer Impact

Calling GZipStream.ReadAsync with a zero-length buffer seemingly never returns. The sync equivalent, GZipStream.Read, correctly returns 0.

The following snippet reproduces the problem:

```csharp
public async static Task Main(string[] args)
{
    using (var stream = new MemoryStream())
    {
        using (var output = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
        {
            output.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
            output.Flush();
        }

        stream.Position = 0;

        using (var gzip = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true))
        {
            gzip.Read(Array.Empty<byte>());
            await gzip.ReadAsync(Array.Empty<byte>(), default);
        }
    }
}
```

# Regression

Yes, the regression was introduced in .NET Core 3.0. The sample code works when targeting netcoreapp2.1 and hangs on netcoreapp3.0 and net5.0.

# Testing

Unit testing.

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


/cc @stephentoub @qmfrederik