### PR TITLE
[Android] Improve memory & pointer handling in Cryptography.Native.Android

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -3,6 +3,7 @@ project(System.Security.Cryptography.Native.Android C)
 add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
 add_compile_options(-Wno-unused-parameter)
 add_compile_options(-Wno-unused-function)
+add_compile_options(-Wnonnull)
 
 set(NATIVECRYPTO_SOURCES
     pal_bignum.c
@@ -17,6 +18,7 @@ set(NATIVECRYPTO_SOURCES
     pal_hmac.c
     pal_jni.c
     pal_lifetime.c
+    pal_memory.c
     pal_misc.c
     pal_rsa.c
     pal_signature.c

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.c
@@ -50,7 +50,7 @@ jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len)
 
     // return new BigInteger(bytes)
     JNIEnv* env = GetJNIEnv();
-    jbyteArray buffArray = (*env)->NewByteArray(env, len);
+    jbyteArray buffArray = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, buffArray, 0, len, (jbyte*)bytes);
     jobject bigNum = (*env)->NewObject(env, g_bigNumClass, g_bigNumCtorWithSign, 1, buffArray);
     (*env)->DeleteLocalRef(env, buffArray);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_bignum.h
@@ -13,5 +13,5 @@ Create a BigInteger from its binary representation.
 
 The returned jobject will be a local reference.
 */
-jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len);
-int32_t AndroidCryptoNative_GetBigNumBytesIncludingPaddingByteForSign(jobject bignum);
+jobject AndroidCryptoNative_BigNumFromBinary(uint8_t* bytes, int32_t len) ARGS_NON_NULL_ALL;
+int32_t AndroidCryptoNative_GetBigNumBytesIncludingPaddingByteForSign(jobject bignum) ARGS_NON_NULL_ALL;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_cipher.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_cipher.c
@@ -52,19 +52,27 @@ DEFINE_CIPHER(Des3Cbc,      128, "DESede/CBC/NoPadding", CIPHER_REQUIRES_IV)
 DEFINE_CIPHER(Des3Cfb8,     128, "DESede/CFB8/NoPadding", CIPHER_REQUIRES_IV)
 DEFINE_CIPHER(Des3Cfb64,    128, "DESede/CFB/NoPadding", CIPHER_REQUIRES_IV)
 
-static bool HasTag(CipherInfo* type)
+//
+// We don't have to check whether `CipherInfo` arguments are valid pointers, as these functions will be called after the
+// context is created and the type stored in `CipherInfo` is asserted to be not NULL on creation time.  Managed code
+// cannot modify the context so it's fairly safe to assume that we're passed a valid pointer here.
+//
+// The entry functions (those that can be called by external code) take care to validate that the context passed to them
+// is a valid pointer and so we can assume the assertion from the preceding paragraph.
+//
+ARGS_NON_NULL_ALL static bool HasTag(CipherInfo* type)
 {
     return (type->flags & CIPHER_HAS_TAG) == CIPHER_HAS_TAG;
 }
 
-static bool RequiresIV(CipherInfo* type)
+ARGS_NON_NULL_ALL static bool RequiresIV(CipherInfo* type)
 {
     return (type->flags & CIPHER_REQUIRES_IV) == CIPHER_REQUIRES_IV;
 }
 
-static jobject GetAlgorithmName(JNIEnv* env, CipherInfo* type)
+ARGS_NON_NULL_ALL static jobject GetAlgorithmName(JNIEnv* env, CipherInfo* type)
 {
-    return JSTRING(type->name);
+    return make_java_string(env, type->name);
 }
 
 CipherCtx* AndroidCryptoNative_CipherCreatePartial(CipherInfo* type)
@@ -84,7 +92,7 @@ CipherCtx* AndroidCryptoNative_CipherCreatePartial(CipherInfo* type)
         return FAIL;
     }
 
-    CipherCtx* ctx = malloc(sizeof(CipherCtx));
+    CipherCtx* ctx = xmalloc(sizeof(CipherCtx));
     ctx->cipher = cipher;
     ctx->type = type;
     ctx->tagLength = TAG_MAX_LENGTH;
@@ -108,7 +116,7 @@ int32_t AndroidCryptoNative_CipherSetTagLength(CipherCtx* ctx, int32_t tagLength
     return SUCCESS;
 }
 
-static int32_t ReinitializeCipher(CipherCtx* ctx)
+ARGS_NON_NULL_ALL static int32_t ReinitializeCipher(CipherCtx* ctx)
 {
     JNIEnv* env = GetJNIEnv();
 
@@ -121,14 +129,14 @@ static int32_t ReinitializeCipher(CipherCtx* ctx)
         return FAIL;
 
     int32_t keyLength = ctx->keySizeInBits / 8;
-    jbyteArray keyBytes = (*env)->NewByteArray(env, keyLength);
+    jbyteArray keyBytes = make_java_byte_array(env, keyLength);
     (*env)->SetByteArrayRegion(env, keyBytes, 0, keyLength, (jbyte*)ctx->key);
     jobject sksObj = (*env)->NewObject(env, g_sksClass, g_sksCtor, keyBytes, algName);
 
     jobject ivPsObj = NULL;
     if (RequiresIV(ctx->type))
     {
-        jbyteArray ivBytes = (*env)->NewByteArray(env, ctx->ivLength);
+        jbyteArray ivBytes = make_java_byte_array(env, ctx->ivLength);
         (*env)->SetByteArrayRegion(env, ivBytes, 0, ctx->ivLength, (jbyte*)ctx->iv);
         if (HasTag(ctx->type))
         {
@@ -216,7 +224,7 @@ int32_t AndroidCryptoNative_CipherUpdateAAD(CipherCtx* ctx, uint8_t* in, int32_t
     abort_if_invalid_pointer_argument(in);
 
     JNIEnv* env = GetJNIEnv();
-    jbyteArray inDataBytes = (*env)->NewByteArray(env, inl);
+    jbyteArray inDataBytes = make_java_byte_array(env, inl);
     (*env)->SetByteArrayRegion(env, inDataBytes, 0, inl, (jbyte*)in);
     (*env)->CallVoidMethod(env, ctx->cipher, g_cipherUpdateAADMethod, inDataBytes);
     (*env)->DeleteLocalRef(env, inDataBytes);
@@ -236,7 +244,7 @@ int32_t AndroidCryptoNative_CipherUpdate(CipherCtx* ctx, uint8_t* outm, int32_t*
     abort_if_invalid_pointer_argument(in);
 
     JNIEnv* env = GetJNIEnv();
-    jbyteArray inDataBytes = (*env)->NewByteArray(env, inl);
+    jbyteArray inDataBytes = make_java_byte_array(env, inl);
     (*env)->SetByteArrayRegion(env, inDataBytes, 0, inl, (jbyte*)in);
 
     *outl = 0;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
@@ -16,7 +16,7 @@ int32_t AndroidCryptoNative_DsaGenerateKey(jobject* dsa, int32_t bits)
     // KeyPair kp = kpg.genKeyPair();
 
     JNIEnv* env = GetJNIEnv();
-    jobject dsaStr = JSTRING("DSA");
+    jobject dsaStr = make_java_string(env, "DSA");
     jobject kpgObj =  (*env)->CallStaticObjectMethod(env, g_keyPairGenClass, g_keyPairGenGetInstanceMethod, dsaStr);
     (*env)->DeleteLocalRef(env, dsaStr);
     if (CheckJNIExceptions(env))
@@ -40,14 +40,12 @@ int32_t AndroidCryptoNative_DsaGenerateKey(jobject* dsa, int32_t bits)
     return SUCCESS;
 }
 
-static jobject GetQParameter(JNIEnv* env, jobject dsa)
+ARGS_NON_NULL_ALL static jobject GetQParameter(JNIEnv* env, jobject dsa)
 {
-    abort_if_invalid_pointer_argument (dsa);
-
     jobject ret = NULL;
 
     INIT_LOCALS(loc, algName, keyFactory, publicKey, publicKeySpec);
-    loc[algName] = JSTRING("DSA");
+    loc[algName] = make_java_string(env, "DSA");
     loc[keyFactory] = (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[algName]);
     loc[publicKey] = (*env)->CallObjectMethod(env, dsa, g_keyPairGetPublicMethod);
     loc[publicKeySpec] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGetKeySpecMethod, loc[publicKey], g_DSAPublicKeySpecClass);
@@ -93,7 +91,7 @@ int32_t AndroidCryptoNative_DsaSizeP(jobject dsa)
 
     JNIEnv* env = GetJNIEnv();
     INIT_LOCALS(loc, algName, keyFactory, publicKey, publicKeySpec, p);
-    loc[algName] = JSTRING("DSA");
+    loc[algName] = make_java_string(env, "DSA");
     loc[keyFactory] = (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[algName]);
     loc[publicKey] = (*env)->CallObjectMethod(env, dsa, g_keyPairGetPublicMethod);
     loc[publicKeySpec] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGetKeySpecMethod, loc[publicKey], g_DSAPublicKeySpecClass);
@@ -113,6 +111,8 @@ error:
 
 int32_t AndroidCryptoNative_DsaSignatureFieldSize(jobject dsa)
 {
+    abort_if_invalid_pointer_argument (dsa);
+
     JNIEnv* env = GetJNIEnv();
     jobject q = GetQParameter(env, dsa);
     if (!q)
@@ -124,9 +124,9 @@ int32_t AndroidCryptoNative_DsaSignatureFieldSize(jobject dsa)
     return byteLength;
 }
 
-static jobject GetDsaSignatureObject(JNIEnv* env)
+ARGS_NON_NULL_ALL static jobject GetDsaSignatureObject(JNIEnv* env)
 {
-    jstring algorithmName = JSTRING("NONEwithDSA");
+    jstring algorithmName = make_java_string(env, "NONEwithDSA");
     jobject signatureObject =
         (*env)->CallStaticObjectMethod(env, g_SignatureClass, g_SignatureGetInstance, algorithmName);
     (*env)->DeleteLocalRef(env, algorithmName);
@@ -220,7 +220,7 @@ int32_t AndroidCryptoNative_GetDsaParameters(
 
     INIT_LOCALS(loc, algName, keyFactory, publicKey, publicKeySpec, privateKey, privateKeySpec);
 
-    loc[algName] = JSTRING("DSA");
+    loc[algName] = make_java_string(env, "DSA");
     loc[keyFactory] = (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[algName]);
     loc[publicKey] = (*env)->CallObjectMethod(env, dsa, g_keyPairGetPublicMethod);
     loc[publicKeySpec] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGetKeySpecMethod, loc[publicKey], g_DSAPublicKeySpecClass);
@@ -286,7 +286,7 @@ int32_t AndroidCryptoNative_DsaKeyCreateByExplicitParameters(
         loc[privateKeySpec] = (*env)->NewObject(env, g_DSAPrivateKeySpecClass, g_DSAPrivateKeySpecCtor, bn[X], bn[P], bn[Q], bn[G]);
     }
 
-    loc[dsa] = JSTRING("DSA");
+    loc[dsa] = make_java_string(env, "DSA");
     loc[keyFactory] = (*env)->CallStaticObjectMethod(env, g_KeyFactoryClass, g_KeyFactoryGetInstanceMethod, loc[dsa]);
     loc[publicKey] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGenPublicMethod, loc[publicKeySpec]);
     ON_EXCEPTION_PRINT_AND_GOTO(error);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecdh.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecdh.c
@@ -15,7 +15,7 @@ int32_t AndroidCryptoNative_EcdhDeriveKey(EC_KEY* ourKey, EC_KEY* peerKey, uint8
 
     JNIEnv* env = GetJNIEnv();
 
-    jstring algorithmName = JSTRING("ECDH");
+    jstring algorithmName = make_java_string(env, "ECDH");
 
     jobject keyAgreement = (*env)->CallStaticObjectMethod(env, g_KeyAgreementClass, g_KeyAgreementGetInstance, algorithmName);
     ReleaseLRef(env, algorithmName);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecdsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecdsa.c
@@ -6,9 +6,9 @@
 #include "pal_signature.h"
 #include "pal_utilities.h"
 
-static jobject GetEcDsaSignatureObject(JNIEnv* env)
+ARGS_NON_NULL_ALL static jobject GetEcDsaSignatureObject(JNIEnv* env)
 {
-    jstring algorithmName = JSTRING("NONEwithECDSA");
+    jstring algorithmName = make_java_string(env, "NONEwithECDSA");
     jobject signatureObject =
         (*env)->CallStaticObjectMethod(env, g_SignatureClass, g_SignatureGetInstance, algorithmName);
     (*env)->DeleteLocalRef(env, algorithmName);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.c
@@ -11,8 +11,7 @@ EC_KEY* AndroidCryptoNative_NewEcKey(jobject curveParameters, jobject keyPair)
     abort_if_invalid_pointer_argument (curveParameters);
     abort_if_invalid_pointer_argument (keyPair);
 
-    EC_KEY* keyInfo = malloc(sizeof(EC_KEY));
-    memset(keyInfo, 0, sizeof(EC_KEY));
+    EC_KEY* keyInfo = xcalloc(1, sizeof(EC_KEY));
     atomic_init(&keyInfo->refCount, 1);
     keyInfo->curveParameters = curveParameters;
     keyInfo->keyPair = keyPair;
@@ -80,25 +79,25 @@ EC_KEY* AndroidCryptoNative_EcKeyCreateByOid(const char* oid)
     jstring oidStr;
     if (strcmp(oid, "1.3.132.0.33") == 0)
     {
-        oidStr = JSTRING("secp224r1");
+        oidStr = make_java_string(env, "secp224r1");
     }
     else if (strcmp(oid, "1.3.132.0.34") == 0 || strcmp(oid, "nistP384") == 0)
     {
-        oidStr = JSTRING("secp384r1");
+        oidStr = make_java_string(env, "secp384r1");
     }
     else if (strcmp(oid, "1.3.132.0.35") == 0 || strcmp(oid, "nistP521") == 0)
     {
-        oidStr = JSTRING("secp521r1");
+        oidStr = make_java_string(env, "secp521r1");
     }
     else if (strcmp(oid, "1.2.840.10045.3.1.7") == 0 || strcmp(oid, "nistP256") == 0)
     {
-        oidStr = JSTRING("secp256r1");
+        oidStr = make_java_string(env, "secp256r1");
     }
     else
     {
-        oidStr = JSTRING(oid);
+        oidStr = make_java_string(env, oid);
     }
-    jstring ec = JSTRING("EC");
+    jstring ec = make_java_string(env, "EC");
 
     // First, generate the key pair based on the curve defined by the oid.
     jobject paramSpec = (*env)->NewObject(env, g_ECGenParameterSpecClass, g_ECGenParameterSpecCtor, oidStr);
@@ -194,7 +193,7 @@ int32_t AndroidCryptoNative_EcKeyGetCurveName(const EC_KEY* key, uint16_t** curv
     jsize nameLength = (*env)->GetStringLength(env, curveNameStr);
 
     // add one for the null terminator.
-    uint16_t* buffer = malloc(sizeof(int16_t) * (size_t)(nameLength + 1));
+    uint16_t* buffer = xmalloc(sizeof(int16_t) * (size_t)(nameLength + 1));
     buffer[nameLength] = 0;
 
     (*env)->GetStringRegion(env, curveNameStr, 0, nameLength, (jchar*)buffer);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_eckey.h
@@ -15,8 +15,8 @@ typedef struct EC_KEY
     jobject keyPair;
 } EC_KEY;
 
-EC_KEY* AndroidCryptoNative_NewEcKey(jobject curveParameters, jobject keyPair);
-EC_KEY* AndroidCryptoNative_NewEcKeyFromKeys(JNIEnv *env, jobject /*ECPublicKey*/ publicKey, jobject /*ECPrivateKey*/ privateKey);
+ARGS_NON_NULL_ALL EC_KEY* AndroidCryptoNative_NewEcKey(jobject curveParameters, jobject keyPair);
+ARGS_NON_NULL(1,2) EC_KEY* AndroidCryptoNative_NewEcKeyFromKeys(JNIEnv *env, jobject /*ECPublicKey*/ publicKey, jobject /*ECPrivateKey*/ privateKey);
 
 /*
 Cleans up and deletes an EC_KEY instance.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
@@ -30,15 +30,15 @@ static jobject GetMessageDigestInstance(JNIEnv* env, intptr_t type)
 {
     jobject mdName = NULL;
     if (type == CryptoNative_EvpSha1())
-        mdName = JSTRING("SHA-1");
+        mdName = make_java_string(env, "SHA-1");
     else if (type == CryptoNative_EvpSha256())
-        mdName = JSTRING("SHA-256");
+        mdName = make_java_string(env, "SHA-256");
     else if (type == CryptoNative_EvpSha384())
-        mdName = JSTRING("SHA-384");
+        mdName = make_java_string(env, "SHA-384");
     else if (type == CryptoNative_EvpSha512())
-        mdName = JSTRING("SHA-512");
+        mdName = make_java_string(env, "SHA-512");
     else if (type == CryptoNative_EvpMd5())
-        mdName = JSTRING("MD5");
+        mdName = make_java_string(env, "MD5");
     else
         return NULL;
 
@@ -61,7 +61,7 @@ int32_t CryptoNative_EvpDigestOneShot(intptr_t type, void* source, int32_t sourc
     if (!mdObj)
         return FAIL;
 
-    jbyteArray bytes = (*env)->NewByteArray(env, sourceSize);
+    jbyteArray bytes = make_java_byte_array(env, sourceSize);
     (*env)->SetByteArrayRegion(env, bytes, 0, sourceSize, (jbyte*) source);
     jbyteArray hashedBytes = (jbyteArray)(*env)->CallObjectMethod(env, mdObj, g_mdDigestWithInputBytes, bytes);
     abort_unless(hashedBytes != NULL, "MessageDigest.digest(...) was not expected to return null");
@@ -100,7 +100,7 @@ int32_t CryptoNative_EvpDigestUpdate(jobject ctx, void* d, int32_t cnt)
         abort_if_invalid_pointer_argument (d);
     JNIEnv* env = GetJNIEnv();
 
-    jbyteArray bytes = (*env)->NewByteArray(env, cnt);
+    jbyteArray bytes = make_java_byte_array(env, cnt);
     (*env)->SetByteArrayRegion(env, bytes, 0, cnt, (jbyte*) d);
     (*env)->CallVoidMethod(env, ctx, g_mdUpdate, bytes);
     (*env)->DeleteLocalRef(env, bytes);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -18,15 +18,15 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
 
     jstring macName = NULL;
     if (type == CryptoNative_EvpSha1())
-        macName = JSTRING("HmacSHA1");
+        macName = make_java_string(env, "HmacSHA1");
     else if (type == CryptoNative_EvpSha256())
-        macName = JSTRING("HmacSHA256");
+        macName = make_java_string(env, "HmacSHA256");
     else if (type == CryptoNative_EvpSha384())
-        macName = JSTRING("HmacSHA384");
+        macName = make_java_string(env, "HmacSHA384");
     else if (type == CryptoNative_EvpSha512())
-        macName = JSTRING("HmacSHA512");
+        macName = make_java_string(env, "HmacSHA512");
     else if (type == CryptoNative_EvpMd5())
-        macName = JSTRING("HmacMD5");
+        macName = make_java_string(env, "HmacMD5");
     else
         return FAIL;
 
@@ -34,7 +34,7 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
 
     if (key && keyLen > 0)
     {
-        keyBytes = (*env)->NewByteArray(env, keyLen);
+        keyBytes = make_java_byte_array(env, keyLen);
         (*env)->SetByteArrayRegion(env, keyBytes, 0, keyLen, (jbyte*)key);
     }
     else
@@ -43,7 +43,7 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
         // so instead create an empty 1-byte length byte array that's initalized to 0.
         // the HMAC algorithm pads keys with zeros until the key is block-length,
         // so this effectively creates the same key as if it were a zero byte-length key.
-        keyBytes = (*env)->NewByteArray(env, 1);
+        keyBytes = make_java_byte_array(env, 1);
     }
 
     jobject sksObj = (*env)->NewObject(env, g_sksClass, g_sksCtor, keyBytes, macName);
@@ -87,7 +87,7 @@ int32_t CryptoNative_HmacUpdate(jobject ctx, uint8_t* data, int32_t len)
 
     abort_if_invalid_pointer_argument (data);
     JNIEnv* env = GetJNIEnv();
-    jbyteArray dataBytes = (*env)->NewByteArray(env, len);
+    jbyteArray dataBytes = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, dataBytes, 0, len, (jbyte*)data);
     (*env)->CallVoidMethod(env, ctx, g_MacUpdate, dataBytes);
     (*env)->DeleteLocalRef(env, dataBytes);
@@ -95,7 +95,7 @@ int32_t CryptoNative_HmacUpdate(jobject ctx, uint8_t* data, int32_t len)
     return CheckJNIExceptions(env) ? FAIL : SUCCESS;
 }
 
-static int32_t DoFinal(JNIEnv* env, jobject mac, uint8_t* data, int32_t* len)
+ARGS_NON_NULL_ALL static int32_t DoFinal(JNIEnv* env, jobject mac, uint8_t* data, int32_t* len)
 {
     // mac.doFinal();
     jbyteArray dataBytes = (jbyteArray)(*env)->CallObjectMethod(env, mac, g_MacDoFinal);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -481,7 +481,7 @@ void ReleaseLRef(JNIEnv *env, jobject lref)
         (*env)->DeleteLocalRef(env, lref);
 }
 
-static bool TryGetClassGRef(JNIEnv *env, const char* name, jclass* out)
+ARGS_NON_NULL_ALL static bool TryGetClassGRef(JNIEnv *env, const char* name, jclass* out)
 {
     *out = NULL;
     LOG_DEBUG("Finding %s class", name);
@@ -505,7 +505,7 @@ jclass GetClassGRef(JNIEnv *env, const char* name)
     return klass;
 }
 
-static jclass GetOptionalClassGRef(JNIEnv *env, const char* name)
+ARGS_NON_NULL_ALL static jclass GetOptionalClassGRef(JNIEnv *env, const char* name)
 {
     jclass klass = NULL;
     if (!TryGetClassGRef(env, name, &klass))
@@ -562,7 +562,7 @@ void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite)
     {
         free(*dst);
     }
-    *dst = (uint8_t*)malloc(len * sizeof(uint8_t));
+    *dst = (uint8_t*)xmalloc(len * sizeof(uint8_t));
     memcpy(*dst, src, len);
 }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -465,6 +465,40 @@ extern jmethodID g_KeyAgreementInit;
 extern jmethodID g_KeyAgreementDoPhase;
 extern jmethodID g_KeyAgreementGenerateSecret;
 
+// Compatibility macros
+#if !defined (__mallocfunc)
+#if defined (__clang__) || defined (__GNUC__)
+#define __mallocfunc __attribute__((__malloc__))
+#else // def (__clang__ || __GNUC__)
+#define __mallocfunc
+#endif // ndef (__clang__ || __GNUC__)
+#endif
+
+#if !defined (__BIONIC_ALLOC_SIZE)
+#if defined (__clang__) || defined (__GNUC__)
+#define __BIONIC_ALLOC_SIZE(...) __attribute__((__alloc_size__(__VA_ARGS__)))
+#else // def (__clang__ || __GNUC__)
+#define __BIONIC_ALLOC_SIZE(...)
+#endif // ndef (__clang__ || __GNUC__)
+#endif
+
+#if !defined (__wur)
+#if defined (__clang__) || defined (__GNUC__)
+#define __wur __attribute__((__warn_unused_result__))
+#else // def (__clang__ || __GNUC__)
+#define __wur
+#endif // ndef (__clang__ || __GNUC__)
+#endif
+
+#if defined (__clang__) || defined (__GNUC__)
+#define ARGS_NON_NULL(...) __attribute__((nonnull (__VA_ARGS__)))
+#else
+#define ARGS_NON_NULL_ALL
+#define ARGS_NON_NULL(_idx1_, ...)
+#endif
+
+#define ARGS_NON_NULL_ALL ARGS_NON_NULL()
+
 // Logging helpers
 #define LOG_DEBUG(fmt, ...) ((void)__android_log_print(ANDROID_LOG_DEBUG, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
 #define LOG_INFO(fmt, ...) ((void)__android_log_print(ANDROID_LOG_INFO, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
@@ -473,7 +507,6 @@ extern jmethodID g_KeyAgreementGenerateSecret;
 #define LOG_FATAL(fmt, ...) ((void)__android_log_print(ANDROID_LOG_FATAL, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
 
 // JNI helpers - assume there is a JNIEnv* variable named env
-#define JSTRING(str) ((jstring)(*env)->NewStringUTF(env, str))
 #define ON_EXCEPTION_PRINT_AND_GOTO(label) if (CheckJNIExceptions(env)) goto label
 
 // Explicitly ignore jobject return value
@@ -501,24 +534,64 @@ do { \
     } \
 } while(0)
 
-void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite);
-jobject ToGRef(JNIEnv *env, jobject lref);
-jobject AddGRef(JNIEnv *env, jobject gref);
-void ReleaseGRef(JNIEnv *env, jobject gref);
-void ReleaseLRef(JNIEnv *env, jobject lref);
-jclass GetClassGRef(JNIEnv *env, const char* name);
+void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite) ARGS_NON_NULL(1,2);
+jobject ToGRef(JNIEnv *env, jobject lref) ARGS_NON_NULL(1);
+jobject AddGRef(JNIEnv *env, jobject gref) ARGS_NON_NULL(1);
+void ReleaseGRef(JNIEnv *env, jobject gref) ARGS_NON_NULL(1);
+void ReleaseLRef(JNIEnv *env, jobject lref) ARGS_NON_NULL(1);
+jclass GetClassGRef(JNIEnv *env, const char* name) ARGS_NON_NULL(1);
 
 // Print and clear any JNI exceptions. Returns true if there was an exception, false otherwise.
-bool CheckJNIExceptions(JNIEnv* env);
+bool CheckJNIExceptions(JNIEnv* env) ARGS_NON_NULL_ALL;
 
 // Clear any JNI exceptions without printing them. Returns true if there was an exception, false otherwise.
-bool TryClearJNIExceptions(JNIEnv* env);
+bool TryClearJNIExceptions(JNIEnv* env) ARGS_NON_NULL_ALL;
 
 // Get any pending JNI exception. Returns true if there was an exception, false otherwise.
-bool TryGetJNIException(JNIEnv* env, jthrowable *ex, bool printException);
+bool TryGetJNIException(JNIEnv* env, jthrowable *ex, bool printException) ARGS_NON_NULL(1,2);
 
-jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);
-jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);
-jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig);
+jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
+jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
+jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 JNIEnv* GetJNIEnv(void);
-int GetEnumAsInt(JNIEnv *env, jobject enumObj);
+
+int GetEnumAsInt(JNIEnv *env, jobject enumObj) ARGS_NON_NULL_ALL;
+
+void* xmalloc (size_t size) __mallocfunc __BIONIC_ALLOC_SIZE(1) __wur;
+void* xcalloc (size_t nmemb, size_t size) __mallocfunc __BIONIC_ALLOC_SIZE(1,2) __wur;
+
+ARGS_NON_NULL_ALL static inline jstring make_java_string (JNIEnv *env, const char* str)
+{
+    jstring ret = (jstring)(*env)->NewStringUTF(env, str);
+    if(ret != NULL)
+    {
+        return ret;
+    }
+
+    CheckJNIExceptions(env);
+    abort();
+}
+
+ARGS_NON_NULL_ALL static inline jbyteArray make_java_byte_array (JNIEnv *env, int32_t flen)
+{
+    jbyteArray ret = (*env)->NewByteArray(env, flen);
+    if(ret != NULL)
+    {
+        return ret;
+    }
+
+    CheckJNIExceptions(env);
+    abort();
+}
+
+ARGS_NON_NULL(1, 3) static inline jobjectArray make_java_object_array (JNIEnv *env, int32_t flen, jclass elementClass, jobject initialElement)
+{
+    jobjectArray ret = (*env)->NewObjectArray(env, flen, elementClass, initialElement);
+    if(ret != NULL)
+    {
+        return ret;
+    }
+
+    CheckJNIExceptions(env);
+    abort();
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_memory.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_memory.c
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <stdlib.h>
+
+#include "pal_jni.h"
+
+void* xmalloc(size_t size)
+{
+    void *ret = malloc(size);
+    abort_unless(ret != NULL, "Out of memory");
+    return ret;
+}
+
+void* xcalloc(size_t nmemb, size_t size)
+{
+    void *ret = calloc(nmemb, size);
+    abort_unless(ret != NULL, "Out of memory");
+    return ret;
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_misc.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_misc.c
@@ -18,7 +18,7 @@ int32_t CryptoNative_GetRandomBytes(uint8_t* buff, int32_t len)
     jobject randObj = (*env)->NewObject(env, g_randClass, g_randCtor);
     abort_unless(randObj != NULL,"Unable to create an instance of java/security/SecureRandom");
 
-    jbyteArray buffArray = (*env)->NewByteArray(env, len);
+    jbyteArray buffArray = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, buffArray, 0, len, (jbyte*)buff);
     (*env)->CallVoidMethod(env, randObj, g_randNextBytesMethod, buffArray);
     (*env)->GetByteArrayRegion(env, buffArray, 0, len, (jbyte*)buff);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_misc.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_misc.h
@@ -8,4 +8,4 @@
 PALEXPORT int32_t CryptoNative_EnsureOpenSslInitialized(void);
 PALEXPORT int32_t CryptoNative_GetRandomBytes(uint8_t* buf, int32_t num);
 
-jobject AndroidCryptoNative_CreateKeyPair(JNIEnv* env, jobject publicKey, jobject privateKey);
+jobject AndroidCryptoNative_CreateKeyPair(JNIEnv* env, jobject publicKey, jobject privateKey) ARGS_NON_NULL(1,2);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.h
@@ -41,5 +41,5 @@ PALEXPORT int32_t AndroidCryptoNative_SetRsaParameters(RSA* rsa,
     uint8_t* p,    int32_t pLength,    uint8_t* dmp1, int32_t dmp1Length, uint8_t* q, int32_t qLength,
     uint8_t* dmq1, int32_t dmq1Length, uint8_t* iqmp, int32_t iqmpLength);
 
-RSA* AndroidCryptoNative_NewRsaFromKeys(JNIEnv* env, jobject /*RSAPublicKey*/ publicKey, jobject /*RSAPrivateKey*/ privateKey);
-RSA* AndroidCryptoNative_NewRsaFromPublicKey(JNIEnv* env, jobject /*RSAPublicKey*/ key);
+RSA* AndroidCryptoNative_NewRsaFromKeys(JNIEnv* env, jobject /*RSAPublicKey*/ publicKey, jobject /*RSAPrivateKey*/ privateKey) ARGS_NON_NULL(1, 2);
+RSA* AndroidCryptoNative_NewRsaFromPublicKey(JNIEnv* env, jobject /*RSAPublicKey*/ key) ARGS_NON_NULL(1, 2);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_signature.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_signature.c
@@ -23,7 +23,7 @@ int32_t AndroidCryptoNative_SignWithSignatureObject(JNIEnv* env,
     (*env)->CallVoidMethod(env, signatureObject, g_SignatureInitSign, privateKey);
     ON_EXCEPTION_PRINT_AND_GOTO(error);
 
-    jbyteArray digestArray = (*env)->NewByteArray(env, dgstlen);
+    jbyteArray digestArray = make_java_byte_array(env, dgstlen);
     (*env)->SetByteArrayRegion(env, digestArray, 0, dgstlen, (const jbyte*)dgst);
     (*env)->CallVoidMethod(env, signatureObject, g_SignatureUpdate, digestArray);
     ReleaseLRef(env, digestArray);
@@ -57,13 +57,13 @@ int32_t AndroidCryptoNative_VerifyWithSignatureObject(JNIEnv* env,
     (*env)->CallVoidMethod(env, signatureObject, g_SignatureInitVerify, publicKey);
     ON_EXCEPTION_PRINT_AND_GOTO(error);
 
-    jbyteArray digestArray = (*env)->NewByteArray(env, dgstlen);
+    jbyteArray digestArray = make_java_byte_array(env, dgstlen);
     (*env)->SetByteArrayRegion(env, digestArray, 0, dgstlen, (const jbyte*)dgst);
     (*env)->CallVoidMethod(env, signatureObject, g_SignatureUpdate, digestArray);
     ReleaseLRef(env, digestArray);
     ON_EXCEPTION_PRINT_AND_GOTO(error);
 
-    jbyteArray sigArray = (*env)->NewByteArray(env, siglen);
+    jbyteArray sigArray = make_java_byte_array(env, siglen);
     (*env)->SetByteArrayRegion(env, sigArray, 0, siglen, (const jbyte*)sig);
     jboolean verified = (*env)->CallBooleanMethod(env, signatureObject, g_SignatureVerify, sigArray);
     ReleaseLRef(env, sigArray);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_signature.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_signature.h
@@ -7,6 +7,7 @@
 
 #define SIGNATURE_VERIFICATION_ERROR -1
 
+ARGS_NON_NULL(1, 2, 3, 4, 6)
 int32_t AndroidCryptoNative_SignWithSignatureObject(JNIEnv* env,
                                                     jobject signatureObject,
                                                     jobject privateKey,
@@ -15,6 +16,7 @@ int32_t AndroidCryptoNative_SignWithSignatureObject(JNIEnv* env,
                                                     uint8_t* sig,
                                                     int32_t* siglen);
 
+ARGS_NON_NULL_ALL
 int32_t AndroidCryptoNative_VerifyWithSignatureObject(JNIEnv* env,
                                                       jobject signatureObject,
                                                       jobject publicKey,

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
@@ -12,9 +12,9 @@
 #include <stdbool.h>
 #include <string.h>
 
-static int32_t PopulateByteArray(JNIEnv* env, jbyteArray source, uint8_t* dest, int32_t* len);
+ARGS_NON_NULL(1,2,4) static int32_t PopulateByteArray(JNIEnv* env, jbyteArray source, uint8_t* dest, int32_t* len);
 
-static void FindCertStart(const uint8_t** buffer, int32_t* len);
+ARGS_NON_NULL_ALL static void FindCertStart(const uint8_t** buffer, int32_t* len);
 
 // Handles both DER and PEM formats
 jobject /*X509Certificate*/ AndroidCryptoNative_X509Decode(const uint8_t* buf, int32_t len)
@@ -31,7 +31,7 @@ jobject /*X509Certificate*/ AndroidCryptoNative_X509Decode(const uint8_t* buf, i
 
     // byte[] bytes = new byte[] { ... }
     // InputStream stream = new ByteArrayInputStream(bytes);
-    loc[bytes] = (*env)->NewByteArray(env, len);
+    loc[bytes] = make_java_byte_array(env, len);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->SetByteArrayRegion(env, loc[bytes], 0, len, (const jbyte*)buf);
     loc[stream] = (*env)->NewObject(env, g_ByteArrayInputStreamClass, g_ByteArrayInputStreamCtor, loc[bytes]);
@@ -39,7 +39,7 @@ jobject /*X509Certificate*/ AndroidCryptoNative_X509Decode(const uint8_t* buf, i
 
     // CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
     // return (X509Certificate)certFactory.generateCertificate(stream);
-    loc[certType] = JSTRING("X.509");
+    loc[certType] = make_java_string(env, "X.509");
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     loc[certFactory] = (*env)->CallStaticObjectMethod(env, g_CertFactoryClass, g_CertFactoryGetInstance, loc[certType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
@@ -86,13 +86,13 @@ int32_t AndroidCryptoNative_X509DecodeCollection(const uint8_t* buf,
 
     // byte[] bytes = new byte[] { ... }
     // InputStream stream = new ByteArrayInputStream(bytes);
-    loc[bytes] = (*env)->NewByteArray(env, bufLen);
+    loc[bytes] = make_java_byte_array(env, bufLen);
     (*env)->SetByteArrayRegion(env, loc[bytes], 0, bufLen, (const jbyte*)buf);
     loc[stream] = (*env)->NewObject(env, g_ByteArrayInputStreamClass, g_ByteArrayInputStreamCtor, loc[bytes]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-    loc[certType] = JSTRING("X.509");
+    loc[certType] = make_java_string(env, "X.509");
     loc[certFactory] = (*env)->CallStaticObjectMethod(env, g_CertFactoryClass, g_CertFactoryGetInstance, loc[certType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
@@ -172,7 +172,7 @@ int32_t AndroidCryptoNative_X509ExportPkcs7(jobject* /*X509Certificate[]*/ certs
     }
 
     // CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-    loc[certType] = JSTRING("X.509");
+    loc[certType] = make_java_string(env, "X.509");
     loc[certFactory] = (*env)->CallStaticObjectMethod(env, g_CertFactoryClass, g_CertFactoryGetInstance, loc[certType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
@@ -181,7 +181,7 @@ int32_t AndroidCryptoNative_X509ExportPkcs7(jobject* /*X509Certificate[]*/ certs
     loc[certPath] =
         (*env)->CallObjectMethod(env, loc[certFactory], g_CertFactoryGenerateCertPathFromList, loc[certList]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-    loc[pkcs7Type] = JSTRING("PKCS7");
+    loc[pkcs7Type] = make_java_string(env, "PKCS7");
     loc[encoded] = (*env)->CallObjectMethod(env, loc[certPath], g_CertPathGetEncoded, loc[pkcs7Type]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
@@ -212,18 +212,18 @@ PAL_X509ContentType AndroidCryptoNative_X509GetContentType(const uint8_t* buf, i
 
     // byte[] bytes = new byte[] { ... }
     // InputStream stream = new ByteArrayInputStream(bytes);
-    loc[bytes] = (*env)->NewByteArray(env, len);
+    loc[bytes] = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, loc[bytes], 0, len, (const jbyte*)buf);
     loc[stream] = (*env)->NewObject(env, g_ByteArrayInputStreamClass, g_ByteArrayInputStreamCtor, loc[bytes]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-    loc[certType] = JSTRING("X.509");
+    loc[certType] = make_java_string(env, "X.509");
     loc[certFactory] = (*env)->CallStaticObjectMethod(env, g_CertFactoryClass, g_CertFactoryGetInstance, loc[certType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // CertPath certPath = certFactory.generateCertPath(stream, "PKCS7");
-    loc[pkcs7Type] = JSTRING("PKCS7");
+    loc[pkcs7Type] = make_java_string(env, "PKCS7");
     loc[certPath] = (*env)->CallObjectMethod(
         env, loc[certFactory], g_CertFactoryGenerateCertPathFromStream, loc[stream], loc[pkcs7Type]);
     if (!TryClearJNIExceptions(env))

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509chain.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509chain.c
@@ -44,7 +44,7 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     // String keyStoreType = "AndroidCAStore";
     // KeyStore keyStore = KeyStore.getInstance(keyStoreType);
     // keyStore.load(null, null);
-    loc[keyStoreType] = JSTRING("AndroidCAStore");
+    loc[keyStoreType] = make_java_string(env, "AndroidCAStore");
     loc[keyStore] = (*env)->CallStaticObjectMethod(env, g_KeyStoreClass, g_KeyStoreGetInstance, loc[keyStoreType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, loc[keyStore], g_KeyStoreLoad, NULL, NULL);
@@ -75,7 +75,7 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     // String certStoreType = "Collection";
     // CollectionCertStoreParameters certStoreParams = new CollectionCertStoreParameters(certList);
     // CertStore certStore = CertStore.getInstance(certStoreType, certStoreParams);
-    loc[certStoreType] = JSTRING("Collection");
+    loc[certStoreType] = make_java_string(env, "Collection");
     loc[certStoreParams] = (*env)->NewObject(
         env, g_CollectionCertStoreParametersClass, g_CollectionCertStoreParametersCtor, loc[certList]);
     loc[certStore] = (*env)->CallStaticObjectMethod(
@@ -85,8 +85,7 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     // params.addCertStore(certStore);
     (*env)->CallVoidMethod(env, loc[params], g_PKIXBuilderParametersAddCertStore, loc[certStore]);
 
-    ret = malloc(sizeof(X509ChainContext));
-    memset(ret, 0, sizeof(X509ChainContext));
+    ret = xcalloc(1, sizeof(X509ChainContext));
     ret->params = AddGRef(env, loc[params]);
     ret->errorList = ToGRef(env, (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtor));
 
@@ -132,7 +131,7 @@ int32_t AndroidCryptoNative_X509ChainBuild(X509ChainContext* ctx, int64_t timeIn
     // String builderType = "PKIX";
     // CertPathBuilder builder = CertPathBuilder.getInstance(builderType);
     // PKIXCertPathBuilderResult result = (PKIXCertPathBuilderResult)builder.build(params);
-    loc[builderType] = JSTRING("PKIX");
+    loc[builderType] = make_java_string(env, "PKIX");
     loc[builder] =
         (*env)->CallStaticObjectMethod(env, g_CertPathBuilderClass, g_CertPathBuilderGetInstance, loc[builderType]);
     loc[result] = (*env)->CallObjectMethod(env, loc[builder], g_CertPathBuilderBuild, params);
@@ -330,7 +329,7 @@ static void PopulateValidationError(JNIEnv* env, jobject error, bool isRevocatio
         jsize messageLen = message == NULL ? 0 : (*env)->GetStringLength(env, message);
 
         // +1 for null terminator
-        messagePtr = malloc(sizeof(uint16_t) * (size_t)(messageLen + 1));
+        messagePtr = xmalloc(sizeof(uint16_t) * (size_t)(messageLen + 1));
         messagePtr[messageLen] = '\0';
         (*env)->GetStringRegion(env, message, 0, messageLen, (jchar*)messagePtr);
     }
@@ -448,7 +447,7 @@ static jobject /*CertPath*/ CreateCertPathFromAnchor(JNIEnv* env, jobject /*Trus
     (*env)->CallBooleanMethod(env, loc[certList], g_ArrayListAdd, loc[trustedCert]);
 
     // CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-    loc[certFactoryType] = JSTRING("X.509");
+    loc[certFactoryType] = make_java_string(env, "X.509");
     loc[certFactory] =
         (*env)->CallStaticObjectMethod(env, g_CertFactoryClass, g_CertFactoryGetInstance, loc[certFactoryType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
@@ -590,7 +589,7 @@ int32_t AndroidCryptoNative_X509ChainValidate(X509ChainContext* ctx,
 
     // String validatorType = "PKIX";
     // CertPathValidator validator = CertPathValidator.getInstance(validatorType);
-    loc[validatorType] = JSTRING("PKIX");
+    loc[validatorType] = make_java_string(env, "PKIX");
     loc[validator] = (*env)->CallStaticObjectMethod(
         env, g_CertPathValidatorClass, g_CertPathValidatorGetInstance, loc[validatorType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -20,7 +20,7 @@ typedef enum
 
 // Returns whether or not the store contains the specified alias
 // If the entry exists, the flags parameter is set based on the contents of the entry
-static bool ContainsEntryForAlias(
+ARGS_NON_NULL_ALL static bool ContainsEntryForAlias(
     JNIEnv* env, jobject /*KeyStore*/ store, jobject /*X509Certificate*/ cert, jstring alias, EntryFlags* flags)
 {
     bool ret = false;
@@ -72,6 +72,7 @@ cleanup:
     return ret;
 }
 
+ARGS_NON_NULL_ALL
 static bool ContainsMatchingCertificateForAlias(JNIEnv* env,
                                                 jobject /*KeyStore*/ store,
                                                 jobject /*X509Certificate*/ cert,
@@ -95,7 +96,7 @@ int32_t AndroidCryptoNative_X509StoreAddCertificate(jobject /*KeyStore*/ store,
 
     JNIEnv* env = GetJNIEnv();
 
-    jstring alias = JSTRING(hashString);
+    jstring alias = make_java_string(env, hashString);
     EntryFlags flags;
     if (ContainsEntryForAlias(env, store, cert, alias, &flags))
     {
@@ -136,7 +137,7 @@ int32_t AndroidCryptoNative_X509StoreAddCertificateWithPrivateKey(jobject /*KeyS
     INIT_LOCALS(loc, alias, certs);
     jobject privateKey = NULL;
 
-    loc[alias] = JSTRING(hashString);
+    loc[alias] = make_java_string(env, hashString);
 
     EntryFlags flags;
     if (ContainsEntryForAlias(env, store, cert, loc[alias], &flags))
@@ -194,7 +195,7 @@ int32_t AndroidCryptoNative_X509StoreAddCertificateWithPrivateKey(jobject /*KeyS
 
     // X509Certificate[] certs = new X509Certificate[] { cert };
     // store.setKeyEntry(alias, privateKey, null, certs);
-    loc[certs] = (*env)->NewObjectArray(env, 1, g_X509CertClass, cert);
+    loc[certs] = make_java_object_array(env, 1, g_X509CertClass, cert);
     (*env)->CallVoidMethod(env, store, g_KeyStoreSetKeyEntry, loc[alias], privateKey, NULL, loc[certs]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
@@ -219,13 +220,14 @@ bool AndroidCryptoNative_X509StoreContainsCertificate(jobject /*KeyStore*/ store
     abort_if_invalid_pointer_argument (hashString);
 
     JNIEnv* env = GetJNIEnv();
-    jstring alias = JSTRING(hashString);
+    jstring alias = make_java_string(env, hashString);
 
     bool containsCert = ContainsMatchingCertificateForAlias(env, store, cert, alias);
     (*env)->DeleteLocalRef(env, alias);
     return containsCert;
 }
 
+ARGS_NON_NULL_ALL
 static void* HandleFromKeys(JNIEnv* env,
                             jobject /*PublicKey*/ publicKey,
                             jobject /*PrivateKey*/ privateKey,
@@ -247,12 +249,12 @@ static void* HandleFromKeys(JNIEnv* env,
         return AndroidCryptoNative_NewRsaFromKeys(env, publicKey, privateKey);
     }
 
-    LOG_INFO("Ignoring unknown privake key type");
+    LOG_INFO("Ignoring unknown private key type");
     *algorithm = PAL_UnknownAlgorithm;
     return NULL;
 }
 
-static int32_t
+ARGS_NON_NULL_ALL static int32_t
 EnumerateCertificates(JNIEnv* env, jobject /*KeyStore*/ store, EnumCertificatesCallback cb, void* context)
 {
     int32_t ret = FAIL;
@@ -329,6 +331,7 @@ int32_t AndroidCryptoNative_X509StoreEnumerateCertificates(jobject /*KeyStore*/ 
     return EnumerateCertificates(env, store, cb, context);
 }
 
+ARGS_NON_NULL_ALL
 static bool SystemAliasFilter(JNIEnv* env, jstring alias)
 {
     const char systemPrefix[] = "system:";
@@ -341,7 +344,7 @@ static bool SystemAliasFilter(JNIEnv* env, jstring alias)
 }
 
 typedef bool (*FilterAliasFunction)(JNIEnv* env, jstring alias);
-static int32_t EnumerateTrustedCertificates(
+ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     JNIEnv* env, jobject /*KeyStore*/ store, bool systemOnly, EnumTrustedCertificatesCallback cb, void* context)
 {
     int32_t ret = FAIL;
@@ -402,7 +405,7 @@ int32_t AndroidCryptoNative_X509StoreEnumerateTrustedCertificates(bool systemOnl
 
     // KeyStore store = KeyStore.getInstance("AndroidCAStore");
     // store.load(null, null);
-    loc[storeType] = JSTRING("AndroidCAStore");
+    loc[storeType] = make_java_string(env, "AndroidCAStore");
     loc[store] = (*env)->CallStaticObjectMethod(env, g_KeyStoreClass, g_KeyStoreGetInstance, loc[storeType]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, loc[store], g_KeyStoreLoad, NULL, NULL);
@@ -422,7 +425,7 @@ jobject /*KeyStore*/ AndroidCryptoNative_X509StoreOpenDefault(void)
 
     // KeyStore store = KeyStore.getInstance("AndroidKeyStore");
     // store.load(null, null);
-    jstring storeType = JSTRING("AndroidKeyStore");
+    jstring storeType = make_java_string(env, "AndroidKeyStore");
     jobject store = (*env)->CallStaticObjectMethod(env, g_KeyStoreClass, g_KeyStoreGetInstance, storeType);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, store, g_KeyStoreLoad, NULL, NULL);
@@ -442,7 +445,7 @@ int32_t AndroidCryptoNative_X509StoreRemoveCertificate(jobject /*KeyStore*/ stor
 
     JNIEnv* env = GetJNIEnv();
 
-    jstring alias = JSTRING(hashString);
+    jstring alias = make_java_string(env, hashString);
     if (!ContainsMatchingCertificateForAlias(env, store, cert, alias))
     {
         // Certificate is not in store - nothing to do


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/pull/52449
Context: https://github.com/dotnet/runtime/commit/5d213e6761c5393619e476b766b8778446155503

This commit makes sure that all memory allocation via the standard POSIX
APIs is checked and, should the allocation fail, the application is
aborted.  This strategy is chosen because whenever Unix allocation
fails, the memory resources are really exhausted and it is safer to
abort the application than risking thrashing memory and causing
unpredictable behavior of the application.

The same strategy is used with the string, byte and object array
allocation using Java JNI APIs.  Allocator functions for these objects
return `NULL` whenever allocation fails and, additionally, throw a Java
`OutOfMemory` exception.  The inline functions introduced to handle
allocation of the above objects check the return result, print
exceptions (if any) and abort the application.  The `NewObject` JNI
function doesn't get the same kind of treatment because there's no way
for us to detect whether the object creation failed because of an
out-of-memory error or because its constructor threw an exception - in
both cases JNI will return `NULL`.

Additionally, some internally used functions are decorated with the
`nonnul` attribute (if supported by the compiler) to indicate which
function pointer arguments mustn't be `NULL`.  This will not help
runtime invalid pointer detection, but it makes it harder to make
mistakes in code of passing a `NULL` value to a function that doesn't
expect it.

At the same time, the internal (static or hidden) functions not always
validate their pointer parameters.  They instead rely on the calling
code to do it for them.

--- Addendum ---

Commit 5d213e6761c5393619e476b766b8778446155503 was accidentally merged
without a commit message, so to not miss the information/context that
was included there, here's the commit message:

POSIX `assert(3)` is used frequently throughout the code to check
validity of certain parameters or assumptions but also to control the
flow of the program.  However, this approach works only in debug
builds (or, rather, when the `NDEBUG` macro is not defined during
compilation).  In release builds (or when the `NDEBUG` macro is
defined), `assert` calls turn into no-ops.  Therefore, they must not be
used to ensure that a certain code path is valid or a return value from
some function is correct etc.

Fix the above use of `assert` by replacing the calls with an inline
function that will check the assertion at all times and `abort()` the
application should the condition be `false`.  This is a desired
behavior, because assertions are used only in places which absolutely
must meet the condition and if not, it's a serious bug either in the
library or the application.

Additionally, add validation checks (using the same assertion mechanism)
for all the pointers passed from the managed/external code that are
dereferenced locally passed to Java functions which require the pointers
to not be `NULL`.

Co-authored-by: Adeel Mujahid <3840695+am11@users.noreply.github.com>