### PR TITLE
Test ios tvos simulator functional tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -169,10 +169,6 @@
 
     <!-- System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
-
-    <!-- Can't AOT in interp mode -->
-    <ProjectExclusions Condition="'$(MonoForceInterpreter)' == 'true'"
-                       Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator') and '$(RunDisablediOSTests)' != 'true'">
@@ -182,10 +178,6 @@
     <!-- Crashes on CI but passes locally https://github.com/dotnet/runtime/issues/52615 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj" />
-
-    <!-- Can't AOT in interp mode -->
-    <ProjectExclusions Condition="'$(MonoForceInterpreter)' == 'true'"
-                       Include="$(RepoRoot)\src\tests\FunctionalTests\tvOS\Simulator\AOT\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(TargetOS)' == 'MacCatalyst') and '$(RunDisablediOSTests)' != 'true'">

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.props
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.props
@@ -1,5 +1,5 @@
 <Project>
-  <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator'">
+  <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator'">
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64'" Include="mtriple=arm64-ios" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm'" Include="mtriple=armv7-ios" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64'" Include="mtriple=x86_64-ios" />
@@ -10,7 +10,7 @@
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm'" Include="mattr=+crc" /> <!-- enable System.Runtime.Intrinsics.Arm (Crc32 and ArmBase for now) -->
     <!--<MonoAOTCompilerDefaultAotArguments Include="direct-pinvoke" />--> <!-- TODO: enable direct-pinvokes (to get rid of -force_loads)-->
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator'">
+  <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator'">
     <MonoAOTCompilerDefaultProcessArguments Include="-O=-float32" />
     <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
   </ItemGroup>

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT/iOS.Simulator.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT/iOS.Simulator.Aot.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="MonoForceInterpreter">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/tests/FunctionalTests/tvOS/Simulator/AOT/tvOS.Simulator.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/tvOS/Simulator/AOT/tvOS.Simulator.Aot.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="MonoForceInterpreter">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
As a follow up to #52606 with this suggestion https://github.com/dotnet/runtime/pull/52606#discussion_r630359939, this PR re-enables the `iOS.Simulator.Aot.Test.csproj` to be ran on CI because `MonoForceInterpreter` can be modified to be `false` when it is added to `TreatAsLocalProperty`. 

Originally, an error along the lines of `MonoForceInterpreter cannot be modified as it is a global property` caused the `iOS.Simulator.Aot.Test.csproj` to fail. With the changes in this PR, the functional test project had passed in a previous build run https://helix.dot.net/api/jobs/67f9e21f-0d40-4c73-952e-e272dc167092/workitems/iOS.Simulator.Aot.Test?api-version=2019-06-17

Fixes #50589
