### PR TITLE
Fix structreturn test

### DIFF
--- a/src/tests/JIT/Directed/StructABI/structreturn.cs
+++ b/src/tests/JIT/Directed/StructABI/structreturn.cs
@@ -1332,7 +1332,7 @@ class TestHFAandHVA
             T value = vector[Vector<T>.Count];
             System.Diagnostics.Debug.Assert(false);
         }
-        catch (IndexOutOfRangeException)
+        catch (ArgumentOutOfRangeException)
         {
             return;
         }


### PR DESCRIPTION
PR #52288 throws ArgumentOutOfRangeException instead of IndexOutOfRangeException.
The test is not updated. It still use IndexOutOfRangeException.