### PR TITLE
Couple simple cleanups in singlefile/bundle

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -72,13 +72,12 @@ namespace Microsoft.NET.HostModel.Bundle
 
             switch (type)
             {
-                case FileType.Symbols:
-                case FileType.NativeBinary:
-                case FileType.Assembly:
-                    return true;
+                case FileType.DepsJson:
+                case FileType.RuntimeConfigJson:
+                    return false;
 
                 default:
-                    return false;
+                    return true;
             }
         }
 

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -208,8 +208,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
         }
         else
         {
-            // The host components will be statically linked with the app-host: https://github.com/dotnet/runtime/issues/32823
-            // Once this work is completed, an outdated hostfxr can only be found for framework-related apps.
+            // An outdated hostfxr can only be found for framework-related apps.
             trace::error(_X("The required library %s does not support single-file apps."), fxr.fxr_path().c_str());			
             need_newer_framework_error();
             rc = StatusCode::FrameworkMissingFailure;


### PR DESCRIPTION

- We should enable compression for all kinds of files, except for those we explicitly do not want to compress
This effectively just flips what we do with "Unknown" kind.

- Removed an outdated comment.