### PR TITLE
Rename Mac Catalyst dylib to libmonosgen, not libcoreclr

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -31,7 +31,7 @@
     <CoreClrLibName>coreclr</CoreClrLibName>
     <CoreClrFileName>$(LibPrefix)$(CoreClrLibName)$(SharedLibExt)</CoreClrFileName>
     <MonoLibName>monosgen-2.0</MonoLibName>
-    <MonoSharedLibName Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true' or '$(TargetsBrowser)' == 'true'">$(MonoLibName)</MonoSharedLibName>
+    <MonoSharedLibName Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsAndroid)' == 'true' or '$(TargetsBrowser)' == 'true'">$(MonoLibName)</MonoSharedLibName>
     <MonoSharedLibName Condition="'$(MonoSharedLibName)' == ''">$(CoreClrLibName)</MonoSharedLibName>
     <MonoSharedLibFileName>$(LibPrefix)$(MonoSharedLibName)$(SharedLibExt)</MonoSharedLibFileName>
     <MonoStaticLibFileName>$(LibPrefix)$(MonoLibName)$(StaticLibExt)</MonoStaticLibFileName>


### PR DESCRIPTION
Fixes #52989

```
unzip -lf artifacts/packages/Debug/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.6.0.0-dev.nupkg | grep dylib$
 10650360  05-20-2021 18:11   runtimes/maccatalyst-x64/native/libmonosgen-2.0.dylib
  1414080  05-20-2021 18:12   runtimes/maccatalyst-x64/native/libSystem.IO.Compression.Native.dylib
   193064  05-20-2021 18:12   runtimes/maccatalyst-x64/native/libSystem.Native.dylib
    55856  05-20-2021 18:12   runtimes/maccatalyst-x64/native/libSystem.Net.Security.Native.dylib
   114528  05-20-2021 18:12   runtimes/maccatalyst-x64/native/libSystem.Security.Cryptography.Native.Apple.dylib
```