### PR TITLE
Modify JIT to support double mapped memory

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1929,24 +1929,12 @@ bool interceptor_ICJI::runWithErrorTrap(void (*function)(void*), void* param)
 }
 
 // get a block of memory for the code, readonly data, and read-write data
-void interceptor_ICJI::allocMem(uint32_t           hotCodeSize,   /* IN */
-                                uint32_t           coldCodeSize,  /* IN */
-                                uint32_t           roDataSize,    /* IN */
-                                uint32_t           xcptnsCount,   /* IN */
-                                CorJitAllocMemFlag flag,          /* IN */
-                                void **             hotCodeBlock,   /* OUT */
-                                void **             hotCodeBlockRW, /* OUT */
-                                void **             coldCodeBlock,  /* OUT */
-                                void **             coldCodeBlockRW,/* OUT */
-                                void **             roDataBlock,    /* OUT */
-                                void **             roDataBlockRW   /* OUT */
-                                )
+void interceptor_ICJI::allocMem(AllocMemArgs *pArgs)
 {
     mc->cr->AddCall("allocMem");
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW,
-                                   coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
-    mc->cr->recAllocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock,
-                        roDataBlock);
+    original_ICorJitInfo->allocMem(pArgs);
+    mc->cr->recAllocMem(pArgs->hotCodeSize, pArgs->coldCodeSize, pArgs->roDataSize, pArgs->xcptnsCount, pArgs->flag, &pArgs->hotCodeBlock, &pArgs->coldCodeBlock,
+                        &pArgs->roDataBlock);
 }
 
 void interceptor_ICJI::doneWritingCode()

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1937,12 +1937,6 @@ void interceptor_ICJI::allocMem(AllocMemArgs *pArgs)
                         &pArgs->roDataBlock);
 }
 
-void interceptor_ICJI::doneWritingCode()
-{
-    mc->cr->AddCall("doneWritingCode");
-    original_ICorJitInfo->doneWritingCode();
-}
-
 // Reserve memory for the method/funclet's unwind information.
 // Note that this must be called before allocMem. It should be
 // called once for the main method, once for every funclet, and

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1934,16 +1934,25 @@ void interceptor_ICJI::allocMem(uint32_t           hotCodeSize,   /* IN */
                                 uint32_t           roDataSize,    /* IN */
                                 uint32_t           xcptnsCount,   /* IN */
                                 CorJitAllocMemFlag flag,          /* IN */
-                                void**             hotCodeBlock,  /* OUT */
-                                void**             coldCodeBlock, /* OUT */
-                                void**             roDataBlock    /* OUT */
+                                void **             hotCodeBlock,   /* OUT */
+                                void **             hotCodeBlockRW, /* OUT */
+                                void **             coldCodeBlock,  /* OUT */
+                                void **             coldCodeBlockRW,/* OUT */
+                                void **             roDataBlock,    /* OUT */
+                                void **             roDataBlockRW   /* OUT */
                                 )
 {
     mc->cr->AddCall("allocMem");
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock,
-                                   coldCodeBlock, roDataBlock);
+    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW,
+                                   coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
     mc->cr->recAllocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock,
                         roDataBlock);
+}
+
+void interceptor_ICJI::doneWritingCode()
+{
+    mc->cr->AddCall("doneWritingCode");
+    original_ICorJitInfo->doneWritingCode();
 }
 
 // Reserve memory for the method/funclet's unwind information.
@@ -2101,6 +2110,7 @@ void interceptor_ICJI::recordCallSite(uint32_t              instrOffset, /* IN *
 // A relocation is recorded if we are pre-jitting.
 // A jump thunk may be inserted if we are jitting
 void interceptor_ICJI::recordRelocation(void*    location,   /* IN  */
+                                        void*    locationRW, /* IN  */
                                         void*    target,     /* IN  */
                                         uint16_t fRelocType, /* IN  */
                                         uint16_t slotNum,    /* IN  */
@@ -2108,7 +2118,7 @@ void interceptor_ICJI::recordRelocation(void*    location,   /* IN  */
                                         )
 {
     mc->cr->AddCall("recordRelocation");
-    original_ICorJitInfo->recordRelocation(location, target, fRelocType, slotNum, addlDelta);
+    original_ICorJitInfo->recordRelocation(location, locationRW, target, fRelocType, slotNum, addlDelta);
     mc->cr->recRecordRelocation(location, target, fRelocType, slotNum, addlDelta);
 }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -1250,20 +1250,10 @@ bool interceptor_ICJI::notifyInstructionSetUsage(
 }
 
 void interceptor_ICJI::allocMem(
-          uint32_t hotCodeSize,
-          uint32_t coldCodeSize,
-          uint32_t roDataSize,
-          uint32_t xcptnsCount,
-          CorJitAllocMemFlag flag,
-          void** hotCodeBlock,
-          void** hotCodeBlockRW,
-          void** coldCodeBlock,
-          void** coldCodeBlockRW,
-          void** roDataBlock,
-          void** roDataBlockRW)
+          AllocMemArgs* pArgs)
 {
     mcs->AddCall("allocMem");
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
+    original_ICorJitInfo->allocMem(pArgs);
 }
 
 void interceptor_ICJI::reserveUnwindInfo(

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -1256,11 +1256,14 @@ void interceptor_ICJI::allocMem(
           uint32_t xcptnsCount,
           CorJitAllocMemFlag flag,
           void** hotCodeBlock,
+          void** hotCodeBlockRW,
           void** coldCodeBlock,
-          void** roDataBlock)
+          void** coldCodeBlockRW,
+          void** roDataBlock,
+          void** roDataBlockRW)
 {
     mcs->AddCall("allocMem");
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
+    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
 }
 
 void interceptor_ICJI::reserveUnwindInfo(
@@ -1363,13 +1366,14 @@ void interceptor_ICJI::recordCallSite(
 
 void interceptor_ICJI::recordRelocation(
           void* location,
+          void* locationRW,
           void* target,
           uint16_t fRelocType,
           uint16_t slotNum,
           int32_t addlDelta)
 {
     mcs->AddCall("recordRelocation");
-    original_ICorJitInfo->recordRelocation(location, target, fRelocType, slotNum, addlDelta);
+    original_ICorJitInfo->recordRelocation(location, locationRW, target, fRelocType, slotNum, addlDelta);
 }
 
 uint16_t interceptor_ICJI::getRelocTypeHint(
@@ -1391,5 +1395,11 @@ uint32_t interceptor_ICJI::getJitFlags(
 {
     mcs->AddCall("getJitFlags");
     return original_ICorJitInfo->getJitFlags(flags, sizeInBytes);
+}
+
+void interceptor_ICJI::doneWritingCode()
+{
+    mcs->AddCall("doneWritingCode");
+    original_ICorJitInfo->doneWritingCode();
 }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -1387,9 +1387,3 @@ uint32_t interceptor_ICJI::getJitFlags(
     return original_ICorJitInfo->getJitFlags(flags, sizeInBytes);
 }
 
-void interceptor_ICJI::doneWritingCode()
-{
-    mcs->AddCall("doneWritingCode");
-    original_ICorJitInfo->doneWritingCode();
-}
-

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -1094,19 +1094,9 @@ bool interceptor_ICJI::notifyInstructionSetUsage(
 }
 
 void interceptor_ICJI::allocMem(
-          uint32_t hotCodeSize,
-          uint32_t coldCodeSize,
-          uint32_t roDataSize,
-          uint32_t xcptnsCount,
-          CorJitAllocMemFlag flag,
-          void** hotCodeBlock,
-          void** hotCodeBlockRW,
-          void** coldCodeBlock,
-          void** coldCodeBlockRW,
-          void** roDataBlock,
-          void** roDataBlockRW)
+          AllocMemArgs* pArgs)
 {
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
+    original_ICorJitInfo->allocMem(pArgs);
 }
 
 void interceptor_ICJI::reserveUnwindInfo(

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -1215,8 +1215,3 @@ uint32_t interceptor_ICJI::getJitFlags(
     return original_ICorJitInfo->getJitFlags(flags, sizeInBytes);
 }
 
-void interceptor_ICJI::doneWritingCode()
-{
-    original_ICorJitInfo->doneWritingCode();
-}
-

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -1100,10 +1100,13 @@ void interceptor_ICJI::allocMem(
           uint32_t xcptnsCount,
           CorJitAllocMemFlag flag,
           void** hotCodeBlock,
+          void** hotCodeBlockRW,
           void** coldCodeBlock,
-          void** roDataBlock)
+          void** coldCodeBlockRW,
+          void** roDataBlock,
+          void** roDataBlockRW)
 {
-    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
+    original_ICorJitInfo->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
 }
 
 void interceptor_ICJI::reserveUnwindInfo(
@@ -1195,12 +1198,13 @@ void interceptor_ICJI::recordCallSite(
 
 void interceptor_ICJI::recordRelocation(
           void* location,
+          void* locationRW,
           void* target,
           uint16_t fRelocType,
           uint16_t slotNum,
           int32_t addlDelta)
 {
-    original_ICorJitInfo->recordRelocation(location, target, fRelocType, slotNum, addlDelta);
+    original_ICorJitInfo->recordRelocation(location, locationRW, target, fRelocType, slotNum, addlDelta);
 }
 
 uint16_t interceptor_ICJI::getRelocTypeHint(
@@ -1219,5 +1223,10 @@ uint32_t interceptor_ICJI::getJitFlags(
           uint32_t sizeInBytes)
 {
     return original_ICorJitInfo->getJitFlags(flags, sizeInBytes);
+}
+
+void interceptor_ICJI::doneWritingCode()
+{
+    original_ICorJitInfo->doneWritingCode();
 }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1866,8 +1866,3 @@ uint32_t MyICJI::getExpectedTargetArchitecture()
     DWORD result = jitInstance->mc->repGetExpectedTargetArchitecture();
     return result;
 }
-
-void MyICJI::doneWritingCode()
-{
-    jitInstance->mc->cr->AddCall("doneWritingCode");
-}

--- a/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1606,9 +1606,12 @@ void MyICJI::allocMem(uint32_t           hotCodeSize,   /* IN */
                       uint32_t           roDataSize,    /* IN */
                       uint32_t           xcptnsCount,   /* IN */
                       CorJitAllocMemFlag flag,          /* IN */
-                      void**             hotCodeBlock,  /* OUT */
-                      void**             coldCodeBlock, /* OUT */
-                      void**             roDataBlock    /* OUT */
+                      void **             hotCodeBlock,   /* OUT */
+                      void **             hotCodeBlockRW, /* OUT */
+                      void **             coldCodeBlock,  /* OUT */
+                      void **             coldCodeBlockRW,/* OUT */
+                      void **             roDataBlock,    /* OUT */
+                      void **             roDataBlockRW   /* OUT */
                       )
 {
     jitInstance->mc->cr->AddCall("allocMem");
@@ -1665,6 +1668,10 @@ void MyICJI::allocMem(uint32_t           hotCodeSize,   /* IN */
     }
     else
         *roDataBlock = nullptr;
+
+    *hotCodeBlockRW = *hotCodeBlock;
+    *coldCodeBlockRW = *coldCodeBlock;
+    *roDataBlockRW = *roDataBlock;
 
     jitInstance->mc->cr->recAllocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock,
                                      coldCodeBlock, roDataBlock);
@@ -1841,6 +1848,7 @@ void MyICJI::recordCallSite(uint32_t              instrOffset, /* IN */
 // A relocation is recorded if we are pre-jitting.
 // A jump thunk may be inserted if we are jitting
 void MyICJI::recordRelocation(void*    location,   /* IN  */
+                              void*    locationRW, /* IN  */
                               void*    target,     /* IN  */
                               uint16_t fRelocType, /* IN  */
                               uint16_t slotNum,    /* IN  */
@@ -1868,4 +1876,9 @@ uint32_t MyICJI::getExpectedTargetArchitecture()
     jitInstance->mc->cr->AddCall("getExpectedTargetArchitecture");
     DWORD result = jitInstance->mc->repGetExpectedTargetArchitecture();
     return result;
+}
+
+void MyICJI::doneWritingCode()
+{
+    jitInstance->mc->cr->AddCall("doneWritingCode");
 }

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -142,6 +142,24 @@ enum CheckedWriteBarrierKinds {
     CWBKind_AddrOfLocal,     // Store through the address of a local (arguably a bug that this happens at all).
 };
 
+struct AllocMemArgs
+{
+    // Input arguments
+    uint32_t hotCodeSize;
+    uint32_t coldCodeSize;
+    uint32_t roDataSize;
+    uint32_t xcptnsCount;
+    CorJitAllocMemFlag flag;
+
+    // Output arguments
+    void* hotCodeBlock;
+    void* hotCodeBlockRW;
+    void* coldCodeBlock;
+    void* coldCodeBlockRW;
+    void* roDataBlock;
+    void* roDataBlockRW;
+};
+
 #include "corjithost.h"
 
 extern "C" void jitStartup(ICorJitHost* host);
@@ -212,17 +230,7 @@ class ICorJitInfo : public ICorDynamicInfo
 public:
     // get a block of memory for the code, readonly data, and read-write data
     virtual void allocMem (
-            uint32_t               hotCodeSize,    /* IN */
-            uint32_t               coldCodeSize,   /* IN */
-            uint32_t               roDataSize,     /* IN */
-            uint32_t               xcptnsCount,    /* IN */
-            CorJitAllocMemFlag  flag,           /* IN */
-            void **             hotCodeBlock,   /* OUT */
-            void **             hotCodeBlockRW, /* OUT */
-            void **             coldCodeBlock,  /* OUT */
-            void **             coldCodeBlockRW,/* OUT */
-            void **             roDataBlock,     /* OUT */
-            void **             roDataBlockRW   /* OUT */
+            AllocMemArgs *pArgs
             ) = 0;
 
     // Reserve memory for the method/funclet's unwind information.

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -218,8 +218,11 @@ public:
             uint32_t               xcptnsCount,    /* IN */
             CorJitAllocMemFlag  flag,           /* IN */
             void **             hotCodeBlock,   /* OUT */
+            void **             hotCodeBlockRW, /* OUT */
             void **             coldCodeBlock,  /* OUT */
-            void **             roDataBlock     /* OUT */
+            void **             coldCodeBlockRW,/* OUT */
+            void **             roDataBlock,     /* OUT */
+            void **             roDataBlockRW   /* OUT */
             ) = 0;
 
     // Reserve memory for the method/funclet's unwind information.
@@ -430,6 +433,7 @@ public:
     // A jump thunk may be inserted if we are jitting
     virtual void recordRelocation(
             void *                 location,   /* IN  */
+            void *                 locationRW, /* IN  */
             void *                 target,     /* IN  */
             uint16_t                   fRelocType, /* IN  */
             uint16_t                   slotNum = 0,  /* IN  */
@@ -452,6 +456,9 @@ public:
         uint32_t        sizeInBytes   /* IN: The size of the buffer. Note that this is effectively a
                                           version number for the CORJIT_FLAGS value. */
         ) = 0;
+
+    // Notify the EE that JIT is done writing to the memory allocated for code
+    virtual void doneWritingCode() = 0;
 };
 
 /**********************************************************************************/

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -464,9 +464,6 @@ public:
         uint32_t        sizeInBytes   /* IN: The size of the buffer. Note that this is effectively a
                                           version number for the CORJIT_FLAGS value. */
         ) = 0;
-
-    // Notify the EE that JIT is done writing to the memory allocated for code
-    virtual void doneWritingCode() = 0;
 };
 
 /**********************************************************************************/

--- a/src/coreclr/inc/icorjitinfoimpl_generated.h
+++ b/src/coreclr/inc/icorjitinfoimpl_generated.h
@@ -641,8 +641,11 @@ void allocMem(
           uint32_t xcptnsCount,
           CorJitAllocMemFlag flag,
           void** hotCodeBlock,
+          void** hotCodeBlockRW,
           void** coldCodeBlock,
-          void** roDataBlock) override;
+          void** coldCodeBlockRW,
+          void** roDataBlock,
+          void** roDataBlockRW) override;
 
 void reserveUnwindInfo(
           bool isFunclet,
@@ -700,6 +703,7 @@ void recordCallSite(
 
 void recordRelocation(
           void* location,
+          void* locationRW,
           void* target,
           uint16_t fRelocType,
           uint16_t slotNum,
@@ -713,6 +717,8 @@ uint32_t getExpectedTargetArchitecture() override;
 uint32_t getJitFlags(
           CORJIT_FLAGS* flags,
           uint32_t sizeInBytes) override;
+
+void doneWritingCode() override;
 
 /**********************************************************************************/
 // clang-format on

--- a/src/coreclr/inc/icorjitinfoimpl_generated.h
+++ b/src/coreclr/inc/icorjitinfoimpl_generated.h
@@ -635,17 +635,7 @@ bool notifyInstructionSetUsage(
           bool supportEnabled) override;
 
 void allocMem(
-          uint32_t hotCodeSize,
-          uint32_t coldCodeSize,
-          uint32_t roDataSize,
-          uint32_t xcptnsCount,
-          CorJitAllocMemFlag flag,
-          void** hotCodeBlock,
-          void** hotCodeBlockRW,
-          void** coldCodeBlock,
-          void** coldCodeBlockRW,
-          void** roDataBlock,
-          void** roDataBlockRW) override;
+          AllocMemArgs* pArgs) override;
 
 void reserveUnwindInfo(
           bool isFunclet,

--- a/src/coreclr/inc/icorjitinfoimpl_generated.h
+++ b/src/coreclr/inc/icorjitinfoimpl_generated.h
@@ -708,8 +708,6 @@ uint32_t getJitFlags(
           CORJIT_FLAGS* flags,
           uint32_t sizeInBytes) override;
 
-void doneWritingCode() override;
-
 /**********************************************************************************/
 // clang-format on
 /**********************************************************************************/

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,12 +43,13 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 12234eca-dfc2-48bc-a320-6155cf25ce17 */
-    0x12234eca,
-    0xdfc2,
-    0x48bc,
-    {0xa3, 0x20, 0x61, 0x55, 0xcf, 0x25, 0xce, 0x17}
+constexpr GUID JITEEVersionIdentifier = { /* 529be99f-ce88-426e-a099-7528a691226c */
+    0x529be99f,
+    0xce88,
+    0x426e,
+    { 0xa0, 0x99, 0x75, 0x28, 0xa6, 0x91, 0x22, 0x6c }
 };
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/jit/ICorJitInfo_API_names.h
+++ b/src/coreclr/jit/ICorJitInfo_API_names.h
@@ -176,6 +176,5 @@ DEF_CLR_API(recordRelocation)
 DEF_CLR_API(getRelocTypeHint)
 DEF_CLR_API(getExpectedTargetArchitecture)
 DEF_CLR_API(getJitFlags)
-DEF_CLR_API(doneWritingCode)
 
 #undef DEF_CLR_API

--- a/src/coreclr/jit/ICorJitInfo_API_names.h
+++ b/src/coreclr/jit/ICorJitInfo_API_names.h
@@ -176,5 +176,6 @@ DEF_CLR_API(recordRelocation)
 DEF_CLR_API(getRelocTypeHint)
 DEF_CLR_API(getExpectedTargetArchitecture)
 DEF_CLR_API(getJitFlags)
+DEF_CLR_API(doneWritingCode)
 
 #undef DEF_CLR_API

--- a/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
+++ b/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
@@ -1526,20 +1526,10 @@ bool WrapICorJitInfo::notifyInstructionSetUsage(
 }
 
 void WrapICorJitInfo::allocMem(
-          uint32_t hotCodeSize,
-          uint32_t coldCodeSize,
-          uint32_t roDataSize,
-          uint32_t xcptnsCount,
-          CorJitAllocMemFlag flag,
-          void** hotCodeBlock,
-          void** hotCodeBlockRW,
-          void** coldCodeBlock,
-          void** coldCodeBlockRW,
-          void** roDataBlock,
-          void** roDataBlockRW)
+          AllocMemArgs* pArgs)
 {
     API_ENTER(allocMem);
-    wrapHnd->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
+    wrapHnd->allocMem(pArgs);
     API_LEAVE(allocMem);
 }
 

--- a/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
+++ b/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
@@ -1532,11 +1532,14 @@ void WrapICorJitInfo::allocMem(
           uint32_t xcptnsCount,
           CorJitAllocMemFlag flag,
           void** hotCodeBlock,
+          void** hotCodeBlockRW,
           void** coldCodeBlock,
-          void** roDataBlock)
+          void** coldCodeBlockRW,
+          void** roDataBlock,
+          void** roDataBlockRW)
 {
     API_ENTER(allocMem);
-    wrapHnd->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
+    wrapHnd->allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
     API_LEAVE(allocMem);
 }
 
@@ -1656,13 +1659,14 @@ void WrapICorJitInfo::recordCallSite(
 
 void WrapICorJitInfo::recordRelocation(
           void* location,
+          void* locationRW,
           void* target,
           uint16_t fRelocType,
           uint16_t slotNum,
           int32_t addlDelta)
 {
     API_ENTER(recordRelocation);
-    wrapHnd->recordRelocation(location, target, fRelocType, slotNum, addlDelta);
+    wrapHnd->recordRelocation(location, locationRW, target, fRelocType, slotNum, addlDelta);
     API_LEAVE(recordRelocation);
 }
 
@@ -1691,6 +1695,13 @@ uint32_t WrapICorJitInfo::getJitFlags(
     uint32_t temp = wrapHnd->getJitFlags(flags, sizeInBytes);
     API_LEAVE(getJitFlags);
     return temp;
+}
+
+void WrapICorJitInfo::doneWritingCode()
+{
+    API_ENTER(doneWritingCode);
+    wrapHnd->doneWritingCode();
+    API_LEAVE(doneWritingCode);
 }
 
 /**********************************************************************************/

--- a/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
+++ b/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
@@ -1687,13 +1687,6 @@ uint32_t WrapICorJitInfo::getJitFlags(
     return temp;
 }
 
-void WrapICorJitInfo::doneWritingCode()
-{
-    API_ENTER(doneWritingCode);
-    wrapHnd->doneWritingCode();
-    API_LEAVE(doneWritingCode);
-}
-
 /**********************************************************************************/
 // clang-format on
 /**********************************************************************************/

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6752,7 +6752,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
     {
         size_t dscSize = dsc->dsSize;
 
-        BYTE *dstRW = dst + writeableOffset;
+        BYTE* dstRW = dst + writeableOffset;
 
         // absolute label table
         if (dsc->dsType == dataSection::blockAbsoluteAddr)
@@ -6761,7 +6761,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
 
             assert(dscSize && dscSize % TARGET_POINTER_SIZE == 0);
             size_t         numElems = dscSize / TARGET_POINTER_SIZE;
-            target_size_t* bDstRW     = (target_size_t*)dstRW;
+            target_size_t* bDstRW   = (target_size_t*)dstRW;
             for (unsigned i = 0; i < numElems; i++)
             {
                 BasicBlock* block = ((BasicBlock**)dsc->dsCont)[i];
@@ -6790,7 +6790,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
             JITDUMP("  section %u, size %u, block relative addr\n", secNum++, dscSize);
 
             size_t    numElems = dscSize / 4;
-            unsigned* uDstRW     = (unsigned*)dstRW;
+            unsigned* uDstRW   = (unsigned*)dstRW;
             insGroup* labFirst = (insGroup*)emitCodeGetCookie(emitComp->fgFirstBB);
 
             for (unsigned i = 0; i < numElems; i++)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5335,13 +5335,13 @@ void emitter::emitComputeCodeSizes()
 // Returns:
 //    size of the method code, in bytes
 //
-unsigned emitter::writeCode(bool contTrkPtrLcls,
+unsigned emitter::writeCode(bool      contTrkPtrLcls,
                             unsigned* prologSize,
                             unsigned* epilogSize,
-                            BYTE* codeBlock,
-                            BYTE* codeBlockRW,
-                            BYTE* coldCodeBlock,
-                            BYTE* coldCodeBlockRW,
+                            BYTE*     codeBlock,
+                            BYTE*     codeBlockRW,
+                            BYTE*     coldCodeBlock,
+                            BYTE*     coldCodeBlockRW,
                             BYTE* consBlock DEBUGARG(unsigned* instrCount))
 {
     BYTE* cp;
@@ -5996,7 +5996,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     BYTE* codeBlockRW;
     BYTE* coldCodeBlock;
     BYTE* coldCodeBlockRW;
-    
+
     assert(emitCurIG == nullptr);
 
     emitCodeBlock = nullptr;
@@ -6171,38 +6171,38 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         assert((roDataAlignmentDelta == 0) || (roDataAlignmentDelta == 4));
     }
 
-    args.hotCodeSize = emitTotalHotCodeSize + roDataAlignmentDelta + emitConsDsc.dsdOffs;
+    args.hotCodeSize  = emitTotalHotCodeSize + roDataAlignmentDelta + emitConsDsc.dsdOffs;
     args.coldCodeSize = emitTotalColdCodeSize;
-    args.roDataSize = 0;
-    args.xcptnsCount = xcptnsCount;
-    args.flag = allocMemFlag;
+    args.roDataSize   = 0;
+    args.xcptnsCount  = xcptnsCount;
+    args.flag         = allocMemFlag;
 
     emitCmpHandle->allocMem(&args);
 
-    codeBlock = (BYTE*)args.hotCodeBlock;
-    codeBlockRW = (BYTE*)args.hotCodeBlockRW;
-    coldCodeBlock = (BYTE*)args.coldCodeBlock;
+    codeBlock       = (BYTE*)args.hotCodeBlock;
+    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
+    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
     coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
 
-    consBlock = codeBlock + emitTotalHotCodeSize + roDataAlignmentDelta;
+    consBlock   = codeBlock + emitTotalHotCodeSize + roDataAlignmentDelta;
     consBlockRW = codeBlockRW + emitTotalHotCodeSize + roDataAlignmentDelta;
 
 #else
 
-    args.hotCodeSize = emitTotalHotCodeSize;
+    args.hotCodeSize  = emitTotalHotCodeSize;
     args.coldCodeSize = emitTotalColdCodeSize;
-    args.roDataSize = emitConsDsc.dsdOffs;
-    args.xcptnsCount = xcptnsCount;
-    args.flag = allocMemFlag;
+    args.roDataSize   = emitConsDsc.dsdOffs;
+    args.xcptnsCount  = xcptnsCount;
+    args.flag         = allocMemFlag;
 
     emitCmpHandle->allocMem(&args);
 
-    codeBlock = (BYTE*)args.hotCodeBlock;
-    codeBlockRW = (BYTE*)args.hotCodeBlockRW;
-    coldCodeBlock = (BYTE*)args.coldCodeBlock;
+    codeBlock       = (BYTE*)args.hotCodeBlock;
+    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
+    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
     coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
-    consBlock = (BYTE*)args.roDataBlock;
-    consBlockRW = (BYTE*)args.roDataBlockRW;
+    consBlock       = (BYTE*)args.roDataBlock;
+    consBlockRW     = (BYTE*)args.roDataBlockRW;
 
 #endif
 
@@ -6224,36 +6224,40 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
     struct Param
     {
-        emitter* pThis;
-        unsigned actualCodeSize;
-        bool contTrkPtrLcls;
+        emitter*  pThis;
+        unsigned  actualCodeSize;
+        bool      contTrkPtrLcls;
         unsigned* prologSize;
         unsigned* epilogSize;
-        BYTE* codeBlock;
-        BYTE* codeBlockRW;
-        BYTE* coldCodeBlock;
-        BYTE* coldCodeBlockRW;
-        BYTE* consBlock;
+        BYTE*     codeBlock;
+        BYTE*     codeBlockRW;
+        BYTE*     coldCodeBlock;
+        BYTE*     coldCodeBlockRW;
+        BYTE*     consBlock;
         INDEBUG(unsigned* instrCount;)
     } param;
 
-    param.pThis = this;
-    param.contTrkPtrLcls = contTrkPtrLcls;
-    param.prologSize = prologSize;
-    param.epilogSize = epilogSize;
-    param.codeBlock = codeBlock;
-    param.codeBlockRW = codeBlockRW;
-    param.coldCodeBlock = coldCodeBlock;
+    param.pThis           = this;
+    param.contTrkPtrLcls  = contTrkPtrLcls;
+    param.prologSize      = prologSize;
+    param.epilogSize      = epilogSize;
+    param.codeBlock       = codeBlock;
+    param.codeBlockRW     = codeBlockRW;
+    param.coldCodeBlock   = coldCodeBlock;
     param.coldCodeBlockRW = coldCodeBlockRW;
-    param.consBlock = consBlock;
+    param.consBlock       = consBlock;
 #ifdef DEBUG
     param.instrCount = instrCount;
 #endif
 
     bool success = comp->eeRunWithErrorTrap<Param>(
         [](Param* pParam) {
-            pParam->actualCodeSize = pParam->pThis->writeCode(pParam->contTrkPtrLcls, pParam->prologSize, pParam->epilogSize, pParam->codeBlock, pParam->codeBlockRW, pParam->coldCodeBlock, pParam->coldCodeBlockRW, pParam->consBlock DEBUGARG(pParam->instrCount));
-        }, &param);
+            pParam->actualCodeSize =
+                pParam->pThis->writeCode(pParam->contTrkPtrLcls, pParam->prologSize, pParam->epilogSize,
+                                         pParam->codeBlock, pParam->codeBlockRW, pParam->coldCodeBlock,
+                                         pParam->coldCodeBlockRW, pParam->consBlock DEBUGARG(pParam->instrCount));
+        },
+        &param);
 
     // Ensure that any attempt to write code after this point will fail
     writeableOffset = 0;
@@ -6748,6 +6752,8 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
     {
         size_t dscSize = dsc->dsSize;
 
+        BYTE *dstRW = dst + writeableOffset;
+
         // absolute label table
         if (dsc->dsType == dataSection::blockAbsoluteAddr)
         {
@@ -6755,7 +6761,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
 
             assert(dscSize && dscSize % TARGET_POINTER_SIZE == 0);
             size_t         numElems = dscSize / TARGET_POINTER_SIZE;
-            target_size_t* bDst     = (target_size_t*)(dst + writeableOffset);
+            target_size_t* bDstRW     = (target_size_t*)dstRW;
             for (unsigned i = 0; i < numElems; i++)
             {
                 BasicBlock* block = ((BasicBlock**)dsc->dsCont)[i];
@@ -6769,13 +6775,13 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
 #ifdef TARGET_ARM
                 target = (BYTE*)((size_t)target | 1); // Or in thumb bit
 #endif
-                bDst[i] = (target_size_t)(size_t)target;
+                bDstRW[i] = (target_size_t)(size_t)target;
                 if (emitComp->opts.compReloc)
                 {
-                    emitRecordRelocation(&(bDst[i]), target, IMAGE_REL_BASED_HIGHLOW);
+                    emitRecordRelocation(&(bDstRW[i]), target, IMAGE_REL_BASED_HIGHLOW);
                 }
 
-                JITDUMP("  " FMT_BB ": 0x%p\n", block->bbNum, bDst[i]);
+                JITDUMP("  " FMT_BB ": 0x%p\n", block->bbNum, bDstRW[i]);
             }
         }
         // relative label table
@@ -6784,7 +6790,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
             JITDUMP("  section %u, size %u, block relative addr\n", secNum++, dscSize);
 
             size_t    numElems = dscSize / 4;
-            unsigned* uDst     = (unsigned*)(dst + writeableOffset);
+            unsigned* uDstRW     = (unsigned*)dstRW;
             insGroup* labFirst = (insGroup*)emitCodeGetCookie(emitComp->fgFirstBB);
 
             for (unsigned i = 0; i < numElems; i++)
@@ -6795,9 +6801,9 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
                 insGroup* lab = (insGroup*)emitCodeGetCookie(block);
 
                 assert(FitsIn<uint32_t>(lab->igOffs - labFirst->igOffs));
-                uDst[i] = lab->igOffs - labFirst->igOffs;
+                uDstRW[i] = lab->igOffs - labFirst->igOffs;
 
-                JITDUMP("  " FMT_BB ": 0x%x\n", block->bbNum, uDst[i]);
+                JITDUMP("  " FMT_BB ": 0x%x\n", block->bbNum, uDstRW[i]);
             }
         }
         else
@@ -6805,7 +6811,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
             // Simple binary data: copy the bytes to the target
             assert(dsc->dsType == dataSection::data);
 
-            memcpy(dst + writeableOffset, dsc->dsCont, dscSize);
+            memcpy(dstRW, dsc->dsCont, dscSize);
 
 #ifdef DEBUG
             if (EMITVERBOSE)
@@ -7510,7 +7516,7 @@ void emitter::emitGCregDeadSet(GCtype gcType, regMaskTP regMask, BYTE* addr)
 unsigned char emitter::emitOutputByte(BYTE* dst, ssize_t val)
 {
     BYTE* dstRW = dst + writeableOffset;
-    *castto(dst + writeableOffset, unsigned char*) = (unsigned char)val;
+    *castto(dstRW, unsigned char*) = (unsigned char)val;
 
 #ifdef DEBUG
 #ifdef TARGET_AMD64

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5314,18 +5314,19 @@ void emitter::emitComputeCodeSizes()
 }
 
 //------------------------------------------------------------------------
-// writeCode: write code bytes into the specified blocks of memory
+// emitEndCodeGen: called at end of code generation to create code, data, and gc info
 //
 // Arguments:
+//    comp - compiler instance
 //    contTrkPtrLcls - true if tracked stack pointers are contiguous on the stack
+//    fullInt - true if method has fully interruptible gc reporting
+//    fullPtrMap - true if gc reporting should use full register pointer map
+//    xcptnsCount - number of EH clauses to report for the method
 //    prologSize [OUT] - prolog size in bytes
 //    epilogSize [OUT] - epilog size in bytes (see notes)
-//    codeBlock [IN] - executable memory address of the code buffer
-//    codeBlockRW [IN] - writeable memory address of the code buffer
-//    coldCodeBlock [IN] - executable memory address of the cold code buffer (if any)
-//    coldCodeBlockRW [IN] - writeable memory address of the cold code buffer (if any)
-//    consBlock [IN] - executable memory address of the read only constant buffer (if any)
-//    instrCount [OUT] - number of generated instructions (debug build only)
+//    codeAddr [OUT] - address of the code buffer
+//    coldCodeAddr [OUT] - address of the cold code buffer (if any)
+//    consAddr [OUT] - address of the read only constant buffer (if any)
 //
 // Notes:
 //    Currently, in methods with multiple epilogs, all epilogs must have the same
@@ -5335,16 +5336,256 @@ void emitter::emitComputeCodeSizes()
 // Returns:
 //    size of the method code, in bytes
 //
-unsigned emitter::writeCode(bool      contTrkPtrLcls,
-                            unsigned* prologSize,
-                            unsigned* epilogSize,
-                            BYTE*     codeBlock,
-                            BYTE*     codeBlockRW,
-                            BYTE*     coldCodeBlock,
-                            BYTE*     coldCodeBlockRW,
-                            BYTE* consBlock DEBUGARG(unsigned* instrCount))
+unsigned emitter::emitEndCodeGen(Compiler* comp,
+                                 bool      contTrkPtrLcls,
+                                 bool      fullyInt,
+                                 bool      fullPtrMap,
+                                 unsigned  xcptnsCount,
+                                 unsigned* prologSize,
+                                 unsigned* epilogSize,
+                                 void**    codeAddr,
+                                 void**    coldCodeAddr,
+                                 void** consAddr DEBUGARG(unsigned* instrCount))
 {
+#ifdef DEBUG
+    if (emitComp->verbose)
+    {
+        printf("*************** In emitEndCodeGen()\n");
+    }
+#endif
+
+    BYTE* consBlock;
+    BYTE* consBlockRW;
+    BYTE* codeBlock;
+    BYTE* codeBlockRW;
+    BYTE* coldCodeBlock;
+    BYTE* coldCodeBlockRW;
     BYTE* cp;
+
+    assert(emitCurIG == nullptr);
+
+    emitCodeBlock = nullptr;
+    emitConsBlock = nullptr;
+
+    emitOffsAdj = 0;
+
+    /* Tell everyone whether we have fully interruptible code or not */
+
+    emitFullyInt   = fullyInt;
+    emitFullGCinfo = fullPtrMap;
+
+#ifndef UNIX_X86_ABI
+    emitFullArgInfo = !emitHasFramePtr;
+#else
+    emitFullArgInfo = fullPtrMap;
+#endif
+
+#if EMITTER_STATS
+    GCrefsTable.record(emitGCrFrameOffsCnt);
+    emitSizeTable.record(static_cast<unsigned>(emitSizeMethod));
+    stkDepthTable.record(emitMaxStackDepth);
+#endif // EMITTER_STATS
+
+    // Default values, correct even if EMIT_TRACK_STACK_DEPTH is 0.
+    emitSimpleStkUsed         = true;
+    u1.emitSimpleStkMask      = 0;
+    u1.emitSimpleByrefStkMask = 0;
+
+#if EMIT_TRACK_STACK_DEPTH
+    /* Convert max. stack depth from # of bytes to # of entries */
+
+    unsigned maxStackDepthIn4ByteElements = emitMaxStackDepth / sizeof(int);
+    JITDUMP("Converting emitMaxStackDepth from bytes (%d) to elements (%d)\n", emitMaxStackDepth,
+            maxStackDepthIn4ByteElements);
+    emitMaxStackDepth = maxStackDepthIn4ByteElements;
+
+    /* Should we use the simple stack */
+
+    if (emitMaxStackDepth > MAX_SIMPLE_STK_DEPTH || emitFullGCinfo)
+    {
+        /* We won't use the "simple" argument table */
+
+        emitSimpleStkUsed = false;
+
+        /* Allocate the argument tracking table */
+
+        if (emitMaxStackDepth <= sizeof(u2.emitArgTrackLcl))
+        {
+            u2.emitArgTrackTab = (BYTE*)u2.emitArgTrackLcl;
+        }
+        else
+        {
+            u2.emitArgTrackTab = (BYTE*)emitGetMem(roundUp(emitMaxStackDepth));
+        }
+
+        u2.emitArgTrackTop   = u2.emitArgTrackTab;
+        u2.emitGcArgTrackCnt = 0;
+    }
+#endif
+
+    if (emitEpilogCnt == 0)
+    {
+        /* No epilogs, make sure the epilog size is set to 0 */
+
+        emitEpilogSize = 0;
+
+#ifdef TARGET_XARCH
+        emitExitSeqSize = 0;
+#endif // TARGET_XARCH
+    }
+
+    /* Return the size of the epilog to the caller */
+
+    *epilogSize = emitEpilogSize;
+
+#ifdef TARGET_XARCH
+    *epilogSize += emitExitSeqSize;
+#endif // TARGET_XARCH
+
+#ifdef DEBUG
+    if (EMIT_INSTLIST_VERBOSE)
+    {
+        printf("\nInstruction list before instruction issue:\n\n");
+        emitDispIGlist(true);
+    }
+
+    emitCheckIGoffsets();
+#endif
+
+    /* Allocate the code block (and optionally the data blocks) */
+
+    // If we're doing procedure splitting and we found cold blocks, then
+    // allocate hot and cold buffers.  Otherwise only allocate a hot
+    // buffer.
+
+    coldCodeBlock = nullptr;
+
+    CorJitAllocMemFlag allocMemFlag = CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
+
+#ifdef TARGET_X86
+    //
+    // These are the heuristics we use to decide whether or not to force the
+    // code to be 16-byte aligned.
+    //
+    // 1. For ngen code with IBC data, use 16-byte alignment if the method
+    //    has been called more than ScenarioHotWeight times.
+    // 2. For JITed code and ngen code without IBC data, use 16-byte alignment
+    //    when the code is 16 bytes or smaller. We align small getters/setters
+    //    because of they are penalized heavily on certain hardware when not 16-byte
+    //    aligned (VSWhidbey #373938). To minimize size impact of this optimization,
+    //    we do not align large methods because of the penalty is amortized for them.
+    //
+    if (emitComp->fgHaveProfileData())
+    {
+        const float scenarioHotWeight = 256.0f;
+        if (emitComp->fgCalledCount > (scenarioHotWeight * emitComp->fgProfileRunsCount()))
+        {
+            allocMemFlag = CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN;
+        }
+    }
+    else
+    {
+        if (emitTotalHotCodeSize <= 16)
+        {
+            allocMemFlag = CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN;
+        }
+    }
+#endif
+
+#ifdef TARGET_XARCH
+    // For x64/x86, align methods that are "optimizations enabled" to 32 byte boundaries if
+    // they are larger than 16 bytes and contain a loop.
+    //
+    if (emitComp->opts.OptimizationEnabled() && !emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
+        (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
+    {
+        allocMemFlag = CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN;
+    }
+#endif
+
+    // This restricts the emitConsDsc.alignment to: 1, 2, 4, 8, 16, or 32 bytes
+    // Alignments greater than 32 would require VM support in ICorJitInfo::allocMem
+    assert(isPow2(emitConsDsc.alignment) && (emitConsDsc.alignment <= 32));
+
+    if (emitConsDsc.alignment == 16)
+    {
+        allocMemFlag = static_cast<CorJitAllocMemFlag>(allocMemFlag | CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN);
+    }
+    else if (emitConsDsc.alignment == 32)
+    {
+        allocMemFlag = static_cast<CorJitAllocMemFlag>(allocMemFlag | CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN);
+    }
+
+    AllocMemArgs args;
+    memset(&args, 0, sizeof(args));
+
+#ifdef TARGET_ARM64
+    // For arm64, we want to allocate JIT data always adjacent to code similar to what native compiler does.
+    // This way allows us to use a single `ldr` to access such data like float constant/jmp table.
+    if (emitTotalColdCodeSize > 0)
+    {
+        // JIT data might be far away from the cold code.
+        NYI_ARM64("Need to handle fix-up to data from cold code.");
+    }
+
+    UNATIVE_OFFSET roDataAlignmentDelta = 0;
+    if (emitConsDsc.dsdOffs && (emitConsDsc.alignment == TARGET_POINTER_SIZE))
+    {
+        UNATIVE_OFFSET roDataAlignment = TARGET_POINTER_SIZE; // 8 Byte align by default.
+        roDataAlignmentDelta = (UNATIVE_OFFSET)ALIGN_UP(emitTotalHotCodeSize, roDataAlignment) - emitTotalHotCodeSize;
+        assert((roDataAlignmentDelta == 0) || (roDataAlignmentDelta == 4));
+    }
+
+    args.hotCodeSize  = emitTotalHotCodeSize + roDataAlignmentDelta + emitConsDsc.dsdOffs;
+    args.coldCodeSize = emitTotalColdCodeSize;
+    args.roDataSize   = 0;
+    args.xcptnsCount  = xcptnsCount;
+    args.flag         = allocMemFlag;
+
+    emitCmpHandle->allocMem(&args);
+
+    codeBlock       = (BYTE*)args.hotCodeBlock;
+    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
+    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
+    coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
+
+    consBlock   = codeBlock + emitTotalHotCodeSize + roDataAlignmentDelta;
+    consBlockRW = codeBlockRW + emitTotalHotCodeSize + roDataAlignmentDelta;
+
+#else
+
+    args.hotCodeSize  = emitTotalHotCodeSize;
+    args.coldCodeSize = emitTotalColdCodeSize;
+    args.roDataSize   = emitConsDsc.dsdOffs;
+    args.xcptnsCount  = xcptnsCount;
+    args.flag         = allocMemFlag;
+
+    emitCmpHandle->allocMem(&args);
+
+    codeBlock       = (BYTE*)args.hotCodeBlock;
+    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
+    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
+    coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
+    consBlock       = (BYTE*)args.roDataBlock;
+    consBlockRW     = (BYTE*)args.roDataBlockRW;
+
+#endif
+
+#ifdef DEBUG
+    if ((allocMemFlag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+    {
+        assert(((size_t)codeBlock & 31) == 0);
+    }
+#endif
+
+    // if (emitConsDsc.dsdOffs)
+    //     printf("Cons=%08X\n", consBlock);
+
+    /* Give the block addresses to the caller and other functions here */
+
+    *codeAddr = emitCodeBlock = codeBlock;
+    *coldCodeAddr = emitColdCodeBlock = coldCodeBlock;
+    *consAddr = emitConsBlock = consBlock;
 
     /* Nothing has been pushed on the stack */
     CLANG_FORMAT_COMMENT_ANCHOR;
@@ -5946,332 +6187,9 @@ unsigned emitter::writeCode(bool      contTrkPtrLcls,
     // Assign the real prolog size
     *prologSize = emitCodeOffset(emitPrologIG, emitPrologEndPos);
 
-    return actualCodeSize;
-}
-
-//------------------------------------------------------------------------
-// emitEndCodeGen: called at end of code generation to create code, data, and gc info
-//
-// Arguments:
-//    comp - compiler instance
-//    contTrkPtrLcls - true if tracked stack pointers are contiguous on the stack
-//    fullInt - true if method has fully interruptible gc reporting
-//    fullPtrMap - true if gc reporting should use full register pointer map
-//    xcptnsCount - number of EH clauses to report for the method
-//    prologSize [OUT] - prolog size in bytes
-//    epilogSize [OUT] - epilog size in bytes (see notes)
-//    codeAddr [OUT] - address of the code buffer
-//    coldCodeAddr [OUT] - address of the cold code buffer (if any)
-//    consAddr [OUT] - address of the read only constant buffer (if any)
-//
-// Notes:
-//    Currently, in methods with multiple epilogs, all epilogs must have the same
-//    size. epilogSize is the size of just one of these epilogs, not the cumulative
-//    size of all of the method's epilogs.
-//
-// Returns:
-//    size of the method code, in bytes
-//
-unsigned emitter::emitEndCodeGen(Compiler* comp,
-                                 bool      contTrkPtrLcls,
-                                 bool      fullyInt,
-                                 bool      fullPtrMap,
-                                 unsigned  xcptnsCount,
-                                 unsigned* prologSize,
-                                 unsigned* epilogSize,
-                                 void**    codeAddr,
-                                 void**    coldCodeAddr,
-                                 void** consAddr DEBUGARG(unsigned* instrCount))
-{
-#ifdef DEBUG
-    if (emitComp->verbose)
-    {
-        printf("*************** In emitEndCodeGen()\n");
-    }
-#endif
-
-    BYTE* consBlock;
-    BYTE* consBlockRW;
-    BYTE* codeBlock;
-    BYTE* codeBlockRW;
-    BYTE* coldCodeBlock;
-    BYTE* coldCodeBlockRW;
-
-    assert(emitCurIG == nullptr);
-
-    emitCodeBlock = nullptr;
-    emitConsBlock = nullptr;
-
-    emitOffsAdj = 0;
-
-    /* Tell everyone whether we have fully interruptible code or not */
-
-    emitFullyInt   = fullyInt;
-    emitFullGCinfo = fullPtrMap;
-
-#ifndef UNIX_X86_ABI
-    emitFullArgInfo = !emitHasFramePtr;
-#else
-    emitFullArgInfo = fullPtrMap;
-#endif
-
-#if EMITTER_STATS
-    GCrefsTable.record(emitGCrFrameOffsCnt);
-    emitSizeTable.record(static_cast<unsigned>(emitSizeMethod));
-    stkDepthTable.record(emitMaxStackDepth);
-#endif // EMITTER_STATS
-
-    // Default values, correct even if EMIT_TRACK_STACK_DEPTH is 0.
-    emitSimpleStkUsed         = true;
-    u1.emitSimpleStkMask      = 0;
-    u1.emitSimpleByrefStkMask = 0;
-
-#if EMIT_TRACK_STACK_DEPTH
-    /* Convert max. stack depth from # of bytes to # of entries */
-
-    unsigned maxStackDepthIn4ByteElements = emitMaxStackDepth / sizeof(int);
-    JITDUMP("Converting emitMaxStackDepth from bytes (%d) to elements (%d)\n", emitMaxStackDepth,
-            maxStackDepthIn4ByteElements);
-    emitMaxStackDepth = maxStackDepthIn4ByteElements;
-
-    /* Should we use the simple stack */
-
-    if (emitMaxStackDepth > MAX_SIMPLE_STK_DEPTH || emitFullGCinfo)
-    {
-        /* We won't use the "simple" argument table */
-
-        emitSimpleStkUsed = false;
-
-        /* Allocate the argument tracking table */
-
-        if (emitMaxStackDepth <= sizeof(u2.emitArgTrackLcl))
-        {
-            u2.emitArgTrackTab = (BYTE*)u2.emitArgTrackLcl;
-        }
-        else
-        {
-            u2.emitArgTrackTab = (BYTE*)emitGetMem(roundUp(emitMaxStackDepth));
-        }
-
-        u2.emitArgTrackTop   = u2.emitArgTrackTab;
-        u2.emitGcArgTrackCnt = 0;
-    }
-#endif
-
-    if (emitEpilogCnt == 0)
-    {
-        /* No epilogs, make sure the epilog size is set to 0 */
-
-        emitEpilogSize = 0;
-
-#ifdef TARGET_XARCH
-        emitExitSeqSize = 0;
-#endif // TARGET_XARCH
-    }
-
-    /* Return the size of the epilog to the caller */
-
-    *epilogSize = emitEpilogSize;
-
-#ifdef TARGET_XARCH
-    *epilogSize += emitExitSeqSize;
-#endif // TARGET_XARCH
-
-#ifdef DEBUG
-    if (EMIT_INSTLIST_VERBOSE)
-    {
-        printf("\nInstruction list before instruction issue:\n\n");
-        emitDispIGlist(true);
-    }
-
-    emitCheckIGoffsets();
-#endif
-
-    /* Allocate the code block (and optionally the data blocks) */
-
-    // If we're doing procedure splitting and we found cold blocks, then
-    // allocate hot and cold buffers.  Otherwise only allocate a hot
-    // buffer.
-
-    coldCodeBlock = nullptr;
-
-    CorJitAllocMemFlag allocMemFlag = CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
-
-#ifdef TARGET_X86
-    //
-    // These are the heuristics we use to decide whether or not to force the
-    // code to be 16-byte aligned.
-    //
-    // 1. For ngen code with IBC data, use 16-byte alignment if the method
-    //    has been called more than ScenarioHotWeight times.
-    // 2. For JITed code and ngen code without IBC data, use 16-byte alignment
-    //    when the code is 16 bytes or smaller. We align small getters/setters
-    //    because of they are penalized heavily on certain hardware when not 16-byte
-    //    aligned (VSWhidbey #373938). To minimize size impact of this optimization,
-    //    we do not align large methods because of the penalty is amortized for them.
-    //
-    if (emitComp->fgHaveProfileData())
-    {
-        const float scenarioHotWeight = 256.0f;
-        if (emitComp->fgCalledCount > (scenarioHotWeight * emitComp->fgProfileRunsCount()))
-        {
-            allocMemFlag = CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN;
-        }
-    }
-    else
-    {
-        if (emitTotalHotCodeSize <= 16)
-        {
-            allocMemFlag = CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN;
-        }
-    }
-#endif
-
-#ifdef TARGET_XARCH
-    // For x64/x86, align methods that are "optimizations enabled" to 32 byte boundaries if
-    // they are larger than 16 bytes and contain a loop.
-    //
-    if (emitComp->opts.OptimizationEnabled() && !emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
-        (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
-    {
-        allocMemFlag = CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN;
-    }
-#endif
-
-    // This restricts the emitConsDsc.alignment to: 1, 2, 4, 8, 16, or 32 bytes
-    // Alignments greater than 32 would require VM support in ICorJitInfo::allocMem
-    assert(isPow2(emitConsDsc.alignment) && (emitConsDsc.alignment <= 32));
-
-    if (emitConsDsc.alignment == 16)
-    {
-        allocMemFlag = static_cast<CorJitAllocMemFlag>(allocMemFlag | CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN);
-    }
-    else if (emitConsDsc.alignment == 32)
-    {
-        allocMemFlag = static_cast<CorJitAllocMemFlag>(allocMemFlag | CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN);
-    }
-
-    AllocMemArgs args;
-    memset(&args, 0, sizeof(args));
-
-#ifdef TARGET_ARM64
-    // For arm64, we want to allocate JIT data always adjacent to code similar to what native compiler does.
-    // This way allows us to use a single `ldr` to access such data like float constant/jmp table.
-    if (emitTotalColdCodeSize > 0)
-    {
-        // JIT data might be far away from the cold code.
-        NYI_ARM64("Need to handle fix-up to data from cold code.");
-    }
-
-    UNATIVE_OFFSET roDataAlignmentDelta = 0;
-    if (emitConsDsc.dsdOffs && (emitConsDsc.alignment == TARGET_POINTER_SIZE))
-    {
-        UNATIVE_OFFSET roDataAlignment = TARGET_POINTER_SIZE; // 8 Byte align by default.
-        roDataAlignmentDelta = (UNATIVE_OFFSET)ALIGN_UP(emitTotalHotCodeSize, roDataAlignment) - emitTotalHotCodeSize;
-        assert((roDataAlignmentDelta == 0) || (roDataAlignmentDelta == 4));
-    }
-
-    args.hotCodeSize  = emitTotalHotCodeSize + roDataAlignmentDelta + emitConsDsc.dsdOffs;
-    args.coldCodeSize = emitTotalColdCodeSize;
-    args.roDataSize   = 0;
-    args.xcptnsCount  = xcptnsCount;
-    args.flag         = allocMemFlag;
-
-    emitCmpHandle->allocMem(&args);
-
-    codeBlock       = (BYTE*)args.hotCodeBlock;
-    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
-    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
-    coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
-
-    consBlock   = codeBlock + emitTotalHotCodeSize + roDataAlignmentDelta;
-    consBlockRW = codeBlockRW + emitTotalHotCodeSize + roDataAlignmentDelta;
-
-#else
-
-    args.hotCodeSize  = emitTotalHotCodeSize;
-    args.coldCodeSize = emitTotalColdCodeSize;
-    args.roDataSize   = emitConsDsc.dsdOffs;
-    args.xcptnsCount  = xcptnsCount;
-    args.flag         = allocMemFlag;
-
-    emitCmpHandle->allocMem(&args);
-
-    codeBlock       = (BYTE*)args.hotCodeBlock;
-    codeBlockRW     = (BYTE*)args.hotCodeBlockRW;
-    coldCodeBlock   = (BYTE*)args.coldCodeBlock;
-    coldCodeBlockRW = (BYTE*)args.coldCodeBlockRW;
-    consBlock       = (BYTE*)args.roDataBlock;
-    consBlockRW     = (BYTE*)args.roDataBlockRW;
-
-#endif
-
-#ifdef DEBUG
-    if ((allocMemFlag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
-    {
-        assert(((size_t)codeBlock & 31) == 0);
-    }
-#endif
-
-    // if (emitConsDsc.dsdOffs)
-    //     printf("Cons=%08X\n", consBlock);
-
-    /* Give the block addresses to the caller and other functions here */
-
-    *codeAddr = emitCodeBlock = codeBlock;
-    *coldCodeAddr = emitColdCodeBlock = coldCodeBlock;
-    *consAddr = emitConsBlock = consBlock;
-
-    struct Param
-    {
-        emitter*  pThis;
-        unsigned  actualCodeSize;
-        bool      contTrkPtrLcls;
-        unsigned* prologSize;
-        unsigned* epilogSize;
-        BYTE*     codeBlock;
-        BYTE*     codeBlockRW;
-        BYTE*     coldCodeBlock;
-        BYTE*     coldCodeBlockRW;
-        BYTE*     consBlock;
-        INDEBUG(unsigned* instrCount;)
-    } param;
-
-    param.pThis           = this;
-    param.contTrkPtrLcls  = contTrkPtrLcls;
-    param.prologSize      = prologSize;
-    param.epilogSize      = epilogSize;
-    param.codeBlock       = codeBlock;
-    param.codeBlockRW     = codeBlockRW;
-    param.coldCodeBlock   = coldCodeBlock;
-    param.coldCodeBlockRW = coldCodeBlockRW;
-    param.consBlock       = consBlock;
-#ifdef DEBUG
-    param.instrCount = instrCount;
-#endif
-
-    bool success = comp->eeRunWithErrorTrap<Param>(
-        [](Param* pParam) {
-            pParam->actualCodeSize =
-                pParam->pThis->writeCode(pParam->contTrkPtrLcls, pParam->prologSize, pParam->epilogSize,
-                                         pParam->codeBlock, pParam->codeBlockRW, pParam->coldCodeBlock,
-                                         pParam->coldCodeBlockRW, pParam->consBlock DEBUGARG(pParam->instrCount));
-        },
-        &param);
-
-    // Ensure that any attempt to write code after this point will fail
-    writeableOffset = 0;
-    // Notify the EE that all code writing is done. It can switch off writeable code memory.
-    emitCmpHandle->doneWritingCode();
-
-    if (!success)
-    {
-        fatal(CORJIT_INTERNALERROR);
-    }
-
     /* Return the amount of code we've generated */
 
-    return param.actualCodeSize;
+    return actualCodeSize;
 }
 
 // See specification comment at the declaration.

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5533,13 +5533,15 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         assert((roDataAlignmentDelta == 0) || (roDataAlignmentDelta == 4));
     }
     emitCmpHandle->allocMem(emitTotalHotCodeSize + roDataAlignmentDelta + emitConsDsc.dsdOffs, emitTotalColdCodeSize, 0,
-                            xcptnsCount, allocMemFlag, (void**)&codeBlock, (void**)&codeBlockRW, (void**)&coldCodeBlock, (void**)&coldCodeBlockRW, (void**)&consBlock, (void**)&consBlockRW);
+                            xcptnsCount, allocMemFlag, (void**)&codeBlock, (void**)&codeBlockRW, (void**)&coldCodeBlock,
+                            (void**)&coldCodeBlockRW, (void**)&consBlock, (void**)&consBlockRW);
 
     consBlock = codeBlock + emitTotalHotCodeSize + roDataAlignmentDelta;
 
 #else
     emitCmpHandle->allocMem(emitTotalHotCodeSize, emitTotalColdCodeSize, emitConsDsc.dsdOffs, xcptnsCount, allocMemFlag,
-                            (void**)&codeBlock, (void**)&codeBlockRW, (void**)&coldCodeBlock, (void**)&coldCodeBlockRW, (void**)&consBlock, (void**)&consBlockRW);
+                            (void**)&codeBlock, (void**)&codeBlockRW, (void**)&coldCodeBlock, (void**)&coldCodeBlockRW,
+                            (void**)&consBlock, (void**)&consBlockRW);
 #endif
 
 #ifdef DEBUG
@@ -5764,7 +5766,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
 
     /* Issue all instruction groups in order */
-    cp = codeBlock;
+    cp              = codeBlock;
     writeableOffset = codeBlockRW - codeBlock;
 
 #define DEFAULT_CODE_BUFFER_INIT 0xcc
@@ -5782,7 +5784,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(emitCurCodeOffs(cp) == emitTotalHotCodeSize);
 
             assert(coldCodeBlock);
-            cp = coldCodeBlock;
+            cp              = coldCodeBlock;
             writeableOffset = coldCodeBlockRW - coldCodeBlock;
 #ifdef DEBUG
             if (emitComp->opts.disAsm || emitComp->verbose)

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1732,13 +1732,13 @@ private:
     void emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt, instruction ins);
     void spillIntArgRegsToShadowSlots();
 
-    unsigned writeCode(bool contTrkPtrLcls,
+    unsigned writeCode(bool      contTrkPtrLcls,
                        unsigned* prologSize,
                        unsigned* epilogSize,
-                       BYTE* codeBlock,
-                       BYTE* codeBlockRW,
-                       BYTE* coldCodeBlock,
-                       BYTE* coldCodeBlockRW,
+                       BYTE*     codeBlock,
+                       BYTE*     codeBlockRW,
+                       BYTE*     coldCodeBlock,
+                       BYTE*     coldCodeBlockRW,
                        BYTE* consBlock DEBUGARG(unsigned* instrCount));
 
 /************************************************************************/

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1618,10 +1618,10 @@ public:
     bool emitIssuing;
 #endif
 
-    BYTE* emitCodeBlock;     // Hot code block
-    BYTE* emitColdCodeBlock; // Cold code block
-    BYTE* emitConsBlock;     // Read-only (constant) data block
-    size_t writeableOffset;  // Offset applied to a code address to get memory location that can be written
+    BYTE*  emitCodeBlock;     // Hot code block
+    BYTE*  emitColdCodeBlock; // Cold code block
+    BYTE*  emitConsBlock;     // Read-only (constant) data block
+    size_t writeableOffset;   // Offset applied to a code address to get memory location that can be written
 
     UNATIVE_OFFSET emitTotalHotCodeSize;
     UNATIVE_OFFSET emitTotalColdCodeSize;

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1732,6 +1732,15 @@ private:
     void emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt, instruction ins);
     void spillIntArgRegsToShadowSlots();
 
+    unsigned writeCode(bool contTrkPtrLcls,
+                       unsigned* prologSize,
+                       unsigned* epilogSize,
+                       BYTE* codeBlock,
+                       BYTE* codeBlockRW,
+                       BYTE* coldCodeBlock,
+                       BYTE* coldCodeBlockRW,
+                       BYTE* consBlock DEBUGARG(unsigned* instrCount));
+
 /************************************************************************/
 /*      The logic that creates and keeps track of instruction groups    */
 /************************************************************************/

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1732,15 +1732,6 @@ private:
     void emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt, instruction ins);
     void spillIntArgRegsToShadowSlots();
 
-    unsigned writeCode(bool      contTrkPtrLcls,
-                       unsigned* prologSize,
-                       unsigned* epilogSize,
-                       BYTE*     codeBlock,
-                       BYTE*     codeBlockRW,
-                       BYTE*     coldCodeBlock,
-                       BYTE*     coldCodeBlockRW,
-                       BYTE* consBlock DEBUGARG(unsigned* instrCount));
-
 /************************************************************************/
 /*      The logic that creates and keeps track of instruction groups    */
 /************************************************************************/

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1621,6 +1621,7 @@ public:
     BYTE* emitCodeBlock;     // Hot code block
     BYTE* emitColdCodeBlock; // Cold code block
     BYTE* emitConsBlock;     // Read-only (constant) data block
+    size_t writeableOffset;  // Offset applied to a code address to get memory location that can be written
 
     UNATIVE_OFFSET emitTotalHotCodeSize;
     UNATIVE_OFFSET emitTotalColdCodeSize;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -5094,7 +5094,7 @@ inline unsigned insEncodeImmT2_Mov(int imm)
  *  Emit a Thumb-1 instruction (a 16-bit integer as code)
  */
 
-/*static*/ unsigned emitter::emitOutput_Thumb1Instr(BYTE* dst, code_t code)
+unsigned emitter::emitOutput_Thumb1Instr(BYTE* dst, code_t code)
 {
     unsigned short word1 = code & 0xffff;
     assert(word1 == code);
@@ -5104,7 +5104,8 @@ inline unsigned insEncodeImmT2_Mov(int imm)
     assert(top5bits < 29);
 #endif
 
-    MISALIGNED_WR_I2(dst, word1);
+    BYTE* dstRW = dst + writeableOffset;
+    MISALIGNED_WR_I2(dstRW, word1);
 
     return sizeof(short);
 }
@@ -5113,7 +5114,7 @@ inline unsigned insEncodeImmT2_Mov(int imm)
  *  Emit a Thumb-2 instruction (two 16-bit integers as code)
  */
 
-/*static*/ unsigned emitter::emitOutput_Thumb2Instr(BYTE* dst, code_t code)
+unsigned emitter::emitOutput_Thumb2Instr(BYTE* dst, code_t code)
 {
     unsigned short word1 = (code >> 16) & 0xffff;
     unsigned short word2 = (code)&0xffff;
@@ -5124,9 +5125,10 @@ inline unsigned insEncodeImmT2_Mov(int imm)
     assert(top5bits >= 29);
 #endif
 
-    MISALIGNED_WR_I2(dst, word1);
-    dst += 2;
-    MISALIGNED_WR_I2(dst, word2);
+    BYTE* dstRW = dst + writeableOffset;
+    MISALIGNED_WR_I2(dstRW, word1);
+    dstRW += 2;
+    MISALIGNED_WR_I2(dstRW, word2);
 
     return sizeof(short) * 2;
 }

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -20,8 +20,8 @@ BYTE* emitOutputIT(BYTE* dst, instruction ins, insFormat fmt, code_t condcode);
 BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 BYTE* emitOutputShortBranch(BYTE* dst, instruction ins, insFormat fmt, ssize_t distVal, instrDescJmp* id);
 
-static unsigned emitOutput_Thumb1Instr(BYTE* dst, code_t code);
-static unsigned emitOutput_Thumb2Instr(BYTE* dst, code_t code);
+unsigned emitOutput_Thumb1Instr(BYTE* dst, code_t code);
+unsigned emitOutput_Thumb2Instr(BYTE* dst, code_t code);
 
 /************************************************************************/
 /*             Debug-only routines to display instructions              */

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -10253,7 +10253,7 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
 /*static*/ unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code)
 {
     assert(sizeof(code_t) == 4);
-    *((code_t*)dst) = code;
+    *((code_t*)(dst + writeableOffset)) = code;
 
     return sizeof(code_t);
 }

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -10253,7 +10253,7 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
 unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code)
 {
     assert(sizeof(code_t) == 4);
-    BYTE* dstRW = dst + writeableOffset;
+    BYTE* dstRW       = dst + writeableOffset;
     *((code_t*)dstRW) = code;
 
     return sizeof(code_t);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -10250,10 +10250,11 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
  *  Emit a 32-bit Arm64 instruction
  */
 
-/*static*/ unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code)
+unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code)
 {
     assert(sizeof(code_t) == 4);
-    *((code_t*)(dst + writeableOffset)) = code;
+    BYTE* dstRW = dst + writeableOffset;
+    *((code_t*)dstRW) = code;
 
     return sizeof(code_t);
 }

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -101,7 +101,7 @@ emitter::code_t emitInsCode(instruction ins, insFormat fmt);
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
 
 //  Emit the 32-bit Arm64 instruction 'code' into the 'dst'  buffer
-static unsigned emitOutput_Instr(BYTE* dst, code_t code);
+unsigned emitOutput_Instr(BYTE* dst, code_t code);
 
 // A helper method to return the natural scale for an EA 'size'
 static unsigned NaturalScale_helper(emitAttr size);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9270,7 +9270,7 @@ void emitter::emitDispIns(
  *  Output nBytes bytes of NOP instructions
  */
 
-BYTE* emitter::emitOutputNOP(BYTE* dstRW, size_t nBytes)
+static BYTE* emitOutputNOP(BYTE* dstRW, size_t nBytes)
 {
     assert(nBytes <= 15);
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9270,7 +9270,7 @@ void emitter::emitDispIns(
  *  Output nBytes bytes of NOP instructions
  */
 
-static BYTE* emitOutputNOP(BYTE* dst, size_t nBytes)
+BYTE* emitter::emitOutputNOP(BYTE* dstRW, size_t nBytes)
 {
     assert(nBytes <= 15);
 
@@ -9284,49 +9284,49 @@ static BYTE* emitOutputNOP(BYTE* dst, size_t nBytes)
     switch (nBytes)
     {
         case 15:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 14:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 13:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 12:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 11:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 10:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 9:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 8:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 7:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 6:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 5:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 4:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 3:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 2:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             FALLTHROUGH;
         case 1:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             break;
         case 0:
             break;
@@ -9335,82 +9335,82 @@ static BYTE* emitOutputNOP(BYTE* dst, size_t nBytes)
     switch (nBytes)
     {
         case 2:
-            *dst++ = 0x66;
+            *dstRW++ = 0x66;
             FALLTHROUGH;
         case 1:
-            *dst++ = 0x90;
+            *dstRW++ = 0x90;
             break;
         case 0:
             break;
         case 3:
-            *dst++ = 0x0F;
-            *dst++ = 0x1F;
-            *dst++ = 0x00;
+            *dstRW++ = 0x0F;
+            *dstRW++ = 0x1F;
+            *dstRW++ = 0x00;
             break;
         case 4:
-            *dst++ = 0x0F;
-            *dst++ = 0x1F;
-            *dst++ = 0x40;
-            *dst++ = 0x00;
+            *dstRW++ = 0x0F;
+            *dstRW++ = 0x1F;
+            *dstRW++ = 0x40;
+            *dstRW++ = 0x00;
             break;
         case 6:
-            *dst++ = 0x66;
+            *dstRW++ = 0x66;
             FALLTHROUGH;
         case 5:
-            *dst++ = 0x0F;
-            *dst++ = 0x1F;
-            *dst++ = 0x44;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
+            *dstRW++ = 0x0F;
+            *dstRW++ = 0x1F;
+            *dstRW++ = 0x44;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
             break;
         case 7:
-            *dst++ = 0x0F;
-            *dst++ = 0x1F;
-            *dst++ = 0x80;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
+            *dstRW++ = 0x0F;
+            *dstRW++ = 0x1F;
+            *dstRW++ = 0x80;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
             break;
         case 15:
             // More than 3 prefixes is slower than just 2 NOPs
-            dst = emitOutputNOP(emitOutputNOP(dst, 7), 8);
+            dstRW = emitOutputNOP(emitOutputNOP(dstRW, 7), 8);
             break;
         case 14:
             // More than 3 prefixes is slower than just 2 NOPs
-            dst = emitOutputNOP(emitOutputNOP(dst, 7), 7);
+            dstRW = emitOutputNOP(emitOutputNOP(dstRW, 7), 7);
             break;
         case 13:
             // More than 3 prefixes is slower than just 2 NOPs
-            dst = emitOutputNOP(emitOutputNOP(dst, 5), 8);
+            dstRW = emitOutputNOP(emitOutputNOP(dstRW, 5), 8);
             break;
         case 12:
             // More than 3 prefixes is slower than just 2 NOPs
-            dst = emitOutputNOP(emitOutputNOP(dst, 4), 8);
+            dstRW = emitOutputNOP(emitOutputNOP(dstRW, 4), 8);
             break;
         case 11:
-            *dst++ = 0x66;
+            *dstRW++ = 0x66;
             FALLTHROUGH;
         case 10:
-            *dst++ = 0x66;
+            *dstRW++ = 0x66;
             FALLTHROUGH;
         case 9:
-            *dst++ = 0x66;
+            *dstRW++ = 0x66;
             FALLTHROUGH;
         case 8:
-            *dst++ = 0x0F;
-            *dst++ = 0x1F;
-            *dst++ = 0x84;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
-            *dst++ = 0x00;
+            *dstRW++ = 0x0F;
+            *dstRW++ = 0x1F;
+            *dstRW++ = 0x84;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
+            *dstRW++ = 0x00;
             break;
     }
 #endif // TARGET_AMD64
 
-    return dst;
+    return dstRW;
 }
 
 //--------------------------------------------------------------------
@@ -9454,7 +9454,9 @@ BYTE* emitter::emitOutputAlign(insGroup* ig, instrDesc* id, BYTE* dst)
     emitComp->loopsAligned++;
 #endif
 
-    return emitOutputNOP(dst, paddingToAdd);
+    BYTE* dstRW = dst + writeableOffset;
+    dstRW = emitOutputNOP(dstRW, paddingToAdd);
+    return dstRW - writeableOffset;
 }
 
 /*****************************************************************************
@@ -12775,7 +12777,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
             if (ins == INS_nop)
             {
-                dst = emitOutputNOP(dst, id->idCodeSize());
+                BYTE* dstRW = dst + writeableOffset;
+                dstRW = emitOutputNOP(dstRW, id->idCodeSize());
+                dst = dstRW - writeableOffset;
                 break;
             }
 
@@ -13897,7 +13901,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             }
 #endif
 
-            dst = emitOutputNOP(dst, diff);
+            BYTE* dstRW = dst + writeableOffset;
+            dstRW = emitOutputNOP(dstRW, diff);
+            dst = dstRW - writeableOffset;
         }
         assert((id->idCodeSize() - ((UNATIVE_OFFSET)(dst - *dp))) == 0);
     }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9455,7 +9455,7 @@ BYTE* emitter::emitOutputAlign(insGroup* ig, instrDesc* id, BYTE* dst)
 #endif
 
     BYTE* dstRW = dst + writeableOffset;
-    dstRW = emitOutputNOP(dstRW, paddingToAdd);
+    dstRW       = emitOutputNOP(dstRW, paddingToAdd);
     return dstRW - writeableOffset;
 }
 
@@ -12778,8 +12778,8 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             if (ins == INS_nop)
             {
                 BYTE* dstRW = dst + writeableOffset;
-                dstRW = emitOutputNOP(dstRW, id->idCodeSize());
-                dst = dstRW - writeableOffset;
+                dstRW       = emitOutputNOP(dstRW, id->idCodeSize());
+                dst         = dstRW - writeableOffset;
                 break;
             }
 
@@ -13902,8 +13902,8 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #endif
 
             BYTE* dstRW = dst + writeableOffset;
-            dstRW = emitOutputNOP(dstRW, diff);
-            dst = dstRW - writeableOffset;
+            dstRW       = emitOutputNOP(dstRW, diff);
+            dst         = dstRW - writeableOffset;
         }
         assert((id->idCodeSize() - ((UNATIVE_OFFSET)(dst - *dp))) == 0);
     }

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -240,6 +240,8 @@ ssize_t emitGetInsAmdCns(instrDesc* id, CnsVal* cv);
 void emitGetInsDcmCns(instrDesc* id, CnsVal* cv);
 ssize_t emitGetInsAmdAny(instrDesc* id);
 
+BYTE* emitOutputNOP(BYTE* dstRW, size_t nBytes);
+
 /************************************************************************/
 /*               Private helpers for instruction output                 */
 /************************************************************************/

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -240,8 +240,6 @@ ssize_t emitGetInsAmdCns(instrDesc* id, CnsVal* cv);
 void emitGetInsDcmCns(instrDesc* id, CnsVal* cv);
 ssize_t emitGetInsAmdAny(instrDesc* id);
 
-BYTE* emitOutputNOP(BYTE* dstRW, size_t nBytes);
-
 /************************************************************************/
 /*               Private helpers for instruction output                 */
 /************************************************************************/

--- a/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
@@ -2317,12 +2317,12 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        static void _allocMem(IntPtr thisHandle, IntPtr* ppException, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** hotCodeBlockRW, void** coldCodeBlock, void** coldCodeBlockRW, void** roDataBlock, void** roDataBlockRW)
+        static void _allocMem(IntPtr thisHandle, IntPtr* ppException, AllocMemArgs* pArgs)
         {
             var _this = GetThis(thisHandle);
             try
             {
-                _this.allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, ref *hotCodeBlock, ref *hotCodeBlockRW, ref *coldCodeBlock, ref *coldCodeBlockRW, ref *roDataBlock, ref *roDataBlockRW);
+                _this.allocMem(ref *pArgs);
             }
             catch (Exception ex)
             {
@@ -2723,7 +2723,7 @@ namespace Internal.JitInterface
             callbacks[153] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, CORINFO_SIG_INFO*, CORINFO_GET_TAILCALL_HELPERS_FLAGS, CORINFO_TAILCALL_HELPERS*, byte>)&_getTailCallHelpers;
             callbacks[154] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, byte, byte>)&_convertPInvokeCalliToCall;
             callbacks[155] = (delegate* unmanaged<IntPtr, IntPtr*, InstructionSet, byte, byte>)&_notifyInstructionSetUsage;
-            callbacks[156] = (delegate* unmanaged<IntPtr, IntPtr*, uint, uint, uint, uint, CorJitAllocMemFlag, void**, void**, void**, void**, void**, void**, void>)&_allocMem;
+            callbacks[156] = (delegate* unmanaged<IntPtr, IntPtr*, AllocMemArgs*, void>)&_allocMem;
             callbacks[157] = (delegate* unmanaged<IntPtr, IntPtr*, byte, byte, uint, void>)&_reserveUnwindInfo;
             callbacks[158] = (delegate* unmanaged<IntPtr, IntPtr*, byte*, byte*, uint, uint, uint, byte*, CorJitFuncKind, void>)&_allocUnwindInfo;
             callbacks[159] = (delegate* unmanaged<IntPtr, IntPtr*, UIntPtr, void*>)&_allocGCInfo;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
@@ -2317,12 +2317,12 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        static void _allocMem(IntPtr thisHandle, IntPtr* ppException, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** coldCodeBlock, void** roDataBlock)
+        static void _allocMem(IntPtr thisHandle, IntPtr* ppException, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** hotCodeBlockRW, void** coldCodeBlock, void** coldCodeBlockRW, void** roDataBlock, void** roDataBlockRW)
         {
             var _this = GetThis(thisHandle);
             try
             {
-                _this.allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, ref *hotCodeBlock, ref *coldCodeBlock, ref *roDataBlock);
+                _this.allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, ref *hotCodeBlock, ref *hotCodeBlockRW, ref *coldCodeBlock, ref *coldCodeBlockRW, ref *roDataBlock, ref *roDataBlockRW);
             }
             catch (Exception ex)
             {
@@ -2490,12 +2490,12 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        static void _recordRelocation(IntPtr thisHandle, IntPtr* ppException, void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
+        static void _recordRelocation(IntPtr thisHandle, IntPtr* ppException, void* location, void* locationRW, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
         {
             var _this = GetThis(thisHandle);
             try
             {
-                _this.recordRelocation(location, target, fRelocType, slotNum, addlDelta);
+                _this.recordRelocation(location, locationRW, target, fRelocType, slotNum, addlDelta);
             }
             catch (Exception ex)
             {
@@ -2548,10 +2548,24 @@ namespace Internal.JitInterface
             }
         }
 
+        [UnmanagedCallersOnly]
+        static void _doneWritingCode(IntPtr thisHandle, IntPtr* ppException)
+        {
+            var _this = GetThis(thisHandle);
+            try
+            {
+                _this.doneWritingCode();
+            }
+            catch (Exception ex)
+            {
+                *ppException = _this.AllocException(ex);
+            }
+        }
+
 
         static IntPtr GetUnmanagedCallbacks()
         {
-            void** callbacks = (void**)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 172);
+            void** callbacks = (void**)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 173);
 
             callbacks[0] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, byte>)&_isJitIntrinsic;
             callbacks[1] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, uint>)&_getMethodAttribs;
@@ -2709,7 +2723,7 @@ namespace Internal.JitInterface
             callbacks[153] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, CORINFO_SIG_INFO*, CORINFO_GET_TAILCALL_HELPERS_FLAGS, CORINFO_TAILCALL_HELPERS*, byte>)&_getTailCallHelpers;
             callbacks[154] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, byte, byte>)&_convertPInvokeCalliToCall;
             callbacks[155] = (delegate* unmanaged<IntPtr, IntPtr*, InstructionSet, byte, byte>)&_notifyInstructionSetUsage;
-            callbacks[156] = (delegate* unmanaged<IntPtr, IntPtr*, uint, uint, uint, uint, CorJitAllocMemFlag, void**, void**, void**, void>)&_allocMem;
+            callbacks[156] = (delegate* unmanaged<IntPtr, IntPtr*, uint, uint, uint, uint, CorJitAllocMemFlag, void**, void**, void**, void**, void**, void**, void>)&_allocMem;
             callbacks[157] = (delegate* unmanaged<IntPtr, IntPtr*, byte, byte, uint, void>)&_reserveUnwindInfo;
             callbacks[158] = (delegate* unmanaged<IntPtr, IntPtr*, byte*, byte*, uint, uint, uint, byte*, CorJitFuncKind, void>)&_allocUnwindInfo;
             callbacks[159] = (delegate* unmanaged<IntPtr, IntPtr*, UIntPtr, void*>)&_allocGCInfo;
@@ -2721,10 +2735,11 @@ namespace Internal.JitInterface
             callbacks[165] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, PgoInstrumentationSchema**, uint*, byte**, HRESULT>)&_getPgoInstrumentationResults;
             callbacks[166] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, PgoInstrumentationSchema*, uint, byte**, HRESULT>)&_allocPgoInstrumentationBySchema;
             callbacks[167] = (delegate* unmanaged<IntPtr, IntPtr*, uint, CORINFO_SIG_INFO*, CORINFO_METHOD_STRUCT_*, void>)&_recordCallSite;
-            callbacks[168] = (delegate* unmanaged<IntPtr, IntPtr*, void*, void*, ushort, ushort, int, void>)&_recordRelocation;
+            callbacks[168] = (delegate* unmanaged<IntPtr, IntPtr*, void*, void*, void*, ushort, ushort, int, void>)&_recordRelocation;
             callbacks[169] = (delegate* unmanaged<IntPtr, IntPtr*, void*, ushort>)&_getRelocTypeHint;
             callbacks[170] = (delegate* unmanaged<IntPtr, IntPtr*, uint>)&_getExpectedTargetArchitecture;
             callbacks[171] = (delegate* unmanaged<IntPtr, IntPtr*, CORJIT_FLAGS*, uint, uint>)&_getJitFlags;
+            callbacks[172] = (delegate* unmanaged<IntPtr, IntPtr*, void>)&_doneWritingCode;
 
             return (IntPtr)callbacks;
         }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
@@ -2548,24 +2548,10 @@ namespace Internal.JitInterface
             }
         }
 
-        [UnmanagedCallersOnly]
-        static void _doneWritingCode(IntPtr thisHandle, IntPtr* ppException)
-        {
-            var _this = GetThis(thisHandle);
-            try
-            {
-                _this.doneWritingCode();
-            }
-            catch (Exception ex)
-            {
-                *ppException = _this.AllocException(ex);
-            }
-        }
-
 
         static IntPtr GetUnmanagedCallbacks()
         {
-            void** callbacks = (void**)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 173);
+            void** callbacks = (void**)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 172);
 
             callbacks[0] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, byte>)&_isJitIntrinsic;
             callbacks[1] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_METHOD_STRUCT_*, uint>)&_getMethodAttribs;
@@ -2739,7 +2725,6 @@ namespace Internal.JitInterface
             callbacks[169] = (delegate* unmanaged<IntPtr, IntPtr*, void*, ushort>)&_getRelocTypeHint;
             callbacks[170] = (delegate* unmanaged<IntPtr, IntPtr*, uint>)&_getExpectedTargetArchitecture;
             callbacks[171] = (delegate* unmanaged<IntPtr, IntPtr*, CORJIT_FLAGS*, uint, uint>)&_getJitFlags;
-            callbacks[172] = (delegate* unmanaged<IntPtr, IntPtr*, void>)&_doneWritingCode;
 
             return (IntPtr)callbacks;
         }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3066,12 +3066,20 @@ namespace Internal.JitInterface
         private byte[] _gcInfo;
         private CORINFO_EH_CLAUSE[] _ehClauses;
 
-        private void allocMem(uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* coldCodeBlock, ref void* roDataBlock)
+        private void doneWritingCode()
+        {
+        }
+
+        private void allocMem(uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* hotCodeBlockRW, ref void* coldCodeBlock, ref void* coldCodeBlockRW, ref void* roDataBlock, ref void* roDataBlockRW)
         {
             hotCodeBlock = (void*)GetPin(_code = new byte[hotCodeSize]);
+            hotCodeBlockRW = hotCodeBlock;
 
             if (coldCodeSize != 0)
+            {
                 coldCodeBlock = (void*)GetPin(_coldCode = new byte[coldCodeSize]);
+                coldCodeBlockRW = coldCodeBlock;
+            }
 
             _codeAlignment = -1;
             if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
@@ -3105,6 +3113,7 @@ namespace Internal.JitInterface
                 _roDataBlob = new MethodReadOnlyDataNode(MethodBeingCompiled);
 
                 roDataBlock = (void*)GetPin(_roData);
+                roDataBlockRW = roDataBlock;
             }
 
             if (_numFrameInfos > 0)
@@ -3280,7 +3289,7 @@ namespace Internal.JitInterface
             };
         }
 
-        private void recordRelocation(void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
+        private void recordRelocation(void* location, void* locationRW, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
         {
             // slotNum is not used
             Debug.Assert(slotNum == 0);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3070,50 +3070,50 @@ namespace Internal.JitInterface
         {
         }
 
-        private void allocMem(uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* hotCodeBlockRW, ref void* coldCodeBlock, ref void* coldCodeBlockRW, ref void* roDataBlock, ref void* roDataBlockRW)
+        private void allocMem(ref AllocMemArgs args)
         {
-            hotCodeBlock = (void*)GetPin(_code = new byte[hotCodeSize]);
-            hotCodeBlockRW = hotCodeBlock;
+            args.hotCodeBlock = (void*)GetPin(_code = new byte[args.hotCodeSize]);
+            args.hotCodeBlockRW = args.hotCodeBlock;
 
-            if (coldCodeSize != 0)
+            if (args.coldCodeSize != 0)
             {
-                coldCodeBlock = (void*)GetPin(_coldCode = new byte[coldCodeSize]);
-                coldCodeBlockRW = coldCodeBlock;
+                args.coldCodeBlock = (void*)GetPin(_coldCode = new byte[args.coldCodeSize]);
+                args.coldCodeBlockRW = args.coldCodeBlock;
             }
 
             _codeAlignment = -1;
-            if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+            if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
             {
                 _codeAlignment = 32;
             }
-            else if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
+            else if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
             {
                 _codeAlignment = 16;
             }
 
-            if (roDataSize != 0)
+            if (args.roDataSize != 0)
             {
                 _roDataAlignment = 8;
 
-                if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN) != 0)
+                if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN) != 0)
                 {
                     _roDataAlignment = 32;
                 }
-                else if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN) != 0)
+                else if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN) != 0)
                 {
                     _roDataAlignment = 16;
                 }
-                else if (roDataSize < 8)
+                else if (args.roDataSize < 8)
                 {
                     _roDataAlignment = PointerSize;
                 }
 
-                _roData = new byte[roDataSize];
+                _roData = new byte[args.roDataSize];
 
                 _roDataBlob = new MethodReadOnlyDataNode(MethodBeingCompiled);
 
-                roDataBlock = (void*)GetPin(_roData);
-                roDataBlockRW = roDataBlock;
+                args.roDataBlock = (void*)GetPin(_roData);
+                args.roDataBlockRW = args.roDataBlock;
             }
 
             if (_numFrameInfos > 0)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3066,10 +3066,6 @@ namespace Internal.JitInterface
         private byte[] _gcInfo;
         private CORINFO_EH_CLAUSE[] _ehClauses;
 
-        private void doneWritingCode()
-        {
-        }
-
         private void allocMem(ref AllocMemArgs args)
         {
             args.hotCodeBlock = (void*)GetPin(_code = new byte[args.hotCodeSize]);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -313,6 +313,25 @@ namespace Internal.JitInterface
         public int Other;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct AllocMemArgs
+    {
+        // Input arguments
+        public uint hotCodeSize;
+        public uint coldCodeSize;
+        public uint roDataSize;
+        public uint xcptnsCount;
+        public CorJitAllocMemFlag flag;
+
+        // Output arguments
+        public void* hotCodeBlock;
+        public void* hotCodeBlockRW;
+        public void* coldCodeBlock;
+        public void* coldCodeBlockRW;
+        public void* roDataBlock;
+        public void* roDataBlockRW;
+    }
+
     // Flags computed by a runtime compiler
     public enum CorInfoMethodRuntimeFlags
     {

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
@@ -101,6 +101,8 @@ CORINFO_JUST_MY_CODE_HANDLE**,ref CORINFO_JUST_MY_CODE_HANDLE_*
 ICorJitInfo::PgoInstrumentationSchema**,ref PgoInstrumentationSchema*
 ICorJitInfo::PgoInstrumentationSchema*,PgoInstrumentationSchema*
 
+AllocMemArgs*, ref AllocMemArgs
+
 ; Enums
 CorInfoClassId
 CorInfoHelpFunc
@@ -306,7 +308,7 @@ FUNCTIONS
     bool getTailCallHelpers(CORINFO_RESOLVED_TOKEN* callToken, CORINFO_SIG_INFO* sig, CORINFO_GET_TAILCALL_HELPERS_FLAGS flags, CORINFO_TAILCALL_HELPERS* pResult);
     bool convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool mustConvert);
     bool notifyInstructionSetUsage(CORINFO_InstructionSet instructionSet,bool supportEnabled);
-    void allocMem(        uint32_t               hotCodeSize,    uint32_t               coldCodeSize,     uint32_t               roDataSize,             uint32_t               xcptnsCount,            CorJitAllocMemFlag  flag,        void**             hotCodeBlock,        void**             hotCodeBlockRW,           void**             coldCodeBlock,           void**             coldCodeBlockRW,          void**             roDataBlock,          void**             roDataBlockRW             );
+    void allocMem(AllocMemArgs* pArgs);
     void reserveUnwindInfo(bool isFunclet, bool isColdCode, uint32_t unwindSize)
     void allocUnwindInfo(uint8_t* pHotCode, uint8_t* pColdCode, uint32_t startOffset, uint32_t endOffset, uint32_t unwindSize, uint8_t* pUnwindBlock, CorJitFuncKind funcKind)
     void* allocGCInfo(size_t size)

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
@@ -324,5 +324,4 @@ FUNCTIONS
     uint16_t getRelocTypeHint(void* target)
     uint32_t getExpectedTargetArchitecture()
     uint32_t getJitFlags(CORJIT_FLAGS* flags, uint32_t  sizeInBytes)
-    void doneWritingCode()
 

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
@@ -306,7 +306,7 @@ FUNCTIONS
     bool getTailCallHelpers(CORINFO_RESOLVED_TOKEN* callToken, CORINFO_SIG_INFO* sig, CORINFO_GET_TAILCALL_HELPERS_FLAGS flags, CORINFO_TAILCALL_HELPERS* pResult);
     bool convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool mustConvert);
     bool notifyInstructionSetUsage(CORINFO_InstructionSet instructionSet,bool supportEnabled);
-    void allocMem(        uint32_t               hotCodeSize,    uint32_t               coldCodeSize,     uint32_t               roDataSize,             uint32_t               xcptnsCount,            CorJitAllocMemFlag  flag,        void**             hotCodeBlock,           void**             coldCodeBlock,          void**             roDataBlock             );
+    void allocMem(        uint32_t               hotCodeSize,    uint32_t               coldCodeSize,     uint32_t               roDataSize,             uint32_t               xcptnsCount,            CorJitAllocMemFlag  flag,        void**             hotCodeBlock,        void**             hotCodeBlockRW,           void**             coldCodeBlock,           void**             coldCodeBlockRW,          void**             roDataBlock,          void**             roDataBlockRW             );
     void reserveUnwindInfo(bool isFunclet, bool isColdCode, uint32_t unwindSize)
     void allocUnwindInfo(uint8_t* pHotCode, uint8_t* pColdCode, uint32_t startOffset, uint32_t endOffset, uint32_t unwindSize, uint8_t* pUnwindBlock, CorJitFuncKind funcKind)
     void* allocGCInfo(size_t size)
@@ -318,8 +318,9 @@ FUNCTIONS
     JITINTERFACE_HRESULT getPgoInstrumentationResults(CORINFO_METHOD_HANDLE ftnHnd, ICorJitInfo::PgoInstrumentationSchema** pSchema, uint32_t* pCountSchemaItems, uint8_t**pInstrumentationData)
     JITINTERFACE_HRESULT allocPgoInstrumentationBySchema(CORINFO_METHOD_HANDLE ftnHnd, ICorJitInfo::PgoInstrumentationSchema* pSchema, uint32_t countSchemaItems, uint8_t** pInstrumentationData)
     void recordCallSite(uint32_t instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_HANDLE methodHandle)
-    void recordRelocation(void* location, void* target, uint16_t fRelocType, uint16_t slotNum, int32_t addlDelta)
+    void recordRelocation(void* location, void* locationRW, void* target, uint16_t fRelocType, uint16_t slotNum, int32_t addlDelta)
     uint16_t getRelocTypeHint(void* target)
     uint32_t getExpectedTargetArchitecture()
     uint32_t getJitFlags(CORJIT_FLAGS* flags, uint32_t  sizeInBytes)
+    void doneWritingCode()
 

--- a/src/coreclr/tools/aot/jitinterface/jitinterface.h
+++ b/src/coreclr/tools/aot/jitinterface/jitinterface.h
@@ -183,7 +183,6 @@ struct JitInterfaceCallbacks
     uint16_t (* getRelocTypeHint)(void * thisHandle, CorInfoExceptionClass** ppException, void* target);
     uint32_t (* getExpectedTargetArchitecture)(void * thisHandle, CorInfoExceptionClass** ppException);
     uint32_t (* getJitFlags)(void * thisHandle, CorInfoExceptionClass** ppException, CORJIT_FLAGS* flags, uint32_t sizeInBytes);
-    void (* doneWritingCode)(void * thisHandle, CorInfoExceptionClass** ppException);
 
 };
 
@@ -1855,12 +1854,5 @@ public:
     uint32_t temp = _callbacks->getJitFlags(_thisHandle, &pException, flags, sizeInBytes);
     if (pException != nullptr) throw pException;
     return temp;
-}
-
-    virtual void doneWritingCode()
-{
-    CorInfoExceptionClass* pException = nullptr;
-    _callbacks->doneWritingCode(_thisHandle, &pException);
-    if (pException != nullptr) throw pException;
 }
 };

--- a/src/coreclr/tools/aot/jitinterface/jitinterface.h
+++ b/src/coreclr/tools/aot/jitinterface/jitinterface.h
@@ -167,7 +167,7 @@ struct JitInterfaceCallbacks
     bool (* getTailCallHelpers)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* callToken, CORINFO_SIG_INFO* sig, CORINFO_GET_TAILCALL_HELPERS_FLAGS flags, CORINFO_TAILCALL_HELPERS* pResult);
     bool (* convertPInvokeCalliToCall)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool mustConvert);
     bool (* notifyInstructionSetUsage)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_InstructionSet instructionSet, bool supportEnabled);
-    void (* allocMem)(void * thisHandle, CorInfoExceptionClass** ppException, uint32_t hotCodeSize, uint32_t coldCodeSize, uint32_t roDataSize, uint32_t xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** hotCodeBlockRW, void** coldCodeBlock, void** coldCodeBlockRW, void** roDataBlock, void** roDataBlockRW);
+    void (* allocMem)(void * thisHandle, CorInfoExceptionClass** ppException, AllocMemArgs* pArgs);
     void (* reserveUnwindInfo)(void * thisHandle, CorInfoExceptionClass** ppException, bool isFunclet, bool isColdCode, uint32_t unwindSize);
     void (* allocUnwindInfo)(void * thisHandle, CorInfoExceptionClass** ppException, uint8_t* pHotCode, uint8_t* pColdCode, uint32_t startOffset, uint32_t endOffset, uint32_t unwindSize, uint8_t* pUnwindBlock, CorJitFuncKind funcKind);
     void* (* allocGCInfo)(void * thisHandle, CorInfoExceptionClass** ppException, size_t size);
@@ -1696,20 +1696,10 @@ public:
 }
 
     virtual void allocMem(
-          uint32_t hotCodeSize,
-          uint32_t coldCodeSize,
-          uint32_t roDataSize,
-          uint32_t xcptnsCount,
-          CorJitAllocMemFlag flag,
-          void** hotCodeBlock,
-          void** hotCodeBlockRW,
-          void** coldCodeBlock,
-          void** coldCodeBlockRW,
-          void** roDataBlock,
-          void** roDataBlockRW)
+          AllocMemArgs* pArgs)
 {
     CorInfoExceptionClass* pException = nullptr;
-    _callbacks->allocMem(_thisHandle, &pException, hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
+    _callbacks->allocMem(_thisHandle, &pException, pArgs);
     if (pException != nullptr) throw pException;
 }
 

--- a/src/coreclr/tools/aot/jitinterface/jitinterface.h
+++ b/src/coreclr/tools/aot/jitinterface/jitinterface.h
@@ -167,7 +167,7 @@ struct JitInterfaceCallbacks
     bool (* getTailCallHelpers)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* callToken, CORINFO_SIG_INFO* sig, CORINFO_GET_TAILCALL_HELPERS_FLAGS flags, CORINFO_TAILCALL_HELPERS* pResult);
     bool (* convertPInvokeCalliToCall)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool mustConvert);
     bool (* notifyInstructionSetUsage)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_InstructionSet instructionSet, bool supportEnabled);
-    void (* allocMem)(void * thisHandle, CorInfoExceptionClass** ppException, uint32_t hotCodeSize, uint32_t coldCodeSize, uint32_t roDataSize, uint32_t xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** coldCodeBlock, void** roDataBlock);
+    void (* allocMem)(void * thisHandle, CorInfoExceptionClass** ppException, uint32_t hotCodeSize, uint32_t coldCodeSize, uint32_t roDataSize, uint32_t xcptnsCount, CorJitAllocMemFlag flag, void** hotCodeBlock, void** hotCodeBlockRW, void** coldCodeBlock, void** coldCodeBlockRW, void** roDataBlock, void** roDataBlockRW);
     void (* reserveUnwindInfo)(void * thisHandle, CorInfoExceptionClass** ppException, bool isFunclet, bool isColdCode, uint32_t unwindSize);
     void (* allocUnwindInfo)(void * thisHandle, CorInfoExceptionClass** ppException, uint8_t* pHotCode, uint8_t* pColdCode, uint32_t startOffset, uint32_t endOffset, uint32_t unwindSize, uint8_t* pUnwindBlock, CorJitFuncKind funcKind);
     void* (* allocGCInfo)(void * thisHandle, CorInfoExceptionClass** ppException, size_t size);
@@ -179,10 +179,11 @@ struct JitInterfaceCallbacks
     JITINTERFACE_HRESULT (* getPgoInstrumentationResults)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_METHOD_HANDLE ftnHnd, ICorJitInfo::PgoInstrumentationSchema** pSchema, uint32_t* pCountSchemaItems, uint8_t** pInstrumentationData);
     JITINTERFACE_HRESULT (* allocPgoInstrumentationBySchema)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_METHOD_HANDLE ftnHnd, ICorJitInfo::PgoInstrumentationSchema* pSchema, uint32_t countSchemaItems, uint8_t** pInstrumentationData);
     void (* recordCallSite)(void * thisHandle, CorInfoExceptionClass** ppException, uint32_t instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_HANDLE methodHandle);
-    void (* recordRelocation)(void * thisHandle, CorInfoExceptionClass** ppException, void* location, void* target, uint16_t fRelocType, uint16_t slotNum, int32_t addlDelta);
+    void (* recordRelocation)(void * thisHandle, CorInfoExceptionClass** ppException, void* location, void* locationRW, void* target, uint16_t fRelocType, uint16_t slotNum, int32_t addlDelta);
     uint16_t (* getRelocTypeHint)(void * thisHandle, CorInfoExceptionClass** ppException, void* target);
     uint32_t (* getExpectedTargetArchitecture)(void * thisHandle, CorInfoExceptionClass** ppException);
     uint32_t (* getJitFlags)(void * thisHandle, CorInfoExceptionClass** ppException, CORJIT_FLAGS* flags, uint32_t sizeInBytes);
+    void (* doneWritingCode)(void * thisHandle, CorInfoExceptionClass** ppException);
 
 };
 
@@ -1701,11 +1702,14 @@ public:
           uint32_t xcptnsCount,
           CorJitAllocMemFlag flag,
           void** hotCodeBlock,
+          void** hotCodeBlockRW,
           void** coldCodeBlock,
-          void** roDataBlock)
+          void** coldCodeBlockRW,
+          void** roDataBlock,
+          void** roDataBlockRW)
 {
     CorInfoExceptionClass* pException = nullptr;
-    _callbacks->allocMem(_thisHandle, &pException, hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
+    _callbacks->allocMem(_thisHandle, &pException, hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, hotCodeBlockRW, coldCodeBlock, coldCodeBlockRW, roDataBlock, roDataBlockRW);
     if (pException != nullptr) throw pException;
 }
 
@@ -1825,13 +1829,14 @@ public:
 
     virtual void recordRelocation(
           void* location,
+          void* locationRW,
           void* target,
           uint16_t fRelocType,
           uint16_t slotNum,
           int32_t addlDelta)
 {
     CorInfoExceptionClass* pException = nullptr;
-    _callbacks->recordRelocation(_thisHandle, &pException, location, target, fRelocType, slotNum, addlDelta);
+    _callbacks->recordRelocation(_thisHandle, &pException, location, locationRW, target, fRelocType, slotNum, addlDelta);
     if (pException != nullptr) throw pException;
 }
 
@@ -1860,5 +1865,12 @@ public:
     uint32_t temp = _callbacks->getJitFlags(_thisHandle, &pException, flags, sizeInBytes);
     if (pException != nullptr) throw pException;
     return temp;
+}
+
+    virtual void doneWritingCode()
+{
+    CorInfoExceptionClass* pException = nullptr;
+    _callbacks->doneWritingCode(_thisHandle, &pException);
+    if (pException != nullptr) throw pException;
 }
 };

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12412,19 +12412,6 @@ void CEEJitInfo::getEHinfo(
     EE_TO_JIT_TRANSITION();
 }
 
-void CEEJitInfo::doneWritingCode()
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    } CONTRACTL_END;
-
-    JIT_TO_EE_TRANSITION();
-
-    EE_TO_JIT_TRANSITION();
-}
-
 
 #endif // CROSSGEN_COMPILE
 
@@ -14252,12 +14239,6 @@ bool CEEInfo::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken,
 }
 
 void CEEInfo::allocMem (AllocMemArgs *pArgs)
-{
-    LIMITED_METHOD_CONTRACT;
-    UNREACHABLE();      // only called on derived class.
-}
-
-void CEEInfo::doneWritingCode ()
 {
     LIMITED_METHOD_CONTRACT;
     UNREACHABLE();      // only called on derived class.

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -643,8 +643,11 @@ public:
             uint32_t            xcptnsCount,    /* IN */
             CorJitAllocMemFlag  flag,           /* IN */
             void **             hotCodeBlock,   /* OUT */
+            void **             hotCodeBlockRW, /* OUT */
             void **             coldCodeBlock,  /* OUT */
-            void **             roDataBlock     /* OUT */
+            void **             coldCodeBlockRW,/* OUT */
+            void **             roDataBlock,    /* OUT */
+            void **             roDataBlockRW   /* OUT */
             ) override final;
 
     void reserveUnwindInfo(bool isFunclet, bool isColdCode, uint32_t unwindSize) override final;
@@ -673,6 +676,8 @@ public:
             CORINFO_EH_CLAUSE* clause               /* OUT */
             ) override final;
 
+    void doneWritingCode() override final;
+
     HRESULT allocPgoInstrumentationBySchema(
             CORINFO_METHOD_HANDLE ftnHnd, /* IN */
             PgoInstrumentationSchema* pSchema, /* IN/OUT */
@@ -695,6 +700,7 @@ public:
 
     void recordRelocation(
             void                    *location,
+            void                    *locationRW,
             void                    *target,
             uint16_t                 fRelocType,
             uint16_t                 slot,
@@ -703,18 +709,6 @@ public:
     uint16_t getRelocTypeHint(void * target) override final;
 
     uint32_t getExpectedTargetArchitecture() override final;
-
-    CodeHeader* GetCodeHeader()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_CodeHeader;
-    }
-
-    void SetCodeHeader(CodeHeader* pValue)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_CodeHeader = pValue;
-    }
 
     void ResetForJitRetry()
     {

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -636,19 +636,7 @@ class CEEJitInfo : public CEEInfo
 public:
     // ICorJitInfo stuff
 
-    void allocMem (
-            uint32_t            hotCodeSize,    /* IN */
-            uint32_t            coldCodeSize,   /* IN */
-            uint32_t            roDataSize,     /* IN */
-            uint32_t            xcptnsCount,    /* IN */
-            CorJitAllocMemFlag  flag,           /* IN */
-            void **             hotCodeBlock,   /* OUT */
-            void **             hotCodeBlockRW, /* OUT */
-            void **             coldCodeBlock,  /* OUT */
-            void **             coldCodeBlockRW,/* OUT */
-            void **             roDataBlock,    /* OUT */
-            void **             roDataBlockRW   /* OUT */
-            ) override final;
+    void allocMem (AllocMemArgs *pArgs) override final;
 
     void reserveUnwindInfo(bool isFunclet, bool isColdCode, uint32_t unwindSize) override final;
 

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -664,8 +664,6 @@ public:
             CORINFO_EH_CLAUSE* clause               /* OUT */
             ) override final;
 
-    void doneWritingCode() override final;
-
     HRESULT allocPgoInstrumentationBySchema(
             CORINFO_METHOD_HANDLE ftnHnd, /* IN */
             PgoInstrumentationSchema* pSchema, /* IN/OUT */

--- a/src/coreclr/zap/zapinfo.cpp
+++ b/src/coreclr/zap/zapinfo.cpp
@@ -1138,50 +1138,38 @@ HRESULT ZapInfo::getPgoInstrumentationResults(CORINFO_METHOD_HANDLE      ftnHnd,
     return pgoResults->m_hr;
 }
 
-void ZapInfo::allocMem(
-    uint32_t            hotCodeSize,    /* IN */
-    uint32_t            coldCodeSize,   /* IN */
-    uint32_t            roDataSize,     /* IN */
-    uint32_t            xcptnsCount,    /* IN */
-    CorJitAllocMemFlag  flag,           /* IN */
-    void **             hotCodeBlock,   /* OUT */
-    void **             hotCodeBlockRW, /* OUT */
-    void **             coldCodeBlock,  /* OUT */
-    void **             coldCodeBlockRW,/* OUT */
-    void **             roDataBlock,    /* OUT */
-    void **             roDataBlockRW   /* OUT */
-    )
+void ZapInfo::allocMem(AllocMemArgs *pArgs)
 {
     bool optForSize = m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_SIZE_OPT);
 
     UINT align = DEFAULT_CODE_ALIGN;
 
-    if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) && !IsReadyToRunCompilation()) align = max(align, 16);
+    if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) && !IsReadyToRunCompilation()) align = max(align, 16);
 
-    m_pCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, hotCodeSize, align);
-    *hotCodeBlock = m_pCode->GetData();
-    *hotCodeBlockRW = m_pCode->GetData();
+    m_pCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, pArgs->hotCodeSize, align);
+    pArgs->hotCodeBlock = m_pCode->GetData();
+    pArgs->hotCodeBlockRW = m_pCode->GetData();
 
-    if (coldCodeSize != 0)
+    if (pArgs->coldCodeSize != 0)
     {
         align = sizeof(DWORD);
 
-        m_pColdCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, coldCodeSize, align);
-        *coldCodeBlock = m_pColdCode->GetData();
-        *coldCodeBlockRW = m_pColdCode->GetData();
+        m_pColdCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, pArgs->coldCodeSize, align);
+        pArgs->coldCodeBlock = m_pColdCode->GetData();
+        pArgs->coldCodeBlockRW = m_pColdCode->GetData();
     }
 
     //
     // Allocate data
     //
 
-    if (roDataSize > 0)
+    if (pArgs->roDataSize > 0)
     {
-        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
+        if (pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
         {
             align = 16;
         }
-        else if (optForSize || (roDataSize < 8))
+        else if (optForSize || (pArgs->roDataSize < 8))
         {
             align = TARGET_POINTER_SIZE;
         }
@@ -1189,36 +1177,36 @@ void ZapInfo::allocMem(
         {
             align = 8;
         }
-        m_pROData = ZapBlobWithRelocs::NewAlignedBlob(m_pImage, NULL, roDataSize, align);
-        *roDataBlock = m_pROData->GetData();
-        *roDataBlockRW = m_pROData->GetData();
+        m_pROData = ZapBlobWithRelocs::NewAlignedBlob(m_pImage, NULL, pArgs->roDataSize, align);
+        pArgs->roDataBlock = m_pROData->GetData();
+        pArgs->roDataBlockRW = m_pROData->GetData();
     }
 
     if (m_pImage->m_stats)
     {
-        m_pImage->m_stats->m_nativeCodeSize     += hotCodeSize;
-        m_pImage->m_stats->m_nativeColdCodeSize += coldCodeSize;
-        m_pImage->m_stats->m_nativeRODataSize   += roDataSize;
+        m_pImage->m_stats->m_nativeCodeSize     += pArgs->hotCodeSize;
+        m_pImage->m_stats->m_nativeColdCodeSize += pArgs->coldCodeSize;
+        m_pImage->m_stats->m_nativeRODataSize   += pArgs->roDataSize;
 
         BOOL haveProfileData = CurrentMethodHasProfileData();
 
         if (haveProfileData)
         {
-            m_pImage->m_stats->m_nativeCodeSizeInProfiledMethods     += hotCodeSize;
-            m_pImage->m_stats->m_nativeColdCodeSizeInProfiledMethods += coldCodeSize;
+            m_pImage->m_stats->m_nativeCodeSizeInProfiledMethods     += pArgs->hotCodeSize;
+            m_pImage->m_stats->m_nativeColdCodeSizeInProfiledMethods += pArgs->coldCodeSize;
         }
 
-        if (coldCodeSize)
+        if (pArgs->coldCodeSize)
         {
             m_pImage->m_stats->m_NumHotColdAllocations++;
 
-            m_pImage->m_stats->m_nativeCodeSizeInSplitMethods     += hotCodeSize;
-            m_pImage->m_stats->m_nativeColdCodeSizeInSplitMethods += coldCodeSize;
+            m_pImage->m_stats->m_nativeCodeSizeInSplitMethods     += pArgs->hotCodeSize;
+            m_pImage->m_stats->m_nativeColdCodeSizeInSplitMethods += pArgs->coldCodeSize;
 
             if (haveProfileData)
             {
-                m_pImage->m_stats->m_nativeCodeSizeInSplitProfiledMethods     += hotCodeSize;
-                m_pImage->m_stats->m_nativeColdCodeSizeInSplitProfiledMethods += coldCodeSize;
+                m_pImage->m_stats->m_nativeCodeSizeInSplitProfiledMethods     += pArgs->hotCodeSize;
+                m_pImage->m_stats->m_nativeColdCodeSizeInSplitProfiledMethods += pArgs->coldCodeSize;
             }
         }
         else

--- a/src/coreclr/zap/zapinfo.cpp
+++ b/src/coreclr/zap/zapinfo.cpp
@@ -4120,10 +4120,6 @@ bool ZapInfo::pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method,
     return m_pEEJitInfo->pInvokeMarshalingRequired(method, sig);
 }
 
-void ZapInfo::doneWritingCode()
-{
-}
-
 LPVOID ZapInfo::GetCookieForPInvokeCalliSig(CORINFO_SIG_INFO* szMetaSig,
                                                  void ** ppIndirection)
 {

--- a/src/coreclr/zap/zapinfo.cpp
+++ b/src/coreclr/zap/zapinfo.cpp
@@ -1145,8 +1145,11 @@ void ZapInfo::allocMem(
     uint32_t            xcptnsCount,    /* IN */
     CorJitAllocMemFlag  flag,           /* IN */
     void **             hotCodeBlock,   /* OUT */
+    void **             hotCodeBlockRW, /* OUT */
     void **             coldCodeBlock,  /* OUT */
-    void **             roDataBlock     /* OUT */
+    void **             coldCodeBlockRW,/* OUT */
+    void **             roDataBlock,    /* OUT */
+    void **             roDataBlockRW   /* OUT */
     )
 {
     bool optForSize = m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_SIZE_OPT);
@@ -1157,6 +1160,7 @@ void ZapInfo::allocMem(
 
     m_pCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, hotCodeSize, align);
     *hotCodeBlock = m_pCode->GetData();
+    *hotCodeBlockRW = m_pCode->GetData();
 
     if (coldCodeSize != 0)
     {
@@ -1164,6 +1168,7 @@ void ZapInfo::allocMem(
 
         m_pColdCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, coldCodeSize, align);
         *coldCodeBlock = m_pColdCode->GetData();
+        *coldCodeBlockRW = m_pColdCode->GetData();
     }
 
     //
@@ -1186,6 +1191,7 @@ void ZapInfo::allocMem(
         }
         m_pROData = ZapBlobWithRelocs::NewAlignedBlob(m_pImage, NULL, roDataSize, align);
         *roDataBlock = m_pROData->GetData();
+        *roDataBlockRW = m_pROData->GetData();
     }
 
     if (m_pImage->m_stats)
@@ -2803,7 +2809,7 @@ void ZapInfo::recordCallSite(uint32_t instrOffset, CORINFO_SIG_INFO *callSig, CO
     return;
 }
 
-void ZapInfo::recordRelocation(void *location, void *target,
+void ZapInfo::recordRelocation(void *location, void *locationRW, void *target,
                                uint16_t fRelocType, uint16_t slotNum, int32_t addlDelta)
 {
     // Factor slotNum into the location address
@@ -4124,6 +4130,10 @@ bool ZapInfo::pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method,
     }
 
     return m_pEEJitInfo->pInvokeMarshalingRequired(method, sig);
+}
+
+void ZapInfo::doneWritingCode()
+{
 }
 
 LPVOID ZapInfo::GetCookieForPInvokeCalliSig(CORINFO_SIG_INFO* szMetaSig,


### PR DESCRIPTION
This change modifies JIT so that it can generate code into
double mapped memory. The code is written into RW mapped memory,
but the relative offsets are computed using the related RX locations.

The change doesn't modify the runtime to provide double mapped memory
yet, the JIT2EE interface allocMem returns the same addresses as RW and
RX. The runtime changes will be part of follow-up PRs. However, it was
already tested with the double mapping enabled locally.