### PR TITLE
Fix installer tests on runtime-staging

### DIFF
--- a/src/installer/tests/Directory.Build.props
+++ b/src/installer/tests/Directory.Build.props
@@ -10,8 +10,9 @@
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>$(NetCoreAppToolCurrent)</TestInfraTargetFramework>
-    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' != 'true'">-notrait category=failing</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' == 'true'">-trait category=failing</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>-notrait category=failing</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' != 'true'">$(TestRunnerAdditionalArguments) -notrait category=FlakyAppHostTests</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' == 'true'">$(TestRunnerAdditionalArguments) -trait category=FlakyAppHostTests</TestRunnerAdditionalArguments>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.Bundle;
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/44657", TestPlatforms.Linux)]
+[assembly: Trait("category", "FlakyAppHostTests")]
 
 namespace AppHost.Bundle.Tests
 {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -6,10 +6,9 @@ using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.Bundle;
 using Xunit;
 
-[assembly: Trait("category", "FlakyAppHostTests")]
-
 namespace AppHost.Bundle.Tests
 {
+    [Trait("category", "FlakyAppHostTests")]
     public class SingleFileApiTests : BundleTestBase, IClassFixture<SingleFileSharedState>
     {
         private SingleFileSharedState sharedTestState;


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/52548 some installer tests that were using `PlatformSpecific(TestPlatforms.Windows)` started failing in the runtime-staging pipeline on Linux, even though they shouldn't have been executing.

Turns out this is because with https://github.com/dotnet/runtime/commit/81771effb2097045b2fca49d4ee4ca252f1e5a94 we're adding the `-trait category=failing` on the runtime-staging pipeline.
This doesn't work since `PlatformSpecific` attribute works by setting the "failing" category.

To fix this use a separate trait that can be used to only run the specific tests we want in runtime-staging.