### PR TITLE
Trim some HttpHeader parsing logic on browser-wasm

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
@@ -6,5 +6,8 @@
     <type fullname="System.Net.Http.HttpClient">
       <method signature="System.Boolean IsNativeHandlerEnabled()" body="stub" value="true" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="true" />
     </type>
+    <type fullname="System.Net.Http.Headers.KnownHeaders">
+      <method signature="System.Boolean get_MinimalHeaderValidation()" body="stub" value="true" feature="System.Net.Http.MinimalHeaderValidation" featurevalue="true" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
@@ -18,7 +18,6 @@ namespace System.Net.Http.Headers
         internal static readonly GenericHeaderParser MultipleValueNameValueWithParametersParser = new GenericHeaderParser(true, NameValueWithParametersHeaderValue.GetNameValueWithParametersLength);
         internal static readonly GenericHeaderParser SingleValueNameValueParser = new GenericHeaderParser(false, ParseNameValue);
         internal static readonly GenericHeaderParser MultipleValueNameValueParser = new GenericHeaderParser(true, ParseNameValue);
-        internal static readonly GenericHeaderParser MailAddressParser = new GenericHeaderParser(false, ParseMailAddress);
         internal static readonly GenericHeaderParser SingleValueProductParser = new GenericHeaderParser(false, ParseProduct);
         internal static readonly GenericHeaderParser MultipleValueProductParser = new GenericHeaderParser(true, ParseProduct);
         internal static readonly GenericHeaderParser RangeConditionParser = new GenericHeaderParser(false, RangeConditionHeaderValue.GetRangeConditionLength);
@@ -36,6 +35,9 @@ namespace System.Net.Http.Headers
         internal static readonly GenericHeaderParser MultipleValueViaParser = new GenericHeaderParser(true, ViaHeaderValue.GetViaLength);
         internal static readonly GenericHeaderParser SingleValueWarningParser = new GenericHeaderParser(false, WarningHeaderValue.GetWarningLength);
         internal static readonly GenericHeaderParser MultipleValueWarningParser = new GenericHeaderParser(true, WarningHeaderValue.GetWarningLength);
+
+        // These parsers are not cached in a static field, so they can be trimmed when not needed
+        internal static GenericHeaderParser GetMailAddressParser() => new GenericHeaderParser(false, ParseMailAddress);
 
         #endregion
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -9,6 +9,9 @@ namespace System.Net.Http.Headers
 {
     internal static class KnownHeaders
     {
+        private static bool MinimalHeaderValidation { get; } =
+            AppContext.TryGetSwitch("System.Net.Http.MinimalHeaderValidation", out bool minimalHeaderValidation) ? minimalHeaderValidation : false;
+
         // If you add a new entry here, you need to add it to TryGetKnownHeader below as well.
 
         public static readonly KnownHeader PseudoStatus = new KnownHeader(":status", HttpHeaderType.Response, parser: null);
@@ -26,7 +29,7 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader AccessControlMaxAge = new KnownHeader("Access-Control-Max-Age");
         public static readonly KnownHeader Age = new KnownHeader("Age", HttpHeaderType.Response | HttpHeaderType.NonTrailing, TimeSpanHeaderParser.Parser, null, H2StaticTable.Age, H3StaticTable.Age0);
         public static readonly KnownHeader Allow = new KnownHeader("Allow", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, H2StaticTable.Allow);
-        public static readonly KnownHeader AltSvc = new KnownHeader("Alt-Svc", HttpHeaderType.Response, AltSvcHeaderParser.Parser, http3StaticTableIndex: H3StaticTable.AltSvcClear);
+        public static readonly KnownHeader AltSvc = new KnownHeader("Alt-Svc", HttpHeaderType.Response, MinimalHeaderValidation ? null : AltSvcHeaderParser.Parser, http3StaticTableIndex: H3StaticTable.AltSvcClear);
         public static readonly KnownHeader AltUsed = new KnownHeader("Alt-Used", HttpHeaderType.Request, parser: null);
         public static readonly KnownHeader Authorization = new KnownHeader("Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, H2StaticTable.Authorization, H3StaticTable.Authorization);
         public static readonly KnownHeader CacheControl = new KnownHeader("Cache-Control", HttpHeaderType.General | HttpHeaderType.NonTrailing, CacheControlHeaderParser.Parser, new string[] { "must-revalidate", "no-cache", "no-store", "no-transform", "private", "proxy-revalidate", "public" }, H2StaticTable.CacheControl, H3StaticTable.CacheControlMaxAge0);
@@ -47,7 +50,7 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader Expect = new KnownHeader("Expect", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueWithParametersParser, new string[] { "100-continue" }, H2StaticTable.Expect);
         public static readonly KnownHeader ExpectCT = new KnownHeader("Expect-CT");
         public static readonly KnownHeader Expires = new KnownHeader("Expires", HttpHeaderType.Content | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.Expires);
-        public static readonly KnownHeader From = new KnownHeader("From", HttpHeaderType.Request, GenericHeaderParser.MailAddressParser, null, H2StaticTable.From);
+        public static readonly KnownHeader From = new KnownHeader("From", HttpHeaderType.Request, MinimalHeaderValidation ? null : GenericHeaderParser.GetMailAddressParser(), null, H2StaticTable.From);
         public static readonly KnownHeader GrpcEncoding = new KnownHeader("grpc-encoding", HttpHeaderType.Custom, null, new string[] { "identity", "gzip", "deflate" });
         public static readonly KnownHeader GrpcMessage = new KnownHeader("grpc-message");
         public static readonly KnownHeader GrpcStatus = new KnownHeader("grpc-status", HttpHeaderType.Custom, null, new string[] { "0" });

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/MailAddressParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/MailAddressParserTest.cs
@@ -1,12 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Mail;
 using System.Net.Http.Headers;
-using System.Text;
 
 using Xunit;
 
@@ -17,7 +12,7 @@ namespace System.Net.Http.Tests
         [Fact]
         public void Properties_ReadValues_MatchExpectation()
         {
-            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            HttpHeaderParser parser = GenericHeaderParser.GetMailAddressParser();
             Assert.False(parser.SupportsMultipleValues);
             Assert.Null(parser.Comparer);
         }
@@ -54,7 +49,7 @@ namespace System.Net.Http.Tests
         private void CheckValidParsedValue(string input, int startIndex, string expectedResult,
             int expectedIndex)
         {
-            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            HttpHeaderParser parser = GenericHeaderParser.GetMailAddressParser();
             object result = null;
             Assert.True(parser.TryParseValue(input, null, ref startIndex, out result),
                 string.Format("TryParse returned false: {0}", input));
@@ -64,7 +59,7 @@ namespace System.Net.Http.Tests
 
         private void CheckInvalidParsedValue(string input, int startIndex)
         {
-            HttpHeaderParser parser = GenericHeaderParser.MailAddressParser;
+            HttpHeaderParser parser = GenericHeaderParser.GetMailAddressParser();
             object result = null;
             int newIndex = startIndex;
             Assert.False(parser.TryParseValue(input, null, ref newIndex, out result),


### PR DESCRIPTION
Introduce a new feature switch: `System.Net.Http.MinimalHeaderValidation`. When set to `true`, this switch will allow for trimming header parsing logic that may not be needed in the app.

Contributes to #44534

Before: 2,644,974 bytes
After: 2,640,488 bytes  (with new feature switch set)

So roughly 4.5KB .br compressed savings in a Blazor WASM app. Opening this PR as "draft" to get feedback on the approach. I'm not convinced this savings is worth the tradeoff. Can anyone think of more header parsers that could be removed with the proposed feature switch?

cc @CoffeeFlux @marek-safar 