### PR TITLE
make `TestBasePriorityOnWindows` not fail when ruinning tests with `-low`

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -82,7 +82,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
             ProcessPriorityClass originalPriority = _process.PriorityClass;
-            Assert.Equal(ProcessPriorityClass.Normal, originalPriority);
+            Assert.Equal(Process.GetCurrentProcess().PriorityClass, originalPriority);
 
             try
             {


### PR DESCRIPTION
I often run tests locally with `-low` - so that I could use machine for something else.
Recently `TestBasePriorityOnWindows` started reporting failures. 

I think it might be failing before, since there were no recent test changes. Perhaps a change in the test harness made it to report the failure in local runs.

Anyways - I think the test needs to be fixed to expect that priority class is inherited from the parent process. 
(if I understand correctly how the `Diagnostics.Process` API works, otherwise we have a bug)