### PR TITLE
catch DirectoryOperationException to check Negotiate as for LdapExcep…

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
@@ -264,6 +264,10 @@ namespace System.DirectoryServices.AccountManagement
                             // we don't return false here even if we failed with ERROR_LOGON_FAILURE. We must check Negotiate
                             // because there might be cases in which SSL fails and Negotiate succeeds
                         }
+                        catch (DirectoryOperationException)
+                        {
+                            // see LdapException
+                        }
 
                         BindLdap(networkCredential, defaultContextOptionsNegotiate);
                         _lastBindMethod = AuthMethod.Negotiate;


### PR DESCRIPTION
resolves https://github.com/dotnet/runtime/issues/51222