### PR TITLE
[iOS] Use weak linking for SecCopyErrorMessageString

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_sec.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_sec.c
@@ -5,9 +5,10 @@
 
 CFStringRef AppleCryptoNative_SecCopyErrorMessageString(OSStatus osStatus)
 {
-#if (defined(TARGET_IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_11_3) || (defined(TARGET_TVOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < __TVOS_11_3)
+    if (__builtin_available(iOS 11.3, tvOS 11.3, *))
+    {
+        return SecCopyErrorMessageString(osStatus, NULL);
+    }
+
     return CFStringCreateWithFormat(NULL, NULL, CFSTR("OSStatus %d"), (int)osStatus);
-#else
-    return SecCopyErrorMessageString(osStatus, NULL);
-#endif
 }


### PR DESCRIPTION
Improves error messages for System.Security.Cryptography methods on newer iOS/tvOS versions.