### PR TITLE
[Android] Cryptography.Native.Android performance tuning

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -390,26 +390,21 @@ namespace System.Security.Cryptography
                     throw new CryptographicException();
                 }
 
+                var androidParameters = new Interop.AndroidCrypto.AndroidSetRsaParametersData
+                {
+                    n = parameters.Modulus, n_length = parameters.Modulus != null ? parameters.Modulus.Length : 0,
+                    e = parameters.Exponent, e_length = parameters.Exponent != null ? parameters.Exponent.Length : 0,
+                    d = parameters.D, d_length = parameters.D != null ? parameters.D.Length : 0,
+                    p = parameters.P, p_length = parameters.P != null ? parameters.P.Length : 0,
+                    dmp1 = parameters.DP, dmp1_length = parameters.DP != null ? parameters.DP.Length : 0,
+                    q = parameters.Q, q_length = parameters.Q != null ? parameters.Q.Length : 0,
+                    dmq1 = parameters.DQ, dmq1_length = parameters.DQ != null ? parameters.DQ.Length : 0,
+                    iqmp = parameters.InverseQ, iqmp_length = parameters.InverseQ != null ? parameters.InverseQ.Length : 0
+                };
+
                 try
                 {
-                    if (!Interop.AndroidCrypto.SetRsaParameters(
-                        key,
-                        parameters.Modulus,
-                        parameters.Modulus != null ? parameters.Modulus.Length : 0,
-                        parameters.Exponent,
-                        parameters.Exponent != null ? parameters.Exponent.Length : 0,
-                        parameters.D,
-                        parameters.D != null ? parameters.D.Length : 0,
-                        parameters.P,
-                        parameters.P != null ? parameters.P.Length : 0,
-                        parameters.DP,
-                        parameters.DP != null ? parameters.DP.Length : 0,
-                        parameters.Q,
-                        parameters.Q != null ? parameters.Q.Length : 0,
-                        parameters.DQ,
-                        parameters.DQ != null ? parameters.DQ.Length : 0,
-                        parameters.InverseQ,
-                        parameters.InverseQ != null ? parameters.InverseQ.Length : 0))
+                    if (!Interop.AndroidCrypto.SetRsaParameters(key, ref androidParameters))
                     {
                         throw new CryptographicException();
                     }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_cipher.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_cipher.c
@@ -334,12 +334,12 @@ int32_t AndroidCryptoNative_CipherSetNonceLength(CipherCtx* ctx, int32_t ivLengt
 
 void AndroidCryptoNative_CipherDestroy(CipherCtx* ctx)
 {
-    if (ctx)
-    {
-        JNIEnv* env = GetJNIEnv();
-        ReleaseGRef(env, ctx->cipher);
-        free(ctx->key);
-        free(ctx->iv);
-        free(ctx);
-    }
+    if (!ctx)
+        return;
+
+    JNIEnv* env = GetJNIEnv();
+    ReleaseGRef(env, ctx->cipher);
+    free(ctx->key);
+    free(ctx->iv);
+    free(ctx);
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.c
@@ -196,25 +196,10 @@ int32_t AndroidCryptoNative_DsaVerify(
     return returnValue;
 }
 
-int32_t AndroidCryptoNative_GetDsaParameters(
-    jobject dsa,
-    jobject* p, int32_t* pLength,
-    jobject* q, int32_t* qLength,
-    jobject* g, int32_t* gLength,
-    jobject* y, int32_t* yLength,
-    jobject* x, int32_t* xLength)
+int32_t AndroidCryptoNative_GetDsaParameters(jobject dsa, AndroidDSAParameters *parameters)
 {
     abort_if_invalid_pointer_argument (dsa);
-    abort_if_invalid_pointer_argument (p);
-    abort_if_invalid_pointer_argument (q);
-    abort_if_invalid_pointer_argument (g);
-    abort_if_invalid_pointer_argument (y);
-    abort_if_invalid_pointer_argument (x);
-    abort_if_invalid_pointer_argument (pLength);
-    abort_if_invalid_pointer_argument (qLength);
-    abort_if_invalid_pointer_argument (gLength);
-    abort_if_invalid_pointer_argument (yLength);
-    abort_if_invalid_pointer_argument (xLength);
+    abort_if_invalid_pointer_argument (parameters);
 
     JNIEnv* env = GetJNIEnv();
 
@@ -226,24 +211,24 @@ int32_t AndroidCryptoNative_GetDsaParameters(
     loc[publicKeySpec] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGetKeySpecMethod, loc[publicKey], g_DSAPublicKeySpecClass);
     ON_EXCEPTION_PRINT_AND_GOTO(error);
 
-    *p = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetP));
-    *q = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetQ));
-    *g = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetG));
-    *y = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetY));
-    *pLength = AndroidCryptoNative_GetBigNumBytes(*p);
-    *qLength = AndroidCryptoNative_GetBigNumBytes(*q);
-    *gLength = AndroidCryptoNative_GetBigNumBytes(*g);
-    *yLength = AndroidCryptoNative_GetBigNumBytes(*y);
+    parameters->p_bn = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetP));
+    parameters->q_bn = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetQ));
+    parameters->g_bn = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetG));
+    parameters->y_bn = ToGRef(env, (*env)->CallObjectMethod(env, loc[publicKeySpec], g_DSAPublicKeySpecGetY));
+    parameters->p_cb = AndroidCryptoNative_GetBigNumBytes(parameters->p_bn);
+    parameters->q_cb = AndroidCryptoNative_GetBigNumBytes(parameters->q_bn);
+    parameters->g_cb = AndroidCryptoNative_GetBigNumBytes(parameters->g_bn);
+    parameters->y_cb = AndroidCryptoNative_GetBigNumBytes(parameters->y_bn);
 
-    *x = NULL;
-    *xLength = 0;
+    parameters->x_bn = NULL;
+    parameters->x_cb = 0;
     loc[privateKey] = (*env)->CallObjectMethod(env, dsa, g_keyPairGetPrivateMethod);
     if (loc[privateKey])
     {
         loc[privateKeySpec] = (*env)->CallObjectMethod(env, loc[keyFactory], g_KeyFactoryGetKeySpecMethod, loc[privateKey], g_DSAPrivateKeySpecClass);
         ON_EXCEPTION_PRINT_AND_GOTO(error);
-        *x = ToGRef(env, (*env)->CallObjectMethod(env, loc[privateKeySpec], g_DSAPrivateKeySpecGetX));
-        *xLength = AndroidCryptoNative_GetBigNumBytes(*x);
+        parameters->x_bn = ToGRef(env, (*env)->CallObjectMethod(env, loc[privateKeySpec], g_DSAPrivateKeySpecGetX));
+        parameters->x_cb = AndroidCryptoNative_GetBigNumBytes(parameters->x_bn);
     }
 
     RELEASE_LOCALS_ENV(loc, ReleaseLRef);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_dsa.h
@@ -51,18 +51,26 @@ AndroidCryptoNative_DsaVerify(
     uint8_t* signature,
     int32_t signatureLength);
 
+typedef struct
+{
+    jobject p_bn;
+    jobject q_bn;
+    jobject g_bn;
+    jobject y_bn;
+    jobject x_bn;
+    int32_t p_cb;
+    int32_t q_cb;
+    int32_t g_cb;
+    int32_t y_cb;
+    int32_t x_cb;
+} AndroidDSAParameters;
+
 /*
 Gets all the parameters from the DSA instance.
 
 Returns 1 upon success, otherwise 0.
 */
-PALEXPORT int32_t AndroidCryptoNative_GetDsaParameters(
-    jobject dsa,
-    jobject* p, int32_t* pLength,
-    jobject* q, int32_t* qLength,
-    jobject* g, int32_t* gLength,
-    jobject* y, int32_t* yLength,
-    jobject* x, int32_t* xLength);
+PALEXPORT int32_t AndroidCryptoNative_GetDsaParameters(jobject dsa, AndroidDSAParameters *parameters);
 
 /*
 Sets all the parameters on the DSA instance.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_ecc_import_export.h
@@ -17,17 +17,83 @@ typedef enum
     Characteristic2 = 4
 } ECCurveType;
 
+typedef struct
+{
+    jobject qx_bn;
+    jobject qy_bn;
+    jobject d_bn;
+    int32_t qx_cb;
+    int32_t qy_cb;
+    int32_t d_cb;
+} AndroidECKeyParameters;
+
+typedef struct
+{
+    jobject qx_bn;
+    jobject qy_bn;
+    jobject p_bn;
+    jobject a_bn;
+    jobject b_bn;
+    jobject gx_bn;
+    jobject gy_bn;
+    jobject order_bn;
+    jobject cofactor_bn;
+    jobject seed_bn;
+    jobject d_bn;
+    int32_t qx_cb;
+    int32_t qy_cb;
+    int32_t p_cb;
+    int32_t a_cb;
+    int32_t b_cb;
+    int32_t gx_cb;
+    int32_t gy_cb;
+    int32_t order_cb;
+    int32_t cofactor_cb;
+    int32_t seed_cb;
+    int32_t d_cb;
+} AndroidECCurveParameters;
+
+typedef struct
+{
+    uint8_t* qx;
+    uint8_t* qy;
+    uint8_t* d;
+    int32_t qx_length;
+    int32_t qy_length;
+    int32_t d_length;
+} AndroidECKeyArrayParameters;
+
+typedef struct
+{
+    uint8_t* qx;
+    uint8_t* qy;
+    uint8_t* d;
+    uint8_t* p;
+    uint8_t* a;
+    uint8_t* b;
+    uint8_t* gx;
+    uint8_t* gy;
+    uint8_t* order;
+    uint8_t* cofactor;
+    uint8_t* seed;
+    int32_t qx_length;
+    int32_t qy_length;
+    int32_t d_length;
+    int32_t p_length;
+    int32_t a_length;
+    int32_t b_length;
+    int32_t gx_length;
+    int32_t gy_length;
+    int32_t order_length;
+    int32_t cofactor_length;
+    int32_t seed_length;
+} AndroidECKeyExplicitParameters;
 /*
 Returns the ECC key parameters.
 */
 PALEXPORT int32_t AndroidCryptoNative_GetECKeyParameters(const EC_KEY* key,
                                                   int32_t includePrivate,
-                                                  jobject* qx,
-                                                  int32_t* cbQx,
-                                                  jobject* qy,
-                                                  int32_t* cbQy,
-                                                  jobject* d,
-                                                  int32_t* cbD);
+                                                  AndroidECKeyParameters *parameters);
 
 /*
 Returns the ECC key and curve parameters.
@@ -35,28 +101,7 @@ Returns the ECC key and curve parameters.
 PALEXPORT int32_t AndroidCryptoNative_GetECCurveParameters(const EC_KEY* key,
                                                     int32_t includePrivate,
                                                     ECCurveType* curveType,
-                                                    jobject* qx,
-                                                    int32_t* cbx,
-                                                    jobject* qy,
-                                                    int32_t* cby,
-                                                    jobject* d,
-                                                    int32_t* cbd,
-                                                    jobject* p,
-                                                    int32_t* cbP,
-                                                    jobject* a,
-                                                    int32_t* cbA,
-                                                    jobject* b,
-                                                    int32_t* cbB,
-                                                    jobject* gx,
-                                                    int32_t* cbGx,
-                                                    jobject* gy,
-                                                    int32_t* cbGy,
-                                                    jobject* order,
-                                                    int32_t* cbOrder,
-                                                    jobject* cofactor,
-                                                    int32_t* cbCofactor,
-                                                    jobject* seed,
-                                                    int32_t* cbSeed);
+                                                    AndroidECCurveParameters* parameters);
 
 /*
 Creates the new EC_KEY instance using the curve oid (friendly name or value) and public key parameters.
@@ -64,36 +109,9 @@ Returns 1 upon success, -1 if oid was not found, otherwise 0.
 */
 PALEXPORT int32_t AndroidCryptoNative_EcKeyCreateByKeyParameters(EC_KEY** key,
                                                           const char* oid,
-                                                          uint8_t* qx,
-                                                          int32_t qxLength,
-                                                          uint8_t* qy,
-                                                          int32_t qyLength,
-                                                          uint8_t* d,
-                                                          int32_t dLength);
+                                                          AndroidECKeyArrayParameters* parameters);
 
 /*
 Returns the new EC_KEY instance using the explicit parameters.
 */
-PALEXPORT EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveType,
-                                                               uint8_t* qx,
-                                                               int32_t qxLength,
-                                                               uint8_t* qy,
-                                                               int32_t qyLength,
-                                                               uint8_t* d,
-                                                               int32_t dLength,
-                                                               uint8_t* p,
-                                                               int32_t pLength,
-                                                               uint8_t* a,
-                                                               int32_t aLength,
-                                                               uint8_t* b,
-                                                               int32_t bLength,
-                                                               uint8_t* gx,
-                                                               int32_t gxLength,
-                                                               uint8_t* gy,
-                                                               int32_t gyLength,
-                                                               uint8_t* order,
-                                                               int32_t nLength,
-                                                               uint8_t* cofactor,
-                                                               int32_t hLength,
-                                                               uint8_t* seed,
-                                                               int32_t sLength);
+PALEXPORT EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveType, AndroidECKeyExplicitParameters* parameters);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -490,6 +490,7 @@ extern jmethodID g_KeyAgreementGenerateSecret;
 #endif // ndef (__clang__ || __GNUC__)
 #endif
 
+// Indexes passed to `ARGS_NON_NULL` are 1-based
 #if defined (__clang__) || defined (__GNUC__)
 #define ARGS_NON_NULL(...) __attribute__((nonnull (__VA_ARGS__)))
 #else

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.h
@@ -21,6 +21,38 @@ typedef struct RSA
     int32_t keyWidthInBits;
 } RSA;
 
+typedef struct
+{
+    jobject* n;
+    jobject* e;
+    jobject* d;
+    jobject* p;
+    jobject* dmp1;
+    jobject* q;
+    jobject* dmq1;
+    jobject* iqmp;
+} AndroidGetRsaParametersData;
+
+typedef struct
+{
+    uint8_t* n;
+    uint8_t* e;
+    uint8_t* d;
+    uint8_t* p;
+    uint8_t* dmp1;
+    uint8_t* q;
+    uint8_t* dmq1;
+    uint8_t* iqmp;
+    int32_t  n_length;
+    int32_t  e_length;
+    int32_t  d_length;
+    int32_t  p_length;
+    int32_t  dmp1_length;
+    int32_t  q_length;
+    int32_t  dmq1_length;
+    int32_t  iqmp_length;
+} AndroidSetRsaParametersData;
+
 #define CIPHER_ENCRYPT_MODE 1
 #define CIPHER_DECRYPT_MODE 2
 
@@ -34,12 +66,8 @@ PALEXPORT int32_t AndroidCryptoNative_RsaSignPrimitive(int32_t flen, uint8_t* fr
 PALEXPORT int32_t AndroidCryptoNative_RsaVerificationPrimitive(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa);
 PALEXPORT int32_t AndroidCryptoNative_RsaSize(RSA* rsa);
 PALEXPORT int32_t AndroidCryptoNative_RsaGenerateKeyEx(RSA* rsa, int32_t bits);
-PALEXPORT int32_t AndroidCryptoNative_GetRsaParameters(RSA* rsa,
-    jobject* n, jobject* e, jobject* d, jobject* p, jobject* dmp1, jobject* q, jobject* dmq1, jobject* iqmp);
-PALEXPORT int32_t AndroidCryptoNative_SetRsaParameters(RSA* rsa,
-    uint8_t* n,    int32_t nLength,    uint8_t* e,    int32_t eLength,    uint8_t* d, int32_t dLength,
-    uint8_t* p,    int32_t pLength,    uint8_t* dmp1, int32_t dmp1Length, uint8_t* q, int32_t qLength,
-    uint8_t* dmq1, int32_t dmq1Length, uint8_t* iqmp, int32_t iqmpLength);
+PALEXPORT int32_t AndroidCryptoNative_GetRsaParameters(RSA* rsa, AndroidGetRsaParametersData* parameters);
+PALEXPORT int32_t AndroidCryptoNative_SetRsaParameters(RSA* rsa, AndroidSetRsaParametersData* parameters);
 
 RSA* AndroidCryptoNative_NewRsaFromKeys(JNIEnv* env, jobject /*RSAPublicKey*/ publicKey, jobject /*RSAPrivateKey*/ privateKey) ARGS_NON_NULL(1, 2);
 RSA* AndroidCryptoNative_NewRsaFromPublicKey(JNIEnv* env, jobject /*RSAPublicKey*/ key) ARGS_NON_NULL(1, 2);


### PR DESCRIPTION
This commit includes mostly small performance improvements related to
p/invokes. A number of functions were passed a lot of parameters (up to
23) which makes the compiler/JIT to pass said parameters on the stack
instead of in CPU registers. The difference is especially noticeable on
ARM devices which can use up to 7 general purpose registers to pass
arguments to a function.

The changes also allow to decrease the number of pointer validation
calls, which should also have a tiny, but non-zero, positive impact on
performance.