### PR TITLE
Add root store directory fallback on Linux/Unix.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -68,21 +68,23 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool PushX509StackField(SafeSharedX509StackHandle stack, SafeX509Handle x509);
 
-        internal static string? GetX509RootStorePath()
+        internal static string? GetX509RootStorePath(out bool defaultPath)
         {
-            return Marshal.PtrToStringAnsi(GetX509RootStorePath_private());
+            IntPtr ptr = GetX509RootStorePath_private(out byte usedDefault);
+            defaultPath = (usedDefault != 0);
+            return Marshal.PtrToStringAnsi(ptr);
         }
 
         internal static string? GetX509RootStoreFile()
         {
-            return Marshal.PtrToStringAnsi(GetX509RootStoreFile_private());
+            return Marshal.PtrToStringAnsi(GetX509RootStoreFile_private(out _));
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]
-        private static extern IntPtr GetX509RootStorePath_private();
+        private static extern IntPtr GetX509RootStorePath_private(out byte defaultPath);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStoreFile")]
-        private static extern IntPtr GetX509RootStoreFile_private();
+        private static extern IntPtr GetX509RootStoreFile_private(out byte defaultPath);
 
         [DllImport(Libraries.CryptoNative)]
         private static extern int CryptoNative_X509StoreSetVerifyTime(

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.c
@@ -6,25 +6,33 @@
 
 #include <assert.h>
 
-const char* CryptoNative_GetX509RootStorePath()
+const char* CryptoNative_GetX509RootStorePath(uint8_t* defaultPath)
 {
+    assert(defaultPath != NULL);
+
     const char* dir = getenv(X509_get_default_cert_dir_env());
+    *defaultPath = 0;
 
     if (!dir)
     {
         dir = X509_get_default_cert_dir();
+        *defaultPath = 1;
     }
 
     return dir;
 }
 
-const char* CryptoNative_GetX509RootStoreFile()
+const char* CryptoNative_GetX509RootStoreFile(uint8_t* defaultPath)
 {
+    assert(defaultPath != NULL);
+
     const char* file = getenv(X509_get_default_cert_file_env());
+    *defaultPath = 0
 
     if (!file)
     {
         file = X509_get_default_cert_file();
+        *defaultPath = 1;
     }
 
     return file;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.c
@@ -27,7 +27,7 @@ const char* CryptoNative_GetX509RootStoreFile(uint8_t* defaultPath)
     assert(defaultPath != NULL);
 
     const char* file = getenv(X509_get_default_cert_file_env());
-    *defaultPath = 0
+    *defaultPath = 0;
 
     if (!file)
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.h
@@ -8,11 +8,11 @@
 Look up the directory in which all certificate files therein are considered
 trusted (root or trusted intermediate).
 */
-PALEXPORT const char* CryptoNative_GetX509RootStorePath(void);
+PALEXPORT const char* CryptoNative_GetX509RootStorePath(uint8_t* defaultPath);
 
 /*
 Look up the file in which all certificates are considered trusted
 (root or trusted intermediate), in addition to those files in
 the root store path.
 */
-PALEXPORT const char* CryptoNative_GetX509RootStoreFile(void);
+PALEXPORT const char* CryptoNative_GetX509RootStoreFile(uint8_t* defaultPath);


### PR DESCRIPTION
When reading the root store directory for the first time, if
the read produced no data and the SSL_CERT_DIR environment
variable wasn't set, see if /etc/ssl/certs gives a different answer.

This change also changes the LastWriteTime model for caching
to not pin the symlink target on the first read, and support the
bundle file being a symlink (and the target being updated to
trigger refresh).

Fixes #38730.