### PR TITLE
Make JsonTypeInfo.ObjectType internal

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -841,7 +841,6 @@ namespace System.Text.Json.Serialization.Metadata
     public partial class JsonTypeInfo
     {
         internal JsonTypeInfo() { }
-        public static readonly System.Type ObjectType;
     }
     public abstract partial class JsonTypeInfo<T> : System.Text.Json.Serialization.Metadata.JsonTypeInfo
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Cached typeof(object). It is faster to cache this than to call typeof(object) multiple times.
         /// </summary>
-        public static readonly Type ObjectType = typeof(object);
+        internal static readonly Type ObjectType = typeof(object);
 
         // The length of the property name embedded in the key (in bytes).
         // The key is a ulong (8 bytes) containing the first 7 bytes of the property name


### PR DESCRIPTION
It should be internal. The mistake occurred during the initial source-gen changes - https://github.com/dotnet/runtime/pull/51149.