### PR TITLE
[tests] Fix CRLF issues in SM.Syndication

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -343,7 +343,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: Browser_wasm_Windows
-      buildArgs: -subset mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+      buildArgs: -subset mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=windows
       timeoutInMinutes: 120
       condition: >-
         or(

--- a/src/libraries/System.ServiceModel.Syndication/tests/Utils/CompareHelper.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/Utils/CompareHelper.cs
@@ -42,6 +42,9 @@ namespace System.ServiceModel.Syndication.Tests
 
         public static void AssertEqualLongString(string expected, string actual)
         {
+            if (!LineEndingsHelper.IsNewLineConsistent)
+                expected = LineEndingsHelper.Normalize(expected);
+
             if (actual != expected)
             {
                 string message = "-- Expected -" + Environment.NewLine + expected + Environment.NewLine + "-- Actual -" + Environment.NewLine + actual + Environment.NewLine;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/52135

When running `System.ServiceModel.Syndication` tests on windows and
targeting `Browser`, the line ending differs between host and target
systems. Use helper `LineEndingsHelper.Normalize` method to update
expected strings.

The `Browser` Environment.NewLine is `\n`, while windows use `\r\n`.
https://github.com/dotnet/runtime/blob/5bd0edfe860e41bdfd690d3743e730594307292e/src/libraries/System.Private.CoreLib/src/System/Environment.UnixOrBrowser.cs#L51

Also set `BrowserHost` property for the build as well. It is also used
in `src/libraries/tests.proj`.