### PR TITLE
Fix versions for Libs subset's native artifacts

### DIFF
--- a/src/installer/corehost.proj
+++ b/src/installer/corehost.proj
@@ -30,7 +30,7 @@
       <BuildArgs Condition="'$(CMakeArgs)' != ''">$(BuildArgs) $(CMakeArgs)</BuildArgs>
       <BuildArgs>$(BuildArgs) -coreclrartifacts $(CoreCLRArtifactsPath)</BuildArgs>
       <BuildArgs Condition="'$(Ninja)' == 'true'">$(BuildArgs) -ninja</BuildArgs>
-      <BuildArgs>$(BuildArgs) -runtimeflavor $(RuntimeFlavor)</BuildArgs>
+      <BuildArgs>$(BuildArgs) -runtimeflavor $(RuntimeFlavor) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
     </PropertyGroup>
 
     <!--

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -5,7 +5,7 @@
     <NativeVersionFile Condition="'$(TargetOS)' != 'windows'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
-    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)</_BuildNativeArgs>
+    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS) /p:OfficialBuildId=$(OfficialBuildId)</_BuildNativeArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During the repo consolidation, we missed passing `OfficialBuildId`
argument to common script from all subsets, which resulted in default
version emitted in the binaries produced by Libs subset in the official
builds.