### PR TITLE
Deterministic bundling issue 3601

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.HostModel.Bundle
         public const uint BundlerMajorVersion = 6;
         public const uint BundlerMinorVersion = 0;
         //Same as Path.GetRandomFileName
-        private const int BundleIdLength = 8;
+        private const int BundleIdLength = 12;
 
         private readonly string HostName;
         private readonly string OutputDir;
@@ -279,7 +279,7 @@ namespace Microsoft.NET.HostModel.Bundle
 
             long headerOffset = 0;
             using (BinaryWriter writer = new BinaryWriter(File.OpenWrite(bundlePath)))
-            using (SHA256 hashAlg = SHA256Managed.Create())
+            using (SHA256 hashAlg = SHA256.Create())
             {
                 Stream bundle = writer.BaseStream;
                 bundle.Position = bundle.Length;
@@ -354,7 +354,7 @@ namespace Microsoft.NET.HostModel.Bundle
 
         private static byte[] ComputeSha256Hash(Stream stream)
         {
-            using (SHA256 sha = new SHA256Managed())
+            using (SHA256 sha = SHA256.Create())
             {
                 return sha.ComputeHash(stream);
             }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -329,7 +329,7 @@ namespace Microsoft.NET.HostModel.Bundle
                         (long startOffset, long compressedSize) = AddToBundle(bundle, file, targetType);
                         FileEntry entry = BundleManifest.AddEntry(targetType, relativePath, startOffset, file.Length, compressedSize, Target.BundleMajorVersion);
                         file.Position = 0;
-                        byte[] hashBytes = SHA256Managed.Create().ComputeHash(file);
+                        byte[] hashBytes = ComputeSha256Hash(file);
                         hashAlg.TransformBlock(hashBytes, 0, hashBytes.Length, hashBytes, 0);
                         Tracer.Log($"Embed: {entry}");
                     }
@@ -350,6 +350,14 @@ namespace Microsoft.NET.HostModel.Bundle
             HostWriter.SetAsBundle(bundlePath, headerOffset);
 
             return bundlePath;
+        }
+
+        private static byte[] ComputeSha256Hash(Stream stream)
+        {
+            using (SHA256 sha = new SHA256Managed())
+            {
+                return sha.ComputeHash(stream);
+            }
         }
     }
 }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.NET.HostModel.Bundle
         // identify this bundle. It is choosen to be compatible
         // with path-names so that the AppHost can use it in
         // extraction path.
-        public readonly string BundleID;
+        public string BundleID { get; internal set; } = Path.GetRandomFileName();
         public readonly uint BundleMajorVersion;
         // The Minor version is currently unused, and is always zero
         public const uint BundleMinorVersion = 0;
@@ -79,7 +79,6 @@ namespace Microsoft.NET.HostModel.Bundle
         {
             BundleMajorVersion = bundleMajorVersion;
             Files = new List<FileEntry>();
-            BundleID = Path.GetRandomFileName();
             Flags = (netcoreapp3CompatMode) ? HeaderFlags.NetcoreApp3CompatMode : HeaderFlags.None;
         }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 
 namespace Microsoft.NET.HostModel.Bundle
 {
@@ -65,7 +66,11 @@ namespace Microsoft.NET.HostModel.Bundle
         // identify this bundle. It is choosen to be compatible
         // with path-names so that the AppHost can use it in
         // extraction path.
-        public string BundleID { get; internal set; } = Path.GetRandomFileName();
+        public string BundleID => GetDeterministicId();
+        private string bundleIdInternal;
+        //Same as Path.GetRandomFileName
+        private const int BundleIdLength = 12;
+        private SHA256 hashAlg = SHA256.Create();
         public readonly uint BundleMajorVersion;
         // The Minor version is currently unused, and is always zero
         public const uint BundleMinorVersion = 0;
@@ -82,10 +87,19 @@ namespace Microsoft.NET.HostModel.Bundle
             Flags = (netcoreapp3CompatMode) ? HeaderFlags.NetcoreApp3CompatMode : HeaderFlags.None;
         }
 
-        public FileEntry AddEntry(FileType type, string relativePath, long offset, long size, long compressedSize, uint bundleMajorVersion)
+        public FileEntry AddEntry(FileType type, FileStream fileContent, string relativePath, long offset, long compressedSize, uint bundleMajorVersion)
         {
-            FileEntry entry = new FileEntry(type, relativePath, offset, size, compressedSize, bundleMajorVersion);
+            if (hashAlg == null)
+            {
+                throw new InvalidOperationException("It is forbidden to change Manifest state after it was written or BundleId was obtained.");
+            }
+
+            FileEntry entry = new FileEntry(type, relativePath, offset, fileContent.Length, compressedSize, bundleMajorVersion);
             Files.Add(entry);
+
+            fileContent.Position = 0;
+            byte[] hashBytes = ComputeSha256Hash(fileContent);
+            hashAlg.TransformBlock(hashBytes, 0, hashBytes.Length, hashBytes, 0);
 
             switch (entry.Type)
             {
@@ -104,6 +118,28 @@ namespace Microsoft.NET.HostModel.Bundle
             }
 
             return entry;
+        }
+
+        private static byte[] ComputeSha256Hash(Stream stream)
+        {
+            using (SHA256 sha = SHA256.Create())
+            {
+                return sha.ComputeHash(stream);
+            }
+        }
+
+        private string GetDeterministicId()
+        {
+            if (bundleIdInternal != null) return bundleIdInternal;
+
+            hashAlg.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            byte[] manifestHash = hashAlg.Hash;
+            bundleIdInternal = Convert.ToBase64String(manifestHash).Substring(BundleIdLength).Replace('/', '_');
+
+            hashAlg.Dispose();
+            hashAlg = null;
+
+            return bundleIdInternal;
         }
 
         public long Write(BinaryWriter writer)

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -154,11 +154,9 @@ namespace Microsoft.NET.HostModel.Tests
             var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
             var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
 
-            // Generate a file specification with duplicate entries
             var fileSpecs = new List<FileSpec>();
             fileSpecs.Add(new FileSpec(BundleHelper.GetHostPath(fixture), BundleHelper.GetHostName(fixture)));
             fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "rel/app.repeat.dll"));
-            fileSpecs.Add(new FileSpec(Path.Join(BundleHelper.GetPublishPath(fixture), "System.dll"), "rel/app.Repeat.dll"));
 
             Bundler bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
             return bundler.GenerateBundle(fileSpecs);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/3601
Bundling should generate id based on the content in order to secure unique but reproducible ids