### PR TITLE
[QUIC] Notify quic streams on connection abort

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Quic.Implementations.MsQuic.Internal;
 using System.Net.Security;
@@ -40,7 +42,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         private X509RevocationMode _revocationMode = X509RevocationMode.Offline;
         private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
 
-        private sealed class State
+        internal sealed class State
         {
             public SafeMsQuicConnectionHandle Handle = null!; // set inside of MsQuicConnection ctor.
 
@@ -61,6 +63,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                 SingleReader = true,
                 SingleWriter = true,
             });
+
+            public readonly ConcurrentDictionary<WeakReference, bool> ActiveStreams = new();
         }
 
         // constructor for inbound connections
@@ -86,6 +90,11 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 _stateHandle.Free();
                 throw;
+            }
+
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(_state, $"[Connection#{_state.GetHashCode()}] inbound connection created");
             }
         }
 
@@ -120,6 +129,11 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 _stateHandle.Free();
                 throw;
+            }
+
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(_state, $"[Connection#{_state.GetHashCode()}] outbound connection created");
             }
         }
 
@@ -171,6 +185,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             state.AbortErrorCode = (long)connectionEvent.Data.ShutdownInitiatedByPeer.ErrorCode;
             state.AcceptQueue.Writer.Complete();
+            NotifyStreamsOnClose(state);
             return MsQuicStatusCodes.Success;
         }
 
@@ -182,13 +197,35 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             // Stop accepting new streams.
             state.AcceptQueue.Writer.Complete();
+            NotifyStreamsOnClose(state);
             return MsQuicStatusCodes.Success;
+        }
+
+        private static void NotifyStreamsOnClose(State state)
+        {
+            var streams = state.ActiveStreams.Keys;
+
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(state, $"[Connection#{state.GetHashCode()}] notifying close to {streams.Count} streams.");
+            }
+
+            foreach (var streamWeakRef in streams)
+            {
+                if (!streamWeakRef.IsAlive)
+                {
+                    continue;
+                }
+
+                var stream = (MsQuicStream?)streamWeakRef.Target;
+                stream?.HandleConnectionClose(state.AbortErrorCode);
+            }
         }
 
         private static uint HandleEventNewStream(State state, ref ConnectionEvent connectionEvent)
         {
             var streamHandle = new SafeMsQuicStreamHandle(connectionEvent.Data.PeerStreamStarted.Stream);
-            var stream = new MsQuicStream(streamHandle, connectionEvent.Data.PeerStreamStarted.Flags);
+            var stream = new MsQuicStream(state, streamHandle, connectionEvent.Data.PeerStreamStarted.Flags);
 
             state.AcceptQueue.Writer.TryWrite(stream);
             return MsQuicStatusCodes.Success;
@@ -284,18 +321,18 @@ namespace System.Net.Quic.Implementations.MsQuic
                 {
                     bool success = connection._remoteCertificateValidationCallback(connection, certificate, chain, sslPolicyErrors);
                     if (!success && NetEventSource.Log.IsEnabled())
-                        NetEventSource.Error(state.Connection, "Remote certificate rejected by verification callback");
+                        NetEventSource.Error(state, $"[Connection#{state.GetHashCode()}] remote certificate rejected by verification callback");
                     return success ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;
                 }
 
                 if (NetEventSource.Log.IsEnabled())
-                    NetEventSource.Info(state.Connection, $"Certificate validation for '${certificate?.Subject}' finished with ${sslPolicyErrors}");
+                    NetEventSource.Info(state, $"[Connection#{state.GetHashCode()}] certificate validation for '${certificate?.Subject}' finished with ${sslPolicyErrors}");
 
                 return (sslPolicyErrors == SslPolicyErrors.None) ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;
             }
             catch (Exception ex)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state.Connection, $"Certificate validation failed ${ex.Message}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, $"[Connection#{state.GetHashCode()}] certificate validation failed ${ex.Message}");
             }
 
             return MsQuicStatusCodes.InternalError;
@@ -326,13 +363,13 @@ namespace System.Net.Quic.Implementations.MsQuic
         internal override QuicStreamProvider OpenUnidirectionalStream()
         {
             ThrowIfDisposed();
-            return new MsQuicStream(_state.Handle, QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
+            return new MsQuicStream(_state, QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
         }
 
         internal override QuicStreamProvider OpenBidirectionalStream()
         {
             ThrowIfDisposed();
-            return new MsQuicStream(_state.Handle, QUIC_STREAM_OPEN_FLAGS.NONE);
+            return new MsQuicStream(_state, QUIC_STREAM_OPEN_FLAGS.NONE);
         }
 
         internal override long GetRemoteAvailableUnidirectionalStreamCount()
@@ -430,6 +467,12 @@ namespace System.Net.Quic.Implementations.MsQuic
             ref ConnectionEvent connectionEvent)
         {
             var state = (State)GCHandle.FromIntPtr(context).Target!;
+
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(state, $"[Connection#{state.GetHashCode()}] received event {connectionEvent.Type}");
+            }
+
             try
             {
                 switch (connectionEvent.Type)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -436,36 +436,6 @@ namespace System.Net.Quic.Tests
                 Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
             }).WaitAsync(TimeSpan.FromSeconds(5));
         }
-
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32050")]
-        [Fact]
-        public async Task Read_ConnectionAborted_Throws()
-        {
-            const int ExpectedErrorCode = 1234;
-
-            await Task.Run(async () =>
-            {
-                using QuicListener listener = CreateQuicListener();
-                ValueTask<QuicConnection> serverConnectionTask = listener.AcceptConnectionAsync();
-
-                using QuicConnection clientConnection = CreateQuicConnection(listener.ListenEndPoint);
-                await clientConnection.ConnectAsync();
-
-                using QuicConnection serverConnection = await serverConnectionTask;
-
-                await using QuicStream clientStream = clientConnection.OpenBidirectionalStream();
-                await clientStream.WriteAsync(new byte[1]);
-
-                await using QuicStream serverStream = await serverConnection.AcceptStreamAsync();
-                await serverStream.ReadAsync(new byte[1]);
-
-                await clientConnection.CloseAsync(ExpectedErrorCode);
-
-                byte[] buffer = new byte[100];
-                QuicConnectionAbortedException ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => serverStream.ReadAsync(buffer).AsTask());
-                Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
-            }).WaitAsync(TimeSpan.FromSeconds(5));
-        }
     }
 
     public sealed class QuicStreamTests_MockProvider : QuicStreamTests<MockProviderFactory> { }


### PR DESCRIPTION
Algorithm and thoughts: 

The only one who knows the Connection was aborted is the Connection itself. Connection's SHUTDOWN_INITIATED_BY_PEER will be immediately followed by Stream's SHUTDOWN_COMPLETED -- which we treat as EndOfStream, hence the issue https://github.com/dotnet/runtime/issues/32050. As soon as we get Connection's SHUTDOWN_INITIATED_BY_PEER, we want to notify all the Connection's Streams that the Connection was aborted, so the Streams would abort all outstanding operations with the correct exception, and throw on subsequent ones, and ignore Stream's SHUTDOWN_COMPLETED.

This can be done by maintaining a list of Streams inside Connection. There are two problems I see with that: allowing Streams be garbage collected and removing Streams from the list on Stream's Dispose and/or garbage collection.

The first one I solved with WeakReferences.

For the second one I see two possible solutions: 
- having a timer inside the Connection that would periodically clean up garbage collected and/or disposed Streams from the list (which I didn't like)
- making Stream to add itself in ctor and remove itself on Dispose. That is what I implemented, but it still is not pretty - because this way Stream also has a link back to Connection. But HTTP/2 also seems to have similar two-way links.

I'm opening that as I already have the working code, but I would be happy to hear other ideas.

Fixes https://github.com/dotnet/runtime/issues/32050