### PR TITLE
Add more natvis visualizations for base VM types.

### DIFF
--- a/src/coreclr/vm/vm.natvis
+++ b/src/coreclr/vm/vm.natvis
@@ -13,4 +13,22 @@ The .NET Foundation licenses this file to you under the MIT license.
             <ExpandedItem>m_value</ExpandedItem>
         </Expand>
     </Type>
+    <Type Name="Volatile&lt;*&gt;">
+        <DisplayString>{m_val}</DisplayString>
+        <Expand>
+            <ExpandedItem>m_val</ExpandedItem>
+        </Expand>
+    </Type>
+    <Type Name="Object">
+        <Expand>
+            <Item Name="[Type]">m_pMethTab</Item>
+            <Item Name="[Header]">*(((PTR_ObjHeader)this)-1)</Item>
+        </Expand>
+    </Type>
+    <Type Name="ObjHeader">
+        <Expand>
+            <Item Name="[Object]">(PTR_Object)(this + 1)</Item>
+            <Item Name="[SyncBlock]" Condition="(m_SyncBlockValue.m_val &amp; 0x0C000000) == 0x08000000">g_pSyncTable [m_SyncBlockValue.m_val &amp; ((1&lt;&lt;26)-1)].m_SyncBlock</Item>
+        </Expand>
+    </Type>
 </AutoVisualizer>

--- a/src/coreclr/vm/vm.natvis
+++ b/src/coreclr/vm/vm.natvis
@@ -31,4 +31,9 @@ The .NET Foundation licenses this file to you under the MIT license.
             <Item Name="[SyncBlock]" Condition="(m_SyncBlockValue.m_val &amp; 0x0C000000) == 0x08000000">g_pSyncTable [m_SyncBlockValue.m_val &amp; ((1&lt;&lt;26)-1)].m_SyncBlock</Item>
         </Expand>
     </Type>
+    <Type Name="MethodTable">
+        <Expand>
+            <Item Name="[Type Name]" Optional="true">debug_m_szClassName,s8</Item>
+        </Expand>
+    </Type>
 </AutoVisualizer>


### PR DESCRIPTION
Add visualization to easily discover the ObjHeader and SyncBlock for an Object, since they are not directly fields on their respective types.

Add a visualization for MethodTable to easily see the type name in VS when using a Debug/Checked build, so the developer doesn't need to go scrolling down the field list to find it.

Contributes to #52772