### PR TITLE
Deps package for Fedora 34

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -25,6 +25,7 @@ parameters:
     rids:
     - centos.7
     - fedora.27
+    - fedora.34
     - opensuse.42
     - oraclelinux.7
     - sles.12

--- a/src/installer/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_fedora.34-x64.json
+++ b/src/installer/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_fedora.34-x64.json
@@ -1,0 +1,40 @@
+{
+    "maintainer_name": ".NET Team",
+    "maintainer_email": "dotnetpackages@dotnetfoundation.org",
+    "vendor": ".NET Foundation",
+
+    "package_name": "%RUNTIME_DEPS_RPM_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": "%RUNTIME_DEPS_RPM_PACKAGE_NAME% %RUNTIME_DEPS_VERSION%",
+    "long_description": ".NET is a development platform that you can use to build command-line applications, microservices and modern websites. This package installs all the system dependencies for .NET Runtime.",
+    "homepage": "https://dot.net/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"%RUNTIME_DEPS_REVISION%",
+        "urgency" : "low",
+        "changelog_message" : "https://github.com/dotnet/core/tree/master/release-notes"
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2018 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2018 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+    
+    "rpm_dependencies":[{
+        "package_name": "libicu",
+        "package_version": ""
+    },
+    {
+        "package_name": "krb5-libs",
+        "package_version": ""
+    }]
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/52667

Adds deps package for Fedora 34 in 5.0 servicing branch.