### PR TITLE
Use the new Microsoft.DotNet.PackageValidation on Microsoft.Extensions* packages.

### DIFF
--- a/global.json
+++ b/global.json
@@ -13,7 +13,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21264.2",
-    "Microsoft.DotNet.PackageValidation" : "1.0.0-preview.6.21272.6",
+    "Microsoft.DotNet.PackageValidation" : "1.0.0-preview.6.21274.7",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21264.2",

--- a/global.json
+++ b/global.json
@@ -13,7 +13,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21264.2",
-    "Microsoft.DotNet.PackageValidation" : "1.0.0-preview.6.21271.12",
+    "Microsoft.DotNet.PackageValidation" : "1.0.0-preview.6.21272.6",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21264.2",

--- a/global.json
+++ b/global.json
@@ -13,6 +13,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21264.2",
+    "Microsoft.DotNet.PackageValidation" : "1.0.0-preview.6.21271.12",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21264.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21264.2",

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -73,6 +73,8 @@
   <!-- Import packaging props -->
   <Import Project="$(RepositoryEngineeringDir)packaging.props" />
 
+  <Import Sdk="Microsoft.DotNet.PackageValidation" Project="Sdk.props" Condition="'$(IsSourceProject)' == 'true'" />
+
   <PropertyGroup>
     <RefRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ref'))</RefRootPath>
   </PropertyGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -146,6 +146,13 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <Import Sdk="Microsoft.DotNet.PackageValidation" Project="Sdk.targets" Condition="'$(IsSourceProject)' == 'true' and !Exists('$(PkgProjPath)')" />
+
+  <PropertyGroup>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$([MSBuild]::Subtract($(MajorVersion), 1)).0.0</PackageValidationBaselineVersion>
+    <EnablePackageBaselineValidation Condition="'$(IsPackable)' == 'true' and '$(MSBuildProjectExtension)' != '.pkgproj' and '$(EnablePackageBaselineValidation)' == ''">true</EnablePackageBaselineValidation>
+  </PropertyGroup>
+
   <Target Name="SetGenApiProperties"
           BeforeTargets="GenerateReferenceAssemblySource">
     <PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -5,6 +5,7 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <CLSCompliant>false</CLSCompliant>
     <IsRuntimeAssembly>false</IsRuntimeAssembly>
+    <PackageValidationBaselineVersion>3.1.15</PackageValidationBaselineVersion>
     <PackageDescription>Suite of xUnit.net tests to check for container compatibility with Microsoft.Extensions.DependencyInjection.</PackageDescription>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -5,10 +5,8 @@
     <!-- Debug IL generation -->
     <ILEmitBackendSaveAssemblies>False</ILEmitBackendSaveAssemblies>
     <Nullable>Annotations</Nullable>
+    <!-- Type 'Microsoft.Extensions.DependencyInjection.ServiceCollection' has been forwaded down.-->
     <NoWarn>$(NoWarn);CP0001</NoWarn>
-<!--
-  'Microsoft.Extensions.DependencyInjection.ServiceCollection' exists on the previous stable version but not on the recent version.
--->
     <PackageDescription>Default implementation of dependency injection for Microsoft.Extensions.DependencyInjection.</PackageDescription>
   </PropertyGroup>
   

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -5,6 +5,10 @@
     <!-- Debug IL generation -->
     <ILEmitBackendSaveAssemblies>False</ILEmitBackendSaveAssemblies>
     <Nullable>Annotations</Nullable>
+    <NoWarn>$(NoWarn);CP0001</NoWarn>
+<!--
+  'Microsoft.Extensions.DependencyInjection.ServiceCollection' exists on the previous stable version but not on the recent version.
+-->
     <PackageDescription>Default implementation of dependency injection for Microsoft.Extensions.DependencyInjection.</PackageDescription>
   </PropertyGroup>
   

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <!-- PKV006 is due to intentional removal of .NETFramework,Version=v4.5.1, .NETStandard,Version=v1.3 and NETStandard,Version=v1.6 target frameworks from the package as they are no longer supported. -->
     <NoWarn>$(NoWarn);PKV006</NoWarn>
     <PackageDescription>Abstractions for reading `.deps` files.
 

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <NoWarn>$(NoWarn);PKV006</NoWarn>
     <PackageDescription>Abstractions for reading `.deps` files.
 
 Commonly Used Types:

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -6,6 +6,8 @@
     <IsShipping>false</IsShipping>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsSourcePackage>true</IsSourcePackage>
+    <!-- This is non-shipping package. -->
+    <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
     <PackageDescription>Internal package for sharing Microsoft.Extensions.Hosting.HostFactoryResolver type.</PackageDescription>
   </PropertyGroup>
 


### PR DESCRIPTION
All the breaking changes are with the baseline version errors. CP0001

PKV006 errror is dependency model is dropping assets for the NS1.3, NS1.6 & net461.
Disabling the errors is really inefficient.

cc @terrajobst 

Blocked on https://github.com/dotnet/sdk/pull/17623