### PR TITLE
add SslStream_RandomWrites_OK test

### DIFF
--- a/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
+++ b/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
@@ -14,13 +14,13 @@ namespace System.Net.Test.Common
         private readonly Stream _innerStream;
         private readonly int _maxSize;
 
-        public RandomReadWriteSizeStream(Stream stream, int maximumSize = int.MaxValue)
+        public RandomReadWriteSizeStream(Stream stream, int maxChunkSize = int.MaxValue)
         {
             _innerStream = stream;
-            _maxSize = maximumSize;
+            _maxSize = maxChunkSize;
         }
 
-        public override bool CanSeek => false;
+        public override bool CanSeek => _innerStream.CanSeek;
 
         public override bool CanRead => _innerStream.CanRead;
 

--- a/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
+++ b/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
@@ -12,12 +12,12 @@ namespace System.Net.Test.Common
     public class RandomReadWriteSizeStream : Stream
     {
         private readonly Stream _innerStream;
-        private readonly int _maxSize;
+        private readonly int _maxChunkSize;
 
         public RandomReadWriteSizeStream(Stream stream, int maxChunkSize = int.MaxValue)
         {
             _innerStream = stream;
-            _maxSize = maxChunkSize;
+            _maxChunkSize = maxChunkSize;
         }
 
         public override bool CanSeek => _innerStream.CanSeek;
@@ -49,7 +49,7 @@ namespace System.Net.Test.Common
         {
             if (buffer.Length > 0)
             {
-                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxSize));
+                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxChunkSize));
                 buffer = buffer.Slice(0, readLength);
             }
 
@@ -62,7 +62,7 @@ namespace System.Net.Test.Common
         {
             if (buffer.Length > 0)
             {
-                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxSize));
+                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxChunkSize));
                 buffer = buffer.Slice(0, readLength);
             }
             return _innerStream.ReadAsync(buffer, cancellationToken);

--- a/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
+++ b/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+    public class RandomReadWriteSizeStream: Stream
+    {
+        private readonly Stream _innerStream;
+        private readonly int _maxSize;
+
+        public RandomReadWriteSizeStream(Stream stream, int maximumSize = int.MaxValue)
+        {
+            _innerStream = stream;
+            _maxSize = maximumSize;
+        }
+
+        public override bool CanSeek => false;
+
+        public override bool CanRead => _innerStream.CanRead;
+
+        public override bool CanTimeout => _innerStream.CanTimeout;
+
+        public override bool CanWrite => _innerStream.CanWrite;
+
+        public override long Position
+        {
+            get => _innerStream.Position;
+            set => _innerStream.Position = value;
+        }
+
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+
+        public override long Length => _innerStream.Length;
+
+        public override void Flush() => _innerStream.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(new Span<byte>(buffer, offset, count));
+        public override int Read(Span<byte> buffer)
+        {
+            if (buffer.Length > 0)
+            {
+                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxSize));
+                buffer = buffer.Slice(0, readLength);
+            }
+
+            return _innerStream.Read(buffer);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ReadAsync(new Memory<byte>(buffer, offset, count)).AsTask();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (buffer.Length > 0)
+            {
+                int readLength = RandomNumberGenerator.GetInt32(1, Math.Min(buffer.Length + 1, _maxSize));
+                buffer = buffer.Slice(0, readLength);
+            }
+            return _innerStream.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) => Write(new ReadOnlySpan<byte>(buffer, offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            while (buffer.Length > 0)
+            {
+                int writeLength = RandomNumberGenerator.GetInt32(buffer.Length + 1);
+                _innerStream.Write(buffer.Slice(0, writeLength));
+                buffer = buffer.Slice(writeLength);
+            }
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count)).AsTask();
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            while (buffer.Length > 0)
+            {
+                int writeLength = RandomNumberGenerator.GetInt32(buffer.Length + 1);
+                await _innerStream.WriteAsync(buffer.Slice(0, writeLength), cancellationToken);
+                buffer = buffer.Slice(writeLength);
+            }
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
+++ b/src/libraries/Common/tests/System/Net/RandomReadWriteSizeStream.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 
 namespace System.Net.Test.Common
 {
-    public class RandomReadWriteSizeStream: Stream
+    // Wrapper stream to artificially chop reads and writes to smaller chunks.
+    public class RandomReadWriteSizeStream : Stream
     {
         private readonly Stream _innerStream;
         private readonly int _maxSize;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -431,7 +431,7 @@ namespace System.Net.Security.Tests
         [InlineData(16384 * 100, 4096, 1024, false)]
         [InlineData(16384 * 100, 4096, 1024, true)]
         [InlineData(16384 * 100, 1024 * 20, 1024, true)]
-        [InlineData(16384 , 3, 3, true)]
+        [InlineData(16384, 3, 3, true)]
         public async Task SslStream_RandomSizeWrites_OK(int bufferSize, int readBufferSize, int writeBufferSize, bool useAsync)
         {
             byte[] dataToCopy = RandomNumberGenerator.GetBytes(bufferSize);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -428,8 +428,10 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
+        [InlineData(16384 * 100, 4096, 1024, false)]
         [InlineData(16384 * 100, 4096, 1024, true)]
         [InlineData(16384 * 100, 1024 * 20, 1024, true)]
+        [InlineData(16384 , 3, 3, true)]
         public async Task SslStream_RandomWrites_OK(int bufferSize, int readBufferSize, int writeBufferSize, bool useAsync)
         {
             byte[] dataToCopy = RandomNumberGenerator.GetBytes(bufferSize);
@@ -467,7 +469,7 @@ namespace System.Net.Security.Tests
                             server.Write(data.Span.Slice(0, writeLength));
                         }
 
-                        data = data.Slice(writeBufferSize);
+                        data = data.Slice(Math.Min(writeBufferSize, data.Length));
                     }
 
                     server.ShutdownAsync().GetAwaiter().GetResult();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -49,6 +49,8 @@
              Link="Common\System\Net\Capability.Security.cs" />
     <Compile Include="$(CommonTestPath)System\Net\SslStreamCertificatePolicy.cs"
              Link="Common\System\Net\SslStreamCertificatePolicy.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\RandomReadWriteSizeStream.cs"
+             Link="Common\System\Net\RandomReadWriteSizeStream.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs"
              Link="Common\System\Net\Configuration.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs"


### PR DESCRIPTION
This test helps with verification when IO does not land on frame a boundary or we get less than expected bytes. 
This was originally part of  #49743.