### PR TITLE
Add public Architecture enum value for s390x

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ProcessorArchitecture.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ProcessorArchitecture.cs
@@ -14,7 +14,8 @@ internal static partial class Interop
             x64,
             ARM,
             ARM64,
-            WASM
+            WASM,
+            S390x
         }
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
+++ b/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
@@ -55,6 +55,8 @@ int32_t SystemNative_GetOSArchitecture()
     return ARCH_X86;
 #elif defined(TARGET_WASM)
     return ARCH_WASM;
+#elif defined(TARGET_S390X)
+    return ARCH_S390X;
 #else
 #error Unidentified Architecture
 #endif
@@ -78,6 +80,8 @@ int32_t SystemNative_GetProcessArchitecture()
     return ARCH_X86;
 #elif defined(TARGET_WASM)
     return ARCH_WASM;
+#elif defined(TARGET_S390X)
+    return ARCH_S390X;
 #else
 #error Unidentified Architecture
 #endif

--- a/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.h
+++ b/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.h
@@ -22,5 +22,6 @@ enum
     ARCH_X64,
     ARCH_ARM,
     ARCH_ARM64,
-    ARCH_WASM
+    ARCH_WASM,
+    ARCH_S390X
 };

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.InteropServices
         Arm = 2,
         Arm64 = 3,
         Wasm = 4,
+        S390x = 5,
     }
     public readonly partial struct OSPlatform : System.IEquatable<System.Runtime.InteropServices.OSPlatform>
     {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/Architecture.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/Architecture.cs
@@ -9,6 +9,7 @@ namespace System.Runtime.InteropServices
         X64,
         Arm,
         Arm64,
-        Wasm
+        Wasm,
+        S390x
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -27,6 +27,8 @@ namespace System.Runtime.InteropServices
                     return Architecture.Arm64;
                 case Interop.Sys.ProcessorArchitecture.WASM:
                     return Architecture.Wasm;
+                case Interop.Sys.ProcessorArchitecture.S390x:
+                    return Architecture.S390x;
                 case Interop.Sys.ProcessorArchitecture.x86:
                 default:
                     Debug.Assert(arch == Interop.Sys.ProcessorArchitecture.x86, "Unidentified Architecture");

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -36,6 +36,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.Equal(Architecture.Wasm, processArch);
                     break;
 
+                case Architecture.S390x:
+                    Assert.Equal(Architecture.S390x, processArch);
+                    break;
+
                 default:
                     Assert.False(true, "Unexpected Architecture.");
                     break;


### PR DESCRIPTION
* Add S390x value to System.Runtime.InteropServices.Architecture enum

* Add native s390x architecture detection

Note to reviewers: This adds a new value to a publicly visible enum, so in that sense it affects the .NET API.  I don't know if there are any special requirements when making such changes.