### PR TITLE
Performance improvement for Guid.Equals using SSE

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -808,8 +808,8 @@ namespace System
         {
             if (Sse2.IsSupported)
             {
-                var g1 = Unsafe.As<Guid, Vector128<byte>>(ref Unsafe.AsRef(left));
-                var g2 = Unsafe.As<Guid, Vector128<byte>>(ref Unsafe.AsRef(right));
+                Vector128<byte> g1 = Unsafe.As<Guid, Vector128<byte>>(ref Unsafe.AsRef(left));
+                Vector128<byte> g2 = Unsafe.As<Guid, Vector128<byte>>(ref Unsafe.AsRef(right));
 
                 if (Sse41.IsSupported)
                 {


### PR DESCRIPTION
Fixes #52296.

Baseline performance:

|            Method |      Mean |     Error |    StdDev |    Median |       Min |       Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------:|----------:|----------:|----------:|----------:|----------:|-------:|------:|------:|----------:|
|        EqualsSame |  1.785 ns | 0.0558 ns | 0.0494 ns |  1.791 ns |  1.702 ns |  1.849 ns |      - |     - |     - |         - |
|    EqualsOperator |  1.709 ns | 0.0133 ns | 0.0125 ns |  1.711 ns |  1.687 ns |  1.730 ns |      - |     - |     - |         - |
| NotEqualsOperator |  1.728 ns | 0.0188 ns | 0.0167 ns |  1.727 ns |  1.701 ns |  1.749 ns |      - |     - |     - |         - |

Updated performance:

|            Method |       Mean |     Error |    StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
|        EqualsSame |  0.3771 ns | 0.0073 ns | 0.0061 ns |  0.3786 ns |  0.3650 ns |  0.3852 ns |      - |     - |     - |         - |
|    EqualsOperator |  0.4260 ns | 0.0101 ns | 0.0095 ns |  0.4285 ns |  0.4060 ns |  0.4413 ns |      - |     - |     - |         - |
| NotEqualsOperator |  0.5709 ns | 0.0349 ns | 0.0327 ns |  0.5577 ns |  0.5437 ns |  0.6605 ns |      - |     - |     - |         - |