### PR TITLE
Reduce DefaultPooledConnectionIdleTimeout default

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http
         public const bool DefaultUseDefaultCredentials = false;
         public const bool DefaultCheckCertificateRevocationList = false;
         public static readonly TimeSpan DefaultPooledConnectionLifetime = Timeout.InfiniteTimeSpan;
-        public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
+        public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromSeconds(110);
         public static readonly TimeSpan DefaultExpect100ContinueTimeout = TimeSpan.FromSeconds(1);
         public static readonly TimeSpan DefaultConnectTimeout = Timeout.InfiniteTimeSpan;
     }

--- a/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http
         public const bool DefaultUseDefaultCredentials = false;
         public const bool DefaultCheckCertificateRevocationList = false;
         public static readonly TimeSpan DefaultPooledConnectionLifetime = Timeout.InfiniteTimeSpan;
-        public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromSeconds(110);
+        public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(1);
         public static readonly TimeSpan DefaultExpect100ContinueTimeout = TimeSpan.FromSeconds(1);
         public static readonly TimeSpan DefaultConnectTimeout = Timeout.InfiniteTimeSpan;
     }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1774,7 +1774,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new SocketsHttpHandler())
             {
-                Assert.Equal(TimeSpan.FromMinutes(2), handler.PooledConnectionIdleTimeout);
+                Assert.Equal(TimeSpan.FromMinutes(1), handler.PooledConnectionIdleTimeout);
 
                 handler.PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan;
                 Assert.Equal(Timeout.InfiniteTimeSpan, handler.PooledConnectionIdleTimeout);
@@ -1957,7 +1957,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(int.MaxValue, handler.MaxConnectionsPerServer);
                 Assert.Equal(64, handler.MaxResponseHeadersLength);
                 Assert.False(handler.PreAuthenticate);
-                Assert.Equal(TimeSpan.FromMinutes(2), handler.PooledConnectionIdleTimeout);
+                Assert.Equal(TimeSpan.FromMinutes(1), handler.PooledConnectionIdleTimeout);
                 Assert.Equal(Timeout.InfiniteTimeSpan, handler.PooledConnectionLifetime);
                 Assert.NotNull(handler.Properties);
                 Assert.Null(handler.Proxy);


### PR DESCRIPTION
- Change DefaultPooledConnectionIdleTimeout from 120 seconds to 60 seconds
- This should reduce the occurrence of socket errors near the timeout when connected to IIS or Kestrel

See https://github.com/dotnet/runtime/issues/52267#issuecomment-840140309

Here's the similar PR for Kestrel to increase its KeepAliveTimeout: https://github.com/dotnet/aspnetcore/pull/32636

Other servers have even smaller default keep-alive timeouts, but I still think this is a good change.

- Node.js [5s](https://nodejs.org/api/http.html#http_server_keepalivetimeout)
- Apache [5s?](https://httpd.apache.org/docs/2.4/mod/core.html#keepalivetimeout)
- NGINX [75s](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)

We'll need to update the API docs at https://github.com/dotnet/dotnet-api-docs/blob/2238750cc696339f0a8f04c786f7fe03b14e51ec/xml/System.Net.Http/SocketsHttpHandler.xml#L623

Addresses #52267

@geoffkizer 