### PR TITLE
Fix mcs merge error for missing pattern

### DIFF
--- a/src/coreclr/ToolBox/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbmerge.cpp
@@ -259,7 +259,8 @@ int verbMerge::FilterDirectory(LPCWSTR                      searchPattern,
         }
         else
         {
-            LogError("Failed to find pattern '%s'. GetLastError()=%u", searchPattern, GetLastError());
+            LogError("Failed to find pattern '%S'. GetLastError()=%u", searchPattern, GetLastError());
+            result = -1;
         }
         goto CLEAN_UP;
     }


### PR DESCRIPTION
1. Print the Unicode pattern properly
2. Return an error code