### PR TITLE
JIT: Fold "cmp & 1" to "cmp"

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14090,6 +14090,14 @@ DONE_MORPHING_CHILDREN:
                 op2 = tree->AsOp()->gtOp2;
             }
 
+            // Fold "cmp & 1" to just "cmp"
+            if (tree->OperIs(GT_AND) && tree->TypeIs(TYP_INT) && op1->OperIsCompare() && op2->IsIntegralConst(1))
+            {
+                DEBUG_DESTROY_NODE(op2);
+                DEBUG_DESTROY_NODE(tree);
+                return op1;
+            }
+
             // See if we can fold floating point operations (can regress minopts mode)
             if (opts.OptimizationEnabled() && varTypeIsFloating(tree->TypeGet()) && !optValnumCSE_phase)
             {


### PR DESCRIPTION
I noticed this pattern after loop clonning (it produces it for the condition for two loops), e.g.:
```csharp
static void Test(int[] arr)
{
    int len = arr.Length;
    for (int i = 0; i < len; i++)
        arr[i] = 0;
}
```
Codegen diff: https://www.diffchecker.com/fdGIQqQJ

(_Obviously, for this specific method the clonned loop should either be removed or not emitted in the first place but that is a different story_)

SuperPMI diffs:
```
asm.aspnet.run.windows.x64.checked.1

Total bytes of base: 4071
Total bytes of diff: 3965
Total bytes of delta: -106 (-2.60% of base)
    diff is an improvement.
```
```
asm.benchmarks.run.windows.x64.checked.1

Total bytes of base: 34862
Total bytes of diff: 34379
Total bytes of delta: -483 (-1.39% of base)
    diff is an improvement.
```
```
asm.libraries.crossgen.windows.x64.checked.5

Total bytes of base: 64797
Total bytes of diff: 63798
Total bytes of delta: -999 (-1.54% of base)
    diff is an improvement.
```
```
asm.libraries.crossgen2.windows.x64.checked.3

Total bytes of base: 44678
Total bytes of diff: 43939
Total bytes of delta: -739 (-1.65% of base)
    diff is an improvement.
```
```
asm.libraries.pmi.windows.x64.checked.1

Total bytes of base: 75612
Total bytes of diff: 74511
Total bytes of delta: -1101 (-1.46% of base)
    diff is an improvement.
```
```
asm.tests.pmi.windows.x64.checked.1

Total bytes of base: 43352
Total bytes of diff: 42533
Total bytes of delta: -819 (-1.89% of base)
    diff is an improvement.
```
```
asm.tests_libraries.pmi.windows.x64.checked.1

Total bytes of base: 103704
Total bytes of diff: 102144
Total bytes of delta: -1560 (-1.50% of base)
    diff is an improvement.
```