### PR TITLE
Force build failure if AOT compiler is missing, and avoid bad path

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -13,6 +13,8 @@
     <PublishReadyToRun>false</PublishReadyToRun>
     <HostJsonTargetPath>tools/</HostJsonTargetPath>
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
+    <AotCompilerFileName>mono-aot-cross</AotCompilerFileName>
+    <AotCompilerFileName Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(AotCompilerFileName).exe</AotCompilerFileName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,5 +24,6 @@
 
   <Target Name="ValidateProperties" BeforeTargets="GenerateNuspec">
     <Error Condition="'$(TargetCrossRid)' == ''" Text="TargetCrossRid not set" />
+    <Error Condition="!Exists('$(MonoAotCrossDir)$(TargetCrossRid)\$(AotCompilerFileName)')" Text="Cross compiler not found in $(MonoAotCrossDir)$(TargetCrossRid)" />
   </Target>
 </Project>

--- a/src/mono/monoaotcross.proj
+++ b/src/mono/monoaotcross.proj
@@ -46,9 +46,9 @@
       <_MonoAOTCrossFiles Include="$(ArtifactsBinDir)mono\$(MonoAotTargetOS).$(MonoAotTargetArchitecture).$(Configuration)\cross\$(MonoAotTargetRid.ToLower())\**" />
     </ItemGroup>
 
-    <Message Text="Copying @(_MonoAOTCrossFiles) to $(RealRuntimeBinDir)cross\$(MonoAotTargetRid.ToLower())" Importance="High" />
+    <Message Text="Copying @(_MonoAOTCrossFiles) to $(RealRuntimeBinDir)cross\$(TargetOS.ToLower())-$(TargetArchitecture.ToLower())\$(MonoAotTargetRid.ToLower())" Importance="High" />
 
-    <Copy SourceFiles="@(_MonoAOTCrossFiles)" DestinationFolder="$(RealRuntimeBinDir)cross\$(MonoAotTargetRid.ToLower())">
+    <Copy SourceFiles="@(_MonoAOTCrossFiles)" DestinationFolder="$(RealRuntimeBinDir)cross\$(TargetOS.ToLower())-$(TargetArchitecture.ToLower())\$(MonoAotTargetRid.ToLower())">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>


### PR DESCRIPTION
An error in paths was introduced last week. Work around that, and make it a fatal build failure if the AOT compiler is missing in future to catch this faster