### PR TITLE
Add clrjit.natvis file

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -367,13 +367,13 @@ convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
 # Include natvis file for Windows
-if (CLR_CMAKE_TARGET_WIN32)
+if (CLR_CMAKE_HOST_WIN32)
   set(JIT_NATVIS_SOURCE
     clrjit.natvis
   )
   convert_to_absolute_path(JIT_NATVIS_SOURCE ${JIT_NATVIS_SOURCE})
   add_linker_flag("/NATVIS:${JIT_NATVIS_SOURCE}")
-endif(CLR_CMAKE_TARGET_WIN32)
+endif(CLR_CMAKE_HOST_WIN32)
 
 set(JIT_DLL_MAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/dllmain.cpp)
 

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -69,7 +69,6 @@ if(CLR_CMAKE_TARGET_WIN32)
 endif(CLR_CMAKE_TARGET_WIN32)
 
 set( JIT_SOURCES
-  clrjit.natvis
   alloc.cpp
   assertionprop.cpp
   bitset.cpp
@@ -252,6 +251,10 @@ if (CLR_CMAKE_TARGET_WIN32)
     vartype.h
   )
 
+  # Append clrjit.natvis file
+  list (APPEND JIT_SOURCES
+    clrjit.natvis)
+
   if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_ARM)
     list (APPEND JIT_HEADERS
       emitarm.h
@@ -363,14 +366,14 @@ convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
 convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
-# Set natvis file
-
-set(JIT_NATVIS_SOURCE
-  clrjit.natvis
-)
-
-convert_to_absolute_path(JIT_NATVIS_SOURCE ${JIT_NATVIS_SOURCE})
-add_linker_flag("/NATVIS:${JIT_NATVIS_SOURCE}")
+# Include natvis file for Windows
+if (CLR_CMAKE_TARGET_WIN32)
+  set(JIT_NATVIS_SOURCE
+    clrjit.natvis
+  )
+  convert_to_absolute_path(JIT_NATVIS_SOURCE ${JIT_NATVIS_SOURCE})
+  add_linker_flag("/NATVIS:${JIT_NATVIS_SOURCE}")
+endif(CLR_CMAKE_TARGET_WIN32)
 
 set(JIT_DLL_MAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/dllmain.cpp)
 

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -363,6 +363,15 @@ convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
 convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
+# Set natvis file
+
+set(JIT_NATVIS_SOURCE
+  clrjit.natvis
+)
+
+convert_to_absolute_path(JIT_NATVIS_SOURCE ${JIT_NATVIS_SOURCE})
+add_linker_flag("/NATVIS:${JIT_NATVIS_SOURCE}")
+
 set(JIT_DLL_MAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/dllmain.cpp)
 
 if(CLR_CMAKE_TARGET_WIN32)

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -69,6 +69,7 @@ if(CLR_CMAKE_TARGET_WIN32)
 endif(CLR_CMAKE_TARGET_WIN32)
 
 set( JIT_SOURCES
+  clrjit.natvis
   alloc.cpp
   assertionprop.cpp
   bitset.cpp

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MIT license.
+-->
+
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+  <Type Name="Compiler">
+    <DisplayString>{{ {info.compFullName,sb} ({info.compMethodHashPrivate,x})}}</DisplayString>
+    <StringView>info.compFullName,sb</StringView>
+  </Type>
+
+  <Type Name="BasicBlock">
+    <DisplayString Condition="bbJumpKind==BBJ_COND || bbJumpKind==BBJ_ALWAYS || bbJumpKind==BBJ_LEAVE || bbJumpKind==BBJ_EHCATCHRET || bbJumpKind==BBJ_CALLFINALLY">BB{bbNum,d}->BB{bbJumpDest->bbNum,d}; {bbJumpKind,en}</DisplayString>
+    <DisplayString>BB{bbNum,d};--- {bbJumpKind}</DisplayString>
+  </Type>
+
+  <Type Name="EHblkDsc">
+    <DisplayString>type={ebdHandlerType}</DisplayString>
+  </Type>
+
+  <!-- GenTree -->
+  <Type Name="GenTree">
+    <DisplayString>{{{gtOper,en}, {gtType,en}}}}</DisplayString>
+  </Type>
+  <Type Name="GenTreeIntCon">
+    <DisplayString>{{IntCon= {((GenTreeIntCon*)this)-&gt;gtIconVal, d}}}</DisplayString>
+  </Type>
+  <Type Name="GenTreeDblCon">
+    <DisplayString>{{DblCon= {((GenTreeDblCon*)this)-&gt;gtDconVal, g}}}</DisplayString>
+  </Type>
+  <Type Name="GenTreeStrCon">
+    <DisplayString>CNS_STR</DisplayString>
+  </Type>
+  <Type Name="GenTreeLngCon">
+    <DisplayString>{{LngCon= {((GenTreeLngCon*)this)-&gt;gtLconVal, l}}}</DisplayString>
+  </Type>
+  <Type Name="GenTreeOp">
+    <DisplayString Condition="this->gtOper==GT_ASG">{{{((GenTreeUnOp*)this)-&gt;gtOper,en}={this-&gt;gtOp2,na}}}</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_CAST">{{{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}}}</DisplayString>
+  </Type>
+
+  <Type Name="LclVarDsc">
+    <DisplayString>{{ {lvType,en} - {lvReason,s} }}</DisplayString>
+  </Type>
+
+  <Type Name="GenTreeLclVar" Inheritable="false">
+    <DisplayString>{{{gtType,en}  V{((GenTreeLclVar*)this)-&gt;_gtLclNum, 02u}}}</DisplayString>
+  </Type>
+
+  <!-- Register allocation -->
+  <Type Name="RefPosition">
+    <DisplayString>{{#{rpNum,d} - {refType,en}}}</DisplayString>
+    <Expand>
+        <Item Name="Referent" Condition="this->isPhysRegRef">(RegRecord*)this-&gt;referent</Item>
+        <Item Name="Referent" Condition="!this->isPhysRegRef">(Interval*)this-&gt;referent</Item>
+        <CustomListItems>
+          <Variable Name="reg" InitialValue="this->registerAssignment" />
+          <Variable Name="regIndex" InitialValue="0" />
+          <Loop Condition="reg != 0">
+            <Item Condition="(reg &amp; 1) != 0">((regNumber)regIndex),en</Item>
+            <Exec>regIndex++</Exec>
+            <Exec>reg = reg >> 1</Exec>
+          </Loop>
+        </CustomListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="Interval">
+    <DisplayString Condition="this->isLocalVar">[V{this->varNum,d}, #{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
+    <DisplayString Condition="this->isConstant">[C{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
+    <DisplayString>[I{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
+  </Type>
+
+  <Type Name="RegRecord">
+    <DisplayString>[reg= {((regNumber)regNum),en}, type= {registerType, en}]</DisplayString>
+    <Expand>
+      <Item Name="[Assigned]">assignedInterval</Item>
+      <Item Name="[Previous]">previousInterval</Item>
+    </Expand>
+  </Type>
+
+  <!-- Emitter -->
+  <Type Name="insGroup">
+    <DisplayString>IG{igNum,d}}</DisplayString>
+  </Type>
+
+  <!-- utils -->
+   <Type Name="jitstd::list&lt;*&gt;">
+    <DisplayString Condition="m_nSize > 0">Size = {m_nSize}</DisplayString>
+    <DisplayString Condition="m_nSize == 0">Empty</DisplayString>
+    <Expand>
+      <LinkedListItems>
+        <Size>m_nSize</Size>
+        <HeadPointer>this->m_pHead</HeadPointer>
+        <NextPointer>this-&gt;m_pNext</NextPointer>
+        <ValueNode>this-&gt;m_value</ValueNode>
+      </LinkedListItems>
+    </Expand>
+  </Type>
+
+</AutoVisualizer>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -39,7 +39,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <DisplayString>[LngCon={((GenTreeLngCon*)this)-&gt;gtLconVal, l}]</DisplayString>
   </Type>
   <Type Name="GenTreeOp">
-    <DisplayString Condition="this->gtOper==GT_ASG">[{((GenTreeUnOp*)this)-&gt;gtOper,en}={this-&gt;gtOp2,na}]</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_ASG">[{this-&gt;gtOp1,na}={this-&gt;gtOp2,na}]</DisplayString>
     <DisplayString Condition="this->gtOper==GT_CAST">[{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}]</DisplayString>
     <DisplayString>[{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -114,7 +114,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <!-- Emitter -->
   <Type Name="insGroup">
     <DisplayString Condition="igFlags &amp; 0x200">IG{igNum,d} [extend]</DisplayString>
-    <DisplayString>IG{igNum,d]</DisplayString>
+    <DisplayString>IG{igNum,d}</DisplayString>
   </Type>
 
   <!-- utils -->

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -9,13 +9,13 @@ The .NET Foundation licenses this file to you under the MIT license.
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 
   <Type Name="Compiler">
-    <DisplayString>{{ {info.compFullName,sb} ({info.compMethodHashPrivate,x})}}</DisplayString>
+    <DisplayString>[{info.compFullName,sb} ({info.compMethodHashPrivate,x})]</DisplayString>
     <StringView>info.compFullName,sb</StringView>
   </Type>
 
   <Type Name="BasicBlock">
     <DisplayString Condition="bbJumpKind==BBJ_COND || bbJumpKind==BBJ_ALWAYS || bbJumpKind==BBJ_LEAVE || bbJumpKind==BBJ_EHCATCHRET || bbJumpKind==BBJ_CALLFINALLY">BB{bbNum,d}->BB{bbJumpDest->bbNum,d}; {bbJumpKind,en}</DisplayString>
-    <DisplayString>BB{bbNum,d};--- {bbJumpKind}</DisplayString>
+    <DisplayString>BB{bbNum,d}; {bbJumpKind,en}</DisplayString>
   </Type>
 
   <Type Name="EHblkDsc">
@@ -24,36 +24,64 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   <!-- GenTree -->
   <Type Name="GenTree">
-    <DisplayString>{{{gtOper,en}, {gtType,en}}}}</DisplayString>
+    <DisplayString>[{gtOper,en}, {gtType,en}}]</DisplayString>
   </Type>
   <Type Name="GenTreeIntCon">
-    <DisplayString>{{IntCon= {((GenTreeIntCon*)this)-&gt;gtIconVal, d}}}</DisplayString>
+    <DisplayString>[IntCon={((GenTreeIntCon*)this)-&gt;gtIconVal, d}]</DisplayString>
   </Type>
   <Type Name="GenTreeDblCon">
-    <DisplayString>{{DblCon= {((GenTreeDblCon*)this)-&gt;gtDconVal, g}}}</DisplayString>
+    <DisplayString>[DblCon={((GenTreeDblCon*)this)-&gt;gtDconVal, g}]</DisplayString>
   </Type>
   <Type Name="GenTreeStrCon">
     <DisplayString>CNS_STR</DisplayString>
   </Type>
   <Type Name="GenTreeLngCon">
-    <DisplayString>{{LngCon= {((GenTreeLngCon*)this)-&gt;gtLconVal, l}}}</DisplayString>
+    <DisplayString>[LngCon={((GenTreeLngCon*)this)-&gt;gtLconVal, l}]</DisplayString>
   </Type>
   <Type Name="GenTreeOp">
-    <DisplayString Condition="this->gtOper==GT_ASG">{{{((GenTreeUnOp*)this)-&gt;gtOper,en}={this-&gt;gtOp2,na}}}</DisplayString>
-    <DisplayString Condition="this->gtOper==GT_CAST">{{{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}}}</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_ASG">[{((GenTreeUnOp*)this)-&gt;gtOper,en}={this-&gt;gtOp2,na}]</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_CAST">[{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}]</DisplayString>
+    <DisplayString>[{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>
 
   <Type Name="LclVarDsc">
-    <DisplayString>{{ {lvType,en} - {lvReason,s} }}</DisplayString>
+    <DisplayString Condition="lvReason==0">[{lvType,en}]</DisplayString>
+    <DisplayString>[{lvType,en}-{lvReason,s}]</DisplayString>
   </Type>
 
   <Type Name="GenTreeLclVar" Inheritable="false">
-    <DisplayString>{{{gtType,en}  V{((GenTreeLclVar*)this)-&gt;_gtLclNum, 02u}}}</DisplayString>
+    <DisplayString>[{gtOper,en}, {gtType,en} V{((GenTreeLclVar*)this)-&gt;_gtLclNum,u}]</DisplayString>
   </Type>
 
   <!-- Register allocation -->
+  <Type Name="LinearScan">
+    <DisplayString>LinearScan</DisplayString>
+    <Expand>
+        <Item Name="AvailableRegs mask">this-&gt;m_AvailableRegs</Item>
+        <CustomListItems>
+          <Variable Name="reg" InitialValue="this->m_AvailableRegs" />
+          <Variable Name="regIndex" InitialValue="0" />
+          <Loop Condition="reg != 0">
+            <Item Condition="(reg &amp; 1) != 0">((regNumber)regIndex),en</Item>
+            <Exec>regIndex++</Exec>
+            <Exec>reg = reg >> 1</Exec>
+          </Loop>
+        </CustomListItems>
+        <Item Name="RegistersWithConstants mask">this-&gt;m_RegistersWithConstants</Item>
+        <CustomListItems>
+          <Variable Name="reg" InitialValue="this->m_RegistersWithConstants" />
+          <Variable Name="regIndex" InitialValue="0" />
+          <Loop Condition="reg != 0">
+            <Item Condition="(reg &amp; 1) != 0">((regNumber)regIndex),en</Item>
+            <Exec>regIndex++</Exec>
+            <Exec>reg = reg >> 1</Exec>
+          </Loop>
+        </CustomListItems>
+    </Expand>
+  </Type>
+
   <Type Name="RefPosition">
-    <DisplayString>{{#{rpNum,d} - {refType,en}}}</DisplayString>
+    <DisplayString>[#{rpNum,d} - {refType,en}]</DisplayString>
     <Expand>
         <Item Name="Referent" Condition="this->isPhysRegRef">(RegRecord*)this-&gt;referent</Item>
         <Item Name="Referent" Condition="!this->isPhysRegRef">(Interval*)this-&gt;referent</Item>
@@ -70,13 +98,13 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Type>
 
   <Type Name="Interval">
-    <DisplayString Condition="this->isLocalVar">[V{this->varNum,d}, #{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
-    <DisplayString Condition="this->isConstant">[C{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
-    <DisplayString>[I{this->intervalIndex, d}, reg= {(regNumber)physReg, en}]</DisplayString>
+    <DisplayString Condition="this->isLocalVar">[V{this->varNum,d}, #{this->intervalIndex, d}, reg={(regNumber)physReg, en}]</DisplayString>
+    <DisplayString Condition="this->isConstant">[C{this->intervalIndex, d}, reg={(regNumber)physReg, en}]</DisplayString>
+    <DisplayString>[I{this->intervalIndex, d}, reg={(regNumber)physReg, en}]</DisplayString>
   </Type>
 
   <Type Name="RegRecord">
-    <DisplayString>[reg= {((regNumber)regNum),en}, type= {registerType, en}]</DisplayString>
+    <DisplayString>[reg={((regNumber)regNum),en}, type={registerType, en}]</DisplayString>
     <Expand>
       <Item Name="[Assigned]">assignedInterval</Item>
       <Item Name="[Previous]">previousInterval</Item>
@@ -85,12 +113,13 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   <!-- Emitter -->
   <Type Name="insGroup">
-    <DisplayString>IG{igNum,d}}</DisplayString>
+    <DisplayString Condition="igFlags &amp; 0x200">IG{igNum,d} [extend]</DisplayString>
+    <DisplayString>IG{igNum,d]</DisplayString>
   </Type>
 
   <!-- utils -->
    <Type Name="jitstd::list&lt;*&gt;">
-    <DisplayString Condition="m_nSize > 0">Size = {m_nSize}</DisplayString>
+    <DisplayString Condition="m_nSize > 0">Size={m_nSize}</DisplayString>
     <DisplayString Condition="m_nSize == 0">Empty</DisplayString>
     <Expand>
       <LinkedListItems>


### PR DESCRIPTION
Add `clrjit.natvis` file for better debugging experience. There are lot of things we can add to this file, but I just included the important ones that I could think of and time permitted. I have added some pattern like `LinkedList` or `Loop` that someone else can refer and add entries to this file for the code they work on.

I am also not 100% sure of what could be useful information to display for each type of `GenTree` node, but from what I have, it should be easy to extend.

Here is the sample visualizer for `jitstd::list<RefPosition>` as well as `RefPosition` and the decomposition of `registerAssignment` inside it to show all the registers. 

![image](https://user-images.githubusercontent.com/12488060/118040067-f1fd4000-b325-11eb-9bef-6a59c1fa41ca.png)

Unfortunately, natvis do not support typedefs or primitive types, so it will be hard to use it more broadly.