### PR TITLE
[macOS] Specify kSecUseDataProtectionKeychain when generating RSA/ECC keys

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
@@ -24,6 +24,10 @@ int32_t AppleCryptoNative_EccGenerateKey(int32_t keySizeBits,
     {
         CFDictionaryAddValue(attributes, kSecAttrKeyType, kSecAttrKeyTypeEC);
         CFDictionaryAddValue(attributes, kSecAttrKeySizeInBits, cfKeySizeValue);
+        if (__builtin_available(macOS 10.15, iOS 13, tvOS 13, *))
+        {
+            CFDictionaryAddValue(attributes, kSecUseDataProtectionKeychain, kCFBooleanTrue);
+        }
 
         *pPrivateKey = SecKeyCreateRandomKey(attributes, pErrorOut);
         if (*pPrivateKey != NULL)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.c
@@ -26,6 +26,10 @@ int32_t AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits,
     {
         CFDictionaryAddValue(attributes, kSecAttrKeyType, kSecAttrKeyTypeRSA);
         CFDictionaryAddValue(attributes, kSecAttrKeySizeInBits, cfKeySizeValue);
+        if (__builtin_available(macOS 10.15, iOS 13, tvOS 13, *))
+        {
+            CFDictionaryAddValue(attributes, kSecUseDataProtectionKeychain, kCFBooleanTrue);
+        }
 
         *pPrivateKey = SecKeyCreateRandomKey(attributes, pErrorOut);
         if (*pPrivateKey != NULL)


### PR DESCRIPTION
Fixes #36107.
Ref: https://github.com/dotnet/runtime/issues/36107#issuecomment-832278148