### PR TITLE
[debugger][interpreter] Generate seq_points even when doesn't have debug information

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4301,7 +4301,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 	gboolean link_bblocks = TRUE;
 	gboolean inlining = td->method != method;
 	InterpBasicBlock *exit_bb = NULL;
-	gboolean without_debug_info = FALSE;
 
 	original_bb = bb = mono_basic_block_split (method, error, header);
 	goto_if_nok (error, exit);
@@ -4360,8 +4359,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			/* Methods without line number info like auto-generated property accessors */
 			seq_point_locs = mono_bitset_new (header->code_size, 0);
 			sym_seq_points = TRUE;
-			if (!mono_debug_image_has_debug_info (m_class_get_image (method->klass)))
-				without_debug_info = TRUE;
 		}
 	}
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4356,7 +4356,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				}
 				mono_debug_free_method_async_debug_info (asyncMethod);
 			}
-		} else if (!method->wrapper_type && !method->dynamic) {
+		} else if (!method->wrapper_type && !method->dynamic && mono_debug_image_has_debug_info (m_class_get_image (method->klass))) {
 			/* Methods without line number info like auto-generated property accessors */
 			seq_point_locs = mono_bitset_new (header->code_size, 0);
 			sym_seq_points = TRUE;
@@ -4534,12 +4534,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				(td->sp > td->stack && (td->sp [-1].type == STACK_TYPE_O || td->sp [-1].type == STACK_TYPE_VT)) ? (td->sp [-1].klass == NULL ? "?" : m_class_get_name (td->sp [-1].klass)) : "");
 		}
 
-		if (without_debug_info && in_offset == 0) {
-			interp_add_ins (td, MINT_SDB_INTR_LOC);
-			last_seq_point = interp_add_ins (td, MINT_SDB_SEQ_POINT);
-		}
-		
-		if (sym_seq_points && mono_bitset_test_fast (seq_point_locs, td->ip - header->code)) {
+		if (td->gen_sdb_seq_points && ((!sym_seq_points && td->stack == td->sp) || (sym_seq_points && mono_bitset_test_fast (seq_point_locs, td->ip - header->code)))) {
 			if (in_offset == 0 || (header->num_clauses && !td->cbb->last_ins))
 				interp_add_ins (td, MINT_SDB_INTR_LOC);
 			last_seq_point = interp_add_ins (td, MINT_SDB_SEQ_POINT);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4301,6 +4301,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 	gboolean link_bblocks = TRUE;
 	gboolean inlining = td->method != method;
 	InterpBasicBlock *exit_bb = NULL;
+	gboolean without_debug_info = FALSE;
 
 	original_bb = bb = mono_basic_block_split (method, error, header);
 	goto_if_nok (error, exit);
@@ -4355,10 +4356,12 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				}
 				mono_debug_free_method_async_debug_info (asyncMethod);
 			}
-		} else if (!method->wrapper_type && !method->dynamic && mono_debug_image_has_debug_info (m_class_get_image (method->klass))) {
+		} else if (!method->wrapper_type && !method->dynamic) {
 			/* Methods without line number info like auto-generated property accessors */
 			seq_point_locs = mono_bitset_new (header->code_size, 0);
 			sym_seq_points = TRUE;
+			if (!mono_debug_image_has_debug_info (m_class_get_image (method->klass)))
+				without_debug_info = TRUE;
 		}
 	}
 
@@ -4531,6 +4534,11 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				(td->sp > td->stack && (td->sp [-1].type == STACK_TYPE_O || td->sp [-1].type == STACK_TYPE_VT)) ? (td->sp [-1].klass == NULL ? "?" : m_class_get_name (td->sp [-1].klass)) : "");
 		}
 
+		if (without_debug_info && in_offset == 0) {
+			interp_add_ins (td, MINT_SDB_INTR_LOC);
+			last_seq_point = interp_add_ins (td, MINT_SDB_SEQ_POINT);
+		}
+		
 		if (sym_seq_points && mono_bitset_test_fast (seq_point_locs, td->ip - header->code)) {
 			if (in_offset == 0 || (header->num_clauses && !td->cbb->last_ins))
 				interp_add_ins (td, MINT_SDB_INTR_LOC);


### PR DESCRIPTION
Trying to generate seq_points even without debug info as it's done in methor-to-ir.

How to reproduce:
1) run sdb
2) bp add method `method_name_sample`
3) Run a mono app attach to sdb.
4) Call the method `method_name_sample` on the assembly without debug info

Breakpoint works on JIT and doesn't work on interpreter.