### PR TITLE
[wasm] Improve exception handling measurements

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Exceptions.cs
+++ b/src/mono/sample/wasm/browser-bench/Exceptions.cs
@@ -15,6 +15,7 @@ namespace Sample
         public ExceptionsTask()
         {
             measurements = new Measurement[] {
+                new NoExceptionHandling(),
                 new TryCatch(),
                 new TryCatchThrow(),
                 new TryCatchFilter(),
@@ -41,10 +42,32 @@ namespace Sample
             public override int InitialSamples => 10000;
         }
 
+        class NoExceptionHandling : ExcMeasurement
+        {
+            public override string Name => "NoExceptionHandling";
+            public override int InitialSamples => 1000000;
+            bool increaseCounter = false;
+            int unusedCounter;
+
+            public override void RunStep()
+            {
+                DoNothing();
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void DoNothing ()
+            {
+                if (increaseCounter)
+                    unusedCounter++;
+            }
+        }
+
         class TryCatch : ExcMeasurement
         {
             public override string Name => "TryCatch";
             public override int InitialSamples => 1000000;
+            bool doThrow = false;
+
             public override void RunStep()
             {
                 try
@@ -58,12 +81,16 @@ namespace Sample
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DoNothing ()
             {
+                if (doThrow)
+                    throw new Exception ("Reached DoThrow and throwed");
             }
         }
 
         class TryCatchThrow : ExcMeasurement
         {
             public override string Name => "TryCatchThrow";
+            bool doThrow = true;
+
             public override void RunStep()
             {
                 try
@@ -78,13 +105,16 @@ namespace Sample
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DoThrow()
             {
-                throw new System.Exception("Reached DoThrow and throwed");
+                if (doThrow)
+                    throw new System.Exception("Reached DoThrow and throwed");
             }
         }
 
         class TryCatchFilter : ExcMeasurement
         {
             public override string Name => "TryCatchFilter";
+            bool doThrow = false;
+
             public override void RunStep()
             {
                 try
@@ -99,12 +129,16 @@ namespace Sample
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DoNothing()
             {
+                if (doThrow)
+                    throw new Exception("Reached DoThrow and throwed");
             }
         }
 
         class TryCatchFilterInline : ExcMeasurement
         {
             public override string Name => "TryCatchFilterInline";
+            bool doThrow = false;
+
             public override void RunStep()
             {
                 try
@@ -119,12 +153,16 @@ namespace Sample
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             void DoNothing()
             {
+                if (doThrow)
+                    throw new Exception("Reached DoThrow and throwed");
             }
         }
 
         class TryCatchFilterThrow : ExcMeasurement
         {
             public override string Name => "TryCatchFilterThrow";
+            bool doThrow = true;
+
             public override void RunStep()
             {
                 try
@@ -142,13 +180,16 @@ namespace Sample
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DoThrow()
             {
-                throw new System.Exception("Reached DoThrow and throwed");
+                if (doThrow)
+                    throw new System.Exception("Reached DoThrow and throwed");
             }
         }
 
         class TryCatchFilterThrowApplies : ExcMeasurement
         {
             public override string Name => "TryCatchFilterThrowApplies";
+            bool doThrow = true;
+
             public override void RunStep()
             {
                 try
@@ -163,7 +204,8 @@ namespace Sample
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DoThrow()
             {
-                throw new System.Exception("Reached DoThrow and throwed");
+                if (doThrow)
+                    throw new System.Exception("Reached DoThrow and throwed");
             }
         }
     }


### PR DESCRIPTION
Add conditional throw to the leaf methods to avoid optimizing out the
exception handling code in `TryCatch` measurement.

Add new `NoExceptionHandling` measurement to measure case when no
exception handling is involved.

Example measurements, chrome/amd64:

| measurement | AOT | interp |
|-:|-:|-:|
|  Exceptions, NoExceptionHandling |     0.0164us |     0.0558us |
|             Exceptions, TryCatch |     0.1400us |     0.0592us |
|        Exceptions, TryCatchThrow |     0.0064ms |     0.0028ms |
|       Exceptions, TryCatchFilter |     0.4415us |     0.0645us |
| Exceptions, TryCatchFilterInline |     0.1263us |     0.0527us |
|   Json, non-ASCII text serialize |     1.4475ms |     8.6952ms |
| Json, non-ASCII text deserialize |     6.5332ms |    12.2220ms |
|            Json, small serialize |     0.2020ms |     0.2362ms |
|          Json, small deserialize |     0.2293ms |     0.3614ms |
|            Json, large serialize |    53.3021ms |    68.0000ms |
|          Json, large deserialize |    61.5176ms |   100.0377ms |