### PR TITLE
Add explicit FSharp.Core package dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,6 +158,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
+    <FSharpVersion>5.0.0</FSharpVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
+++ b/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Formats.Cbor.csproj" />
     <ProjectReference Include="CborDocument\System.Formats.Cbor.Tests.DataModel.fsproj" />
+    <PackageReference Include="FSharp.Core" Version="$(FSharpVersion)" />
     <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
     <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>


### PR DESCRIPTION
This is required when all nuget dependencies are already downloaded and there's no network during build. This is the case on tizen.

Before:
```
[  393s] 22:53:48.492     3>/home/abuild/rpmbuild/BUILD/coreclr-6.0.0/.dotnet/sdk/6.0.100-preview.2.21155.3/NuGet.RestoreEx.targets(19,5): error NU1801: Unable to load the service index for source https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json. [/home/abuild/rpmbuild/BUILD/coreclr-6.0.0/Build.proj]
[  393s] 22:53:48.493     3>/home/abuild/rpmbuild/BUILD/coreclr-6.0.0/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj : error NU1101: Unable to find package FSharp.Core. No packages exist with this id in source(s): dotnet-eng, dotnet-public, dotnet-tools, dotnet6, dotnet6-transport, richnav [/home/abuild/rpmbuild/BUILD/coreclr-6.0.0/Build.proj]
[  393s]                      Writing assets file to disk. Path: /home/abuild/rpmbuild/BUILD/coreclr-6.0.0/artifacts/obj/System.Formats.Cbor.Tests/project.assets.json (TaskId:35)
[  393s]                      Failed to restore /home/abuild/rpmbuild/BUILD/coreclr-6.0.0/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj (in 4.06 sec). (TaskId:35)
```

After:
```
[  394s]                      Restored /home/abuild/rpmbuild/BUILD/coreclr-6.0.0/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj (in 32 ms). (TaskId:35)
```

cc @alpencolt @jkotas 