### PR TITLE
Debug.Assert on invalid EventSource parameters

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2065,7 +2065,7 @@ namespace System.Diagnostics.Tracing
                     return;
                 }
 
-                Debug.Assert(arg is not string stringArg || stringArg.IndexOf('\0') == -1, $"{infos[i].Name} may not contain null chars");
+                Debug.Assert(arg is not string stringArg || !stringArg.Contains('\0'), $"{infos[i].Name} may not contain null chars");
             }
         }
 


### PR DESCRIPTION
Inspired by #52710 and #52025

For tests running against a debug CoreLib build, flag invalid parameters (number, types & null in case of strings).

`Debug.Fail` on any `ReportOutOfBandMessage`.