### PR TITLE
enable regions by default in standalone gc

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28565,7 +28565,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
 #ifdef MULTIPLE_HEAPS
     assert (survived <= (size_t)heap_segment_survived (region));
 #else
-    assert (survived == heap_segment_survived (region));
+    assert (survived == (size_t)heap_segment_survived (region));
 #endif //MULTIPLE_HEAPS
 #endif //_DEBUG
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20925,7 +20925,7 @@ size_t gc_heap::get_promoted_bytes()
     dprintf (3, ("h%d getting surv", heap_number));
     size_t region_count = get_total_region_count();
     size_t promoted = 0;
-    for (int i = 0; i < region_count; i++)
+    for (size_t i = 0; i < region_count; i++)
     {
         if (survived_per_region[i] > 0)
         {
@@ -28563,7 +28563,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
         ((survived == heap_segment_survived (region)) ? "same as" : "diff from"),
         heap_segment_survived (region)));
 #ifdef MULTIPLE_HEAPS
-    assert (survived <= heap_segment_survived (region));
+    assert (survived <= (size_t)heap_segment_survived (region));
 #else
     assert (survived == heap_segment_survived (region));
 #endif //MULTIPLE_HEAPS

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28134,7 +28134,7 @@ void gc_heap::thread_final_regions (bool compact_p)
         heap_segment* current_region = heap_segment_rw (generation_start_segment (generation_of (gen_idx)));
         dprintf (REGIONS_LOG, ("gen%d start from %Ix", gen_idx, heap_segment_mem (current_region)));
 
-        while (current_region = find_first_valid_region (current_region, compact_p))
+        while (current_region == find_first_valid_region (current_region, compact_p))
         {
             assert (!compact_p || 
                     (heap_segment_plan_gen_num (current_region) == heap_segment_gen_num (current_region)));
@@ -28473,7 +28473,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
     uint8_t* saved_last_unmarked_obj_end = 0;
     size_t saved_obj_brick = 0;
     size_t saved_next_obj_brick = 0;
-#endif _DEBUG
+#endif //_DEBUG
 
     while (x < end)
     {

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28134,7 +28134,7 @@ void gc_heap::thread_final_regions (bool compact_p)
         heap_segment* current_region = heap_segment_rw (generation_start_segment (generation_of (gen_idx)));
         dprintf (REGIONS_LOG, ("gen%d start from %Ix", gen_idx, heap_segment_mem (current_region)));
 
-        while (current_region == find_first_valid_region (current_region, compact_p))
+        while ((current_region = find_first_valid_region (current_region, compact_p)))
         {
             assert (!compact_p || 
                     (heap_segment_plan_gen_num (current_region) == heap_segment_gen_num (current_region)));

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -53,9 +53,10 @@ inline void FATAL_GC_ERROR()
 // 
 // This means any empty regions can be freely used for any generation. For 
 // Server GC we will balance regions between heaps.
-#ifdef HOST_64BIT
-//#define USE_REGIONS
-#endif //HOST_64BIT
+// For now enable regions by default for only StandAlone GC builds
+#if defined (HOST_64BIT) && defined (BUILD_AS_STANDALONE)
+#define USE_REGIONS
+#endif //HOST_64BIT && BUILD_AS_STANDALONE
 
 #ifdef USE_REGIONS
 // Currently this -


### PR DESCRIPTION
I am seeing that ~40 odd p0 tests are failing with regions. But enabling by default makes things easier to investigate such failures and enable some automation. Assuming standalone GC is not used much externally?