### PR TITLE
Delete suspicious code in RuntimeType

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -822,35 +822,7 @@ namespace System
                         declaringType = RuntimeTypeHandle.GetBaseType(declaringType);
                     }
                     #endregion
-
-                    #region Populate Literal Fields on Interfaces
-                    if (ReflectedType.IsGenericParameter)
-                    {
-                        Type[] interfaces = ReflectedType.BaseType!.GetInterfaces();
-
-                        for (int i = 0; i < interfaces.Length; i++)
-                        {
-                            // Populate literal fields defined on any of the interfaces implemented by the declaring type
-                            PopulateLiteralFields(filter, (RuntimeType)interfaces[i], ref list);
-                            PopulateRtFields(filter, (RuntimeType)interfaces[i], ref list);
-                        }
-                    }
-                    else
-                    {
-                        Type[]? interfaces = RuntimeTypeHandle.GetInterfaces(ReflectedType);
-
-                        if (interfaces != null)
-                        {
-                            for (int i = 0; i < interfaces.Length; i++)
-                            {
-                                // Populate literal fields defined on any of the interfaces implemented by the declaring type
-                                PopulateLiteralFields(filter, (RuntimeType)interfaces[i], ref list);
-                                PopulateRtFields(filter, (RuntimeType)interfaces[i], ref list);
-                            }
-                        }
-                    }
-                    #endregion
-
+                    
                     return list.ToArray();
                 }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -822,7 +822,7 @@ namespace System
                         declaringType = RuntimeTypeHandle.GetBaseType(declaringType);
                     }
                     #endregion
-                    
+
                     return list.ToArray();
                 }
 


### PR DESCRIPTION
This code indicates that we can somehow get to fields on interfaces by reflecting on fields of a type implementing the interface. If that's the case, we have work to do in IL Linker. But I have not been able to find a way to do that, mostly because static fields don't get inherited the same as instance fields and we don't allow instance fields on interfaces.

Deleting the code to see if we have any failing tests.