### PR TITLE
Annotate some APIs in System.Security.Cryptography.* as unsupported on iOS/tvOS

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -96,6 +96,8 @@ namespace System.Security.Cryptography
     {
         protected AsymmetricSignatureFormatter() { }
         public abstract byte[] CreateSignature(byte[] rgbHash);
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         public virtual byte[] CreateSignature(System.Security.Cryptography.HashAlgorithm hash) { throw null; }
         public abstract void SetHashAlgorithm(string strName);
         public abstract void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureFormatter.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography
         public abstract void SetKey(AsymmetricAlgorithm key);
         public abstract void SetHashAlgorithm(string strName);
 
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
         public virtual byte[] CreateSignature(HashAlgorithm hash)
         {
             if (hash == null)

--- a/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.cs
@@ -46,6 +46,8 @@ namespace System.Security.Cryptography.Xml
         public DSAKeyValue() { }
         public DSAKeyValue(System.Security.Cryptography.DSA key) { }
         public System.Security.Cryptography.DSA Key { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         public override System.Xml.XmlElement GetXml() { throw null; }
         public override void LoadXml(System.Xml.XmlElement value) { }
     }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using System.Xml;
 
 #pragma warning disable CA5384 // Do Not Use Digital Signature Algorithm (DSA)
@@ -48,6 +49,8 @@ namespace System.Security.Cryptography.Xml
         /// <returns>
         /// An <see cref="XmlElement"/> containing the XML representation.
         /// </returns>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
         public override XmlElement GetXml()
         {
             XmlDocument xmlDocument = new XmlDocument();


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/47910

Based on the `System.Security.Cryptography.Xml.Tests` library tests throwing PNSE on iOS/tvOS:
- System.Security.Cryptography.Xml.Tests.DSAKeyValueTest.GetXml
- System.Security.Cryptography.Xml.Tests.DSAKeyValueTest.GetXml_SameDsa
- System.Security.Cryptography.Xml.Tests.SignedXmlTest.AsymmetricDSASignature