### PR TITLE
Mark HostFactoryResolver againa as source package

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -5,6 +5,7 @@
     <EnableBinPlacing>false</EnableBinPlacing>
     <IsShipping>false</IsShipping>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IsSourcePackage>true</IsSourcePackage>
     <PackageDescription>Internal package for sharing Microsoft.Extensions.Hosting.HostFactoryResolver type.</PackageDescription>
   </PropertyGroup>
 


### PR DESCRIPTION
During the migration from pkgproj to csproj, the `<IsSourcePackage />` declaration was lost. Setting this again to auto-generate the expected build target.

cc @dougbu 