### PR TITLE
Fix a 32-bit specific bug in `fgMorphCast`

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1410,18 +1410,9 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
     }
 }
 
-inline void CanonicalizeCastNode(GenTreeCast* cast)
-{
-    if (varTypeIsFloating(cast->CastOp()))
-    {
-        cast->gtFlags &= ~GTF_UNSIGNED;
-    }
-}
-
 inline GenTreeCast* Compiler::gtNewCastNode(var_types typ, GenTree* op1, bool fromUnsigned, var_types castType)
 {
     GenTreeCast* cast = new (this, GT_CAST) GenTreeCast(typ, op1, fromUnsigned, castType);
-    CanonicalizeCastNode(cast);
 
     return cast;
 }
@@ -1437,7 +1428,6 @@ inline GenTreeCast* Compiler::gtNewCastNodeL(var_types typ, GenTree* op1, bool f
 
     GenTreeCast* cast =
         new (this, LargeOpOpcode()) GenTreeCast(typ, op1, fromUnsigned, castType DEBUGARG(/*largeNode*/ true));
-    CanonicalizeCastNode(cast);
 
     return cast;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1410,10 +1410,20 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
     }
 }
 
+inline void CanonicalizeCastNode(GenTreeCast* cast)
+{
+    if (varTypeIsFloating(cast->CastOp()))
+    {
+        cast->gtFlags &= ~GTF_UNSIGNED;
+    }
+}
+
 inline GenTreeCast* Compiler::gtNewCastNode(var_types typ, GenTree* op1, bool fromUnsigned, var_types castType)
 {
-    GenTreeCast* res = new (this, GT_CAST) GenTreeCast(typ, op1, fromUnsigned, castType);
-    return res;
+    GenTreeCast* cast = new (this, GT_CAST) GenTreeCast(typ, op1, fromUnsigned, castType);
+    CanonicalizeCastNode(cast);
+
+    return cast;
 }
 
 inline GenTreeCast* Compiler::gtNewCastNodeL(var_types typ, GenTree* op1, bool fromUnsigned, var_types castType)
@@ -1425,9 +1435,11 @@ inline GenTreeCast* Compiler::gtNewCastNodeL(var_types typ, GenTree* op1, bool f
 
     /* Make a big node first and then change it to be GT_CAST */
 
-    GenTreeCast* res =
+    GenTreeCast* cast =
         new (this, LargeOpOpcode()) GenTreeCast(typ, op1, fromUnsigned, castType DEBUGARG(/*largeNode*/ true));
-    return res;
+    CanonicalizeCastNode(cast);
+
+    return cast;
 }
 
 inline GenTreeIndir* Compiler::gtNewMethodTableLookup(GenTree* object)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3531,6 +3531,11 @@ struct GenTreeCast : public GenTreeOp
     GenTreeCast(var_types type, GenTree* op, bool fromUnsigned, var_types castType DEBUGARG(bool largeNode = false))
         : GenTreeOp(GT_CAST, type, op, nullptr DEBUGARG(largeNode)), gtCastType(castType)
     {
+        // We do not allow casts from floating point types to be treated as from
+        // unsigned to avoid bugs related to wrong GTF_UNSIGNED in case the
+        // CastOp's type changes.
+        assert(!varTypeIsFloating(op) || !fromUnsigned);
+
         gtFlags |= fromUnsigned ? GTF_UNSIGNED : GTF_EMPTY;
     }
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13456,10 +13456,16 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     callNode = varTypeIsFloating(impStackTop().val->TypeGet());
                 }
 
-                // At this point uns, ovf, callNode are all set.
-
                 op1 = impPopStack().val;
                 impBashVarAddrsToI(op1);
+
+                // Casts from floating point types must not have GTF_UNSIGNED set.
+                if (varTypeIsFloating(op1))
+                {
+                    uns = false;
+                }
+
+                // At this point uns, ovf, callNode are all set.
 
                 if (varTypeIsSmall(lclTyp) && !ovfl && op1->gtType == TYP_INT && op1->gtOper == GT_AND)
                 {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13456,7 +13456,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     callNode = varTypeIsFloating(impStackTop().val->TypeGet());
                 }
 
-                // At this point uns, ovf, callNode all set
+                // At this point uns, ovf, callNode are all set.
 
                 op1 = impPopStack().val;
                 impBashVarAddrsToI(op1);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -183,20 +183,15 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
         // do we need to do it in two steps R -> I, '-> smallType
         CLANG_FORMAT_COMMENT_ANCHOR;
 
-#if defined(TARGET_ARM64) || defined(TARGET_AMD64)
         if (dstSize < genTypeSize(TYP_INT))
         {
-            oper = gtNewCastNodeL(TYP_INT, oper, tree->IsUnsigned(), TYP_INT);
+            oper = gtNewCastNodeL(TYP_INT, oper, /* fromUnsigned */ false, TYP_INT);
             oper->gtFlags |= (tree->gtFlags & (GTF_OVERFLOW | GTF_EXCEPT));
-            tree->gtFlags &= ~GTF_UNSIGNED;
+            // We must not mistreat the original cast, which was from a floating point type,
+            // as from an unsigned type, since we now have a TYP_INT node for the source and
+            // CAST_OVF(BYTE <- INT) != CAST_OVF(BYTE <- UINT).
+            assert(!tree->IsUnsigned());
         }
-#else
-        if (dstSize < TARGET_POINTER_SIZE)
-        {
-            oper = gtNewCastNodeL(TYP_I_IMPL, oper, false, TYP_I_IMPL);
-            oper->gtFlags |= (tree->gtFlags & (GTF_OVERFLOW | GTF_EXCEPT));
-        }
-#endif
         else
         {
             /* Note that if we need to use a helper call then we can not morph oper */

--- a/src/tests/JIT/Directed/Convert/signed_overflow_conversions_are_not_treated_as_unsigned.il
+++ b/src/tests/JIT/Directed/Convert/signed_overflow_conversions_are_not_treated_as_unsigned.il
@@ -1,0 +1,409 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime { auto }
+.assembly SignedOverflowConversionsAreNotTreatedAsUnsigned { }
+
+.class auto SignedOverflowConversionsAreNotTreatedAsUnsigned extends [System.Runtime]System.Object
+{
+  .method private static void Print(class [System.Runtime]System.String) cil managed
+  {
+    ldarg 0
+    call void [System.Console]System.Console::WriteLine(class [System.Runtime]System.String)
+    ret
+  }
+
+  .method private hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .locals init
+    (
+      [0] int32 result
+    )
+    
+    ldc.i4 100
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I1_Un_FromMinusTwoFloat32()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I2_Un_FromMinusTwoFloat32()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I4_Un_FromMinusTwoFloat32()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I8_Un_FromMinusTwoFloat32()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I1_Un_FromMinusTwoFloat64()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I2_Un_FromMinusTwoFloat64()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I4_Un_FromMinusTwoFloat64()
+    add
+    stloc result
+    
+    ldloc result
+    call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::TestConv_Ovf_I8_Un_FromMinusTwoFloat64()
+    add
+    stloc result
+    
+    ldloc result
+    ldloc result
+    ldc.i4 100
+    ceq
+    brtrue SUCCESS
+
+    ldstr "FAILED"
+    call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+    ret
+
+SUCCESS:
+    ret
+  }
+
+  .method private hidebysig static int32 TestConv_Ovf_I1_Un_FromMinusTwoFloat32() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float32 minusTwoFloat32,
+      [1] int32 result
+    )
+    
+    ldc.r4 -2.0
+    stloc minusTwoFloat32
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat32
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I1_Un_FromFloat32(float32)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i1.ovf.un(-2.0f) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:    
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I2_Un_FromMinusTwoFloat32() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float32 minusTwoFloat32,
+      [1] int32 result
+    )
+    
+    ldc.r4 -2.0
+    stloc minusTwoFloat32
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat32
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I2_Un_FromFloat32(float32)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i2.ovf.un(-2.0f) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:    
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I4_Un_FromMinusTwoFloat32() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float32 minusTwoFloat32,
+      [1] int32 result
+    )
+    
+    ldc.r4 -2.0
+    stloc minusTwoFloat32
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat32
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I4_Un_FromFloat32(float32)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i4.ovf.un(-2.0f) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I8_Un_FromMinusTwoFloat32() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float32 minusTwoFloat32,
+      [1] int32 result
+    )
+    
+    ldc.r4 -2.0
+    stloc minusTwoFloat32
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat32
+      call int64 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I8_Un_FromFloat32(float32)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i8.ovf.un(-2.0f) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I1_Un_FromMinusTwoFloat64() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float64 minusTwoFloat64,
+      [1] int32 result
+    )
+    
+    ldc.r8 -2.0
+    stloc minusTwoFloat64
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat64
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I1_Un_FromFloat64(float64)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i1.ovf.un(-2.0d) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I2_Un_FromMinusTwoFloat64() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float64 minusTwoFloat64,
+      [1] int32 result
+    )
+    
+    ldc.r8 -2.0
+    stloc minusTwoFloat64
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat64
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I2_Un_FromFloat64(float64)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i2.ovf.un(-2.0d) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I4_Un_FromMinusTwoFloat64() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float64 minusTwoFloat64,
+      [1] int32 result
+    )
+    
+    ldc.r8 -2.0
+    stloc minusTwoFloat64
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat64
+      call int32 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I4_Un_FromFloat64(float64)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i4.ovf.un(-2.0d) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+  
+  .method private hidebysig static int32 TestConv_Ovf_I8_Un_FromMinusTwoFloat64() cil managed noinlining
+  {
+    .locals init
+    (
+      [0] float64 minusTwoFloat64,
+      [1] int32 result
+    )
+    
+    ldc.r8 -2.0
+    stloc minusTwoFloat64
+    ldc.i4 0
+    stloc result
+
+    .try
+    {
+      ldloc minusTwoFloat64
+      call int64 SignedOverflowConversionsAreNotTreatedAsUnsigned::Conv_Ovf_I8_Un_FromFloat64(float64)
+      pop
+      leave END
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      ldc.i4 1
+      stloc result
+      ldstr "conv.i8.ovf.un(-2.0d) resulted in an OverflowException!"
+      call void SignedOverflowConversionsAreNotTreatedAsUnsigned::Print(class [System.Runtime]System.String)
+      leave END
+    }
+
+END:
+    ldloc result
+    ret
+  }
+
+  .method private hidebysig static int32 Conv_Ovf_I1_Un_FromFloat32(float32 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i1.un
+    ret
+  }
+  
+  .method private hidebysig static int32 Conv_Ovf_I2_Un_FromFloat32(float32 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i2.un
+    ret
+  }
+  
+  .method private hidebysig static int32 Conv_Ovf_I4_Un_FromFloat32(float32 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i4.un
+    ret
+  }
+  
+  .method private hidebysig static int64 Conv_Ovf_I8_Un_FromFloat32(float32 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i8.un
+    ret
+  }
+  
+  .method private hidebysig static int32 Conv_Ovf_I1_Un_FromFloat64(float64 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i1.un
+    ret
+  }
+  
+  .method private hidebysig static int32 Conv_Ovf_I2_Un_FromFloat64(float64 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i2.un
+    ret
+  }
+  
+  .method private hidebysig static int32 Conv_Ovf_I4_Un_FromFloat64(float64 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i4.un
+    ret
+  }
+  
+  .method private hidebysig static int64 Conv_Ovf_I8_Un_FromFloat64(float64 input) cil managed noinlining
+  {
+    ldarg 0
+    conv.ovf.i8.un
+    ret
+  }
+}

--- a/src/tests/JIT/Directed/Convert/signed_overflow_conversions_are_not_treated_as_unsigned.ilproj
+++ b/src/tests/JIT/Directed/Convert/signed_overflow_conversions_are_not_treated_as_unsigned.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="signed_overflow_conversions_are_not_treated_as_unsigned.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1322,6 +1322,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/ldind_conv/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/signed_overflow_conversions_are_not_treated_as_unsigned/**">
+            <Issue>https://github.com/dotnet/runtime/issues/51323</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/coverage/compiler/FilterToHandler/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
It used to be that in the importer, whether the cast was to be marked as GTF_UNSIGNED was decided exclusively based on the incoming opcode. However, the flag only makes sense for casts from integral sources, and it turns out morph had a bug where it failed to clear this flag which resulted in
bad codegen.

The bug went as follows: `gtMorphCast` turns casts from an FP type into a small integer into a chain of casts: `CAST(small integer <- FP)` => `CAST(small integer <- CAST(TYP_INT <- FP))`. On 32 bit platforms, the code failed to clear the `GTF_UNSIGNED` flag from the original tree, which meant that the outer cast thought it had `TYP_UINT` as the source. This matters for checked casts: `conv.ovf.i2.un(-2.0d)`, which is a legitimate conversion, was interpreted
wrongly as an overflowing one as the resulting codegen only checked the upper bound via an unsigned compare.

The fix is two-fold: clear `GTF_UNSIGNED` for `GT_CAST` nodes with FP sources on creation and unify the 64 bit and 32 bit paths in `gtMorphCast`, which, after the removal of `GTF_UNSIGNED`, are identical.

This is a zero-diff change across all SPMI collections for Windows x64, Linux x64, Linux ARM64.

This **is not** a zero-diff change for Windows x86. Instances of bad codegen have been corrected in some tests.

Diffs for the aforementioned tests:
```
Top method regressions (bytes):
          12 (13.64% of base) : 235214.dasm - ConvTest:test25():short
          12 (13.64% of base) : 235147.dasm - ConvTest:test25():short
          10 (11.63% of base) : 235213.dasm - ConvTest:test24():byte
          10 (11.63% of base) : 235146.dasm - ConvTest:test24():byte
           9 ( 4.46% of base) : 86456.dasm - DevDiv_578217.Program:ILGEN_METHOD(ushort,float,int,ushort,ubyte,short,int):short
           7 ( 2.27% of base) : 86411.dasm - ILGEN_CLASS:ILGEN_METHOD(int):ubyte
           7 (10.45% of base) : 235247.dasm - ConvTest:test25():short
           7 (10.45% of base) : 235181.dasm - ConvTest:test25():short
           5 ( 7.69% of base) : 235246.dasm - ConvTest:test24():byte
           5 ( 2.67% of base) : 84471.dasm - FullProof:Test():int
           5 ( 7.69% of base) : 235180.dasm - ConvTest:test24():byte

Top method improvements (bytes):
         -67 (-33.00% of base) : 86409.dasm - ILGEN_CLASS:ILGEN_METHOD(short,ushort,ushort,int):float
```

`ConvTest` (`JIT\Methodical\NaN\r8nanconv_il_r\r8nanconv`), `FullProof` (`JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b309576\bug2`) and `DevDiv_578217` diffs are as expected, ~~still investigating what happened in the `ILGEN` method - it looks like `UMOD` was not transfomed into `CORINFO_HELP_ULMOD`~~ - weird code, see below.