### PR TITLE
Use Platform-Guard Assertion Annotations for some known cases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,7 +47,7 @@
     <MicrosoftCodeAnalysisVersion>3.8.0</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview5.21219.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview5.21262.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpVersion>
     <!-- Arcade dependencies -->

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Extensions.Logging.Console
             _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
 
             _messageQueue = new ConsoleLoggerProcessor();
-            // TODO update when https://github.com/dotnet/runtime/issues/44922 implemented
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || DoesWindowsConsoleSupportAnsi())
+
+            if (DoesWindowsConsoleSupportAnsi())
             {
                 _messageQueue.Console = new AnsiLogConsole();
                 _messageQueue.ErrorConsole = new AnsiLogConsole(stdErr: true);
@@ -60,8 +60,14 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
+        [UnsupportedOSPlatformGuard("windows")]
         private static bool DoesWindowsConsoleSupportAnsi()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return true;
+            }
+
             // for Windows, check the console mode
             var stdOutHandle = Interop.Kernel32.GetStdHandle(Interop.Kernel32.STD_OUTPUT_HANDLE);
             if (!Interop.Kernel32.GetConsoleMode(stdOutHandle, out int consoleMode))

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Logging.Console
 
             _messageQueue = new ConsoleLoggerProcessor();
 
-            if (DoesWindowsConsoleSupportAnsi())
+            if (DoesConsoleSupportAnsi())
             {
                 _messageQueue.Console = new AnsiLogConsole();
                 _messageQueue.ErrorConsole = new AnsiLogConsole(stdErr: true);
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         [UnsupportedOSPlatformGuard("windows")]
-        private static bool DoesWindowsConsoleSupportAnsi()
+        private static bool DoesConsoleSupportAnsi()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -352,6 +352,7 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpHandler : System.Net.Http.HttpMessageHandler
     {
         public SocketsHttpHandler() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute("browser")]
         public static bool IsSupported { get { throw null; } }
         public bool AllowAutoRedirect { get { throw null; } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -16,6 +16,7 @@ namespace System.Net.Http
     [UnsupportedOSPlatform("browser")]
     public sealed class SocketsHttpHandler : HttpMessageHandler
     {
+        [UnsupportedOSPlatformGuard("browser")]
         public static bool IsSupported => false;
 
         public bool UseCookies

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -79,7 +79,7 @@ namespace System.Net.Http
         [SupportedOSPlatformGuard("linux")]
         [SupportedOSPlatformGuard("macOS")]
         [SupportedOSPlatformGuard("Windows")]
-        private readonly bool _http3Enabled;
+        private readonly bool _http3Enabled = (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
         private Http3Connection? _http3Connection;
         private SemaphoreSlim? _http3ConnectionCreateLock;
         internal readonly byte[]? _http3EncodedAuthorityHostHeader;
@@ -286,7 +286,7 @@ namespace System.Net.Http
 
         private static List<SslApplicationProtocol> CreateHttp3ApplicationProtocols()
         {
-            // TODO: Replace with Platform-Guard Assertion Annotations once https://github.com/dotnet/runtime/issues/44922 is finished
+            // TODO: Cannot use instance field _http3Enabled in static method
             if ((OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
             {
                 // TODO: Once the HTTP/3 versions are part of SslApplicationProtocol, see https://github.com/dotnet/runtime/issues/1293, move this back to field initialization.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -76,6 +76,9 @@ namespace System.Net.Http
         private byte[]? _http2AltSvcOriginUri;
         internal readonly byte[]? _http2EncodedAuthorityHostHeader;
 
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("macOS")]
+        [SupportedOSPlatformGuard("Windows")]
         private readonly bool _http3Enabled;
         private Http3Connection? _http3Connection;
         private SemaphoreSlim? _http3ConnectionCreateLock;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -59,11 +59,6 @@ namespace System.Net.Http
 
         internal bool _enableMultipleHttp2Connections;
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
-        private readonly bool _http3Enabled = (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
-
         internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? _connectCallback;
         internal Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? _plaintextStreamFilter;
 
@@ -128,7 +123,7 @@ namespace System.Net.Http
             };
 
             // TODO: Remove if/when QuicImplementationProvider is removed from System.Net.Quic.
-            if (_http3Enabled)
+            if (HttpConnectionPool.IsHttp3Supported())
             {
                 settings._quicImplementationProvider = _quicImplementationProvider;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -59,6 +59,11 @@ namespace System.Net.Http
 
         internal bool _enableMultipleHttp2Connections;
 
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("macOS")]
+        [SupportedOSPlatformGuard("Windows")]
+        private readonly bool _http3Enabled = (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
         internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? _connectCallback;
         internal Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? _plaintextStreamFilter;
 
@@ -122,9 +127,8 @@ namespace System.Net.Http
                 _plaintextStreamFilter = _plaintextStreamFilter
             };
 
-            // TODO: Replace with Platform-Guard Assertion Annotations once https://github.com/dotnet/runtime/issues/44922 is finished
             // TODO: Remove if/when QuicImplementationProvider is removed from System.Net.Quic.
-            if ((OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            if (_http3Enabled)
             {
                 settings._quicImplementationProvider = _quicImplementationProvider;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -42,6 +42,7 @@ namespace System.Net.Http
         /// <summary>
         /// Gets a value that indicates whether the handler is supported on the current platform.
         /// </summary>
+        [UnsupportedOSPlatformGuard("browser")]
         public static bool IsSupported => true;
 
         public bool UseCookies

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/HttpClientTest.cs
@@ -9,6 +9,11 @@ using System.Threading.Tasks;
 
 class Program
 {
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("macOS")]
+    [SupportedOSPlatformGuard("Windows")]
+    private static bool IsHttp3Supported => (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
     static async Task<int> Main(string[] args)
     {
         using var client = new HttpClient();
@@ -19,12 +24,7 @@ class Program
         const string quicDll = "System.Net.Quic.dll";
         var quicDllExists = File.Exists(Path.Combine(AppContext.BaseDirectory, quicDll));
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
-        private readonly bool _http3Enabled = (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
-
-        if (_http3Enabled)
+        if (IsHttp3Supported)
         {
             Console.WriteLine($"Expected {quicDll} is {(quicDllExists ? "present - OK" : "missing - BAD")}.");
             return quicDllExists ? 100 : -1;

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/HttpClientTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 class Program
@@ -18,8 +19,12 @@ class Program
         const string quicDll = "System.Net.Quic.dll";
         var quicDllExists = File.Exists(Path.Combine(AppContext.BaseDirectory, quicDll));
 
-        // TODO: Replace with Platform-Guard Assertion Annotations once https://github.com/dotnet/runtime/issues/44922 is finished
-        if ((OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("macOS")]
+        [SupportedOSPlatformGuard("Windows")]
+        private readonly bool _http3Enabled = (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
+        if (_http3Enabled)
         {
             Console.WriteLine($"Expected {quicDll} is {(quicDllExists ? "present - OK" : "missing - BAD")}.");
             return quicDllExists ? 100 : -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -45,13 +45,11 @@ namespace System.Threading.Tasks
             if (Thread.IsThreadStartSupported && (options & TaskCreationOptions.LongRunning) != 0)
             {
                 // Run LongRunning tasks on their own dedicated thread.
-#pragma warning disable CA1416 // TODO: https://github.com/dotnet/runtime/issues/44922
                 new Thread(s_longRunningThreadWork)
                 {
                     IsBackground = true,
                     Name = ".NET Long Running Task"
                 }.UnsafeStart(task);
-#pragma warning restore CA1416
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -163,8 +163,8 @@ namespace System.Threading
             Initialize();
         }
 
-        [UnsupportedOSPlatformGuard("browser")]
 #if !TARGET_BROWSER
+        [UnsupportedOSPlatformGuard("browser")]
         internal const bool IsThreadStartSupported = true;
 
         /// <summary>Causes the operating system to change the state of the current instance to <see cref="ThreadState.Running"/>, and optionally supplies an object containing data to be used by the method the thread executes.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -164,6 +164,7 @@ namespace System.Threading
         }
 
 #if !TARGET_BROWSER
+        [UnsupportedOSPlatformGuard("browser")]
         internal const bool IsThreadStartSupported = true;
 
         /// <summary>Causes the operating system to change the state of the current instance to <see cref="ThreadState.Running"/>, and optionally supplies an object containing data to be used by the method the thread executes.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -163,8 +163,8 @@ namespace System.Threading
             Initialize();
         }
 
-#if !TARGET_BROWSER
         [UnsupportedOSPlatformGuard("browser")]
+#if !TARGET_BROWSER
         internal const bool IsThreadStartSupported = true;
 
         /// <summary>Causes the operating system to change the state of the current instance to <see cref="ThreadState.Running"/>, and optionally supplies an object containing data to be used by the method the thread executes.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -165,7 +165,7 @@ namespace System.Threading
 
 #if !TARGET_BROWSER
         [UnsupportedOSPlatformGuard("browser")]
-        internal const bool IsThreadStartSupported = true;
+        internal static bool IsThreadStartSupported => true;
 
         /// <summary>Causes the operating system to change the state of the current instance to <see cref="ThreadState.Running"/>, and optionally supplies an object containing data to be used by the method the thread executes.</summary>
         /// <param name="parameter">An object that contains data to be used by the method the thread executes.</param>

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
@@ -8,7 +8,7 @@ namespace System.Threading
     public partial class Thread
     {
         [UnsupportedOSPlatformGuard("browser")]
-        internal const bool IsThreadStartSupported = false;
+        internal static bool IsThreadStartSupported => false;
 
         [UnsupportedOSPlatform("browser")]
         public void Start() => throw new PlatformNotSupportedException();

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
@@ -7,6 +7,7 @@ namespace System.Threading
 {
     public partial class Thread
     {
+        [UnsupportedOSPlatformGuard("browser")]
         internal const bool IsThreadStartSupported = false;
 
         [UnsupportedOSPlatform("browser")]


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/issues/44922 now we have `Platform-Guard Assertion Annotation` [attributes ](https://github.com/dotnet/runtime/issues/51541) added to libraries and the Platform Compatibility Analyzer now [supports ](https://github.com/dotnet/roslyn-analyzers/pull/5087) them. So its time to use `SupportedOSPlatformGuard` and `UnsupportedOSPlatformGuard` whenever needed