### PR TITLE
Override BaseType in TypeRefTypeSystemType

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
@@ -60,6 +60,9 @@ namespace Internal.TypeSystem
         /// </summary>
         public abstract MetadataType MetadataBaseType { get; }
 
+        // Make sure children remember to override both MetadataBaseType and BaseType.
+        public abstract override DefType BaseType { get; }
+
         /// <summary>
         /// If true, the type cannot be used as a base type of any other type.
         /// </summary>

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -151,6 +151,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override ModuleDesc Module => _module;
 
+        public override DefType BaseType => MetadataBaseType;
+
         public override MetadataType MetadataBaseType
         {
             get


### PR DESCRIPTION
BaseType is being used to determine whether the type is a value type or
class type. This meant that `dotnet-pgo merge` would always produce
metadata saying that all types were class types.

In practice, this meant that we had the following behavior:
```
.\dotnet-pgo.exe merge --input IBCTrace28800.mibc --output identity.mibc
.\dotnet-pgo.exe merge --input IBCTrace28800.mibc --input identity.mibc --output foo.mibc
Opening IBCTrace28800.mibc
Opening identity.mibc
Unhandled exception. System.Exception: Same type `[S.P.CoreLib]System.ReadOnlySpan`1` used as both ValueType and non-ValueType
   at Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem.TypeRefTypeSystemType.SetIsValueType(Boolean isValueType)
   at Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem.TypeRefTypeSystemContext.TypeRefSignatureParserProvider.GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, Byte rawTypeKind)
```

The same problem would occur when using compare-mibc to compare a
merged mibc file with some of its constituents. These scenarios work
now.

I don't think this actually has any negative effect when the runtime consumes the .mibc files, however, though I have not looked in detail.

cc @davidwrighton 