### PR TITLE
Add support for TLS and connectionless LDAP connections on Linux

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -99,6 +99,7 @@ namespace System.DirectoryServices.Protocols
         LDAP_OPT_SECURITY_CONTEXT = 0x99,
         LDAP_OPT_ROOTDSE_CACHE = 0x9a, // Not Supported in Linux
         LDAP_OPT_DEBUG_LEVEL = 0x5001,
+        LDAP_OPT_URI = 0x5006, // Not Supported in Windows
         LDAP_OPT_X_SASL_REALM = 0x6101,
         LDAP_OPT_X_SASL_AUTHCID = 0x6102,
         LDAP_OPT_X_SASL_AUTHZID = 0x6103

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -61,6 +61,8 @@ internal delegate int LDAP_SASL_INTERACT_PROC(IntPtr ld, uint flags, IntPtr defa
 
 internal static partial class Interop
 {
+    public const string LDAP_SASL_SIMPLE = null;
+
     internal static partial class Ldap
     {
         static Ldap()
@@ -75,10 +77,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_initialize", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_initialize(out IntPtr ld, string hostname);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_init", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern IntPtr ldap_init(string hostName, int portNumber);
+        public static extern int ldap_initialize(out IntPtr ld, string uri);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_unbind_ext_s", CharSet = CharSet.Ansi)]
         public static extern int ldap_unbind_ext_s(IntPtr ld, ref IntPtr serverctrls, ref IntPtr clientctrls);
@@ -126,6 +125,9 @@ internal static partial class Interop
         public static extern int ldap_set_option_ptr([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref IntPtr inValue);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
+        public static extern int ldap_set_option_string([In] ConnectionHandle ldapHandle, [In] LdapOption option, string inValue);
+
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
         public static extern int ldap_set_option_referral([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref LdapReferralCallback outValue);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_start_tls_s", CharSet = CharSet.Ansi)]
@@ -143,14 +145,11 @@ internal static partial class Interop
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_reference", CharSet = CharSet.Ansi)]
         public static extern int ldap_parse_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr referrals, IntPtr ServerControls, byte freeIt);
 
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_sasl_bind_s", CharSet = CharSet.Ansi)]
+        internal static extern int ldap_sasl_bind([In] ConnectionHandle ld, string dn, string mechanism, berval cred, IntPtr serverctrls, IntPtr clientctrls, IntPtr servercredp);
+
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_sasl_interactive_bind_s", CharSet = CharSet.Ansi)]
         internal static extern int ldap_sasl_interactive_bind([In] ConnectionHandle ld, string dn, string mechanism, IntPtr serverctrls, IntPtr clientctrls, uint flags, [MarshalAs(UnmanagedType.FunctionPtr)] LDAP_SASL_INTERACT_PROC proc, IntPtr defaults);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_simple_bind_s", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_simple_bind([In] ConnectionHandle ld, string who, string passwd);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_bind_s", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_bind_s([In] ConnectionHandle ld, string who, string passwd, int method);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_err2string", CharSet = CharSet.Ansi)]
         public static extern IntPtr ldap_err2string(int err);

--- a/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
+++ b/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
@@ -28,6 +28,34 @@ and to test and view status
 
     docker exec -it slapd01 slapcat
 
+SLAPD OPENLDAP SERVER WITH TLS
+==============================
+
+The osixia/openldap container image automatically creates a TLS lisener with a self-signed certificate. This can be used to test TLS.
+
+Start the container, with TLS on port 1636, without client certificate verification:
+
+    docker run --publish 1389:389 --publish 1636:636 --name ldap --hostname ldap.local --detach --rm --env LDAP_TLS_VERIFY_CLIENT=never --env LDAP_ADMIN_PASSWORD=password osixia/openldap --loglevel debug
+
+Extract the CA certificate and write to a temporary file:
+
+    docker exec ldap cat /container/service/slapd/assets/certs/ca.crt > /tmp/ca.crt
+
+Set the LDAP client CA certificate path in `/etc/ldap/ldap.conf` so OpenLDAP trusts the self-signed certificate:
+
+    # /etc/ldap/ldap.conf
+    #...
+    TLS_CACERT /tmp/ca.crt
+
+Finally, map the `ldap.local` hostname manually set above to the loopback address:
+
+    # /etc/hosts
+    127.0.0.1 ldap.local
+
+To test and view the status:
+
+    ldapsearch -H ldaps://ldap.local:1636 -b dc=example,dc=org -x -D cn=admin,dc=example,dc=org -w password
+
 ACTIVE DIRECTORY
 ================
 
@@ -82,6 +110,15 @@ Note:
         <User>danmose-domain\Administrator</User>
         <Password>%TESTPASSWORD%</Password>
         <AuthenticationTypes>ServerBind,None</AuthenticationTypes>
+    </Connection>
+    <Connection Name="SLAPD OPENLDAP SERVER TLS">
+        <ServerName>ldap.local</ServerName>
+        <SearchDN>DC=example,DC=org</SearchDN>
+        <Port>1636</Port>
+        <User>cn=admin,dc=example,dc=org</User>
+        <Password>password</Password>
+        <AuthenticationTypes>ServerBind,None</AuthenticationTypes>
+        <UseTls>true</UseTls>
     </Connection>
 
 </Configuration>

--- a/src/libraries/Common/tests/System/DirectoryServices/LdapConfiguration.cs
+++ b/src/libraries/Common/tests/System/DirectoryServices/LdapConfiguration.cs
@@ -10,7 +10,7 @@ namespace System.DirectoryServices.Tests
 {
     internal class LdapConfiguration
     {
-        private LdapConfiguration(string serverName, string searchDn, string userName, string password, string port, AuthenticationTypes at)
+        private LdapConfiguration(string serverName, string searchDn, string userName, string password, string port, AuthenticationTypes at, bool useTls)
         {
             ServerName = serverName;
             SearchDn = searchDn;
@@ -18,6 +18,7 @@ namespace System.DirectoryServices.Tests
             Password = password;
             Port = port;
             AuthenticationTypes = at;
+            UseTls = useTls;
         }
 
         private static LdapConfiguration s_ldapConfiguration = GetConfiguration("LDAP.Configuration.xml");
@@ -30,6 +31,7 @@ namespace System.DirectoryServices.Tests
         internal string Port { get; set; }
         internal string SearchDn { get; set; }
         internal AuthenticationTypes AuthenticationTypes { get; set; }
+        internal bool UseTls { get; set; }
         internal string LdapPath => string.IsNullOrEmpty(Port) ? $"LDAP://{ServerName}/{SearchDn}" : $"LDAP://{ServerName}:{Port}/{SearchDn}";
         internal string RootDSEPath => string.IsNullOrEmpty(Port) ? $"LDAP://{ServerName}/rootDSE" : $"LDAP://{ServerName}:{Port}/rootDSE";
         internal string UserNameWithNoDomain
@@ -104,6 +106,7 @@ namespace System.DirectoryServices.Tests
                 string user = "";
                 string password = "";
                 AuthenticationTypes at = AuthenticationTypes.None;
+                bool useTls = false;
 
                 XElement child = connection.Element("ServerName");
                 if (child != null)
@@ -130,6 +133,12 @@ namespace System.DirectoryServices.Tests
                         val = Environment.GetEnvironmentVariable(val.Substring(1, val.Length - 2));
                     }
                     password = val;
+                }
+
+                child = connection.Element("UseTls");
+                if (child != null)
+                {
+                    useTls = bool.Parse(child.Value);
                 }
 
                 child = connection.Element("AuthenticationTypes");
@@ -161,7 +170,7 @@ namespace System.DirectoryServices.Tests
                             at |= AuthenticationTypes.Signing;
                     }
 
-                    ldapConfig = new LdapConfiguration(serverName, searchDn, user, password, port, at);
+                    ldapConfig = new LdapConfiguration(serverName, searchDn, user, password, port, at, useTls);
                 }
             }
             catch (Exception ex)

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -92,12 +92,32 @@ namespace System.DirectoryServices.Protocols
 
         internal static int SetPtrOption(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr inValue) => Interop.Ldap.ldap_set_option_ptr(ldapHandle, option, ref inValue);
 
+        internal static int SetStringOption(ConnectionHandle ldapHandle, LdapOption option, string inValue) => Interop.Ldap.ldap_set_option_string(ldapHandle, option, inValue);
+
         internal static int SetReferralOption(ConnectionHandle ldapHandle, LdapOption option, ref LdapReferralCallback outValue) => Interop.Ldap.ldap_set_option_referral(ldapHandle, option, ref outValue);
 
         // This option is not supported in Linux, so it would most likely throw.
         internal static int SetServerCertOption(ConnectionHandle ldapHandle, LdapOption option, VERIFYSERVERCERT outValue) => Interop.Ldap.ldap_set_option_servercert(ldapHandle, option, outValue);
 
-        internal static int BindToDirectory(ConnectionHandle ld, string who, string passwd) => Interop.Ldap.ldap_simple_bind(ld, who, passwd);
+        internal static int BindToDirectory(ConnectionHandle ld, string who, string passwd)
+        {
+            IntPtr passwordPtr = IntPtr.Zero;
+            try
+            {
+                passwordPtr = LdapPal.StringToPtr(passwd);
+                berval passwordBerval = new berval
+                {
+                    bv_len = passwd.Length,
+                    bv_val = passwordPtr,
+                };
+
+                return Interop.Ldap.ldap_sasl_bind(ld, who, Interop.LDAP_SASL_SIMPLE, passwordBerval, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(passwordPtr);
+            }
+        }
 
         internal static int StartTls(ConnectionHandle ldapHandle, ref int ServerReturnValue, ref IntPtr Message, IntPtr ServerControls, IntPtr ClientControls) => Interop.Ldap.ldap_start_tls(ldapHandle, ref ServerReturnValue, ref Message, ServerControls, ClientControls);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -32,8 +32,20 @@ namespace System.DirectoryServices.Protocols
             // available during init.
             Debug.Assert(!_ldapHandle.IsInvalid);
 
-            string scheme = "ldap://";
+            string scheme = null;
             LdapDirectoryIdentifier directoryIdentifier = (LdapDirectoryIdentifier)_directoryIdentifier;
+            if (directoryIdentifier.Connectionless)
+            {
+                scheme = "cldap://";
+            }
+            else if (SessionOptions.SecureSocketLayer)
+            {
+                scheme = "ldaps://";
+            }
+            else
+            {
+                scheme = "ldap://";
+            }
 
             string uris = null;
             string[] servers = directoryIdentifier.Servers;

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net;
+using System.Text;
 using System.Runtime.InteropServices;
 
 namespace System.DirectoryServices.Protocols
@@ -12,13 +13,55 @@ namespace System.DirectoryServices.Protocols
         // Linux doesn't support setting FQDN so we mark the flag as if it is already set so we don't make a call to set it again.
         private bool _setFQDNDone = true;
 
-        private void InternalInitConnectionHandle(string hostname) => _ldapHandle = new ConnectionHandle(Interop.Ldap.ldap_init(hostname, ((LdapDirectoryIdentifier)_directoryIdentifier).PortNumber), _needDispose);
+        private void InternalInitConnectionHandle(string hostname)
+        {
+            if ((LdapDirectoryIdentifier)_directoryIdentifier == null)
+            {
+                throw new NullReferenceException();
+            }
+
+            _ldapHandle = new ConnectionHandle();
+        }
 
         private int InternalConnectToServer()
         {
+            // In Linux you don't have to call Connect after calling init. You
+            // directly call bind. However, we set the URI for the connection
+            // here instead of during initialization because we need access to
+            // the SessionOptions property to properly define it, which is not
+            // available during init.
             Debug.Assert(!_ldapHandle.IsInvalid);
-            // In Linux you don't have to call Connect after calling init. You directly call bind.
-            return 0;
+
+            string scheme = "ldap://";
+            LdapDirectoryIdentifier directoryIdentifier = (LdapDirectoryIdentifier)_directoryIdentifier;
+
+            string uris = null;
+            string[] servers = directoryIdentifier.Servers;
+            if (servers != null && servers.Length != 0)
+            {
+                StringBuilder temp = new StringBuilder(200);
+                for (int i = 0; i < servers.Length; i++)
+                {
+                    if (i != 0)
+                    {
+                        temp.Append(' ');
+                    }
+                    temp.Append(scheme);
+                    temp.Append(servers[i]);
+                    temp.Append(':');
+                    temp.Append(directoryIdentifier.PortNumber);
+                }
+                if (temp.Length != 0)
+                {
+                    uris = temp.ToString();
+                }
+            }
+            else
+            {
+                uris = $"{scheme}:{directoryIdentifier.PortNumber}";
+            }
+
+            return LdapPal.SetStringOption(_ldapHandle, LdapOption.LDAP_OPT_URI, uris);
         }
 
         private int InternalBind(NetworkCredential tempCredential, SEC_WINNT_AUTH_IDENTITY_EX cred, BindMethod method)
@@ -30,7 +73,7 @@ namespace System.DirectoryServices.Protocols
             }
             else
             {
-                error = Interop.Ldap.ldap_simple_bind(_ldapHandle, cred.user, cred.password);
+                error = LdapPal.BindToDirectory(_ldapHandle, cred.user, cred.password);
             }
 
             return error;

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -9,12 +9,7 @@ namespace System.DirectoryServices.Protocols
     {
         private static void PALCertFreeCRLContext(IntPtr certPtr) { /* No op */ }
 
-        [SupportedOSPlatform("windows")]
-        public bool SecureSocketLayer
-        {
-            get => throw new PlatformNotSupportedException();
-            set => throw new PlatformNotSupportedException();
-        }
+        public bool SecureSocketLayer { get; set; }
 
         public int ProtocolVersion
         {

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -15,5 +15,11 @@ namespace System.DirectoryServices.Protocols
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
+
+        public int ProtocolVersion
+        {
+            get => GetPtrValueHelper(LdapOption.LDAP_OPT_VERSION).ToInt32();
+            set => SetPtrValueHelper(LdapOption.LDAP_OPT_VERSION, new IntPtr(value));
+        }
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
@@ -23,5 +23,11 @@ namespace System.DirectoryServices.Protocols
                 SetIntValueHelper(LdapOption.LDAP_OPT_SSL, temp);
             }
         }
+
+        public int ProtocolVersion
+        {
+            get => GetIntValueHelper(LdapOption.LDAP_OPT_VERSION);
+            set => SetIntValueHelper(LdapOption.LDAP_OPT_VERSION, value);
+        }
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -168,12 +168,6 @@ namespace System.DirectoryServices.Protocols
             }
         }
 
-        public int ProtocolVersion
-        {
-            get => GetIntValueHelper(LdapOption.LDAP_OPT_VERSION);
-            set => SetIntValueHelper(LdapOption.LDAP_OPT_VERSION, value);
-        }
-
         public string HostName
         {
             get => GetStringValueHelper(LdapOption.LDAP_OPT_HOST_NAME, false);
@@ -783,6 +777,33 @@ namespace System.DirectoryServices.Protocols
 
             int temp = value;
             int error = LdapPal.SetIntOption(_connection._ldapHandle, option, ref temp);
+
+            ErrorChecking.CheckAndSetLdapError(error);
+        }
+
+        private IntPtr GetPtrValueHelper(LdapOption option)
+        {
+            if (_connection._disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            IntPtr outValue = new IntPtr(0);
+            int error = LdapPal.GetPtrOption(_connection._ldapHandle, option, ref outValue);
+            ErrorChecking.CheckAndSetLdapError(error);
+
+            return outValue;
+        }
+
+        private void SetPtrValueHelper(LdapOption option, IntPtr value)
+        {
+            if (_connection._disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            IntPtr temp = value;
+            int error = LdapPal.SetPtrOption(_connection._ldapHandle, option, ref temp);
 
             ErrorChecking.CheckAndSetLdapError(error);
         }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -630,6 +630,7 @@ namespace System.DirectoryServices.Protocols.Tests
             // Set server protocol before bind; OpenLDAP servers default
             // to LDAP v2, which we do not support, and will return LDAP_PROTOCOL_ERROR
             connection.SessionOptions.ProtocolVersion = 3;
+            connection.SessionOptions.SecureSocketLayer = LdapConfiguration.Configuration.UseTls;
             connection.Bind();
 
             connection.Timeout = new TimeSpan(0, 3, 0);


### PR DESCRIPTION
May fix #43890.

This PR does a few things for LDAP support in Linux for System.DirectoryServices.Protocols:

- Replaces deprecated OpenLDAP methods `ldap_init` and `ldap_simple_bind_s` with `ldap_create` and `ldap_sasl_bind_s`, respectively. 
- Fixes a problem with setting the LDAP version on the connection by using `IntPtr` types rather than `int` directly.
- Adds support for TLS and connectionless LDAP connections.

The first two points are prerequisites for the ultimate goal, which is to add LDAP TLS support to Linux. Let me know if you want me to break this up into multiple PRs.

# Testing

I tested this using by running the `osixia/openldap` image with a TLS listener on 1636, and extracted the self-signed CA to a file:

```
docker run -p 1389:389 -p 1636:636 --name ldap -d --rm -e LDAP_TLS_VERIFY_CLIENT=never osixia/openldap --loglevel debug
docker exec ldap cat /container/service/slapd/assets/certs/ca.crt > /tmp/ca.crt
```

I set the LDAP client CA certificate path in `/etc/ldap/ldap.conf` so OpenLDAP would trust the self-signed certificate:

```
# /etc/ldap/ldap.conf
#...
TLS_CACERT /tmp/ca.crt
```

(I'm testing with OpenLDAP 2.10.12 on Ubuntu 20.04, in case paths for configs differ on different distributions.)
I also had to map the short container ID (e.g. `7fb28b4656af`) to `127.0.0.1` in `/etc/hosts`.

Finally, I ran `env LDAP_TEST_SERVER_INDEX=4 dotnet test` to select the new test configuration I added in `LdapConfiguration.xml` using TLS, and change the hostname to the short container ID in `/etc/hosts` to make sure the client validated the server certificate. All tests passed successfully locally, and I could see the successful binds and operations in the container logs.