### PR TITLE
Put failing WebSockets tests under ActiveIssue for Android

### DIFF
--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -349,6 +349,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52645", TestPlatforms.Android)]
         public async Task WebSocketWithoutDeflateShouldThrowOnCompressedMessage()
         {
             WebSocketTestStream stream = new();
@@ -363,6 +364,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52645", TestPlatforms.Android)]
         public async Task ReceiveUncompressedMessageWhenCompressionEnabled()
         {
             // We should be able to handle the situation where even if we have
@@ -378,7 +380,7 @@ namespace System.Net.WebSockets.Tests
                 DangerousDeflateOptions = new WebSocketDeflateOptions()
             });
 
-            // Server sends uncompressed 
+            // Server sends uncompressed
             await SendTextAsync("Hello", server);
 
             // Although client has deflate options, it should still be able
@@ -399,6 +401,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52645", TestPlatforms.Android)]
         public async Task ReceiveInvalidCompressedData()
         {
             WebSocketTestStream stream = new();


### PR DESCRIPTION
As per https://github.com/dotnet/runtime/pull/52052#issuecomment-838655841, putting the failing tests under ActiveIssue.

Tracking issue: https://github.com/dotnet/runtime/issues/52645

cc @steveisok