### PR TITLE
[Android][libraries] Active issue remaining android failing tests

### DIFF
--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
@@ -143,6 +143,7 @@ namespace System.Net.Http.Json.Functional.Tests
             => AssertExtensions.Throws<ArgumentNullException>("inputType", () => JsonContent.Create(null, inputType: null, mediaType: null));
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52650", TestPlatforms.Android)]
         public void JsonContentThrowsOnIncompatibleTypeAsync()
         {
             using (HttpClient client = new HttpClient())

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/CountersTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/CountersTest.cs
@@ -28,6 +28,7 @@ namespace MonoTests.System.Runtime.Caching
     {
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "Wasm is single-threaded, which makes TestEventListener ineffective.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52652", TestPlatforms.Android)]
         public async void Basic_Counters()
         {
             string cacheName = "Basic_Counters_Test";


### PR DESCRIPTION
There were two more test suites producing failures on runtime staging on CI
ActiveIssuing the failing test facts to get the lanes passing.