### PR TITLE
Fix references to MDArray methods

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
@@ -233,7 +233,7 @@ namespace Internal.TypeSystem
                                 var parameters = new TypeDesc[_owningType.Rank];
                                 for (int i = 0; i < _owningType.Rank; i++)
                                     parameters[i] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
-                                _signature = new MethodSignature(0, 0, _owningType.ElementType, parameters);
+                                _signature = new MethodSignature(0, 0, _owningType.ElementType, parameters, MethodSignature.EmbeddedSignatureMismatchPermittedFlag);
                                 break;
                             }
                         case ArrayMethodKind.Set:
@@ -242,7 +242,7 @@ namespace Internal.TypeSystem
                                 for (int i = 0; i < _owningType.Rank; i++)
                                     parameters[i] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
                                 parameters[_owningType.Rank] = _owningType.ElementType;
-                                _signature = new MethodSignature(0, 0, this.Context.GetWellKnownType(WellKnownType.Void), parameters);
+                                _signature = new MethodSignature(0, 0, this.Context.GetWellKnownType(WellKnownType.Void), parameters, MethodSignature.EmbeddedSignatureMismatchPermittedFlag);
                                 break;
                             }
                         case ArrayMethodKind.Address:
@@ -250,7 +250,7 @@ namespace Internal.TypeSystem
                                 var parameters = new TypeDesc[_owningType.Rank];
                                 for (int i = 0; i < _owningType.Rank; i++)
                                     parameters[i] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
-                                _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters);
+                                _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters, MethodSignature.EmbeddedSignatureMismatchPermittedFlag);
                             }
                             break;
                         case ArrayMethodKind.AddressWithHiddenArg:
@@ -259,7 +259,7 @@ namespace Internal.TypeSystem
                                 parameters[0] = Context.GetWellKnownType(WellKnownType.IntPtr);
                                 for (int i = 0; i < _owningType.Rank; i++)
                                     parameters[i + 1] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
-                                _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters);
+                                _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters, MethodSignature.EmbeddedSignatureMismatchPermittedFlag);
                             }
                             break;
                         default:
@@ -277,7 +277,7 @@ namespace Internal.TypeSystem
                                 var argTypes = new TypeDesc[numArgs];
                                 for (int i = 0; i < argTypes.Length; i++)
                                     argTypes[i] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
-                                _signature = new MethodSignature(0, 0, this.Context.GetWellKnownType(WellKnownType.Void), argTypes);
+                                _signature = new MethodSignature(0, 0, this.Context.GetWellKnownType(WellKnownType.Void), argTypes, MethodSignature.EmbeddedSignatureMismatchPermittedFlag);
                             }
                             break;
                     }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -60,6 +60,9 @@ namespace Internal.TypeSystem
             return $"0.1.1.2.{(parameterIndex + 1).ToStringInvariant()}.1";
         }
 
+        // Provide a means to create a MethodSignature which ignores EmbeddedSignature data in the MethodSignatures it is compared to
+        public static EmbeddedSignatureData[] EmbeddedSignatureMismatchPermittedFlag = new EmbeddedSignatureData[0];
+
         public MethodSignature(MethodSignatureFlags flags, int genericParameterCount, TypeDesc returnType, TypeDesc[] parameters, EmbeddedSignatureData[] embeddedSignatureData = null)
         {
             _flags = flags;
@@ -168,7 +171,15 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return _embeddedSignatureData != null;
+                return _embeddedSignatureData != null && _embeddedSignatureData.Length != 0;
+            }
+        }
+
+        public bool EmbeddedSignatureMismatchPermitted
+        {
+            get
+            {
+                return _embeddedSignatureData == EmbeddedSignatureMismatchPermittedFlag;
             }
         }
 
@@ -218,6 +229,13 @@ namespace Internal.TypeSystem
             }
 
             if (this._embeddedSignatureData == null && otherSignature._embeddedSignatureData == null)
+            {
+                return true;
+            }
+
+            // Array methods do not need to have matching details for the array parameters they support
+            if (this.EmbeddedSignatureMismatchPermitted ||
+                otherSignature.EmbeddedSignatureMismatchPermitted)
             {
                 return true;
             }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -12,6 +12,7 @@
          included in compilation of this project -->
     <EnableDefaultItems>false</EnableDefaultItems>
     <Platforms>AnyCPU;x64</Platforms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>    
@@ -37,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs" />
+    <Compile Include="../../Common/TypeSystem/IL/ILReader.cs" />
     <Compile Include="ArchitectureSpecificFieldLayoutTests.cs" />
     <Compile Include="CanonicalizationTests.cs" />
     <Compile Include="ConstraintsValidationTest.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/ILTestAssembly.ilproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/ILTestAssembly.ilproj
@@ -18,6 +18,7 @@
     <Compile Include="VirtualFunctionOverride.il" />
     <Compile Include="Signature.il" />
     <Compile Include="MethodImplOverride1.il" />
+    <Compile Include="MDArrayFunctionResolution.il" />
   </ItemGroup>
 
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/MDArrayFunctionResolution.il
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/MDArrayFunctionResolution.il
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.class public auto ansi beforefieldinit MDArrayFunctionResolution
+       extends [CoreTestAssembly]System.Object
+{
+  .method private hidebysig static void  MethodWithUseOfMDArrayFunctions() cil managed
+  {
+    .entrypoint
+    // Code size       44 (0x2c)
+    .maxstack  5
+    .locals init (int32[0...,0...][0...,0...][0...,0...] V_0)
+    IL_0000:  ldc.i4.1
+    IL_0001:  ldc.i4.1
+    IL_0002:  newobj     instance void int32[0...,0...][0...,0...][0...,0...]::.ctor(int32,
+                                                                                   int32)
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  ldc.i4.0
+    IL_000a:  ldc.i4.0
+    IL_000b:  ldc.i4.s   123
+    IL_000d:  ldc.i4.2
+    IL_000e:  newobj     instance void int32[0...,0...][0...,0...]::.ctor(int32,
+                                                                        int32)
+    IL_0013:  call       instance void int32[0...,0...][0...,0...][0...,0...]::Set(int32,
+                                                                                 int32,
+                                                                                 int32[0...,0...][0...,0...])
+    IL_0018:  ldstr      "Hello world"
+    IL_001d:  ldloc.0
+    IL_001e:  ldc.i4.0
+    IL_001f:  ldc.i4.0
+    IL_0020:  call       instance int32[0...,0...][0...,0...] int32[0...,0...][0...,0...][0...,0...]::Get(int32,
+                                                                                                        int32)
+pop
+pop
+    IL_002a:  nop
+    IL_002b:  ret
+} // end of method MethodWithUseOfMDArrayFunctions
+
+
+}


### PR DESCRIPTION
- References to the Array methods follow special rules, one of which is that the lobounds/range of the array type is immaterial in the signatures of those methods.
- Fix the problem identified in #52703 and add a test to our type system test suite so that it doesn't come back

Fixes #52703 