### PR TITLE
Allow TimeZoneInfo display names to use any of the installed Windows languages

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MUI.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MUI.cs
@@ -7,9 +7,10 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        internal const uint MUI_PREFERRED_UI_LANGUAGES = 0x10;
+        internal const uint MUI_USER_PREFERRED_UI_LANGUAGES = 0x10;
+        internal const uint MUI_USE_INSTALLED_LANGUAGES = 0x20;
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        internal static extern unsafe bool GetFileMUIPath(uint dwFlags, string pcwszFilePath, char* pwszLanguage, ref int pcchLanguage, char* pwszFileMUIPath, ref int pcchFileMUIPath, ref long pululEnumerator);
+        internal static extern unsafe bool GetFileMUIPath(uint dwFlags, string pcwszFilePath, char* pwszLanguage, ref uint pcchLanguage, char* pwszFileMUIPath, ref uint pcchFileMUIPath, ref ulong pululEnumerator);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -37,6 +37,8 @@ namespace System
             "Zulu"
         };
 
+        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
+
         private TimeZoneInfo(byte[] data, string id, bool dstDisabled)
         {
             _id = id;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -36,7 +36,7 @@ namespace System
         private const int MaxKeyLength = 255;
         private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
-        private static readonly Dictionary<int, string> s_FileMuiPathCache = new();
+        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
 
         private sealed partial class CachedData
         {
@@ -746,11 +746,11 @@ namespace System
         private static string TryGetCachedFileMuiPath(string filePath, CultureInfo cultureInfo)
         {
             string? result;
-            int hash = HashCode.Combine(filePath, cultureInfo);
+            string cacheKey = $"{cultureInfo.Name};{filePath}";
 
             lock (s_FileMuiPathCache)
             {
-                if (s_FileMuiPathCache.TryGetValue(hash, out result))
+                if (s_FileMuiPathCache.TryGetValue(cacheKey, out result))
                 {
                     return result;
                 }
@@ -760,7 +760,7 @@ namespace System
 
             lock (s_FileMuiPathCache)
             {
-                s_FileMuiPathCache.TryAdd(hash, result);
+                s_FileMuiPathCache.TryAdd(cacheKey, result);
             }
 
             return result;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -743,7 +743,7 @@ namespace System
         /// Searches the installed OS languages for either an exact matching culture, or one that has the same parent.
         /// If not found, uses the preferred default OS UI language, to align with prior behavior.
         /// </summary>
-        private static string TryGetCachedFileMuiPath(string filePath, CultureInfo cultureInfo)
+        private static string GetCachedFileMuiPath(string filePath, CultureInfo cultureInfo)
         {
             string? result;
             string cacheKey = $"{cultureInfo.Name};{filePath}";
@@ -756,7 +756,7 @@ namespace System
                 }
             }
 
-            result = TryGetFileMuiPath(filePath, cultureInfo);
+            result = GetFileMuiPath(filePath, cultureInfo);
 
             lock (s_FileMuiPathCache)
             {
@@ -771,7 +771,7 @@ namespace System
         /// Searches the installed OS languages for either an exact matching culture, or one that has the same parent.
         /// If not found, uses the preferred default OS UI language, to align with prior behavior.
         /// </summary>
-        private static unsafe string TryGetFileMuiPath(string filePath, CultureInfo cultureInfo)
+        private static unsafe string GetFileMuiPath(string filePath, CultureInfo cultureInfo)
         {
             char* fileMuiPath = stackalloc char[Interop.Kernel32.MAX_PATH];
             char* language = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH];
@@ -792,7 +792,7 @@ namespace System
                     // Recurse to search using the parent of the desired culture.
                     if (cultureInfo.Parent.Name != string.Empty)
                     {
-                        return TryGetFileMuiPath(filePath, cultureInfo.Parent);
+                        return GetFileMuiPath(filePath, cultureInfo.Parent);
                     }
 
                     // Final fallback, using the preferred installed UI language.
@@ -844,7 +844,7 @@ namespace System
         /// If a localized resource file exists, we LoadString resource ID "123" and
         /// return it to our caller.
         /// </summary>
-        private static string TryGetLocalizedNameByMuiNativeResource(string resource, CultureInfo? cultureInfo = null)
+        private static string GetLocalizedNameByMuiNativeResource(string resource, CultureInfo? cultureInfo = null)
         {
             if (string.IsNullOrEmpty(resource))
             {
@@ -884,7 +884,7 @@ namespace System
             }
 
             // Get the MUI File Path
-            string fileMuiPath = TryGetCachedFileMuiPath(filePath, cultureInfo);
+            string fileMuiPath = GetCachedFileMuiPath(filePath, cultureInfo);
             if (fileMuiPath == string.Empty)
             {
                 // not likely, but we could not resolve a MUI path
@@ -899,7 +899,7 @@ namespace System
             resourceId = -resourceId;
 
             // Finally, get the resource from the resource path
-            return TryGetLocalizedNameByNativeResource(fileMuiPath, resourceId);
+            return GetLocalizedNameByNativeResource(fileMuiPath, resourceId);
         }
 
         /// <summary>
@@ -909,7 +909,7 @@ namespace System
         /// "resource.dll" is a language-specific resource DLL.
         /// If the localized resource DLL exists, LoadString(resource) is returned.
         /// </summary>
-        private static unsafe string TryGetLocalizedNameByNativeResource(string filePath, int resource)
+        private static unsafe string GetLocalizedNameByNativeResource(string filePath, int resource)
         {
             IntPtr handle = IntPtr.Zero;
             try
@@ -959,17 +959,17 @@ namespace System
             // try to load the strings from the native resource DLL(s)
             if (!string.IsNullOrEmpty(displayNameMuiResource))
             {
-                displayName = TryGetLocalizedNameByMuiNativeResource(displayNameMuiResource);
+                displayName = GetLocalizedNameByMuiNativeResource(displayNameMuiResource);
             }
 
             if (!string.IsNullOrEmpty(standardNameMuiResource))
             {
-                standardName = TryGetLocalizedNameByMuiNativeResource(standardNameMuiResource);
+                standardName = GetLocalizedNameByMuiNativeResource(standardNameMuiResource);
             }
 
             if (!string.IsNullOrEmpty(daylightNameMuiResource))
             {
-                daylightName = TryGetLocalizedNameByMuiNativeResource(daylightNameMuiResource);
+                daylightName = GetLocalizedNameByMuiNativeResource(daylightNameMuiResource);
             }
 
             // fallback to using the standard registry keys
@@ -991,7 +991,7 @@ namespace System
         /// Helper function that takes a string representing a time_zone_name registry key name
         /// and returns a TimeZoneInfo instance.
         /// </summary>
-        private static TimeZoneInfoResult TryGetTimeZoneFromLocalMachine(string id, out TimeZoneInfo? value, out Exception? e)
+        private static TimeZoneInfoResult GetTimeZoneFromLocalMachine(string id, out TimeZoneInfo? value, out Exception? e)
         {
             e = null;
 
@@ -1093,7 +1093,7 @@ namespace System
                     // try to load the string from the native resource DLL(s)
                     if (!string.IsNullOrEmpty(standardNameMuiResource))
                     {
-                        standardDisplayName = TryGetLocalizedNameByMuiNativeResource(standardNameMuiResource);
+                        standardDisplayName = GetLocalizedNameByMuiNativeResource(standardNameMuiResource);
                     }
 
                     // fallback to using the standard registry key

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -36,6 +36,9 @@ namespace System
         private const int MaxKeyLength = 255;
         private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
+        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
+        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
+
         private sealed partial class CachedData
         {
             private static TimeZoneInfo GetCurrentOneYearLocal()

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -36,8 +36,6 @@ namespace System
         private const int MaxKeyLength = 255;
         private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
-        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
-
         private sealed partial class CachedData
         {
             private static TimeZoneInfo GetCurrentOneYearLocal()

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -773,8 +773,8 @@ namespace System
         /// </summary>
         private static unsafe string GetFileMuiPath(string filePath, CultureInfo cultureInfo)
         {
-            char* fileMuiPath = stackalloc char[Interop.Kernel32.MAX_PATH];
-            char* language = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH];
+            char* fileMuiPath = stackalloc char[Interop.Kernel32.MAX_PATH + 1];
+            char* language = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1];
             uint fileMuiPathLength = Interop.Kernel32.MAX_PATH;
             uint languageLength = Interop.Kernel32.LOCALE_NAME_MAX_LENGTH;
             ulong enumerator = 0;
@@ -804,6 +804,7 @@ namespace System
 
                     if (succeeded)
                     {
+                        fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
                         return new string(fileMuiPath);
                     }
 
@@ -812,9 +813,11 @@ namespace System
                 }
 
                 // Lookup succeeded.  Check for exact match to the desired culture.
+                language[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH] = '\0';
                 var lang = new string(language);
                 if (string.Equals(lang, cultureInfo.Name, StringComparison.OrdinalIgnoreCase))
                 {
+                    fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
                     return new string(fileMuiPath);
                 }
 
@@ -824,6 +827,7 @@ namespace System
                 {
                     if (ci.Parent.Name.Equals(cultureInfo.Name, StringComparison.OrdinalIgnoreCase))
                     {
+                        fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
                         return new string(fileMuiPath);
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -995,7 +995,7 @@ namespace System
         /// Helper function that takes a string representing a time_zone_name registry key name
         /// and returns a TimeZoneInfo instance.
         /// </summary>
-        private static TimeZoneInfoResult GetTimeZoneFromLocalMachine(string id, out TimeZoneInfo? value, out Exception? e)
+        private static TimeZoneInfoResult TryGetTimeZoneFromLocalMachine(string id, out TimeZoneInfo? value, out Exception? e)
         {
             e = null;
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -54,6 +54,12 @@ namespace System
         private const string UtcId = "UTC";
         private const string LocalId = "Local";
 
+#if TARGET_WINDOWS
+        // This field is only used in TimeZoneInfo.Win32.cs, but needs to be defined here to ensure it is initialized
+        // before the call to CreateUtcTimeZone during static field initialization of s_utcTimeZone.
+        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
+#endif
+
         private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
 
         private static CachedData s_cachedData = new CachedData();

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -54,14 +54,6 @@ namespace System
         private const string UtcId = "UTC";
         private const string LocalId = "Local";
 
-#if TARGET_WINDOWS
-        // This field is only used in TimeZoneInfo.Win32.cs, but needs to be defined here to ensure it is initialized
-        // before the call to CreateUtcTimeZone during static field initialization of s_utcTimeZone.
-        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
-#endif
-
-        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
-
         private static CachedData s_cachedData = new CachedData();
 
         //

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2723,7 +2723,8 @@ namespace System.Tests
             }).Dispose();
         }
 
-        private static bool CanTestWindowsNlsDisplayNames => s_isWindows && RemoteExecutor.IsSupported && WindowsUILanguageHelper.GetInstalledWin32CulturesWithUniqueLanguages().Length > 1;
+        private static readonly CultureInfo[] s_CulturesForWindowsNlsDisplayNamesTest = WindowsUILanguageHelper.GetInstalledWin32CulturesWithUniqueLanguages();
+        private static bool CanTestWindowsNlsDisplayNames => RemoteExecutor.IsSupported && s_CulturesForWindowsNlsDisplayNamesTest.Length > 1;
 
         [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(nameof(CanTestWindowsNlsDisplayNames))]
@@ -2731,7 +2732,7 @@ namespace System.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                var cultures = WindowsUILanguageHelper.GetInstalledWin32CulturesWithUniqueLanguages();
+                CultureInfo[] cultures = s_CulturesForWindowsNlsDisplayNamesTest;
 
                 CultureInfo.CurrentUICulture = cultures[0];
                 TimeZoneInfo.ClearCachedData();
@@ -2741,9 +2742,9 @@ namespace System.Tests
                 TimeZoneInfo.ClearCachedData();
                 TimeZoneInfo tz2 = TimeZoneInfo.FindSystemTimeZoneById(s_strPacific);
 
-                Assert.True(tz1.StandardName != tz2.DisplayName, $"The display name '{tz1.DisplayName}' should be different between {cultures[0].Name} and {cultures[1].Name}.");
+                Assert.True(tz1.DisplayName != tz2.DisplayName, $"The display name '{tz1.DisplayName}' should be different between {cultures[0].Name} and {cultures[1].Name}.");
                 Assert.True(tz1.StandardName != tz2.StandardName, $"The standard name '{tz1.StandardName}' should be different between {cultures[0].Name} and {cultures[1].Name}.");
-                Assert.True(tz1.StandardName != tz2.DaylightName, $"The daylight name '{tz1.DaylightName}' should be different between {cultures[0].Name} and {cultures[1].Name}.");
+                Assert.True(tz1.DaylightName != tz2.DaylightName, $"The daylight name '{tz1.DaylightName}' should be different between {cultures[0].Name} and {cultures[1].Name}.");
             }).Dispose();
         }
 
@@ -3009,7 +3010,7 @@ namespace System.Tests
         }
 
         //  This helper class is used to retrieve information about installed OS languages from Windows.
-        //  It should only be using in Windows platform-specific tests.
+        //  Its methods returns empty when run on non-Windows platforms.
         private static class WindowsUILanguageHelper
         {
             public static CultureInfo[] GetInstalledWin32CulturesWithUniqueLanguages() =>
@@ -3020,6 +3021,11 @@ namespace System.Tests
 
             public static CultureInfo[] GetInstalledWin32Cultures()
             {
+                if (!OperatingSystem.IsWindows())
+                {
+                    return new CultureInfo[0];
+                }
+
                 var context = new EnumContext();
                 EnumUILanguagesProc proc = EnumUiLanguagesCallback;
 


### PR DESCRIPTION
`TimeZoneInfo` on Windows previously was locked to using only the OS default UI language for its `DisplayName`, `StandardName` and `DaylightName` properties  (contrast with Unix where it will use the `CultureInfo.CurrentUICulture`).

Since the data comes from the NLS resources installed with Windows language packs, we still can't support *all* languages on Windows.  However, with this change we can now support any that are installed.  If the `CurrentUICulture` matches one of the languages installed (e.g. `fr-FR` = `fr-FR`) it will use it.  Otherwise, it will search for an installed language with the same parent language (e.g. `fr-CA` ≈ `fr-FR`) to use.  Finally, it will fallback to the existing behavior of using the default language.

Note, the unit test will only run if there are at least two languages installed that have different root languages, as we need to compare that lang1's values are different than lang2's.  I'm not sure if there are any machines in Helix set up like this, but the test does work on my local machine with English and French installed.

Fixes #50310

@tarekgh 