### PR TITLE
Conditionally run CallSitesAreUniquePerServiceTypeAndSlot test based on threading support

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -739,7 +739,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void CallSitesAreUniquePerServiceTypeAndSlot()
         {
             // Connected graph
@@ -747,7 +747,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // Class4 -> Class3
             // Class5 -> Class2 -> Class3
             var types = new Type[] { typeof(Class1), typeof(Class2), typeof(Class3), typeof(Class4), typeof(Class5) };
-
 
             for (int i = 0; i < 100; i++)
             {
@@ -776,7 +775,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void CallSitesAreUniquePerServiceTypeAndSlotWithOpenGenericInGraph()
         {
             // Connected graph


### PR DESCRIPTION
These two tests have been failing on wasm because monitor wait is not supported (`System.PlatformNotSupportedException : Cannot wait on monitors on this runtime.`)

https://runfo.azurewebsites.net/search/tests/?q=started%3A%7E7+definition%3Aruntime+name%3ACallSitesAreUniquePerServiceTypeAndSlot