### PR TITLE
JIT: peel off dominant switch case under PGO

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -646,19 +646,32 @@ void BasicBlock::dspJumpKind()
             break;
 
         case BBJ_SWITCH:
+        {
             printf(" ->");
 
-            unsigned jumpCnt;
-            jumpCnt = bbJumpSwt->bbsCount;
-            BasicBlock** jumpTab;
-            jumpTab = bbJumpSwt->bbsDstTab;
-            do
+            const unsigned     jumpCnt = bbJumpSwt->bbsCount;
+            BasicBlock** const jumpTab = bbJumpSwt->bbsDstTab;
+
+            for (unsigned i = 0; i < jumpCnt; i++)
             {
-                printf("%c" FMT_BB, (jumpTab == bbJumpSwt->bbsDstTab) ? ' ' : ',', (*jumpTab)->bbNum);
-            } while (++jumpTab, --jumpCnt);
+                printf("%c" FMT_BB, (i == 0) ? ' ' : ',', jumpTab[i]->bbNum);
+
+                const bool isDefault = bbJumpSwt->bbsHasDefault && (i == jumpCnt - 1);
+                if (isDefault)
+                {
+                    printf("[def]");
+                }
+
+                const bool isDominant = bbJumpSwt->bbsHasDominantCase && (i == bbJumpSwt->bbsDominantCase);
+                if (isDominant)
+                {
+                    printf("[dom(" FMT_WT ")]", bbJumpSwt->bbsDominantFraction);
+                }
+            }
 
             printf(" (switch)");
-            break;
+        }
+        break;
 
         default:
             unreached();
@@ -1629,4 +1642,28 @@ bool BasicBlock::hasEHBoundaryOut()
 #endif // FEATURE_EH_FUNCLETS
 
     return returnVal;
+}
+
+//------------------------------------------------------------------------
+// BBswtDesc copy ctor: copy a switch descriptor
+//
+// Arguments:
+//    comp - compiler instance
+//    other - existing switch descriptor to copy
+//
+BBswtDesc::BBswtDesc(Compiler* comp, const BBswtDesc* other)
+    : bbsDstTab(nullptr)
+    , bbsCount(other->bbsCount)
+    , bbsDominantCase(other->bbsDominantCase)
+    , bbsDominantFraction(other->bbsDominantFraction)
+    , bbsHasDefault(other->bbsHasDefault)
+    , bbsHasDominantCase(other->bbsHasDominantCase)
+{
+    // Allocate and fill in a new dst tab
+    //
+    bbsDstTab = new (comp, CMK_BasicBlock) BasicBlock*[bbsCount];
+    for (unsigned i = 0; i < bbsCount; i++)
+    {
+        bbsDstTab[i] = other->bbsDstTab[i];
+    }
 }

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1198,6 +1198,51 @@ typedef JitHashTable<BasicBlock*, JitPtrKeyFuncs<BasicBlock>, BlkVector> BlkToBl
 // Map from Block to Block.  Used for a variety of purposes.
 typedef JitHashTable<BasicBlock*, JitPtrKeyFuncs<BasicBlock>, BasicBlock*> BlockToBlockMap;
 
+// BBswtDesc -- descriptor for a switch block
+//
+//  Things to know:
+//  1. If bbsHasDefault is true, the default case is the last one in the array of basic block addresses
+//     namely bbsDstTab[bbsCount - 1].
+//  2. bbsCount must be at least 1, for the default case. bbsCount cannot be zero. It appears that the ECMA spec
+//     allows for a degenerate switch with zero cases. Normally, the optimizer will optimize degenerate
+//     switches with just a default case to a BBJ_ALWAYS branch, and a switch with just two cases to a BBJ_COND.
+//     However, in debuggable code, we might not do that, so bbsCount might be 1.
+//
+struct BBswtDesc
+{
+    BasicBlock** bbsDstTab; // case label table address
+    unsigned     bbsCount;  // count of cases (includes 'default' if bbsHasDefault)
+
+    // Case number and likelihood of most likely case
+    // (only known with PGO, only valid if bbsHasDominantCase is true)
+    unsigned             bbsDominantCase;
+    BasicBlock::weight_t bbsDominantFraction;
+
+    bool bbsHasDefault;      // true if last switch case is a default case
+    bool bbsHasDominantCase; // true if switch has a dominant case
+
+    BBswtDesc() : bbsHasDefault(true), bbsHasDominantCase(false)
+    {
+    }
+
+    BBswtDesc(Compiler* comp, const BBswtDesc* other);
+
+    void removeDefault()
+    {
+        assert(bbsHasDefault);
+        assert(bbsCount > 0);
+        bbsHasDefault = false;
+        bbsCount--;
+    }
+
+    BasicBlock* getDefault()
+    {
+        assert(bbsHasDefault);
+        assert(bbsCount > 0);
+        return bbsDstTab[bbsCount - 1];
+    }
+};
+
 // In compiler terminology the control flow between two BasicBlocks
 // is typically referred to as an "edge".  Most well known are the
 // backward branches for loops, which are often called "back-edges".
@@ -1251,45 +1296,6 @@ struct BasicBlockList
 
     BasicBlockList(BasicBlock* blk, BasicBlockList* rest) : next(rest), block(blk)
     {
-    }
-};
-
-// BBswtDesc -- descriptor for a switch block
-//
-//  Things to know:
-//  1. If bbsHasDefault is true, the default case is the last one in the array of basic block addresses
-//     namely bbsDstTab[bbsCount - 1].
-//  2. bbsCount must be at least 1, for the default case. bbsCount cannot be zero. It appears that the ECMA spec
-//     allows for a degenerate switch with zero cases. Normally, the optimizer will optimize degenerate
-//     switches with just a default case to a BBJ_ALWAYS branch, and a switch with just two cases to a BBJ_COND.
-//     However, in debuggable code, we might not do that, so bbsCount might be 1.
-//
-struct BBswtDesc
-{
-    BasicBlock**         bbsDstTab; // case label table address
-    unsigned             bbsCount;  // count of cases (includes 'default' if bbsHasDefault)
-    unsigned             bbsDominantCase;
-    BasicBlock::weight_t bbsDominantFraction;
-    bool                 bbsHasDefault;
-    bool                 bbsHasDominantCase;
-
-    BBswtDesc() : bbsHasDefault(true), bbsHasDominantCase(false)
-    {
-    }
-
-    void removeDefault()
-    {
-        assert(bbsHasDefault);
-        assert(bbsCount > 0);
-        bbsHasDefault = false;
-        bbsCount--;
-    }
-
-    BasicBlock* getDefault()
-    {
-        assert(bbsHasDefault);
-        assert(bbsCount > 0);
-        return bbsDstTab[bbsCount - 1];
     }
 };
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -85,44 +85,7 @@ class typeInfo;
 struct BasicBlockList;
 struct flowList;
 struct EHblkDsc;
-
-/*****************************************************************************
- *
- *  The following describes a switch block.
- *
- *  Things to know:
- *  1. If bbsHasDefault is true, the default case is the last one in the array of basic block addresses
- *     namely bbsDstTab[bbsCount - 1].
- *  2. bbsCount must be at least 1, for the default case. bbsCount cannot be zero. It appears that the ECMA spec
- *     allows for a degenerate switch with zero cases. Normally, the optimizer will optimize degenerate
- *     switches with just a default case to a BBJ_ALWAYS branch, and a switch with just two cases to a BBJ_COND.
- *     However, in debuggable code, we might not do that, so bbsCount might be 1.
- */
-struct BBswtDesc
-{
-    BasicBlock** bbsDstTab; // case label table address
-    unsigned     bbsCount;  // count of cases (includes 'default' if bbsHasDefault)
-    bool         bbsHasDefault;
-
-    BBswtDesc() : bbsHasDefault(true)
-    {
-    }
-
-    void removeDefault()
-    {
-        assert(bbsHasDefault);
-        assert(bbsCount > 0);
-        bbsHasDefault = false;
-        bbsCount--;
-    }
-
-    BasicBlock* getDefault()
-    {
-        assert(bbsHasDefault);
-        assert(bbsCount > 0);
-        return bbsDstTab[bbsCount - 1];
-    }
-};
+struct BBswtDesc;
 
 struct StackEntry
 {
@@ -1291,6 +1254,47 @@ struct BasicBlockList
     }
 };
 
+// BBswtDesc -- descriptor for a switch block
+//
+//  Things to know:
+//  1. If bbsHasDefault is true, the default case is the last one in the array of basic block addresses
+//     namely bbsDstTab[bbsCount - 1].
+//  2. bbsCount must be at least 1, for the default case. bbsCount cannot be zero. It appears that the ECMA spec
+//     allows for a degenerate switch with zero cases. Normally, the optimizer will optimize degenerate
+//     switches with just a default case to a BBJ_ALWAYS branch, and a switch with just two cases to a BBJ_COND.
+//     However, in debuggable code, we might not do that, so bbsCount might be 1.
+//
+struct BBswtDesc
+{
+    BasicBlock**         bbsDstTab; // case label table address
+    unsigned             bbsCount;  // count of cases (includes 'default' if bbsHasDefault)
+    unsigned             bbsDominantCase;
+    BasicBlock::weight_t bbsDominantFraction;
+    bool                 bbsHasDefault;
+    bool                 bbsHasDominantCase;
+
+    BBswtDesc() : bbsHasDefault(true), bbsHasDominantCase(false)
+    {
+    }
+
+    void removeDefault()
+    {
+        assert(bbsHasDefault);
+        assert(bbsCount > 0);
+        bbsHasDefault = false;
+        bbsCount--;
+    }
+
+    BasicBlock* getDefault()
+    {
+        assert(bbsHasDefault);
+        assert(bbsCount > 0);
+        return bbsDstTab[bbsCount - 1];
+    }
+};
+
+// flowList -- control flow edge
+//
 struct flowList
 {
 public:

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1805,7 +1805,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
 
     // If either block or bNext has a profile weight
     // or if both block and bNext have non-zero weights
-    // then we wil use the max weight for the block.
+    // then we will use the max weight for the block.
     //
     const bool hasProfileWeight = block->hasProfileWeight() || bNext->hasProfileWeight();
     const bool hasNonZeroWeight = (block->bbWeight > BB_ZERO_WEIGHT) || (bNext->bbWeight > BB_ZERO_WEIGHT);
@@ -3745,17 +3745,17 @@ bool Compiler::fgOptimizeSwitchJumps()
 
     for (BasicBlock* block = fgFirstBB; block != NULL; block = block->bbNext)
     {
-        if (block->IsLIR())
-        {
-            break;
-        }
+        // Lowering expands switches, so calling this method on lowered IR
+        // does not make sense.
+        //
+        assert(!block->IsLIR());
 
-        if (block->isRunRarely())
+        if (block->bbJumpKind != BBJ_SWITCH)
         {
             continue;
         }
 
-        if (block->bbJumpKind != BBJ_SWITCH)
+        if (block->isRunRarely())
         {
             continue;
         }

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2551,7 +2551,7 @@ void EfficientEdgeCountReconstructor::Propagate()
 //    info - associated block info
 //
 // Notes:
-//    We do this during reconstructdion because we have a clean look at the edge
+//    We do this during reconstruction because we have a clean look at the edge
 //    weights. If we defer until we recompute edge weights later we may fail to solve
 //    for them.
 //
@@ -2590,7 +2590,7 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
 {
     assert(block->bbJumpKind == BBJ_SWITCH);
 
-    const BasicBlock::weight_t sufficientSamples  = 100.0f;
+    const BasicBlock::weight_t sufficientSamples  = 30.0f;
     const BasicBlock::weight_t sufficientFraction = 0.3f;
 
     if (info->m_weight < sufficientSamples)

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2031,6 +2031,9 @@ private:
         block->bbSparseCountInfo = info;
     }
 
+    void MarkInterestingBlocks(BasicBlock* block, BlockInfo* info);
+    void MarkInterestingSwitches(BasicBlock* block, BlockInfo* info);
+
     // Flags for noting and handling various error cases.
     //
     bool m_badcode;
@@ -2531,7 +2534,158 @@ void EfficientEdgeCountReconstructor::Propagate()
         assert(info->m_weightKnown);
 
         m_comp->fgSetProfileWeight(block, info->m_weight);
+
+        // Mark blocks that might be worth optimizing further, given
+        // what we know about the PGO data.
+        //
+        MarkInterestingBlocks(block, info);
     }
+}
+
+//------------------------------------------------------------------------
+// EfficientEdgeCountReconstructor::MarkInterestingBlocks: look for blocks
+//   that are worth specially optimizing, given the block and edge profile data
+//
+// Arguments:
+//    block - block of interest
+//    info - associated block info
+//
+// Notes:
+//    We do this during reconstructdion because we have a clean look at the edge
+//    weights. If we defer until we recompute edge weights later we may fail to solve
+//    for them.
+//
+//    Someday we'll keep the edge profile info viable all throughout compilation and
+//    we can defer this screening until later. Doing so will catch more cases as
+//    optimizations can sharpen the profile data.
+//
+void EfficientEdgeCountReconstructor::MarkInterestingBlocks(BasicBlock* block, BlockInfo* info)
+{
+    switch (block->bbJumpKind)
+    {
+        case BBJ_SWITCH:
+            MarkInterestingSwitches(block, info);
+            break;
+
+        default:
+            break;
+    }
+}
+
+//------------------------------------------------------------------------
+// EfficientEdgeCountReconstructor::MarkInterestingSwitches: look for switch blocks
+//   that are worth specially optimizing, given the block and edge profile data
+//
+// Arguments:
+//    block - block of interest
+//    info - associated block info
+//
+// Notes:
+//    See if one of the non-default switch cases dominates and should be peeled
+//    from the switch during flow opts.
+//
+//    If so, information is added to the bbJmpSwt for the block for use later.
+//
+void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block, BlockInfo* info)
+{
+    assert(block->bbJumpKind == BBJ_SWITCH);
+
+    const BasicBlock::weight_t sufficientSamples  = 100.0f;
+    const BasicBlock::weight_t sufficientFraction = 0.3f;
+
+    if (info->m_weight < sufficientSamples)
+    {
+        return;
+    }
+
+    JITDUMP("Switch in " FMT_BB " was hit " FMT_WT " >= " FMT_WT " times, checking for dominant edge\n", block->bbNum,
+            info->m_weight, sufficientSamples);
+    Edge* dominantEdge = info->m_outgoingEdges;
+
+    for (Edge* edge = dominantEdge->m_nextOutgoingEdge; edge != nullptr; edge = edge->m_nextOutgoingEdge)
+    {
+        if (edge->m_weightKnown)
+        {
+            if (!dominantEdge->m_weightKnown || (edge->m_weight > dominantEdge->m_weight))
+            {
+                dominantEdge = edge;
+            }
+        }
+    }
+
+    if (!dominantEdge->m_weightKnown)
+    {
+        JITDUMP("No edges with known counts, sorry\n");
+        return;
+    }
+
+    BasicBlock::weight_t fraction = dominantEdge->m_weight / info->m_weight;
+
+    // Because of count inconsistency we can see nonsensical ratios. Cap these.
+    //
+    if (fraction > 1.0)
+    {
+        fraction = 1.0;
+    }
+
+    if (fraction < sufficientFraction)
+    {
+        JITDUMP("Maximum edge likelihood is " FMT_WT " < " FMT_WT "; not sufficient to trigger peeling)\n", fraction,
+                sufficientFraction);
+        return;
+    }
+
+    // Despite doing "edge" instrumentation, we only use a single edge probe for a given successor block.
+    // Multiple switch cases may lead to this block. So we also need to show that there's just one switch
+    // case that can lead to the dominant edge's target block.
+    //
+    // If it turns out often we fail at this stage, we might consider building a histogram of switch case
+    // values at runtime, similar to what we do for classes at virtual call sites.
+    //
+    const unsigned     caseCount    = block->bbJumpSwt->bbsCount;
+    BasicBlock** const jumpTab      = block->bbJumpSwt->bbsDstTab;
+    unsigned           dominantCase = caseCount;
+
+    for (unsigned i = 0; i < caseCount; i++)
+    {
+        if (jumpTab[i] == dominantEdge->m_targetBlock)
+        {
+            if (dominantCase != caseCount)
+            {
+                JITDUMP("Both case %u and %u lead to " FMT_BB "-- can't optimize\n", i, dominantCase,
+                        jumpTab[i]->bbNum);
+                dominantCase = caseCount;
+                break;
+            }
+
+            dominantCase = i;
+        }
+    }
+
+    if (dominantCase == caseCount)
+    {
+        // Multiple (or no) cases lead to the dominant case target.
+        //
+        return;
+    }
+
+    if (block->bbJumpSwt->bbsHasDefault && (dominantCase == caseCount - 1))
+    {
+        // Dominant case is the default case.
+        // This effectively gets peeled already, so defer.
+        //
+        JITDUMP("Default case %u uniquely leads to target " FMT_BB " of dominant edge, so will be peeled already\n",
+                dominantCase, dominantEdge->m_targetBlock->bbNum);
+        return;
+    }
+
+    JITDUMP("Non-default case %u uniquely leads to target " FMT_BB " of dominant edge with likelihood " FMT_WT
+            "; marking for peeling\n",
+            dominantCase, dominantEdge->m_targetBlock->bbNum, fraction);
+
+    block->bbJumpSwt->bbsHasDominantCase  = true;
+    block->bbJumpSwt->bbsDominantCase     = dominantCase;
+    block->bbJumpSwt->bbsDominantFraction = fraction;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2679,14 +2679,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
 
         case BBJ_SWITCH:
         {
-            to->bbJumpSwt            = new (this, CMK_BasicBlock) BBswtDesc();
-            to->bbJumpSwt->bbsCount  = from->bbJumpSwt->bbsCount;
-            to->bbJumpSwt->bbsDstTab = new (this, CMK_BasicBlock) BasicBlock*[from->bbJumpSwt->bbsCount];
-
-            for (unsigned i = 0; i < from->bbJumpSwt->bbsCount; i++)
-            {
-                to->bbJumpSwt->bbsDstTab[i] = from->bbJumpSwt->bbsDstTab[i];
-            }
+            to->bbJumpSwt = new (this, CMK_BasicBlock) BBswtDesc(this, from->bbJumpSwt);
         }
         break;
 


### PR DESCRIPTION
If we have PGO data and the dominant non-default switch case has more than
30% of the profile, add an explicit test for that case upstream of the switch.

We don't see switches all that often anymore as CSC is quite aggressive about
turning them into if-then-else trees, but they still show up in the async
methods.