### PR TITLE
HttpStress: also disable firewall for HTTP2 runs

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -88,6 +88,13 @@ jobs:
     name: buildStress
     displayName: Build HttpStress
 
+    # Firewall is disabled for the test runs, since it can lead to unexpected TCP failures on CI machines, which are unrelated to the HTTP logic.
+    # See: https://github.com/dotnet/runtime/issues/50854
+  - powershell: |
+      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+    name: disableFirewall
+    displayName: Disable Firewall
+
   - powershell: |
       cd '$(httpStressProject)'
       $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
@@ -95,13 +102,6 @@ jobs:
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 2.0
     condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
-
-    # Firewall is disabled for HTTP 1.1 runs.
-    # See: https://github.com/dotnet/runtime/issues/50854
-  - powershell: |
-      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
-    name: disableFirewall
-    displayName: Disable Firewall
 
   - powershell: |
       cd '$(httpStressProject)'


### PR DESCRIPTION
In our internal team discussion we decided that we need to rule out the Windows Firewall as a cause for further failure types documented in #42211.

I see some chance that the *System.Net.Sockets.SocketException (10054)" (Windows + HTTP 2.0 case)* might be caused by the firewall sending an RST, would be great to exclude that option.

/cc @GrabYourPitchforks @ManickaP 