### PR TITLE
Use of WCHAR in `corinfo.h` leaves consumer with dependency on pal_mstypes/windows.h

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1817,7 +1817,7 @@ struct CORINFO_Object
 struct CORINFO_String : public CORINFO_Object
 {
     unsigned                stringLen;
-    WCHAR                   chars[1];       // actually of variable size
+    char16_t                chars[1];       // actually of variable size
 };
 
 struct CORINFO_Array : public CORINFO_Object

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2635,7 +2635,7 @@ public:
                 unsigned int           *cILOffsets,         // [OUT] size of pILOffsets
                 uint32_t              **pILOffsets,         // [OUT] IL offsets of interest
                                                             //       jit MUST free with freeArray!
-                ICorDebugInfo::BoundaryTypes *implictBoundaries // [OUT] tell jit, all boundries of this type
+                ICorDebugInfo::BoundaryTypes *implicitBoundaries // [OUT] tell jit, all boundaries of this type
                 ) = 0;
 
     // Report back the mapping from IL to native code,

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2635,7 +2635,7 @@ public:
                 unsigned int           *cILOffsets,         // [OUT] size of pILOffsets
                 uint32_t              **pILOffsets,         // [OUT] IL offsets of interest
                                                             //       jit MUST free with freeArray!
-                ICorDebugInfo::BoundaryTypes *implicitBoundaries // [OUT] tell jit, all boundaries of this type
+                ICorDebugInfo::BoundaryTypes *implictBoundaries // [OUT] tell jit, all boundries of this type
                 ) = 0;
 
     // Report back the mapping from IL to native code,

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1411,7 +1411,7 @@ const WCHAR* Compiler::eeGetCPString(size_t strHandle)
         return nullptr;
     }
 
-    return (asString->chars);
+    return (WCHAR*)(asString->chars);
 #endif // HOST_UNIX
 }
 


### PR DESCRIPTION
This changes a field from `WCHAR` (which at this point, is an alias to `char16_t`) to the `char16_t` so that anyone consuming this header doesn't need to include either `pal_mstypes` or `windows.h` first.

This is the only dependency on the PAL types in this header, all the other occurrences have been fixed.

```
Error: D:\a\Pyjion\Pyjion\CoreCLR\src\coreclr\inc\corinfo.h(1817,29): error C3646: 'chars': unknown override specifier [D:\a\Pyjion\build\pyjionlib.vcxproj]
214
Error: D:\a\Pyjion\Pyjion\CoreCLR\src\coreclr\inc\corinfo.h(1817,34): error C2143: syntax error: missing ',' before '[' [D:\a\Pyjion\build\pyjionlib.vcxproj]
215
Error: D:\a\Pyjion\Pyjion\CoreCLR\src\coreclr\inc\corinfo.h(1817,37): error C2238: unexpected token(s) preceding ';' [D:\a\Pyjion\build\pyjionlib.vcxproj]

```