### PR TITLE
Fix OfficialBuildId property passing down to scripts

### DIFF
--- a/src/installer/corehost.proj
+++ b/src/installer/corehost.proj
@@ -30,7 +30,8 @@
       <BuildArgs Condition="'$(CMakeArgs)' != ''">$(BuildArgs) $(CMakeArgs)</BuildArgs>
       <BuildArgs>$(BuildArgs) -coreclrartifacts $(CoreCLRArtifactsPath)</BuildArgs>
       <BuildArgs Condition="'$(Ninja)' == 'true'">$(BuildArgs) -ninja</BuildArgs>
-      <BuildArgs>$(BuildArgs) -runtimeflavor $(RuntimeFlavor) /p:OfficialBuildId="$(OfficialBuildId)"</BuildArgs>
+      <BuildArgs>$(BuildArgs) -runtimeflavor $(RuntimeFlavor)</BuildArgs>
+      <BuildArgs Condition="'$(OfficialBuildId)' != ''">$(BuildArgs) /p:OfficialBuildId="$(OfficialBuildId)"</BuildArgs>
     </PropertyGroup>
 
     <!--

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -5,8 +5,8 @@
     <NativeVersionFile Condition="'$(TargetOS)' != 'windows'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
-    <OfficialBuildIdArg Condition="'$(OfficialBuildId)' != ''"> /p:OfficialBuildId="$(OfficialBuildId)"</OfficialBuildIdArg>
-    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)$(OfficialBuildIdArg)</_BuildNativeArgs>
+    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)</_BuildNativeArgs>
+    <_BuildNativeArgs Condition="'$(OfficialBuildId)' != ''">$(_BuildNativeArgs) /p:OfficialBuildId="$(OfficialBuildId)"</_BuildNativeArgs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -5,7 +5,8 @@
     <NativeVersionFile Condition="'$(TargetOS)' != 'windows'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
-    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS) /p:OfficialBuildId="$(OfficialBuildId)"</_BuildNativeArgs>
+    <OfficialBuildIdArg Condition="'$(OfficialBuildId)' != ''"> /p:OfficialBuildId="$(OfficialBuildId)"</OfficialBuildIdArg>
+    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)$(OfficialBuildIdArg)</_BuildNativeArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/commit/4267d564affb062f934126e285aed9d9608adfee

Validated the fix in https://github.com/dotnet/runtime/pull/52897

cc @am11 