### PR TITLE
GT_COPY source should be marked as consume during resolution

### DIFF
--- a/docs/design/coreclr/jit/lsra-detail.md
+++ b/docs/design/coreclr/jit/lsra-detail.md
@@ -170,11 +170,11 @@ There are four main phases to LSRA:
 
         -   For fork edges (the source block has multiple targets, but
             each target has only that one source), any required
-            resolution is placed at the target.
+            resolution is placed at the individual target(s).
 
         -   For join edges (a single target block has multiple sources,
             but each source has only that one target), any required
-            resolution is placed at the source.
+            resolution is placed at the individual source(s).
 
         -   Critical edges require more complicated handling, and may
             require splitting of the edge for placement of resolution.
@@ -707,7 +707,7 @@ LinearScanAllocation(List<RefPosition> refPositions)
            - Next, for the remaining variables, classify them as either:
              - In different registers at one or more targets. These require that the edge
                be split so that we can insert the move on the edge (this is the `diffResolutionSet`).
-             - In the same register at each target (this is the `sameResolutionSet`).
+             - In the same register at each target (this is the `sameResolutionSet`), but different from the end of this block.
                For these, we can insert a move at the end of this block, as long as they
                don't write to any of the registers read by the `diffResolutionSet` as those
                must remain live into the split block.

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -57,6 +57,44 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Type Name="LinearScan">
     <DisplayString>LinearScan</DisplayString>
     <Expand>
+        <Item Name="inVarToRegMaps">"InVarToRegMaps"</Item>
+        <CustomListItems>
+          <Variable Name="block" InitialValue="this-&gt;compiler-&gt;fgFirstBB" />
+          <Variable Name="bbLiveInMap" InitialValue="block ? block->bbLiveIn[0] : 0" />
+          <Variable Name="inVarMap" InitialValue="block ? this->inVarToRegMaps[block->bbNum] : 0" />
+          <Variable Name="varIndex" InitialValue="0" />
+          <Loop Condition="block">
+              <Item Name="---BB{block->bbNum,2u}---">block->bbNum,2u</Item>
+              <Exec>varIndex = 0</Exec>
+              <Exec>inVarMap = this->inVarToRegMaps[block->bbNum]</Exec>
+              <Exec>bbLiveInMap = block->bbLiveIn[0]</Exec>
+              <Loop Condition="bbLiveInMap != 0">
+                <Item Name="V{this->localVarIntervals[varIndex]->varNum,2u}" Condition="(bbLiveInMap &amp; 1) != 0">((regNumber)inVarMap[varIndex]),en</Item>
+                <Exec>varIndex++</Exec>
+                <Exec>bbLiveInMap = bbLiveInMap >> 1</Exec>
+              </Loop>
+            <Exec>block = block->bbNext</Exec>
+          </Loop>
+        </CustomListItems>
+        <Item Name="outVarToRegMaps">"OutVarToRegMaps"</Item>
+        <CustomListItems>
+          <Variable Name="block" InitialValue="this-&gt;compiler-&gt;fgFirstBB" />
+          <Variable Name="bbLiveInMap" InitialValue="block ? block->bbLiveIn[0] : 0" />
+          <Variable Name="outVarMap" InitialValue="block ? this->outVarToRegMaps[block->bbNum] : 0" />
+          <Variable Name="varIndex" InitialValue="0" />
+          <Loop Condition="block">
+              <Item Name="---BB{block->bbNum,2u}---">block->bbNum,2u</Item>
+              <Exec>varIndex = 0</Exec>
+              <Exec>outVarMap = this->outVarToRegMaps[block->bbNum]</Exec>
+              <Exec>bbLiveInMap = block->bbLiveIn[0]</Exec>
+              <Loop Condition="bbLiveInMap != 0">
+                <Item Name="V{this->localVarIntervals[varIndex]->varNum,2u}" Condition="(bbLiveInMap &amp; 1) != 0">((regNumber)outVarMap[varIndex]),en</Item>
+                <Exec>varIndex++</Exec>
+                <Exec>bbLiveInMap = bbLiveInMap >> 1</Exec>
+              </Loop>
+            <Exec>block = block->bbNext</Exec>
+          </Loop>
+        </CustomListItems>
         <Item Name="AvailableRegs mask">this-&gt;m_AvailableRegs</Item>
         <CustomListItems>
           <Variable Name="reg" InitialValue="this->m_AvailableRegs" />


### PR DESCRIPTION
While doing the resolution for switch tables, also take into account the source of `SWITCH_TABLE` operand and do not use that register of the source for resolution. Below is the failure that this PR fixes. On left-side, we load the jump table's index in `r0` but before using it in `ldr pc`, overwrite it with different variable `lr` before we try to reload it in `mov r7, r0`.

![image](https://user-images.githubusercontent.com/12488060/119033728-678a9100-b962-11eb-9fac-692e936d47ce.png)

The fix is similar to the one done for Arm64 in https://github.com/dotnet/runtime/pull/48833.

Fixes: https://github.com/dotnet/runtime/issues/52945

While debugging, I also updated the natvis for `LinearScan` so it can display the inVarMap for each block along with register allocated to it. Sample screenshot:

![image](https://user-images.githubusercontent.com/12488060/119033464-1a0e2400-b962-11eb-9ba5-c4cbdb57a063.png)

