### PR TITLE
Fix Sysctl() in buffer size autodetection mode

### DIFF
--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -35,8 +35,9 @@ internal static partial class Interop
         {
             IntPtr bytesLength = (IntPtr)len;
             int ret = -1;
+            bool autoSize = (value == null && len == 0);
 
-            if (value == null && len == 0)
+            if (autoSize)
             {
                 // do one try to see how much data we need
                 ret = Sysctl(name, name_len, value, &bytesLength);
@@ -48,8 +49,33 @@ internal static partial class Interop
             }
 
             ret = Sysctl(name, name_len, value, &bytesLength);
+            while (autoSize && ret != 0 && GetLastErrorInfo().Error == Error.ENOMEM)
+            {
+                // Do not use ReAllocHGlobal() here: we don't care about
+                // previous contents, and proper checking of value returned
+                // will make code more complex.
+                Marshal.FreeHGlobal((IntPtr)value);
+                if (bytesLength == int.MaxValue)
+                {
+                    throw new OutOfMemoryException();
+                }
+                if (bytesLength >= int.MaxValue / 2)
+                {
+                    bytesLength = int.MaxValue;
+                }
+                else
+                {
+                    bytesLength *= 2;
+                }
+                value = (byte*)Marshal.AllocHGlobal(bytesLength);
+                ret = Sysctl(name, name_len, value, &bytesLength);
+            }
             if (ret != 0)
             {
+                if (autoSize)
+                {
+                    Marshal.FreeHGlobal((IntPtr)value);
+                }
                 throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastWin32Error()));
             }
 

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -55,17 +55,17 @@ internal static partial class Interop
                 // previous contents, and proper checking of value returned
                 // will make code more complex.
                 Marshal.FreeHGlobal((IntPtr)value);
-                if (bytesLength == int.MaxValue)
+                if ((int)bytesLength == int.MaxValue)
                 {
                     throw new OutOfMemoryException();
                 }
-                if (bytesLength >= int.MaxValue / 2)
+                if ((int)bytesLength >= int.MaxValue / 2)
                 {
-                    bytesLength = int.MaxValue;
+                    bytesLength = (IntPtr)int.MaxValue;
                 }
                 else
                 {
-                    bytesLength *= 2;
+                    bytesLength = (IntPtr)((int)bytesLength * 2);
                 }
                 value = (byte*)Marshal.AllocHGlobal(bytesLength);
                 ret = Sysctl(name, name_len, value, &bytesLength);


### PR DESCRIPTION
The code `private static unsafe void Sysct()` in the
`Interop/BSD/System.Native/Interop.Sysctl.cs` has two flaws in the case
`value == null && len == 0`.

First, in case of failure, this code doesn't call `FreeHGlobal()` on the memory it
allocated right before. I.e., we have pure memory leak.

Second, the "I don't know how much memory is needed, please allocated it by
yourself" idea standing behind `value == null && len == 0` assumes the `Sysctl()`
itself being responsible to avoid `ENOMEM` condition. It could happen when, for
example, we ask to list all processes in the system: this list could be expanded
between first and second actual `sysctl()` calls, making the second call fail. So
instead of a single try, we should try to allocate a bit more memory and try
again; not force all our callers to do this themselves, by catching
`InvalidOperationException` and analyzing it.

fixes #52823 

**WARNING**: This code was not tested, since I'm writing it on OpenBSD. Yes, I'm looking at running dotnet there, but that's a totally separate issue.