### PR TITLE
Move metadata off the executable heaps

### DIFF
--- a/src/coreclr/debug/daccess/fntableaccess.cpp
+++ b/src/coreclr/debug/daccess/fntableaccess.cpp
@@ -171,7 +171,7 @@ static NTSTATUS OutOfProcessFunctionTableCallback_JIT(IN  ReadMemoryFunction    
 
         move(Hp, pHp);
 
-        if (Hp.CLRPersonalityRoutine == MinAddress)
+        if (Hp.GetModuleBase() == MinAddress)
         {
             DWORD_PTR          pThisHeader;
             DWORD_PTR          hdrOffset;

--- a/src/coreclr/debug/daccess/fntableaccess.cpp
+++ b/src/coreclr/debug/daccess/fntableaccess.cpp
@@ -171,7 +171,7 @@ static NTSTATUS OutOfProcessFunctionTableCallback_JIT(IN  ReadMemoryFunction    
 
         move(Hp, pHp);
 
-        if (pHp == MinAddress)
+        if (Hp.CLRPersonalityRoutine == MinAddress)
         {
             DWORD_PTR          pThisHeader;
             DWORD_PTR          hdrOffset;

--- a/src/coreclr/debug/daccess/fntableaccess.h
+++ b/src/coreclr/debug/daccess/fntableaccess.h
@@ -41,7 +41,18 @@ struct FakeHeapList
     DWORD_PTR           pHdrMap;        // changed from DWORD*
     size_t              maxCodeHeapSize;
     size_t              reserveForJumpStubs;
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
     DWORD_PTR           CLRPersonalityRoutine;
+#endif
+
+    DWORD_PTR GetModuleBase()
+    {
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+        return CLRPersonalityRoutine;
+#else
+        return mapBase;
+#endif
+    }
 };
 
 typedef struct _FakeHpRealCodeHdr

--- a/src/coreclr/debug/daccess/fntableaccess.h
+++ b/src/coreclr/debug/daccess/fntableaccess.h
@@ -41,6 +41,7 @@ struct FakeHeapList
     DWORD_PTR           pHdrMap;        // changed from DWORD*
     size_t              maxCodeHeapSize;
     size_t              reserveForJumpStubs;
+    DWORD_PTR           CLRPersonalityRoutine;
 };
 
 typedef struct _FakeHpRealCodeHdr

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3481,7 +3481,7 @@ ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFun
         TADDR addr = PTR_TO_TADDR(block->pVirtualAddress);
         size_t size = block->dwVirtualSize;
 
-        BOOL bCurrentBlock = (block == pLoaderHeap->m_pCurBlock);
+        BOOL bCurrentBlock = (block == pLoaderHeap->m_pFirstBlock);
 
         pFunc(addr,size,bCurrentBlock);
 
@@ -3538,7 +3538,7 @@ ClrDataAccess::TraverseVirtCallStubHeap(CLRDATA_ADDRESS pAppDomain, VCSHeapType 
                 TADDR addr = PTR_TO_TADDR(block->pVirtualAddress);
                 size_t size = block->dwVirtualSize;
 
-                BOOL bCurrentBlock = (block == pLoaderHeap->m_pCurBlock);
+                BOOL bCurrentBlock = (block == pLoaderHeap->m_pFirstBlock);
                 pFunc(addr, size, bCurrentBlock);
 
                 block = block->pNext;

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -301,6 +301,12 @@ protected:
         return m_pEndReservedRegion - m_pAllocPtr;
     }
 
+    PTR_BYTE UnlockedGetAllocPtr()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pAllocPtr;
+    }
+
 private:
     // Get some more committed pages - either commit some more in the current reserved region, or, if it
     // has run out, reserve another set of pages
@@ -847,6 +853,18 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         return UnlockedGetReservedBytesFree();
+    }
+
+    PTR_BYTE GetAllocPtr()
+    {
+        WRAPPER_NO_CONTRACT;
+        return UnlockedGetAllocPtr();
+    }
+
+    void ReservePages(size_t size)
+    {
+        WRAPPER_NO_CONTRACT;
+        UnlockedReservePages(size);
     }
 };
 

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -201,8 +201,6 @@ private:
     PTR_BYTE            m_pPtrToEndOfCommittedRegion;
     PTR_BYTE            m_pEndReservedRegion;
 
-    PTR_LoaderHeapBlock m_pCurBlock;
-
     // When we need to ClrVirtualAlloc() MEM_RESERVE a new set of pages, number of bytes to reserve
     DWORD               m_dwReserveBlockSize;
 

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -982,6 +982,8 @@ UnlockedLoaderHeap::~UnlockedLoaderHeap()
             fSuccess = ClrVirtualFree(pVirtualAddress, 0, MEM_RELEASE);
             _ASSERTE(fSuccess);
         }
+
+        delete pSearch;
     }
 
     if (m_reservedBlock.m_fReleaseMemory)
@@ -1047,11 +1049,21 @@ size_t UnlockedLoaderHeap::GetBytesAvailReservedRegion()
 
 #define SETUP_NEW_BLOCK(pData, dwSizeToCommit, dwSizeToReserve)                     \
         m_pPtrToEndOfCommittedRegion = (BYTE *) (pData) + (dwSizeToCommit);         \
-        m_pAllocPtr                  = (BYTE *) (pData) + sizeof(LoaderHeapBlock);  \
+        m_pAllocPtr                  = (BYTE *) (pData);                            \
         m_pEndReservedRegion         = (BYTE *) (pData) + (dwSizeToReserve);
 
 
 #ifndef DACCESS_COMPILE
+
+void ReleaseReservedMemory(BYTE* value)
+{
+    if (value)
+    {
+        ClrVirtualFree(value, 0, MEM_RELEASE);
+    }
+}
+
+using ReservedMemoryHolder = SpecializedWrapper<BYTE, ReleaseReservedMemory>;
 
 BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
 {
@@ -1065,13 +1077,10 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
 
     size_t dwSizeToReserve;
 
-    // Add sizeof(LoaderHeapBlock)
-    dwSizeToCommit += sizeof(LoaderHeapBlock);
-
     // Round to page size again
     dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
 
-    void *pData = NULL;
+    ReservedMemoryHolder pData = NULL;
     BOOL fReleaseMemory = TRUE;
 
     // We were provided with a reserved memory block at instance creation time, so use it if it's big enough.
@@ -1079,7 +1088,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         m_reservedBlock.dwVirtualSize >= dwSizeToCommit)
     {
         // Get the info out of the block.
-        pData = m_reservedBlock.pVirtualAddress;
+        pData = (PTR_BYTE)m_reservedBlock.pVirtualAddress;
         dwSizeToReserve = m_reservedBlock.dwVirtualSize;
         fReleaseMemory = m_reservedBlock.m_fReleaseMemory;
 
@@ -1126,15 +1135,16 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         return FALSE;
     }
 
+    if (!fReleaseMemory)
+    {
+        pData.SuppressRelease();
+    }
+
     // Commit first set of pages, since it will contain the LoaderHeapBlock
     void *pTemp = ClrVirtualAlloc(pData, dwSizeToCommit, MEM_COMMIT, (m_Options & LHF_EXECUTABLE) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
     if (pTemp == NULL)
     {
         //_ASSERTE(!"Unable to ClrVirtualAlloc commit in a loaderheap");
-
-        // Unable to commit - release pages
-        if (fReleaseMemory)
-            ClrVirtualFree(pData, 0, MEM_RELEASE);
 
         return FALSE;
     }
@@ -1147,24 +1157,19 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
                                     ((const BYTE *) pData) + dwSizeToReserve,
                                     (void *) this))
         {
-
-            if (fReleaseMemory)
-                ClrVirtualFree(pData, 0, MEM_RELEASE);
-
             return FALSE;
         }
     }
 
+    LoaderHeapBlock *pNewBlock = new (nothrow) LoaderHeapBlock;
+    if (pNewBlock == NULL)
+    {
+        return FALSE;
+    }
+
     m_dwTotalAlloc += dwSizeToCommit;
 
-    LoaderHeapBlock *pNewBlock;
-
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-    // Always assume we are touching executable heap
-    auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
-#endif // defined(HOST_OSX) && defined(HOST_ARM64)
-
-    pNewBlock = (LoaderHeapBlock *) pData;
+    pData.SuppressRelease();
 
     pNewBlock->dwVirtualSize    = dwSizeToReserve;
     pNewBlock->pVirtualAddress  = pData;
@@ -1179,7 +1184,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         pCurBlock = pCurBlock->pNext;
 
     if (pCurBlock != NULL)
-        m_pCurBlock->pNext = pNewBlock;
+        pCurBlock->pNext = pNewBlock;
     else
         m_pFirstBlock = pNewBlock;
 
@@ -1827,15 +1832,10 @@ void UnlockedLoaderHeap::DumpFreeList()
             size_t dwsize = pBlock->m_dwSize;
             BOOL ccbad = FALSE;
             BOOL sizeunaligned = FALSE;
-            BOOL sizesmall = FALSE;
 
             if ( 0 != (dwsize & ALLOC_ALIGN_CONSTANT) )
             {
                 sizeunaligned = TRUE;
-            }
-            if ( dwsize < sizeof(LoaderHeapBlock))
-            {
-                sizesmall = TRUE;
             }
 
             for (size_t i = sizeof(LoaderHeapFreeBlock); i < dwsize; i++)
@@ -1850,7 +1850,6 @@ void UnlockedLoaderHeap::DumpFreeList()
             printf("Addr = %pxh, Size = %lxh", pBlock, ((ULONG)dwsize));
             if (ccbad) printf(" *** ERROR: NOT CC'd ***");
             if (sizeunaligned) printf(" *** ERROR: size not a multiple of ALLOC_ALIGN_CONSTANT ***");
-            if (sizesmall) printf(" *** ERROR: size smaller than sizeof(LoaderHeapFreeBlock) ***");
             printf("\n");
 
             pBlock = pBlock->m_pNext;

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -910,7 +910,6 @@ UnlockedLoaderHeap::UnlockedLoaderHeap(DWORD dwReserveBlockSize,
     }
     CONTRACTL_END;
 
-    m_pCurBlock                  = NULL;
     m_pFirstBlock                = NULL;
 
     m_dwReserveBlockSize         = dwReserveBlockSize;
@@ -1173,23 +1172,11 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
 
     pNewBlock->dwVirtualSize    = dwSizeToReserve;
     pNewBlock->pVirtualAddress  = pData;
-    pNewBlock->pNext            = NULL;
+    pNewBlock->pNext            = m_pFirstBlock;
     pNewBlock->m_fReleaseMemory = fReleaseMemory;
 
-    LoaderHeapBlock *pCurBlock = m_pCurBlock;
-
-    // Add to linked list
-    while (pCurBlock != NULL &&
-           pCurBlock->pNext != NULL)
-        pCurBlock = pCurBlock->pNext;
-
-    if (pCurBlock != NULL)
-        pCurBlock->pNext = pNewBlock;
-    else
-        m_pFirstBlock = pNewBlock;
-
-    // If we want to use the memory immediately...
-    m_pCurBlock = pNewBlock;
+    // Add to the linked list
+    m_pFirstBlock = pNewBlock;
 
     SETUP_NEW_BLOCK(pData, dwSizeToCommit, dwSizeToReserve);
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3543,9 +3543,9 @@ void EEJitManager::DeleteCodeHeap(HeapList *pHeapList)
         pHp->SetNext(pHeapList->GetNext());
     }
 
-    DeleteEEFunctionTable((PVOID)pHeapList->mapBase);
+    DeleteEEFunctionTable((PVOID)pHeapList->GetModuleBase());
 
-    ExecutionManager::DeleteRange((TADDR)pHeapList->mapBase);
+    ExecutionManager::DeleteRange((TADDR)pHeapList->GetModuleBase());
 
     LOG((LF_JIT, LL_INFO100, "DeleteCodeHeap start" FMT_ADDR "end" FMT_ADDR "\n",
                               (const BYTE*)pHeapList->startAddress,


### PR DESCRIPTION
This change moves metadata structures that manage blocks of heap memory
out of the heaps in preparation for the W^X changes that will make the
heap memory read-execute only and modifying the metadata would require
unnecessary mappings and unmappings of the memory as read-write.

The structures moved in this change are the following:
* LoaderHeapBlock
* FreeBlock
* HeapList

Contributes to #50391