### PR TITLE
Fixed a bug in websocket receive, when a compressed frame with no payload is received.

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1246,7 +1246,7 @@ namespace System.Net.WebSockets
 
             // Return the read header
             resultHeader = header;
-            resultHeader.Processed = header.PayloadLength == 0;
+            resultHeader.Processed = header.PayloadLength == 0 && !header.Compressed;
             return null;
         }
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -607,6 +607,51 @@ namespace System.Net.WebSockets.Tests
             }
         }
 
+        [Fact]
+        public async Task CompressedMessageWithEmptyLastFrame()
+        {
+            WebSocketTestStream stream = new();
+            using WebSocket server = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions
+            {
+                IsServer = true,
+                KeepAliveInterval = TimeSpan.Zero,
+                DangerousDeflateOptions = new()
+            });
+
+            byte[] frame1 = new byte[1024];
+            byte[] frame2 = new byte[2048];
+
+            await server.SendAsync(frame1, WebSocketMessageType.Binary, false, CancellationToken);
+            await server.SendAsync(frame2, WebSocketMessageType.Binary, false, CancellationToken);
+
+            // Add empty end of message frame manually, because the compression routine cannot
+            // produce empty segments.
+            stream.Remote.Enqueue(0x80, 0x00);
+
+            using WebSocket client = WebSocket.CreateFromStream(stream.Remote, new WebSocketCreationOptions
+            {
+                IsServer = false,
+                KeepAliveInterval = TimeSpan.Zero,
+                DangerousDeflateOptions = new()
+            });
+
+            int messageSize = 0;
+            byte[] buffer = new byte[128];
+
+            while (true)
+            {
+                WebSocketReceiveResult result = await client.ReceiveAsync(buffer, CancellationToken);
+                messageSize += result.Count;
+
+                if (result.EndOfMessage)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(frame1.Length + frame2.Length, messageSize);
+        }
+
         private ValueTask SendTextAsync(string text, WebSocket websocket, bool disableCompression = false)
         {
             WebSocketMessageFlags flags = WebSocketMessageFlags.EndOfMessage;


### PR DESCRIPTION
There are extremely rare cases where it is possible to receive an empty frame, part of compressed a message.

If such a frame happened to be the last frame of the message, and there was leftover data available in the inflater, the receive
operation would ignore the data and think that there is nothing and return 0 bytes received to the user.

https://github.com/dotnet/runtime/blob/b306268b614145908061b14dd24d860dcf3bd6b9/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs#L1249

https://github.com/dotnet/runtime/blob/b306268b614145908061b14dd24d860dcf3bd6b9/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs#L810-L817

One other condition for this case is that the receive buffer is small enough, so the inflate cannot flush everything to the user. This was caught by @BrennanConroy running Autobahn Testsuite with receive buffer size of **4096**. The Testsuite sends such frames occasionally to make sure the implementation handles them correctly.

Our internal implementation however cannot produce such frame. When sending an empty compressed frame, the resulting payload will always be 1 byte - a zero.

The fix for this is to treat empty compressed frames as not processed, until inflation has been run.

@BrennanConroy could you try and run your test server with this branch, please?

Fixes #52551 

//cc @CarnaViire 