### PR TITLE
Allow building paltests without coreclr_misc

### DIFF
--- a/src/coreclr/components.cmake
+++ b/src/coreclr/components.cmake
@@ -6,13 +6,12 @@ add_component(paltests paltests_install)
 add_component(iltools)
 
 # Define coreclr_all as the fallback component and make every component depend on this component.
-# iltools should be a minimal subset, so don't add a dependency on coreclr_misc
+# iltools and paltests should be minimal subsets, so don't add a dependency on coreclr_misc
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME coreclr_misc)
 add_component(coreclr_misc)
 add_dependencies(jit coreclr_misc)
 add_dependencies(alljits coreclr_misc)
 add_dependencies(runtime coreclr_misc)
-add_dependencies(paltests_install coreclr_misc)
 
 # The runtime build requires the clrjit and iltools builds
 add_dependencies(runtime jit iltools)


### PR DESCRIPTION
Remove dependency on coreclr_misc for the paltests_install component.

@jkoritzinsky @jkotas With https://github.com/dotnet/runtime/pull/49545 I added support for building clr.iltools and clr.paltests on a platform that doesn't support the coreclr JIT (s390x).  However, after https://github.com/dotnet/runtime/pull/49906 this stopped working again.

One of the problems in the new scheme is that the paltests now depend on coreclr_misc, which includes superpmi, which apparently depends on JIT internals and does not build on s390x.  I don't really see why this dependency is necessary -- simply removing it fixes this problem for me again.   (Separately, I'm wondering if superpmi shouldn't be part of the runtime component instead of coreclr_misc?)

Does this look reasonable to you or am I missing something here?