### PR TITLE
Enable Android arm device tests

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -143,6 +143,7 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms:
+    - Android_arm
     - Android_arm64
     variables:
       # map dependencies variables to local variables
@@ -171,17 +172,6 @@ jobs:
           eq(variables['librariesContainsChange'], true),
           eq(variables['monoContainsChange'], true),
           eq(variables['isFullMatrix'], true))
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    platforms:
-    - Android_arm
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Build_Subset_Mono
-      buildArgs: -subset mono+libs
 
 #
 # Build the whole product using Mono and run libraries tests

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -592,6 +592,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52980", TestPlatforms.Android)]
         public static void MismatchKeyIdentifiers()
         {
             X509Extension[] intermediateExtensions = new []

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -592,7 +592,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52980", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52976", TestPlatforms.Android)]
         public static void MismatchKeyIdentifiers()
         {
             X509Extension[] intermediateExtensions = new []

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.props
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.props
@@ -15,7 +15,15 @@
     <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Android'">
+    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm'" Include="mtriple=armv7-linux-gnueabi-thumbv7s" />
     <MonoAOTCompilerDefaultAotArguments Include="static" />
+    <!-- Default trampolines run out for libraries tests -->
+    <MonoAOTCompilerDefaultAotArguments Include="nimt-trampolines=2000" />
+    <MonoAOTCompilerDefaultAotArguments Include="ntrampolines=10000" />
+    <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
+    <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
+    <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
+    <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=21000" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <MonoAOTCompilerDefaultAotArguments Include="no-opt" />


### PR DESCRIPTION
As a result of https://github.com/dotnet/xharness/issues/584 being fixed, we can now run arm 32 bit apps on our arm64 devices. 