### PR TITLE
Fix OperatingSystem.IsAndroidVersionAtLeast()

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
+++ b/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
@@ -7,6 +7,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/utsname.h>
+#if defined(TARGET_ANDROID)
+#include <sys/system_properties.h>
+#endif
 
 const char* SystemNative_GetUnixName()
 {
@@ -15,10 +18,23 @@ const char* SystemNative_GetUnixName()
 
 char* SystemNative_GetUnixRelease()
 {
+#if defined(TARGET_ANDROID)
+    // get the Android API level
+    char sdk_ver_str[PROP_VALUE_MAX];
+    if (__system_property_get("ro.build.version.sdk", sdk_ver_str))
+    {
+        return strdup(sdk_ver_str);
+    }
+    else
+    {
+        return NULL;
+    }
+#else
     struct utsname _utsname;
     return uname(&_utsname) != -1 ?
         strdup(_utsname.release) :
         NULL;
+#endif
 }
 
 int32_t SystemNative_GetUnixVersion(char* version, int* capacity)

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -133,7 +133,7 @@ namespace System
         /// Indicates whether the current application is running on Linux.
         /// </summary>
         public static bool IsLinux() =>
-#if TARGET_LINUX
+#if TARGET_LINUX && !TARGET_ANDROID
             true;
 #else
             false;
@@ -166,7 +166,7 @@ namespace System
 #endif
 
         /// <summary>
-        /// Check for the Android version (returned by 'uname') with a >= version comparison. Used to guard APIs that were added in the given Android release.
+        /// Check for the Android API level (returned by 'ro.build.version.sdk') with a >= version comparison. Used to guard APIs that were added in the given Android release.
         /// </summary>
         public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
             => IsAndroid() && IsOSVersionAtLeast(major, minor, build, revision);

--- a/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
@@ -93,11 +93,13 @@ namespace System.Tests
         public static void TestIsOSVersionAtLeast_FreeBSD() => TestIsOSVersionAtLeast("FreeBSD");
 
         [Fact, PlatformSpecific(TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49868", TestPlatforms.Android)]
         public static void TestIsOSPlatform_Android() => TestIsOSPlatform("Android", OperatingSystem.IsAndroid);
 
         [Fact, PlatformSpecific(TestPlatforms.Android)]
         public static void TestIsOSVersionAtLeast_Android() => TestIsOSVersionAtLeast("Android");
+
+        [Fact, PlatformSpecific(TestPlatforms.Android)]
+        public static void TestIsOSVersionAtLeast_Android_21() => Assert.True(OperatingSystem.IsAndroidVersionAtLeast(21)); // 21 is our min supported version
 
         [Fact, PlatformSpecific(TestPlatforms.iOS)]
         public static void TestIsOSPlatform_IOS() => TestIsOSPlatform("iOS", OperatingSystem.IsIOS);

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/ChaCha20Poly1305Tests.cs
@@ -451,7 +451,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
             else if (PlatformDetection.IsAndroid)
             {
                 // Android with API Level 28 is the minimum API Level support for ChaChaPoly1305.
-                expectedIsSupported = GetAndroidSdkVersion() >= 28;
+                expectedIsSupported = OperatingSystem.IsAndroidVersionAtLeast(28);
             }
             else if (PlatformDetection.OpenSslPresentOnSystem &&
                 (PlatformDetection.IsOSX || PlatformDetection.IsOpenSslSupported))
@@ -461,23 +461,6 @@ namespace System.Security.Cryptography.Algorithms.Tests
             }
 
             Assert.Equal(expectedIsSupported, ChaCha20Poly1305.IsSupported);
-        }
-
-        private static int GetAndroidSdkVersion()
-        {
-            using Process proc = new Process();
-            proc.StartInfo.FileName = "getprop";
-            proc.StartInfo.Arguments = " ro.build.version.sdk";
-            proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.RedirectStandardOutput = true;
-            proc.Start();
-            string stdout = proc.StandardOutput.ReadToEnd();
-
-            // This should never take more than a second.
-            int sdkVersion = -1;
-            bool success = proc.WaitForExit(5_000) && int.TryParse(stdout, out sdkVersion);
-            Assert.True(success, "Could not determine Android SDK version for current device.");
-            return sdkVersion;
         }
     }
 }


### PR DESCRIPTION
The implementation called into uname() which returns the Linux kernel version, but the API as specified in https://github.com/dotnet/designs/blob/main/accepted/2020/platform-checks/platform-checks.md expects the Android API level to be passed in and checked.

Also fix `OperatingSystem.IsLinux()` to return false on Android.