### PR TITLE
[Release/5.0] - Fix versions for Libs native artifacts

### DIFF
--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -5,7 +5,9 @@
     <NativeVersionFile Condition="'$(TargetOS)' != 'Windows_NT'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
-    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS) /p:OfficialBuildId="$(OfficialBuildId)"</_BuildNativeArgs>
+    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)</_BuildNativeArgs>
+    <_BuildNativeArgs Condition="'$(OfficialBuildId)' != ''">$(_BuildNativeArgs) /p:OfficialBuildId="$(OfficialBuildId)"</_BuildNativeArgs>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -5,7 +5,7 @@
     <NativeVersionFile Condition="'$(TargetOS)' != 'Windows_NT'">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">$(NetCoreAppCurrent)</TargetFramework>
-    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS)</_BuildNativeArgs>
+    <_BuildNativeArgs>$(TargetArchitecture) $(Configuration) outconfig $(TargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) -os $(TargetOS) /p:OfficialBuildId="$(OfficialBuildId)"</_BuildNativeArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of #52799 and #52917

During the repo consolidation, we missed passing OfficialBuildId
argument to common script from all subsets, which resulted in default
version emitted in the binaries produced by Libs subset in the official
builds.

## Customer Impact
Version of libraries native binaries cannot be figured out.

## Testing
Built libraries and manually checked that the build Id is there.

## Risk
Low, it only adds the missing embedded version hash / official version number to the binaries.

## Regression
Yes, it was ok in 3.1, got broken during repo consolidation.
