### PR TITLE
Eliminate chained casts to small types

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -726,13 +726,53 @@ OPTIMIZECAST:
             break;
 
             case GT_CAST:
-                /* Check for two consecutive casts into the same dstType */
+                // Check for two consecutive casts into the same dstType.
+                // Also check for consecutive casts to small types.
                 if (!tree->gtOverflow())
                 {
-                    var_types dstType2 = oper->CastToType();
-                    if (dstType == dstType2)
+                    var_types dstCastToType = dstType;
+                    var_types srcCastToType = oper->CastToType();
+                    if (dstCastToType == srcCastToType)
                     {
                         goto REMOVE_CAST;
+                    }
+                    // We can take advantage of the implicit zero/sign-extension for
+                    // small integer types and eliminate some casts.
+                    if (opts.OptimizationEnabled() && !oper->gtOverflow() && !gtIsActiveCSE_Candidate(oper) &&
+                        varTypeIsSmall(dstCastToType) && varTypeIsSmall(srcCastToType))
+                    {
+                        // Gather some facts about our casts.
+                        bool     srcZeroExtends = varTypeIsUnsigned(srcCastToType);
+                        bool     dstZeroExtends = varTypeIsUnsigned(dstCastToType);
+                        unsigned srcCastToSize  = genTypeSize(srcCastToType);
+                        unsigned dstCastToSize  = genTypeSize(dstCastToType);
+
+                        // If the previous cast to a smaller type was zero-extending,
+                        // this cast will also always be zero-extending. Example:
+                        // CAST(ubyte): 000X => CAST(short): Sign-extend(0X) => 000X.
+                        if (srcZeroExtends && (dstCastToSize > srcCastToSize))
+                        {
+                            dstZeroExtends = true;
+                        }
+
+                        // Case #1: cast to a smaller or equal in size type.
+                        // We can discard the intermediate cast. Examples:
+                        // CAST(short): --XX => CAST(ubyte): 000X.
+                        // CAST(ushort): 00XX => CAST(short): --XX.
+                        if (dstCastToSize <= srcCastToSize)
+                        {
+                            tree->AsCast()->CastOp() = oper->AsCast()->CastOp();
+                            DEBUG_DESTROY_NODE(oper);
+                        }
+                        // Case #2: cast to a larger type with the same effect.
+                        // Here we can eliminate the outer cast. Example:
+                        // CAST(byte): ---X => CAST(short): Sign-extend(-X) => ---X.
+                        // Example of a sequence where this does not hold:
+                        // CAST(byte): ---X => CAST(ushort): Zero-extend(-X) => 00-X.
+                        else if (srcZeroExtends == dstZeroExtends)
+                        {
+                            goto REMOVE_CAST;
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
We can take advantage of the implicit zero/sign-extension for small integer types and eliminate some casts.

<details>
<summary>Diffs as of first commit. Regressions are caused by losing some CSEs</summary>

```
Using JIT/EE Version from jiteeversionguid.h: 12234eca-dfc2-48bc-a320-6155cf25ce17

aspnet.run.windows.x64.checked.mch: 8 total methods with Code Size differences (8 improved, 0 regressed), 2 unchanged
benchmarks.run.windows.x64.checked.mch: 7 total methods with Code Size differences (6 improved, 1 regressed), 2 unchanged
libraries.crossgen.windows.x64.checked.mch: 118 total files with Code Size differences (102 improved, 16 regressed), 15 unchanged
libraries.crossgen2.windows.x64.checked.mch: 134 total files with Code Size differences (118 improved, 16 regressed), 15 unchanged
libraries.pmi.windows.x64.checked.mch: 70 total methods with Code Size differences (64 improved, 6 regressed), 3 unchanged
tests.pmi.windows.x64.checked.mch: 727 total methods with Code Size differences (725 improved, 2 regressed), 50 unchanged
tests_libraries.pmi.windows.x64.checked.mch: 86 total files with Code Size differences (84 improved, 2 regressed), 8 unchanged
```
</details>

Draft until:
1\) ~~Formatter is happy.~~
2\) ~~Regular CI is happy.~~
3\) ~~Investigation into special-casing local variables normalized on load to avoid regressions is complete.~~ - most of the improvements are coming from this, so it is a trade-off.
4\) ~~Investigation into generalizing this for larger types and/or checked casts is complete~~ - I will be refactoring `fgMorphCast` some more in the (hopefully near) future, so out of scope for now.