### PR TITLE
Disable EventSource_EventsRaisedAsExpected

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -33,6 +33,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50639")]
         public void EventSource_EventsRaisedAsExpected()
         {
             RemoteExecutor.Invoke(() =>


### PR DESCRIPTION
Disable failing test System.Net.Sockets.Tests.LoggingTest.EventSource_EventsRaisedAsExpected

Tracked by #50639