### PR TITLE
fixing assert for accounting

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28504,7 +28504,11 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
         region_index, heap_segment_mem (region), survived, 
         ((survived == heap_segment_survived (region)) ? "same as" : "diff from"),
         heap_segment_survived (region)));
+#ifdef MULTIPLE_HEAPS
+    assert (survived <= heap_segment_survived (region));
+#else
     assert (survived == heap_segment_survived (region));
+#endif //MULTIPLE_HEAPS
 #endif //_DEBUG
 
     assert (last_marked_obj_end);


### PR DESCRIPTION
I was going to change this in my last checkin but accidentally missed it. in `sweep_region_in_plan` I had an assert that says the survived we calculate should be exactly the same as what we recorded but this is not necessarily the case for server GC - the recorded could be a bit bigger as multiple threads might try to mark the same object and both are counting the size.