### PR TITLE
Return null when Variant contains BSTR

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
@@ -633,6 +633,10 @@ namespace System.Runtime.InteropServices
             get
             {
                 Debug.Assert(VariantType == VarEnum.VT_BSTR);
+                if (_typeUnion._unionTypes._bstr == IntPtr.Zero)
+                {
+                    return null;
+                }
                 return (string)Marshal.PtrToStringBSTR(this._typeUnion._unionTypes._bstr);
             }
             set

--- a/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
@@ -628,7 +628,7 @@ namespace System.Runtime.InteropServices
 
         // VT_BSTR
 
-        public string AsBstr
+        public string? AsBstr
         {
             get
             {


### PR DESCRIPTION
I found this one when implement VARIANT marshalling for NativeAOT. Without that I have to resort to duplicate implementation in that class.
PR where I discover this - https://github.com/dotnet/runtimelab/pull/1142
Problem is `Marshal.PtrToStringBSTR` throw exception when passed `IntPtr.Zero`, but `Marshal.StringToBSTR` produce `IntPtr.Zero` when given null.