### PR TITLE
Exclude platform support attributes from .NET Framework builds

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -240,8 +240,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
-  <!-- If a project is downlevel from net5.0 but uses the platform support attributes, then we include the
-       System.Runtime.Versioning*Platform* annotation attribute classes in the project as internal.
+  <!-- If a project targets .NET Core downlevel from net5.0 but uses the platform support attributes, then we
+       include the System.Runtime.Versioning*Platform* annotation attribute classes in the project as internal.
 
        If a project has specified assembly-level SupportedOSPlatforms or UnsupportedOSPlatforms,
        we can infer the need without having IncludePlatformAttributes set. -->
@@ -249,7 +249,7 @@
     <IncludePlatformAttributes Condition="'$(IncludePlatformAttributes)' == '' and ('$(SupportedOSPlatforms)' != '' or '$(UnsupportedOSPlatforms)' != '')">true</IncludePlatformAttributes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IncludePlatformAttributes)' == 'true' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
+  <ItemGroup Condition="'$(IncludePlatformAttributes)' == 'true' and '$(TargetFrameworkIdentifier)' != '.NETFramework' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
     <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\PlatformAttributes.cs" Link="System\Runtime\Versioning\PlatformAttributes.cs" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -6,7 +6,9 @@
 
 namespace Microsoft.Extensions.Logging
 {
+#if !NETFRAMEWORK
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+#endif
     public static partial class ConsoleLoggerExtensions
     {
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsole(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { throw null; }
@@ -64,7 +66,9 @@ namespace Microsoft.Extensions.Logging.Console
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Please use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
         public bool UseUtcTimestamp { get { throw null; } set { } }
     }
+#if !NETFRAMEWORK
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+#endif
     [Microsoft.Extensions.Logging.ProviderAliasAttribute("Console")]
     public partial class ConsoleLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/AnsiParsingLogConsole.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/AnsiParsingLogConsole.cs
@@ -7,10 +7,12 @@ using System.Runtime.Versioning;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+#endif
     internal sealed class AnsiParsingLogConsole : IConsole
     {
         private readonly TextWriter _textWriter;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
@@ -8,7 +8,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     internal sealed class ConsoleLogger : ILogger
     {
         private readonly string _name;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
@@ -13,7 +13,9 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging
 {
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     public static class ConsoleLoggerExtensions
     {
         /// <summary>
@@ -156,7 +158,9 @@ namespace Microsoft.Extensions.Logging
         }
     }
 
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     internal sealed class ConsoleLoggerFormatterConfigureOptions<TFormatter, TOptions> : ConfigureFromConfigurationOptions<TOptions>
         where TOptions : ConsoleFormatterOptions
         where TFormatter : ConsoleFormatter
@@ -167,7 +171,9 @@ namespace Microsoft.Extensions.Logging
         }
     }
 
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     internal sealed class ConsoleLoggerFormatterOptionsChangeTokenSource<TFormatter, TOptions> : ConfigurationChangeTokenSource<TOptions>
         where TOptions : ConsoleFormatterOptions
         where TFormatter : ConsoleFormatter

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -8,7 +8,9 @@ using System.Threading;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     internal class ConsoleLoggerProcessor : IDisposable
     {
         private const int _maxQueuedMessages = 1024;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Extensions.Logging.Console
     /// <summary>
     /// A provider of <see cref="ConsoleLogger"/> instances.
     /// </summary>
+#if !NETFRAMEWORK
     [UnsupportedOSPlatform("browser")]
+#endif
     [ProviderAlias("Console")]
     public class ConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
@@ -8,7 +8,9 @@ using System.Runtime.Versioning;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
+#if !NETFRAMEWORK
     [SupportedOSPlatform("windows")]
+#endif
     internal sealed class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx

--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
@@ -607,7 +607,9 @@ namespace System.Configuration
         protected virtual string ValueAttributeName { get { throw null; } }
         public virtual object Create(object parent, object context, System.Xml.XmlNode section) { throw null; }
     }
+#if !NETFRAMEWORK
     [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+#endif
     public sealed partial class DpapiProtectedConfigurationProvider : System.Configuration.ProtectedConfigurationProvider
     {
         public DpapiProtectedConfigurationProvider() { }

--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -594,12 +594,18 @@ namespace System.Drawing
         public static System.Drawing.Graphics FromHwndInternal(System.IntPtr hwnd) { throw null; }
         public static System.Drawing.Graphics FromImage(System.Drawing.Image image) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+#endif
         [System.ObsoleteAttribute("Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations.", DiagnosticId = "SYSLIB0016", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public object GetContextInfo() { throw null; }
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+#endif
         public void GetContextInfo(out PointF offset) { throw null; }
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+#endif
         public void GetContextInfo(out PointF offset, out Region? clip) { throw null; }
         public static System.IntPtr GetHalftonePalette() { throw null; }
         public System.IntPtr GetHdc() { throw null; }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
@@ -647,13 +647,17 @@ namespace System.IO
             FileSystem.MoveFile(fullSourceFileName, fullDestFileName, overwrite);
         }
 
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows")]
+#endif
         public static void Encrypt(string path)
         {
             FileSystem.Encrypt(path ?? throw new ArgumentNullException(nameof(path)));
         }
 
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows")]
+#endif
         public static void Decrypt(string path)
         {
             FileSystem.Decrypt(path ?? throw new ArgumentNullException(nameof(path)));

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -183,10 +183,14 @@ namespace System.IO
             return new FileInfo(destinationFileName);
         }
 
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows")]
+#endif
         public void Decrypt() => File.Decrypt(FullPath);
 
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows")]
+#endif
         public void Encrypt() => File.Encrypt(FullPath);
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -44,11 +44,17 @@ namespace System.Net.Http
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateValidationCallback { get { throw null; } set { } }
         public System.Net.ICredentials? ServerCredentials { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
+#endif
         public bool TcpKeepAliveEnabled { get { throw null; } set { } }
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
+#endif
         public System.TimeSpan TcpKeepAliveTime { get { throw null; } set { } }
+#if !NETFRAMEWORK
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
+#endif
         public System.TimeSpan TcpKeepAliveInterval { get { throw null; } set { } }
         public System.Net.Http.WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -423,7 +423,9 @@ namespace System.Net.Http
         /// If enabled, the values of <see cref="TcpKeepAliveInterval" /> and <see cref="TcpKeepAliveTime"/> will be forwarded
         /// to set WINHTTP_OPTION_TCP_KEEPALIVE, enabling and configuring TCP keep-alive for the backing TCP socket.
         /// </remarks>
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows10.0.19041")]
+#endif
         public bool TcpKeepAliveEnabled
         {
             get
@@ -445,7 +447,9 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 2 hours.
         /// </remarks>
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows10.0.19041")]
+#endif
         public TimeSpan TcpKeepAliveTime
         {
             get
@@ -468,7 +472,9 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 1 second.
         /// </remarks>
+#if !NETFRAMEWORK
         [SupportedOSPlatform("windows10.0.19041")]
+#endif
         public TimeSpan TcpKeepAliveInterval
         {
             get


### PR DESCRIPTION
As was discovered by @ViktorHofer, the build currently allows the `OSPlatformAttribute` types to be included in the .NET Framework assemblies. This is occurring for assemblies that utilize `SupportedOSPlatform` or `UnsupportedOSPlatform` and a .NET Framework target exists. Through the logic in `src/libraries/Directory.Build.targets` where `$(IncludePlatformAttributes)` is handled, we add the types as internal to any target down-level from net5.0. We should have excluded .NET Framework from that down-leveling though.

<details>
<summary>Here are the assemblies that currently end up getting internal copies of these attributes:</summary>

* net461-windows-Debug\Microsoft.Diagnostics.Tracing.EventSource.dll
* net461-Debug\Microsoft.Extensions.Logging.Console.dll
    * ref\net461-Debug\Microsoft.Extensions.Logging.Console.dll
* net461-Debug\Microsoft.Extensions.Logging.EventLog.dll
    * ref\net461-Debug\Microsoft.Extensions.Logging.EventLog.dll
* net472-Debug\Microsoft.IO.Redist.dll
* net461-windows-Debug\Microsoft.Win32.Registry.dll
    * ref\net461-Debug\Microsoft.Win32.Registry.dll
* net461-windows-Debug\Microsoft.Win32.Registry.AccessControl.dll
    * ref\net461-Debug\Microsoft.Win32.Registry.AccessControl.dll
* net461-Debug\Microsoft.Win32.SystemEvents.dll
    * ref\net461-Debug\Microsoft.Win32.SystemEvents.dll
* net461-Debug\System.Configuration.ConfigurationManager.dll
    * ref\net461-Debug\System.Configuration.ConfigurationManager.dll
* net461-windows-Debug\System.Data.Odbc.dll
    * ref\net461-Debug\System.Data.Odbc.dll
* net461-windows-Debug\System.Data.OleDb.dll
    * ref\net461-Debug\System.Data.OleDb.dll
* net461-Debug\System.Diagnostics.EventLog.dll
    * ref\net461-Debug\System.Diagnostics.EventLog.dll
* net461-Debug\System.Diagnostics.PerformanceCounter.dll
    * ref\net461-Debug\System.Diagnostics.PerformanceCounter.dll
* net461-Debug\System.Drawing.Common.dll
    * ref\net461-Debug\System.Drawing.Common.dll
* net461-windows-Debug\System.IO.FileSystem.AccessControl.dll
    * ref\net461-Debug\System.IO.FileSystem.AccessControl.dll
* net461-windows-Debug\System.IO.Ports.dll
    * ref\net461-Debug\System.IO.Ports.dll
* net461-windows-Debug\System.Net.Http.WinHttpHandler.dll
    * ref\net461-Debug\System.Net.Http.WinHttpHandler.dll
* net461-windows-Debug\System.Security.AccessControl.dll
    * ref\net461-Debug\System.Security.AccessControl.dll
* net461-windows-Debug\System.Security.Cryptography.Pkcs.dll
    * ref\net461-Debug\System.Security.Cryptography.Pkcs.dll
* net461-windows-Debug\System.Security.Cryptography.ProtectedData.dll
    * ref\net461-Debug\System.Security.Cryptography.ProtectedData.dll
* net461-Debug\System.Security.Cryptography.Xml.dll
    * ref\net461-Debug\System.Security.Cryptography.Xml.dll
* net461-Debug\System.Security.Permissions.dll
    * ref\net461-Debug\System.Security.Permissions.dll
* net461-windows-Debug\System.Security.Principal.Windows.dll
    * ref\net461-Debug\System.Security.Principal.Windows.dll
* net461-windows-Debug\System.ServiceModel.Syndication.dll
    * ref\net461-Debug\System.ServiceModel.Syndication.dll
* net461-windows-Debug\System.ServiceProcess.ServiceController.dll
    * ref\net461-Debug\System.ServiceProcess.ServiceController.dll
* net461-windows-Debug\System.Text.Encoding.CodePages.dll
    * ref\net461-Debug\System.Text.Encoding.CodePages.dll
* net461-windows-Debug\System.Threading.AccessControl.dll
    * ref\net461-Debug\System.Threading.AccessControl.dll

</details>

With this change, the `$(IncludePlatformAttributes)` property will no longer be respected when targeting .NET Framework. This requires any OSPlatform attribute usage in assemblies that target .NET Framework to be wrapped in `#if !NETFRAMEWORK`.

After making these changes, I verified through ILSpy that none of the assemblies shown above include the OSPlatformAttribute types anymore.