### PR TITLE
Regression and Perf Fixes

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1058,13 +1058,6 @@ namespace System.Diagnostics
                 }
             }
 
-            activity.IsAllDataRequested = request == ActivitySamplingResult.AllData || request == ActivitySamplingResult.AllDataAndRecorded;
-
-            if (request == ActivitySamplingResult.AllDataAndRecorded)
-            {
-                activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-            }
-
             if (parentId != null)
             {
                 activity._parentId = parentId;
@@ -1081,6 +1074,13 @@ namespace System.Diagnostics
                 activity.ActivityTraceFlags = parentContext.TraceFlags;
                 activity._parentTraceFlags = (byte) parentContext.TraceFlags;
                 activity._traceState = parentContext.TraceState;
+            }
+
+            activity.IsAllDataRequested = request == ActivitySamplingResult.AllData || request == ActivitySamplingResult.AllDataAndRecorded;
+
+            if (request == ActivitySamplingResult.AllDataAndRecorded)
+            {
+                activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
             }
 
             if (startTime != default)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
@@ -196,35 +196,35 @@ namespace System.Diagnostics.Metrics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void NotifyMeasurement<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+        internal void NotifyMeasurement<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state) where T : struct
         {
-            if (measurement is byte byteMeasurement)
+            if (typeof(T) == typeof(byte))
             {
-                _byteMeasurementCallback(instrument, byteMeasurement, tags, state);
+                _byteMeasurementCallback(instrument, (byte)(object)measurement, tags, state);
             }
-            else if (measurement is short shortMeasurement)
+            if (typeof(T) == typeof(short))
             {
-                _shortMeasurementCallback(instrument, shortMeasurement, tags, state);
+                _shortMeasurementCallback(instrument, (short)(object)measurement, tags, state);
             }
-            else if (measurement is int intMeasurement)
+            if (typeof(T) == typeof(int))
             {
-                _intMeasurementCallback(instrument, intMeasurement, tags, state);
+                _intMeasurementCallback(instrument, (int)(object)measurement, tags, state);
             }
-            else if (measurement is long longMeasurement)
+            if (typeof(T) == typeof(long))
             {
-                _longMeasurementCallback(instrument, longMeasurement, tags, state);
+                _longMeasurementCallback(instrument, (long)(object)measurement, tags, state);
             }
-            else if (measurement is float floatMeasurement)
+            if (typeof(T) == typeof(float))
             {
-                _floatMeasurementCallback(instrument, floatMeasurement, tags, state);
+                _floatMeasurementCallback(instrument, (float)(object)measurement, tags, state);
             }
-            else if (measurement is double doubleMeasurement)
+            if (typeof(T) == typeof(double))
             {
-                _doubleMeasurementCallback(instrument, doubleMeasurement, tags, state);
+                _doubleMeasurementCallback(instrument, (double)(object)measurement, tags, state);
             }
-            else if (measurement is decimal decimalMeasurement)
+            if (typeof(T) == typeof(decimal))
             {
-                _decimalMeasurementCallback(instrument, decimalMeasurement, tags, state);
+                _decimalMeasurementCallback(instrument, (decimal)(object)measurement, tags, state);
             }
         }
     }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -247,6 +247,37 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void EnsureRecordingTest()
+        {
+            RemoteExecutor.Invoke(() => {
+                Activity.ForceDefaultIdFormat = true;
+                Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+
+                ActivitySource aSource = new ActivitySource("EnsureRecordingTest");
+
+                ActivityListener listener = new ActivityListener
+                {
+                    ShouldListenTo = (activitySource) => true,
+                    Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) =>
+                    {
+                        // Access activityOptions.TraceId to ensure generating the non-default value.
+                        ActivityTraceId traceId = activityOptions.TraceId;
+                        Assert.NotEqual(default(ActivityTraceId), traceId);
+                        return ActivitySamplingResult.AllDataAndRecorded;
+                    }
+                };
+
+                ActivitySource.AddActivityListener(listener);
+
+                Activity a = aSource.StartActivity("RecordedActivity");
+                Assert.NotNull(a);
+
+                Assert.True(a.Recorded);
+                Assert.True((a.Context.TraceFlags & ActivityTraceFlags.Recorded) != 0);
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestExpectedListenersReturnValues()
         {
             RemoteExecutor.Invoke(() => {
@@ -947,7 +978,7 @@ namespace System.Diagnostics.Tests
                         Assert.Null(a3.Parent);
                         Assert.Equal("ParentId", a3.ParentId);
 
-                        ActivityContext parentContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
+                        ActivityContext parentContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
                         using (Activity a4 = aSource.CreateActivity("a4", ActivityKind.Internal, parentContext, tags, links))
                         {
                             Assert.NotNull(a4);


### PR DESCRIPTION
This change is fixing two issues: 
- Fixes a regression of setting the recording trace flags on the Activity when having a parent context and the samplers returning a recording flag on. We used to use the parent context trace flags but now we consider the sampler returned value. 
- Fixes extra allocation which was happening when recording a measurement in the metrics instruments. Teh original written code was working fine on .NET 5.0 and 6.0 as the jit was avoiding the extra allocation. But on .NET Core and Full Framework this optimization was not happening. The change here is to avoid this extra allocation.