### PR TITLE
Don't call result.ToString() in Random.AssertInRange

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -210,7 +210,7 @@ namespace System
             {
                 if (result != minInclusive)
                 {
-                    Debug.Assert(false, $"Expected {minInclusive} == {result}");
+                    Debug.Fail($"Expected {minInclusive} == {result}");
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace System
             if (result < 0.0 || result >= 1.0)
             {
                 // Avoid calling result.ToString() when the Assert condition is not met
-                Debug.Assert(false, $"Expected 0.0 <= {result} < 1.0");
+                Debug.Fail($"Expected 0.0 <= {result} < 1.0");
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -203,7 +203,7 @@ namespace System
             {
                 if (result < minInclusive || result >= maxExclusive)
                 {
-                    Debug.Assert(false, $"Expected {minInclusive} <= {result} < {maxExclusive}");
+                    Debug.Fail($"Expected {minInclusive} <= {result} < {maxExclusive}");
                 }
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -201,11 +201,17 @@ namespace System
         {
             if (maxExclusive > minInclusive)
             {
-                Debug.Assert(result >= minInclusive && result < maxExclusive, $"Expected {minInclusive} <= {result} < {maxExclusive}");
+                if (result < minInclusive || result >= maxExclusive)
+                {
+                    Debug.Assert(false, $"Expected {minInclusive} <= {result} < {maxExclusive}");
+                }
             }
             else
             {
-                Debug.Assert(result == minInclusive, $"Expected {minInclusive} == {result}");
+                if (result != minInclusive)
+                {
+                    Debug.Assert(false, $"Expected {minInclusive} == {result}");
+                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -210,8 +210,14 @@ namespace System
         }
 
         [Conditional("DEBUG")]
-        private static void AssertInRange(double result) =>
-            Debug.Assert(result >= 0.0 && result < 1.0f, $"Expected 0.0 <= {result} < 1.0");
+        private static void AssertInRange(double result)
+        {
+            if (result < 0.0 || result >= 1.0)
+            {
+                // Avoid calling result.ToString() when the Assert condition is not met
+                Debug.Assert(false, $"Expected 0.0 <= {result} < 1.0");
+            }
+        }
 
         /// <summary>Random implementation that delegates all calls to a ThreadStatic Impl instance.</summary>
         private sealed class ThreadSafeRandom : Random


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/52894

Double.ToString() is quite slow in Checked (partially because of get_CurrentCulture calls + in general I guess Grisu is full of asserts)