### PR TITLE
Fix cmake warning

### DIFF
--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -33,7 +33,7 @@ if (CLR_CMAKE_HOST_OS STREQUAL CLR_CMAKE_TARGET_OS)
             DESTINATIONS . sharedFramework
             COMPONENT crosscomponents
         )
-    endif(CLR_CMAKE_TARGET_UNIX)
+    endif()
 endif()
 
 if(NOT CLR_CMAKE_HOST_LINUX AND NOT CLR_CMAKE_HOST_OSX AND NOT FEATURE_CROSSBITNESS)


### PR DESCRIPTION
Fix this:
```
 CMake Warning (dev) in crosscomponents.cmake:
    A logical block opening on the line

      C:/gh/runtime4/src/coreclr/crosscomponents.cmake:24 (if)

    closes on the line

      C:/gh/runtime4/src/coreclr/crosscomponents.cmake:36 (endif)

    with mis-matching arguments.
  Call Stack (most recent call first):
    CMakeLists.txt:254 (include)
  This warning is for project developers.  Use -Wno-dev to suppress it.
```