### PR TITLE
Handle thread at safe point as managed frame in Sample Profiler.

### DIFF
--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -411,7 +411,7 @@ mono_wrapper_info_create (MonoMethodBuilder *mb, WrapperSubtype subtype);
 void
 mono_marshal_set_wrapper_info (MonoMethod *method, WrapperInfo *info);
 
-WrapperInfo*
+MONO_COMPONENT_API WrapperInfo*
 mono_marshal_get_wrapper_info (MonoMethod *wrapper);
 
 MonoMethod *


### PR DESCRIPTION
Mono running in hybrid/coop suspended at safe point was always treated as an external frame by sample profiler. External frames will show up as unmanaged code in tools like perfview, but since a safe point is not considered external, it should be seen as cpu time for the managed method calling the safe point.

PR add logic to detect if a frame is at a safe point and if so makes sure the right flags are set for callstack marking it as executing managed code.