### PR TITLE
Fix creation of platforms and sources package

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- The project doesn't compile anything therefore create the package during build. -->
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(BuildAllConfigurations)' == 'true'">true</GeneratePackageOnBuild>
     <IsShipping>false</IsShipping>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsSourcePackage>true</IsSourcePackage>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -5,7 +5,7 @@
     <AvoidRestoreCycleOnSelfReference>true</AvoidRestoreCycleOnSelfReference>
     <AssemblyName>Microsoft.NETCore.Platforms.BuildTasks</AssemblyName>
     <!-- The only output of this project is the package as the tasks aren't packaged. -->
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(BuildAllConfigurations)' == 'true'">true</GeneratePackageOnBuild>
 
     <IsSourceProject>false</IsSourceProject>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Fixes the official build failures

```
.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21264.2\tools\SdkTasks\PublishBuildAssets.proj(43,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Repeated Asset entry: 'Microsoft.Extensions.HostFactoryResolver.Sources' - '6.0.0-preview.6.21271.1' 
.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21264.2\tools\SdkTasks\PublishBuildAssets.proj(43,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Repeated Asset entry: 'Microsoft.NETCore.Platforms' - '6.0.0-preview.6.21271.1' 
.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21264.2\tools\SdkTasks\PublishBuildAssets.proj(43,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Repeated Asset entry: 'assets/symbols/Microsoft.Extensions.HostFactoryResolver.Sources.6.0.0-preview.6.21271.1.symbols.nupkg' - '6.0.0-preview.6.21271.1' 
.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21264.2\tools\SdkTasks\PublishBuildAssets.proj(43,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) InvalidOperationException: Duplicate entries are not allowed for publishing to BAR, as this can cause race conditions and unexpected behavior at Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry.MergeBuildManifests(List`1 buildsMetadata) in /_/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs:line 510 at Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry.PushMetadataAsync(CancellationToken cancellationToken) in /_/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs:line 97 
```