### PR TITLE
Make the lookup for getApplicationProtocol optional

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -967,7 +967,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SSLEngine =                       GetClassGRef(env, "javax/net/ssl/SSLEngine");
     g_SSLEngineBeginHandshake =         GetMethod(env, false, g_SSLEngine, "beginHandshake", "()V");
     g_SSLEngineCloseOutbound =          GetMethod(env, false, g_SSLEngine, "closeOutbound", "()V");
-    g_SSLEngineGetApplicationProtocol = GetMethod(env, false, g_SSLEngine, "getApplicationProtocol", "()Ljava/lang/String;");
+    g_SSLEngineGetApplicationProtocol = GetOptionalMethod(env, false, g_SSLEngine, "getApplicationProtocol", "()Ljava/lang/String;");
     g_SSLEngineGetHandshakeStatus =     GetMethod(env, false, g_SSLEngine, "getHandshakeStatus", "()Ljavax/net/ssl/SSLEngineResult$HandshakeStatus;");
     g_SSLEngineGetSession =             GetMethod(env, false, g_SSLEngine, "getSession", "()Ljavax/net/ssl/SSLSession;");
     g_SSLEngineGetSSLParameters =       GetMethod(env, false, g_SSLEngine, "getSSLParameters", "()Ljavax/net/ssl/SSLParameters;");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -652,6 +652,12 @@ void AndroidCryptoNative_SSLStreamRelease(SSLStream* sslStream)
 
 int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream, uint8_t* out, int32_t* outLen)
 {
+    if (g_SSLEngineGetApplicationProtocol == NULL)
+    {
+        LOG_ERROR ("SSLStreamGetApplicationProtocol is only supported from API level 29 and above");
+        return FAIL;
+    }
+
     abort_if_invalid_pointer_argument (sslStream);
     abort_if_invalid_pointer_argument (outLen);
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -654,7 +654,7 @@ int32_t AndroidCryptoNative_SSLStreamGetApplicationProtocol(SSLStream* sslStream
 {
     if (g_SSLEngineGetApplicationProtocol == NULL)
     {
-        LOG_ERROR ("SSLStreamGetApplicationProtocol is only supported from API level 29 and above");
+        // SSLEngine.getApplicationProtocol() is only supported from API level 29 and above
         return FAIL;
     }
 


### PR DESCRIPTION
The method getApplicationProtocol in javax.net.ssl.SSLEngine is only supported on API level 29 and above, so running on older devices would result in a crash. 

This change makes the initial method lookup optional and AndroidCryptoNative_SSLStreamGetApplicationProtocol in pal_sslstream.c will error if it is not supported.

Fixes https://github.com/dotnet/runtime/issues/52965