### PR TITLE
Emit JITStarting, MethodLoad, ModuleLoad and AssemblyLoad EventPipe events on Mono.

### DIFF
--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -166,13 +166,11 @@ def generateClrEventPipeWriteEventsImpl(
             WriteEventImpl.append("\n    return ERROR_SUCCESS;\n}\n\n")
 
     # EventPipeProvider and EventPipeEvent initialization
-    callbackName = ""
+    callbackName = 'EventPipeEtwCallback' + providerPrettyName
     createProviderFunc = ""
     if runtimeFlavor.coreclr:
-        callbackName = 'EventPipeEtwCallback' + providerPrettyName
         createProviderFunc = "EventPipeAdapter::CreateProvider"
     elif runtimeFlavor.mono:
-        callbackName = "NULL"
         createProviderFunc = "create_provider"
 
     eventPipeCallbackCastExpr = ""
@@ -181,6 +179,8 @@ def generateClrEventPipeWriteEventsImpl(
     else:
         eventPipeCallbackCastExpr = "(EventPipeCallback)"
 
+    if runtimeFlavor.mono:
+        WriteEventImpl.append("void " + callbackName + "(const uint8_t *, unsigned long, uint8_t, uint64_t,	uint64_t, EventFilterDescriptor *, void *);\n\n")
 
     if extern: WriteEventImpl.append('extern "C" ')
     WriteEventImpl.append(

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -727,7 +727,7 @@ typedef struct _DOTNET_TRACE_CONTEXT
 
             if is_windows:
                 eventpipeProviderCtxName = providerSymbol + "_EVENTPIPE_Context"
-                Clrallevents.write(('constexpr ' if target_cpp else 'const ') + 'EVENTPIPE_TRACE_CONTEXT ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
+                Clrallevents.write(('constexpr ' if target_cpp else '') + 'EVENTPIPE_TRACE_CONTEXT ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
 
     if write_xplatheader:
         clrproviders = os.path.join(incDir, "clrproviders.h")

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -714,6 +714,10 @@ typedef struct _DOTNET_TRACE_CONTEXT
             else:
                 Clrallevents.write("\n")
 
+        if not is_windows and not write_xplatheader:
+            Clrallevents.write(eventpipe_trace_context_typedef)  # define EVENTPIPE_TRACE_CONTEXT
+            Clrallevents.write("\n")
+
         for providerNode in tree.getElementsByTagName('provider'):
             templateNodes = providerNode.getElementsByTagName('template')
             allTemplates  = parseTemplateNodes(templateNodes)
@@ -725,9 +729,12 @@ typedef struct _DOTNET_TRACE_CONTEXT
             providerName = providerNode.getAttribute('name')
             providerSymbol = providerNode.getAttribute('symbol')
 
+            eventpipeProviderCtxName = providerSymbol + "_EVENTPIPE_Context"
             if is_windows:
-                eventpipeProviderCtxName = providerSymbol + "_EVENTPIPE_Context"
                 Clrallevents.write(('constexpr ' if target_cpp else '') + 'EVENTPIPE_TRACE_CONTEXT ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
+
+            if not is_windows and not write_xplatheader:
+                Clrallevents.write('__attribute__((weak)) EVENTPIPE_TRACE_CONTEXT ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
 
     if write_xplatheader:
         clrproviders = os.path.join(incDir, "clrproviders.h")

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -1734,7 +1734,6 @@ ep_rt_mono_write_event_module_load (MonoImage *image)
 		uint32_t module_native_pdb_age = 0;
 
 		uint32_t reserved_flags = 0;
-		uint64_t binding_id = 0;
 
 		// Netcore has a 1:1 between assemblies and modules, so its always a manifest module.
 		uint32_t module_flags = MODULE_FLAGS_MANIFEST_MODULE;

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2152,6 +2152,12 @@ ep_rt_mono_write_event_method_load (
 	MonoMethod *method,
 	MonoJitInfo *ji);
 
+bool
+ep_rt_mono_write_event_module_load (MonoImage *image);
+
+bool
+ep_rt_mono_write_event_assembly_load (MonoAssembly *assembly);
+
 /*
 * EventPipe provider callbacks.
 */

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -707,7 +707,8 @@ inline
 void
 ep_rt_provider_config_init (EventPipeProviderConfiguration *provider_config)
 {
-	;
+	extern void ep_rt_mono_provider_config_init (EventPipeProviderConfiguration *provider_config);
+	ep_rt_mono_provider_config_init (provider_config);
 }
 
 static
@@ -724,7 +725,8 @@ inline
 bool
 ep_rt_providers_validate_all_disabled (void)
 {
-	return true;
+	extern bool ep_rt_mono_providers_validate_all_disabled (void);
+	return ep_rt_mono_providers_validate_all_disabled ();
 }
 
 static
@@ -2146,6 +2148,11 @@ ep_rt_mono_write_event_ee_startup_start (void);
 
 bool
 ep_rt_mono_write_event_jit_start (MonoMethod *method);
+
+bool
+ep_rt_mono_write_event_method_il_to_native_map (
+	MonoMethod *method,
+	MonoJitInfo *ji);
 
 bool
 ep_rt_mono_write_event_method_load (

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2144,5 +2144,58 @@ ep_rt_volatile_store_ptr_without_barrier (
 bool
 ep_rt_mono_write_event_ee_startup_start (void);
 
+bool
+ep_rt_mono_write_event_jit_start (MonoMethod *method);
+
+bool
+ep_rt_mono_write_event_method_load (
+	MonoMethod *method,
+	MonoJitInfo *ji);
+
+/*
+* EventPipe provider callbacks.
+*/
+
+void
+EventPipeEtwCallbackDotNETRuntime (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data);
+
+void
+EventPipeEtwCallbackDotNETRuntimeRundown (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data);
+
+void
+EventPipeEtwCallbackDotNETRuntimePrivate (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data);
+
+void
+EventPipeEtwCallbackDotNETRuntimeStress (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data);
+
+
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_RT_MONO_H__ */

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -1,13 +1,15 @@
 # Native runtime events supported by Mono runtime.
 
-RuntimeInformationDCStart
-RuntimeInformationDCStart
 AppDomainDCEnd_V1
-DCEndInit_V1
+AssemblyDCEnd_V1
 DCEndComplete_V1
+DCEndInit_V1
+DomainModuleDCEnd_V1
 EEStartupStart_V1
 MethodDCEndILToNativeMap
 MethodDCEndVerbose_V1
-DomainModuleDCEnd_V1
-AssemblyDCEnd_V1
+MethodJittingStarted_V1
+MethodLoad_V1
+MethodLoadVerbose_V1
 ModuleDCEnd_V2
+RuntimeInformationDCStart

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -9,7 +9,9 @@ DomainModuleDCEnd_V1
 DomainModuleLoad_V1
 EEStartupStart_V1
 MethodDCEndILToNativeMap
+MethodDCEnd_V1
 MethodDCEndVerbose_V1
+MethodILToNativeMap
 MethodJittingStarted_V1
 MethodLoad_V1
 MethodLoadVerbose_V1

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -2,9 +2,11 @@
 
 AppDomainDCEnd_V1
 AssemblyDCEnd_V1
+AssemblyLoad_V1
 DCEndComplete_V1
 DCEndInit_V1
 DomainModuleDCEnd_V1
+DomainModuleLoad_V1
 EEStartupStart_V1
 MethodDCEndILToNativeMap
 MethodDCEndVerbose_V1
@@ -12,4 +14,5 @@ MethodJittingStarted_V1
 MethodLoad_V1
 MethodLoadVerbose_V1
 ModuleDCEnd_V2
+ModuleLoad_V2
 RuntimeInformationDCStart

--- a/src/mono/mono/eventpipe/test/ep-teardown-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-teardown-tests.c
@@ -13,6 +13,7 @@ test_teardown (void)
 	if (eventpipe_test_domain)
 		mono_jit_cleanup (eventpipe_test_domain);
 
+	unlink (TEST_FILE_2);
 	unlink (TEST_FILE);
 
 	return NULL;

--- a/src/mono/mono/eventpipe/test/ep-teardown-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-teardown-tests.c
@@ -3,6 +3,7 @@
 #include <mono/mini/jit.h>
 
 #define TEST_FILE "./ep_test_create_file.txt"
+#define TEST_FILE_2 "./ep_test_create_file_2.txt"
 
 extern MonoDomain *eventpipe_test_domain;
 

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -13,6 +13,7 @@
 
 #define TEST_PROVIDER_NAME "MyTestProvider"
 #define TEST_FILE "./ep_test_create_file.txt"
+#define TEST_FILE_2 "./ep_test_create_file_2.txt"
 
 //#define TEST_PERF
 
@@ -371,6 +372,86 @@ test_enable_disable_default_provider_config (void)
 
 ep_on_exit:
 	ep_disable (session_id);
+	return result;
+
+ep_on_error:
+	if (!result)
+		result = FAILED ("Failed at test location=%i", test_location);
+	ep_exit_error_handler ();
+}
+
+static RESULT
+test_enable_disable_multiple_default_provider_config (void)
+{
+	RESULT result = NULL;
+	uint32_t test_location = 0;
+
+	EventPipeSessionID session_id_1 = 0;
+	EventPipeSessionID session_id_2 = 0;
+
+	session_id_1 = ep_enable_2 (
+		TEST_FILE,
+		1,
+		NULL,
+		EP_SESSION_TYPE_FILE,
+		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
+		false,
+		NULL,
+		NULL);
+
+	if (!session_id_1) {
+		result = FAILED ("Failed to enable session");
+		ep_raise_error ();
+	}
+
+	test_location = 2;
+
+	result = validate_default_provider_config ((EventPipeSession *)session_id_1);
+	ep_raise_error_if_nok (result == NULL);
+
+	test_location = 3;
+
+	ep_start_streaming (session_id_1);
+
+	if (!ep_enabled ()) {
+		result = FAILED ("event pipe disabled");
+		ep_raise_error ();
+	}
+
+	test_location = 4;
+
+	session_id_2 = ep_enable_2 (
+		TEST_FILE_2,
+		1,
+		NULL,
+		EP_SESSION_TYPE_FILE,
+		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
+		false,
+		NULL,
+		NULL);
+
+	if (!session_id_2) {
+		result = FAILED ("Failed to enable session");
+		ep_raise_error ();
+	}
+
+	test_location = 5;
+
+	result = validate_default_provider_config ((EventPipeSession *)session_id_2);
+	ep_raise_error_if_nok (result == NULL);
+
+	test_location = 6;
+
+	ep_start_streaming (session_id_2);
+
+	if (!ep_enabled ()) {
+		result = FAILED ("event pipe disabled");
+		ep_raise_error ();
+	}
+
+ep_on_exit:
+	ep_disable (session_id_1);
+	ep_disable (session_id_2);
 	return result;
 
 ep_on_error:
@@ -1327,6 +1408,7 @@ static Test ep_tests [] = {
 #endif
 	{"test_eventpipe_mem_checkpoint", test_eventpipe_mem_checkpoint},
 	{"test_enable_disable_default_provider_config", test_enable_disable_default_provider_config},
+	{"test_enable_disable_multiple_default_provider_config", test_enable_disable_multiple_default_provider_config},
 	{"test_enable_disable_provider_parse_default_config", test_enable_disable_provider_parse_default_config},
 	{"test_eventpipe_reset_mem_checkpoint", test_eventpipe_reset_mem_checkpoint},
 	{"test_eventpipe_teardown", test_eventpipe_teardown},


### PR DESCRIPTION
Add support to emit JITStarting, MethodLoad, ModuleLoad and AssemblyLoad EventPipe events on Mono.

The JITStarting and MethodLoad is hooked up to existing profiler events jit_begin, jit_done meaning that it will cover JIT as well as loading of AOT methods or transformation of interpreter methods.

The module/assembly load events are hooked up to existing profiler events, image_loaded and assembly_loaded.

Profiler callbacks are dynamically added/removed based on EventPipe provider enable/disable callbacks, meaning that when no eventpipe session is using the runtime provider, all callbacks registered by that provider will be removed from mono profiler and runtime won't take any additional cost once a session (using the runtime provider) has been disabled.

These additional events gives some extra data in prefview making it possible to view JIT stats:

![image](https://user-images.githubusercontent.com/11529140/118978477-a9720200-b977-11eb-8994-3af366b35d02.png)

It also adds the JittingStarted metrics into the "Any Stack" view giving some more data points per callstacks:

![image](https://user-images.githubusercontent.com/11529140/118978683-dfaf8180-b977-11eb-8f30-1aa29e2d52bb.png)

These new events can also be consumed directly from the nettrace stream, making it possible to do custom presentations of JIT statistics combined with callstack information.