### PR TITLE
[tests] Fix CRLF issues in M.E.Http

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -50,11 +51,11 @@ namespace Microsoft.Extensions.Http.Logging
                     m.EventId == LoggingScopeHttpMessageHandler.Log.EventIds.RequestHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
 Authorization: *
 Cache-Control: no-cache
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -62,11 +63,11 @@ Cache-Control: no-cache
                     m.EventId == LoggingHttpMessageHandler.Log.EventIds.RequestHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
 Authorization: *
 Cache-Control: no-cache
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -74,11 +75,11 @@ Cache-Control: no-cache
                     m.EventId == LoggingHttpMessageHandler.Log.EventIds.ResponseHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
 X-Sensitive: *
 Y-Non-Sensitive: innocuous value
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -86,11 +87,11 @@ Y-Non-Sensitive: innocuous value
                     m.EventId == LoggingScopeHttpMessageHandler.Log.EventIds.ResponseHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
 X-Sensitive: *
 Y-Non-Sensitive: innocuous value
-", message.Message);
+"), message.Message);
         }
 
         [Fact]
@@ -131,11 +132,11 @@ Y-Non-Sensitive: innocuous value
                     m.EventId == LoggingScopeHttpMessageHandler.Log.EventIds.RequestHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
 Authorization: *
 Cache-Control: no-cache
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -143,11 +144,11 @@ Cache-Control: no-cache
                     m.EventId == LoggingHttpMessageHandler.Log.EventIds.RequestHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
 Authorization: *
 Cache-Control: no-cache
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -155,11 +156,11 @@ Cache-Control: no-cache
                     m.EventId == LoggingHttpMessageHandler.Log.EventIds.ResponseHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
 X-Sensitive: *
 Y-Non-Sensitive: innocuous value
-", message.Message);
+"), message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -167,11 +168,11 @@ Y-Non-Sensitive: innocuous value
                     m.EventId == LoggingScopeHttpMessageHandler.Log.EventIds.ResponseHeader &&
                     m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
             }));
-            Assert.StartsWith(
+            Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
 X-Sensitive: *
 Y-Non-Sensitive: innocuous value
-", message.Message);
+"), message.Message);
         }
 
         private class TestMessageHandler : HttpClientHandler

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -296,7 +296,6 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows' and '$(RunDisabledWasmTestsOnWindows)' != 'true'">
     <!-- Issue: https://github.com/dotnet/runtime/issues/52138 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Http\tests\Microsoft.Extensions.Http.Tests\Microsoft.Extensions.Http.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests/System.Text.Json.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.CodeDom\tests\System.CodeDom.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/52008

When running `Microsoft.Extensions.Http` tests on windows and
targeting `Browser`, the line ending differs between host and target
systems. Use helper `LineEndingsHelper.Normalize` method to update
expected strings.

The `Browser` Environment.NewLine is `\n`, while windows use `\r\n`.
https://github.com/dotnet/runtime/blob/5bd0edfe860e41bdfd690d3743e730594307292e/src/libraries/System.Private.CoreLib/src/System/Environment.UnixOrBrowser.cs#L51