### PR TITLE
[iOS][tvOS][tests] Re add ios tvos simulator functional tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -182,7 +182,7 @@
     <!-- Crashes on CI but passes locally https://github.com/dotnet/runtime/issues/52615 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj" />
-    
+
     <!-- Can't AOT in interp mode -->
     <ProjectExclusions Condition="'$(MonoForceInterpreter)' == 'true'"
                        Include="$(RepoRoot)\src\tests\FunctionalTests\tvOS\Simulator\AOT\**\*.Test.csproj" />
@@ -396,7 +396,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator')">
-    <!-- Disable tvOS.Simulator.Aot.Test.csproj temporarily due to https://github.com/dotnet/runtime/issues/49757 -->
     <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\tvOS\**\*.Test.csproj"
                       Exclude="@(ProjectExclusions)"
                       BuildInParallel="false" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -170,7 +170,9 @@
     <!-- System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
 
-    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT\iOS.Simulator.Aot.Test.csproj" />
+    <!-- Can't AOT in interp mode -->
+    <ProjectExclusions Condition="'$(MonoForceInterpreter)' == 'true'"
+                       Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator') and '$(RunDisablediOSTests)' != 'true'">
@@ -180,6 +182,10 @@
     <!-- Crashes on CI but passes locally https://github.com/dotnet/runtime/issues/52615 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj" />
+    
+    <!-- Can't AOT in interp mode -->
+    <ProjectExclusions Condition="'$(MonoForceInterpreter)' == 'true'"
+                       Include="$(RepoRoot)\src\tests\FunctionalTests\tvOS\Simulator\AOT\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(TargetOS)' == 'MacCatalyst') and '$(RunDisablediOSTests)' != 'true'">
@@ -390,6 +396,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator')">
+    <!-- Disable tvOS.Simulator.Aot.Test.csproj temporarily due to https://github.com/dotnet/runtime/issues/49757 -->
     <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\tvOS\**\*.Test.csproj"
                       Exclude="@(ProjectExclusions)"
                       BuildInParallel="false" />

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT/Program.cs
@@ -10,7 +10,7 @@ public static class Program
 {
     [DllImport("__Internal")]
     public static extern void mono_ios_set_summary (string value);
-    
+
     public static async Task<int> Main(string[] args)
     {
         mono_ios_set_summary($"Starting functional test");

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT/Program.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+public static class Program
+{
+    [DllImport("__Internal")]
+    public static extern void mono_ios_set_summary (string value);
+    
+    public static async Task<int> Main(string[] args)
+    {
+        mono_ios_set_summary($"Starting functional test");
+        Console.WriteLine("Done!");
+        await Task.Delay(5000);
+
+        return 42;
+    }
+}

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT/iOS.Simulator.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT/iOS.Simulator.Aot.Test.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <MonoForceInterpreter>false</MonoForceInterpreter>
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <TestRuntime>true</TestRuntime>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetOS Condition="'$(TargetOS)' == ''">iOSSimulator</TargetOS>
+    <MainLibraryFileName>iOS.Simulator.Aot.Test.dll</MainLibraryFileName>
+    <IncludesTestRunner>false</IncludesTestRunner>
+    <ExpectedExitCode>42</ExpectedExitCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/FunctionalTests/tvOS/Simulator/AOT/Program.cs
+++ b/src/tests/FunctionalTests/tvOS/Simulator/AOT/Program.cs
@@ -10,7 +10,7 @@ public static class Program
 {
     [DllImport("__Internal")]
     public static extern void mono_ios_set_summary (string value);
-    
+
     public static async Task<int> Main(string[] args)
     {
         mono_ios_set_summary($"Starting functional test");

--- a/src/tests/FunctionalTests/tvOS/Simulator/AOT/Program.cs
+++ b/src/tests/FunctionalTests/tvOS/Simulator/AOT/Program.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+public static class Program
+{
+    [DllImport("__Internal")]
+    public static extern void mono_ios_set_summary (string value);
+    
+    public static async Task<int> Main(string[] args)
+    {
+        mono_ios_set_summary($"Starting functional test");
+        Console.WriteLine("Done!");
+        await Task.Delay(5000);
+
+        return 42;
+    }
+}

--- a/src/tests/FunctionalTests/tvOS/Simulator/AOT/tvOS.Simulator.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/tvOS/Simulator/AOT/tvOS.Simulator.Aot.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <MonoForceInterpreter>false</MonoForceInterpreter>
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <TestRuntime>true</TestRuntime>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <MainLibraryFileName>tvOS.Simulator.Aot.Test.dll</MainLibraryFileName>
+    <IncludesTestRunner>false</IncludesTestRunner>
+    <ExpectedExitCode>42</ExpectedExitCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The iOS simulator and tvOS simulator AOT functional tests had been removed in a previous commit, but instead, they will be brought back for local development usage, and skipped on CI until we add a way to bypass the `Global property cannot be modified` error.