### PR TITLE
[build] Define NO_UNALIGNED_ACCESS for 32-bit arm platforms

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -353,6 +353,8 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   set(HOST_ARM64 1)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(HOST_ARM 1)
+  # fixme: use separate defines for host/target
+  set(NO_UNALIGNED_ACCESS 1)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
   set(HOST_S390X 1)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "wasm")
@@ -405,6 +407,8 @@ elseif(TARGET_ARCH MATCHES "arm")
   add_definitions("-DARM_FPU_VFP=1")
   set(TARGET_SIZEOF_VOID_P 4)
   set(SIZEOF_REGISTER 4)
+  # fixme: use separate defines for host/target
+  set(NO_UNALIGNED_ACCESS 1)
 elseif(TARGET_ARCH STREQUAL "s390x")
   set(TARGET_S390X 1)
   set(MONO_ARCHITECTURE "\"s390x\"")
@@ -418,17 +422,6 @@ elseif(TARGET_ARCH STREQUAL "wasm")
 else()
   message(FATAL_ERROR "TARGET_ARCH='${TARGET_ARCH}' not supported.")
 endif()
-
-######################################
-# ARCH CHECKS
-######################################
-
-if(HOST_ARM OR TARGET_ARM)
-  # wish: this should be two separate defines, but they're used for both host
-  # and target in the runtime.
-  set(NO_UNALIGNED_ACCESS 1)
-endif()
-
 
 ######################################
 # HEADER/FUNCTION CHECKS

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -420,6 +420,17 @@ else()
 endif()
 
 ######################################
+# ARCH CHECKS
+######################################
+
+if(HOST_ARM OR TARGET_ARM)
+  # wish: this should be two separate defines, but they're used for both host
+  # and target in the runtime.
+  set(NO_UNALIGNED_ACCESS 1)
+endif()
+
+
+######################################
 # HEADER/FUNCTION CHECKS
 ######################################
 include(configure)

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -908,6 +908,9 @@
 /* size of target machine integer registers */
 #define SIZEOF_REGISTER @SIZEOF_REGISTER@
 
+/* host or target doesn't allow unaligned memory access */
+#cmakedefine NO_UNALIGNED_ACCESS 1
+
 /* Support for the visibility ("hidden") attribute */
 #cmakedefine HAVE_VISIBILITY_HIDDEN 1
 


### PR DESCRIPTION
Possibly related to crashes on Android like this:

```
05-18 10:59:07.466 17076 17076 F libc    : Fatal signal 7 (SIGBUS), code 1 (BUS_ADRALN), fault addr 0xb9c95a41 in tid 17076 (simplehellomaui), pid 17076 (simplehellomaui)
05-18 10:59:07.501 17104 17104 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdTombstone
05-18 10:59:07.502   989   989 I tombstoned: received crash request for pid 17076
05-18 10:59:07.503 17104 17104 I crash_dump32: performing dump of process 17076 (target tid = 17076)
05-18 10:59:07.512 17104 17104 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-18 10:59:07.512 17104 17104 F DEBUG   : Build fingerprint: 'google/crosshatch/crosshatch:11/RQ2A.210405.005/7181113:user/release-keys'
05-18 10:59:07.512 17104 17104 F DEBUG   : Revision: 'MP1.0'
05-18 10:59:07.512 17104 17104 F DEBUG   : ABI: 'arm'
05-18 10:59:07.515 17104 17104 F DEBUG   : Timestamp: 2021-05-18 10:59:07+0200
05-18 10:59:07.515 17104 17104 F DEBUG   : pid: 17076, tid: 17076, name: simplehellomaui  >>> com.microsoft.simplehellomaui <<<
05-18 10:59:07.515 17104 17104 F DEBUG   : uid: 10364
05-18 10:59:07.515 17104 17104 F DEBUG   : signal 7 (SIGBUS), code 1 (BUS_ADRALN), fault addr 0xb9c95a41
05-18 10:59:07.515 17104 17104 F DEBUG   :     r0  bb4a5cd0  r1  b9c95a49  r2  00000000  r3  e94c7520
05-18 10:59:07.515 17104 17104 F DEBUG   :     r4  0000000c  r5  00000000  r6  ff843c50  r7  ff843e70
05-18 10:59:07.515 17104 17104 F DEBUG   :     r8  b69547f8  r9  e99eac50  r10 00000000  r11 00000021
05-18 10:59:07.515 17104 17104 F DEBUG   :     ip  e94c74f0  sp  ff843c48  lr  bb31e0dd  pc  bb3a4d24
05-18 10:59:07.531   709   709 E Layer   : [Surface(name=Task=1)/@0x52e6b1a - animation-leash#0] No local sync point found
05-18 10:59:07.532   709   709 E Layer   : [Surface(name=Task=1571)/@0x9c90165 - animation-leash#0] No local sync point found
05-18 10:59:07.706 17104 17104 F DEBUG   : backtrace:
05-18 10:59:07.707 17104 17104 F DEBUG   :       #00 pc 000ddd24  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mono_method_to_ir+9232) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #01 pc 000d7777  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (inline_method+622) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #02 pc 000ec0a3  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mono_method_to_ir+67470) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #03 pc 000cda6d  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mini_method_compile+2264) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #04 pc 000cf413  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mono_jit_compile_method_inner+50) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #05 pc 000d1d7f  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mono_jit_compile_method_with_opt+1766) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #06 pc 0012d94d  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (common_call_trampoline+832) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #07 pc 0012d5cb  /data/app/~~J4DFQ3c1v2YGrEurX7TNjg==/com.microsoft.simplehellomaui-_jGGPiZpZ3yT-QCTNDcgvQ==/lib/arm/libmonosgen-2.0.so (mono_magic_trampoline+62) (BuildId: d0a4e41a500357a621884b64f6ca8533b62a664b)
05-18 10:59:07.707 17104 17104 F DEBUG   :       #08 pc 0000006a <anonymous:b7986000>
```