### PR TITLE
Sockets.tests: TcpReceiveSendGetsCanceledByDispose: remove Timeout.

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -994,7 +994,7 @@ namespace System.Net.Sockets.Tests
             { false, true, false },
         };
 
-        [Theory(Timeout = 40000)]
+        [Theory]
         [MemberData(nameof(TcpReceiveSendGetsCanceledByDispose_Data))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
         public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, bool ipv6Server, bool dualModeClient)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1026,7 +1026,9 @@ namespace System.Net.Sockets.Tests
                             var buffer = new ArraySegment<byte>(new byte[4096]);
                             while (true)
                             {
-                                SendAsync(socket1, buffer).GetAwaiter().GetResult();
+                                SendAsync(socket1, buffer)
+                                    .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout))
+                                    .GetAwaiter().GetResult();
                             }
                         });
                     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -950,7 +950,8 @@ namespace System.Net.Sockets.Tests
                 msDelay *= 2;
                 Task disposeTask = Task.Run(() => socket.Dispose());
 
-                await Task.WhenAny(disposeTask, receiveTask).WaitAsync(TimeSpan.FromSeconds(30));
+                await Task.WhenAny(disposeTask, receiveTask)
+                          .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                 await disposeTask;
 
                 SocketError? localSocketError = null;
@@ -1035,14 +1036,17 @@ namespace System.Net.Sockets.Tests
                     msDelay *= 2;
                     Task disposeTask = Task.Run(() => socket1.Dispose());
 
-                    await Task.WhenAny(disposeTask, socketOperation).WaitAsync(TimeSpan.FromSeconds(30));
-                    await disposeTask;
+                    await Task.WhenAny(disposeTask, socketOperation)
+                              .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
+                    await disposeTask
+                              .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
 
                     SocketError? localSocketError = null;
                     bool disposedException = false;
                     try
                     {
-                        await socketOperation;
+                        await socketOperation
+                              .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                     }
                     catch (SocketException se)
                     {
@@ -1077,7 +1081,8 @@ namespace System.Net.Sockets.Tests
                         {
                             try
                             {
-                                int received = await ReceiveAsync(socket2, receiveBuffer);
+                                int received = await ReceiveAsync(socket2, receiveBuffer)
+                                                     .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
                                 if (received == 0)
                                 {
                                     break;


### PR DESCRIPTION
This timeout is not needed and masks a more useful exception thrown
by the test.

To help debug https://github.com/dotnet/runtime/issues/52597.

@antonfirsov ptal