### PR TITLE
[libraries][MacCatalyst] Update MacCatalyst min required CMake version

### DIFF
--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.6.2)
 include(CheckCCompilerFlag)
 
-if(CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
-     # CMake 3.14.5 contains bug fixes for iOS
-     cmake_minimum_required(VERSION 3.14.5)
- endif()
+if(CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
+    # CMake 3.14.5 contains bug fixes for iOS
+    cmake_minimum_required(VERSION 3.14.5)
+elseif(CLR_CMAKE_TARGET_MACCATALYST)
+    # CMake 3.18.1 properly generates MacCatalyst C and CXX compilers
+    cmake_minimum_required(VERSION 3.18.1)
+endif()
 cmake_policy(SET CMP0042 NEW)
 
 project(CoreFX C)


### PR DESCRIPTION
When building library tests for MacCatalyst x64 with CMake version 3.16.4, this error was being hit
```
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018: The "AppleAppBuilderTask" task failed unexpectedly. [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018: System.Exception: Error: Process returned non-zero exit code: CMake Error at CMakeLists.txt:3 (project): [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:   No CMAKE_C_COMPILER could be found. [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018: CMake Error at CMakeLists.txt:3 (project): [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:   No CMAKE_CXX_COMPILER could be found. [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:  [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:    at Utils.RunProcess(String path, String args, IDictionary`2 envVars, String workingDir, Boolean ignoreErrors, Boolean silent, MessageImportance outputMessageImportance, MessageImportance debugMessageImportance) in /Users/mdhwang/runtime_ios/src/tasks/Common/Utils.cs:line 99 [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:    at Xcode.GenerateXCode(String projectName, String entryPointLib, IEnumerable`1 asmFiles, String workspace, String binDir, String monoInclude, Boolean preferDylibs, Boolean useConsoleUiTemplate, Boolean forceAOT, Boolean forceInterpreter, Boolean invariantGlobalization, Boolean stripDebugSymbols, String staticLinkedComponentNames, String nativeMainSource) in /Users/mdhwang/runtime_ios/src/tasks/AppleAppBuilder/Xcode.cs:line 285 [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:    at AppleAppBuilderTask.Execute() in /Users/mdhwang/runtime_ios/src/tasks/AppleAppBuilder/AppleAppBuilder.cs:line 206 [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
/Users/mdhwang/runtime_ios/eng/testing/tests.mobile.targets(190,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [/Users/mdhwang/runtime_ios/src/libraries/System.Console/tests/System.Console.Tests.csproj]
```

This is resolved by updating the CMake version, and 3.18.1 is the first version that doesn't hit this error.