### PR TITLE
Delete an unnecessary pessimization for x86.

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3953,17 +3953,13 @@ inline Compiler::lvaPromotionType Compiler::lvaGetPromotionType(const LclVarDsc*
         return PROMOTION_TYPE_DEPENDENT;
     }
 
-    // We have a parameter that could be enregistered
-    CLANG_FORMAT_COMMENT_ANCHOR;
-
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
-
-    // The struct parameter is a register candidate
-    return PROMOTION_TYPE_INDEPENDENT;
-#else
-    // The struct parameter is not enregistered
+// We have a parameter that could be enregistered
+#if defined(TARGET_ARM)
+    // TODO-Cleanup: return INDEPENDENT for arm32.
     return PROMOTION_TYPE_DEPENDENT;
-#endif
+#else  // !TARGET_ARM
+    return PROMOTION_TYPE_INDEPENDENT;
+#endif // !TARGET_ARM
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Now if we have an incoming struct its fields can be enregistered on x86. 
It includes both cases:
1. the struct is coming on stack but we copy it to regs;
2. the struct is coming on reg, in x86 case it is only possible for something like `struct {int}` and the field is used from the reg.

```
benchmarks.run.windows.x86
  Total bytes of delta: -2195 (-1.25% of base)
  440 total files with Code Size differences (340 improved, 100 regressed), 120 unchanged.
libraries.crossgen.windows.x86
  Total bytes of delta: -10702 (-1.71% of base)
  2274 total files with Code Size differences (1827 improved, 447 regressed), 1043 unchanged.
libraries.crossgen2.windows.x86
  Total bytes of delta: -5375 (-3.53% of base)
  938 total files with Code Size differences (771 improved, 167 regressed), 169 unchanged.
libraries.pmi.windows.x86
  Total bytes of delta: -18612 (-1.50% of base)
  3752 total files with Code Size differences (2828 improved, 924 regressed), 1593 unchanged.
tests.pmi.windows.x86
  Total bytes of delta: -3563 (-6.94% of base)
  419 total files with Code Size differences (380 improved, 39 regressed), 59 unchanged.
tests_libraries.pmi.windows.x86
  Total bytes of delta: -3892 (-0.61% of base)
  1220 total files with Code Size differences (890 improved, 330 regressed), 1705 unchanged.
```

the regressions are from additional reg pressure + CSE, nothing stands up.
libraries diffs are very nice, hope some people are still using x86 :-)

I will do it for arm32 as well, this condition was breaking a struct contract that I need to satisfy for struct enreg, the contract is:
**if struct's promotion type is 'DEPENDENT' the struct should be marked as 'doNotEnreg`.**