### PR TITLE
Use GeneratedDllImport in System.Diagnostics.FileVersionInfo and System.Runtime.InteropServices.RuntimeInformation

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
@@ -10,8 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUnixVersion", CharSet = CharSet.Ansi, SetLastError = true)]
-        private static extern int GetUnixVersion(byte[] version, ref int capacity);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUnixVersion", CharSet = CharSet.Ansi, SetLastError = true)]
+        private static partial int GetUnixVersion(byte[] version, ref int capacity);
 
         internal static string GetUnixVersion()
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
@@ -53,13 +53,13 @@ internal static partial class Interop
             HasBirthTime = 1,
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
-        internal static extern int FStat(SafeHandle fd, out FileStatus output);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
+        internal static partial int FStat(SafeHandle fd, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
-        internal static extern int Stat(string path, out FileStatus output);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", CharSet = CharSet.Ansi, SetLastError = true)]
+        internal static partial int Stat(string path, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
-        internal static extern int LStat(string path, out FileStatus output);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", CharSet = CharSet.Ansi, SetLastError = true)]
+        internal static partial int LStat(string path, out FileStatus output);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNativeSystemInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNativeSystemInfo.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern void GetNativeSystemInfo(out SYSTEM_INFO lpSystemInfo);
+        [GeneratedDllImport(Libraries.Kernel32)]
+        internal static partial void GetNativeSystemInfo(out SYSTEM_INFO lpSystemInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNativeSystemInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNativeSystemInfo.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32)]
-        internal static partial void GetNativeSystemInfo(out SYSTEM_INFO lpSystemInfo);
+        [DllImport(Libraries.Kernel32)]
+        internal static unsafe extern void GetNativeSystemInfo(SYSTEM_INFO* lpSystemInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemInfo.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);
+        [GeneratedDllImport(Libraries.Kernel32)]
+        internal static partial void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemInfo.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32)]
-        internal static partial void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);
+        [DllImport(Libraries.Kernel32)]
+        internal static unsafe extern void GetSystemInfo(SYSTEM_INFO* lpSystemInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [DllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoExW")]
-        internal static extern bool GetFileVersionInfoEx(
+        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoExW")]
+        internal static partial bool GetFileVersionInfoEx(
                     uint dwFlags,
                     string lpwstrFilename,
                     uint dwHandle,

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoSizeEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoSizeEx.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [DllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoSizeExW")]
-        internal static extern uint GetFileVersionInfoSizeEx(uint dwFlags, string lpwstrFilename, out uint lpdwHandle);
+        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoSizeExW")]
+        internal static partial uint GetFileVersionInfoSizeEx(uint dwFlags, string lpwstrFilename, out uint lpdwHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [DllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "VerQueryValueW")]
-        internal static extern bool VerQueryValue(IntPtr pBlock, string lpSubBlock, out IntPtr lplpBuffer, out uint puLen);
+        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "VerQueryValueW")]
+        internal static partial bool VerQueryValue(IntPtr pBlock, string lpSubBlock, out IntPtr lplpBuffer, out uint puLen);
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -148,7 +148,10 @@ namespace System.IO.MemoryMappedFiles
         private static int GetSystemPageAllocationGranularity()
         {
             Interop.Kernel32.SYSTEM_INFO info;
-            Interop.Kernel32.GetSystemInfo(out info);
+            unsafe
+            {
+                Interop.Kernel32.GetSystemInfo(&info);
+            }
 
             return (int)info.dwAllocationGranularity;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -57,7 +57,12 @@ namespace System
         {
             get
             {
-                Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO info);
+                Interop.Kernel32.SYSTEM_INFO info;
+                unsafe
+                {
+                    Interop.Kernel32.GetSystemInfo(&info);
+                }
+
                 return info.dwPageSize;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/MemoryFailPoint.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/MemoryFailPoint.Windows.cs
@@ -9,7 +9,12 @@ namespace System.Runtime
     {
         private static ulong GetTopOfMemory()
         {
-            Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO info);
+            Interop.Kernel32.SYSTEM_INFO info;
+            unsafe
+            {
+                Interop.Kernel32.GetSystemInfo(&info);
+            }
+
             return (ulong)info.lpMaximumApplicationAddress;
         }
 

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -38,6 +38,7 @@
              Link="Common\Interop\Windows\Kernel32\Interop.GetSystemInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Memory" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Reflection.Extensions" />
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -41,7 +41,12 @@ namespace System.Runtime.InteropServices
 
                 if (osArch == -1)
                 {
-                    Interop.Kernel32.GetNativeSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                    Interop.Kernel32.SYSTEM_INFO sysInfo;
+                    unsafe
+                    {
+                        Interop.Kernel32.GetNativeSystemInfo(&sysInfo);
+                    }
+
                     osArch = s_osArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                 }
 
@@ -59,7 +64,12 @@ namespace System.Runtime.InteropServices
 
                 if (processArch == -1)
                 {
-                    Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                    Interop.Kernel32.SYSTEM_INFO sysInfo;
+                    unsafe
+                    {
+                        Interop.Kernel32.GetSystemInfo(&sysInfo);
+                    }
+
                     processArch = s_processArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                 }
 


### PR DESCRIPTION
`System.Diagnostics.FileVersionInfo`:
|  | Original size (B) | Converted size (B) | + (B) | + (%) |
| ------- | -----------: | ------------: | ----: | ----: |
| linux | 16896 | 18432 | 1536 | 9.09 |
| windows | 14336 | 15872 | 1536 | 10.71 |
| linux R2R | 30208 | 34304 | 4096 | 13.56 |
| windows R2R | 22016 | 26624 | 4608 | 20.93 |

`System.Runtime.InteropServices.RuntimeInformation`:
|  | Original size (B) | Converted size (B) | + (B) | + (%) |
| ------- | -----------: | ------------: | ----: | ----: |
| linux | 11776 | 12800 | 1024 | 8.70 |
| windows | 12288 | 12288 | 0 | 0.00 |
| linux R2R | 18432 | 20992 | 2560 | 13.89 |
| windows R2R | 18944 | 19456 | 512 | 2.70 |

cc @AaronRobinsonMSFT @jkoritzinsky 