### PR TITLE
Fixing the GetInterfaceMap tests for mono in the runtime repo.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1663,9 +1663,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/Emit/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/GetInterfaceMapConsumer/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34389</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/InvokeConsumer/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
Addressing 4 issues for GetInterfaceMap and default interface methods
 - Only methods marked as virtual on on interface should be added to the
   interface map. (no static or instance)
 - If the found target method is ambiguous (a diamond) the target is
   null.
 - If the found target method's class in an interface, then the target
   class is the interface class, else it is the class of the RuntimeType
   (aka this)
 - If the found target method is abstract (reabstraction) then the
   target is null.

Fixes #34389