### PR TITLE
Disable crossgen2determinism test on OSX arm64

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -749,6 +749,9 @@
         <ExcludeList Include="$(XunitTestBinBase)readytorun/crossgen2/**">
             <Issue>https://github.com/dotnet/runtime/issues/49365</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)readytorun/determinism/crossgen2determinism/**">
+            <Issue>https://github.com/dotnet/runtime/issues/52529</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
/cc @dotnet/runtime-infrastructure, @dotnet/crossgen-contrib 