### PR TITLE
New deps package for Fedora 34

### DIFF
--- a/src/installer/pkg/sfx/installers.proj
+++ b/src/installer/pkg/sfx/installers.proj
@@ -12,6 +12,7 @@
   <ItemGroup Condition="'$(BuildRpmPackage)' == 'true'">
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.7.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.27.proj" />
+    <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.34.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-oraclelinux.7.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-rhel.7.proj" />

--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.34.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.34.proj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <GenerateInstallers Condition="'$(BuildRpmPackage)' != 'true'">false</GenerateInstallers>
+    <PackageTargetOS>fedora.34</PackageTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <LinuxPackageDependency Include="libicu;krb5-libs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/52667

Fedora 34 does not include compat-openssl10 - we should not require it in our deps package.

This PR introduces new deps package for Fedora 34+ releases.