### PR TITLE
Check that 'lvDoNotEnregister' is set as necessary. 

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3433,6 +3433,7 @@ public:
         DNER_NoRegVars,   // opts.compFlags & CLFLG_REGVAR is not set
         DNER_MinOptsGC,   // It is a GC Ref and we are compiling MinOpts
 #if !defined(TARGET_64BIT)
+        DNER_LongParamVar,   // It is a long parameter.
         DNER_LongParamField, // It is a decomposed field of a long parameter.
 #endif
 #ifdef JIT32_GCENCODER

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -356,6 +356,7 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
     }
     else
     {
+        m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(Compiler::DNER_LocalField));
         loResult->SetOper(GT_LCL_FLD);
         loResult->AsLclFld()->SetLclOffs(0);
         loResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2635,6 +2635,9 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
         case DNER_LongParamField:
             JITDUMP("it is a decomposed field of a long parameter\n");
             break;
+        case DNER_LongParamVar:
+            JITDUMP("it is a long parameter\n");
+            break;
 #endif
         default:
             unreached();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3959,6 +3959,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                                     {
                                         // Can't use the existing field's type, so use GT_LCL_FLD to swizzle
                                         // to a new type
+                                        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                                         argObj->ChangeOper(GT_LCL_FLD);
                                         argObj->gtType = structBaseType;
                                     }
@@ -3983,6 +3984,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         else if (genTypeSize(varDsc->TypeGet()) != genTypeSize(structBaseType))
                         {
                             // Not a promoted struct, so just swizzle the type by using GT_LCL_FLD
+                            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                             argObj->ChangeOper(GT_LCL_FLD);
                             argObj->gtType = structBaseType;
                         }

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -139,7 +139,11 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
         // replace the expression by GT_LCL_VAR or GT_LCL_FLD.
         BlockRange().Remove(indir);
 
-        var_types lclType = comp->lvaGetDesc(addr->AsLclVar())->TypeGet();
+        const GenTreeLclVar* lclAddr = addr->AsLclVar();
+        const unsigned       lclNum  = lclAddr->GetLclNum();
+        LclVarDsc*           varDsc  = comp->lvaGetDesc(lclNum);
+
+        var_types lclType = varDsc->TypeGet();
 
         if (lclType == simdType)
         {
@@ -156,7 +160,11 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
                 addr->gtFlags |= GTF_VAR_USEASG;
             }
 
-            comp->lvaSetVarDoNotEnregister(addr->AsLclFld()->GetLclNum() DEBUGARG(Compiler::DNER_LocalField));
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_LocalField));
+        }
+        if (varDsc->lvPromotedStruct())
+        {
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_IsStructArg));
         }
 
         addr->gtType = simdType;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_49780/Runtime_49780.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_49780/Runtime_49780.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Diagnostics;
+
+namespace Runtime_49489
+{
+    public class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Callee(float fltRef0, float fltRef1, float fltReg2, float fltReg3, float fltReg4, float fltReg5, float fltReg6, float fltReg7, Vector2 simd8)
+        {
+            const double eps = 1E-10;
+            Debug.Assert(Math.Abs(simd8.X) <= eps);
+            Debug.Assert(Math.Abs(simd8.Y - 1) <= eps);
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Caller()
+        {
+            Vector2 simd8;
+            simd8.X = 0;
+            simd8.Y = 1;
+            return Callee(0, 0, 0, 0, 0, 0, 0, 0, simd8);
+
+        }
+
+        static int Main(string[] args)
+        {
+            return Caller();
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_49780/Runtime_49780.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_49780/Runtime_49780.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In order to enable https://github.com/dotnet/runtime/issues/43867 by default we need to make sure that all structs that should be on the stack are marked as doNotEnreg. Currently, it is not very important because all structs are getting their 'doNotEnreg' just because they are structs. 

This PR adds check that after lowering we have correct `lvDoNotEnreg` flag on variables that are accessed via their address or via non-promoted fields or with both promoted and non-promoted accesses. 

If you see more contracts related to doNotEnreg that can be added - please comment. There are also many unclear parts about multi-reg nodes that I am going to address soon.

No diffs (all available spmi collections) as expected. 

Fixes https://github.com/dotnet/runtime/issues/49780 (change in rationalize RewriteSIMDIndir).

Contributes to https://github.com/dotnet/runtime/issues/43867, needed #53269 (phi store of long vars were not decomposed so the contract for them did not hold), #53067, #52803.