### PR TITLE
JIT: work around issues invoking the unboxed entry when prejitting

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21008,6 +21008,14 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         {
             JITDUMP("Have a direct explicit tail call to boxed entry point; can't optimize further\n");
         }
+        else if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT))
+        {
+            // Per https://github.com/dotnet/runtime/issues/52483, crossgen2 seemingly gets
+            // confused about whether the unboxed entry requires an extra arg.
+            // So defer further optimization for now.
+            //
+            JITDUMP("Have a direct boxed entry point, prejitting. Can't optimize further yet.\n");
+        }
         else
         {
             JITDUMP("Have a direct call to boxed entry point. Trying to optimize to call an unboxed entry point\n");


### PR DESCRIPTION
If the jit devirtualizes a call to a value class method, it will try
and update the call to invoke the unboxed entry for the method. This
entry sometimes requires an explicit type context argument.

There are cases where the prejit host seemingly does not properly deduce
when the unboxed entry requires this extra argument. Until this is resolved,
defer this optimization when prejitting.

See #52483 for details.