### PR TITLE
TcpReceiveSendGetsCanceledByDispose: fix test timing out with latest RHEL7 kernel

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1003,8 +1003,9 @@ namespace System.Net.Sockets.Tests
         {
             // RHEL7 kernel has a bug preventing close(AF_UNKNOWN) to succeed with IPv6 sockets.
             // In this case Dispose will trigger a graceful shutdown, which means that receive will succeed on socket2.
+            // This bug is fixed in kernel 3.10.0-1160.25+.
             // TODO: Remove this, once CI machines are updated to a newer kernel.
-            bool expectGracefulShutdown = UsesSync && PlatformDetection.IsRedHatFamily7 && receiveOrSend && (ipv6Server || dualModeClient);
+            bool mayShutdownGraceful = UsesSync && PlatformDetection.IsRedHatFamily7 && receiveOrSend && (ipv6Server || dualModeClient);
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens
             // before the operation is started, the peer won't see a ConnectionReset SocketException and we won't
@@ -1092,17 +1093,17 @@ namespace System.Net.Sockets.Tests
                             }
                         }
 
-                        if (!expectGracefulShutdown)
+                        try
                         {
                             Assert.Equal(SocketError.ConnectionReset, peerSocketError);
                         }
-                        else
+                        catch when (mayShutdownGraceful)
                         {
                             Assert.Null(peerSocketError);
                         }
                     }
                 }
-            }, maxAttempts: 10, retryWhen: e => e is XunitException);
+            }, maxAttempts: 8, retryWhen: e => e is XunitException);
         }
 
         [Fact]


### PR DESCRIPTION
The timeout on this test is less than the accumulated delay on retries,
which causes the test to timeout on a RHEL7 system that has the kernel bug fixed.

Fixes https://github.com/dotnet/runtime/issues/52597.

@antonfirsov ptal