### PR TITLE
Prepare the COM apartment and context at a safe time

### DIFF
--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1382,7 +1382,7 @@ public:
 
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
-    void FinishInitialization();
+    void PrepareApartmentAndContext();
 
 #ifdef FEATURE_COMINTEROP
     bool IsDisableComObjectEagerCleanup()


### PR DESCRIPTION
Prepare the COM apartment and context at a safe time during thread start up.

This is a regression introduced by https://github.com/dotnet/runtime/pull/52023

Fixes #52738 