### PR TITLE
[release/5.0] Fix for Issue 49058 - Do not count page cache towards cgroup’s memory load

### DIFF
--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -47,8 +47,7 @@ Abstract:
 #define PROC_STATM_FILENAME "/proc/self/statm"
 #define CGROUP1_MEMORY_LIMIT_FILENAME "/memory.limit_in_bytes"
 #define CGROUP2_MEMORY_LIMIT_FILENAME "/memory.max"
-#define CGROUP1_MEMORY_USAGE_FILENAME "/memory.usage_in_bytes"
-#define CGROUP2_MEMORY_USAGE_FILENAME "/memory.current"
+#define CGROUP_MEMORY_STAT_FILENAME "/memory.stat"
 #define CGROUP1_CFS_QUOTA_FILENAME "/cpu.cfs_quota_us"
 #define CGROUP1_CFS_PERIOD_FILENAME "/cpu.cfs_period_us"
 #define CGROUP2_CPU_MAX_FILENAME "/cpu.max"
@@ -62,12 +61,37 @@ class CGroup
 
     static char *s_memory_cgroup_path;
     static char *s_cpu_cgroup_path;
+
+    static const char *s_mem_stat_key_names[];
+    static size_t s_mem_stat_key_lengths[];
+    static size_t s_mem_stat_n_keys;
 public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
         s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
         s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
+
+        if (s_cgroup_version == 1)
+        {
+            s_mem_stat_n_keys = 4;
+            s_mem_stat_key_names[0] = "total_inactive_anon ";
+            s_mem_stat_key_names[1] = "total_active_anon ";
+            s_mem_stat_key_names[2] = "total_dirty ";
+            s_mem_stat_key_names[3] = "total_unevictable ";
+        }
+        else
+        {
+            s_mem_stat_n_keys = 3;
+            s_mem_stat_key_names[0] = "anon ";
+            s_mem_stat_key_names[1] = "file_dirty ";
+            s_mem_stat_key_names[2] = "unevictable ";
+        }
+
+        for (size_t i = 0; i < s_mem_stat_n_keys; i++)
+        {
+            s_mem_stat_key_lengths[i] = strlen(s_mem_stat_key_names[i]);
+        }
     }
 
     static void Cleanup()
@@ -96,9 +120,9 @@ public:
         if (s_cgroup_version == 0)
             return false;
         else if (s_cgroup_version == 1)
-            return GetCGroupMemoryUsage(val, CGROUP1_MEMORY_USAGE_FILENAME);
+            return GetCGroupMemoryUsage(val);
         else if (s_cgroup_version == 2)
-            return GetCGroupMemoryUsage(val, CGROUP2_MEMORY_USAGE_FILENAME);
+            return GetCGroupMemoryUsage(val);
         else
         {
             assert(!"Unknown cgroup version.");
@@ -232,7 +256,9 @@ private:
             if (filesystemType == nullptr || lineLen > maxLineLen)
             {
                 free(filesystemType);
+                filesystemType = nullptr;
                 free(options);
+                options = nullptr;
                 filesystemType = (char*)malloc(lineLen+1);
                 if (filesystemType == nullptr)
                     goto done;
@@ -319,7 +345,9 @@ private:
             if (subsystem_list == nullptr || lineLen > maxLineLen)
             {
                 free(subsystem_list);
+                subsystem_list = nullptr;
                 free(cgroup_path);
+                cgroup_path = nullptr;
                 subsystem_list = (char*)malloc(lineLen+1);
                 if (subsystem_list == nullptr)
                     goto done;
@@ -399,31 +427,50 @@ private:
         return result;
     }
 
-    static bool GetCGroupMemoryUsage(size_t *val, const char *filename)
+    static bool GetCGroupMemoryUsage(size_t *val)
     {
         if (s_memory_cgroup_path == nullptr)
             return false;
 
-        char* mem_usage_filename = nullptr;
-        if (asprintf(&mem_usage_filename, "%s%s", s_memory_cgroup_path, filename) < 0)
+        char* stat_filename = nullptr;
+        if (asprintf(&stat_filename, "%s%s", s_memory_cgroup_path, CGROUP_MEMORY_STAT_FILENAME) < 0)
             return false;
 
-        uint64_t temp = 0;
-        bool result = ReadMemoryValueFromFile(mem_usage_filename, &temp);
-        if (result)
+        FILE *stat_file = fopen(stat_filename, "r");
+        free(stat_filename);
+        if (stat_file == nullptr)
+            return false;
+
+        char *line = nullptr;
+        size_t lineLen = 0;
+        size_t readValues = 0;
+        char* endptr;
+
+        *val = 0;
+        while (getline(&line, &lineLen, stat_file) != -1 && readValues < s_mem_stat_n_keys)
         {
-            if (temp > std::numeric_limits<size_t>::max())
+            for (size_t i = 0; i < s_mem_stat_n_keys; i++)
             {
-                *val = std::numeric_limits<size_t>::max();
-            }
-            else
-            {
-                *val = (size_t)temp;
+                if (strncmp(line, s_mem_stat_key_names[i], s_mem_stat_key_lengths[i]) == 0)
+                {
+                    errno = 0;
+                    const char* startptr = line + s_mem_stat_key_lengths[i];
+                    *val += strtoll(startptr, &endptr, 10);
+                    if (endptr != startptr && errno == 0)
+                        readValues++;
+
+                    break;
+                }
             }
         }
 
-        free(mem_usage_filename);
-        return result;
+        fclose(stat_file);
+        free(line);
+
+        if (readValues == s_mem_stat_n_keys)
+            return true;
+
+        return false;
     }
 
     static bool GetCGroup1CpuLimit(uint32_t *val)
@@ -582,6 +629,10 @@ private:
 int CGroup::s_cgroup_version = 0;
 char *CGroup::s_memory_cgroup_path = nullptr;
 char *CGroup::s_cpu_cgroup_path = nullptr;
+
+const char *CGroup::s_mem_stat_key_names[4] = {};
+size_t CGroup::s_mem_stat_key_lengths[4] = {};
+size_t CGroup::s_mem_stat_n_keys = 0;
 
 void InitializeCGroup()
 {

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -37,8 +37,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #define PROC_STATM_FILENAME "/proc/self/statm"
 #define CGROUP1_MEMORY_LIMIT_FILENAME "/memory.limit_in_bytes"
 #define CGROUP2_MEMORY_LIMIT_FILENAME "/memory.max"
-#define CGROUP1_MEMORY_USAGE_FILENAME "/memory.usage_in_bytes"
-#define CGROUP2_MEMORY_USAGE_FILENAME "/memory.current"
+#define CGROUP_MEMORY_STAT_FILENAME "/memory.stat"
 #define CGROUP1_CFS_QUOTA_FILENAME "/cpu.cfs_quota_us"
 #define CGROUP1_CFS_PERIOD_FILENAME "/cpu.cfs_period_us"
 #define CGROUP2_CPU_MAX_FILENAME "/cpu.max"
@@ -50,12 +49,37 @@ class CGroup
 
     static char *s_memory_cgroup_path;
     static char *s_cpu_cgroup_path;
+
+    static const char *s_mem_stat_key_names[];
+    static size_t s_mem_stat_key_lengths[];
+    static size_t s_mem_stat_n_keys;
 public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
         s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
         s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
+
+        if (s_cgroup_version == 1)
+        {
+            s_mem_stat_n_keys = 4;
+            s_mem_stat_key_names[0] = "total_inactive_anon ";
+            s_mem_stat_key_names[1] = "total_active_anon ";
+            s_mem_stat_key_names[2] = "total_dirty ";
+            s_mem_stat_key_names[3] = "total_unevictable ";
+        }
+        else
+        {
+            s_mem_stat_n_keys = 3;
+            s_mem_stat_key_names[0] = "anon ";
+            s_mem_stat_key_names[1] = "file_dirty ";
+            s_mem_stat_key_names[2] = "unevictable ";
+        }
+
+        for (size_t i = 0; i < s_mem_stat_n_keys; i++)
+        {
+            s_mem_stat_key_lengths[i] = strlen(s_mem_stat_key_names[i]);
+        }
     }
 
     static void Cleanup()
@@ -84,9 +108,9 @@ public:
         if (s_cgroup_version == 0)
             return false;
         else if (s_cgroup_version == 1)
-            return GetCGroupMemoryUsage(val, CGROUP1_MEMORY_USAGE_FILENAME);
+            return GetCGroupMemoryUsage(val);
         else if (s_cgroup_version == 2)
-            return GetCGroupMemoryUsage(val, CGROUP2_MEMORY_USAGE_FILENAME);
+            return GetCGroupMemoryUsage(val);
         else
         {
             _ASSERTE(!"Unknown cgroup version.");
@@ -222,7 +246,9 @@ private:
             if (filesystemType == nullptr || lineLen > maxLineLen)
             {
                 PAL_free(filesystemType);
+                filesystemType = nullptr;
                 PAL_free(options);
+                options = nullptr;
                 filesystemType = (char*)PAL_malloc(lineLen+1);
                 if (filesystemType == nullptr)
                     goto done;
@@ -308,7 +334,9 @@ private:
             if (subsystem_list == nullptr || lineLen > maxLineLen)
             {
                 PAL_free(subsystem_list);
+                subsystem_list = nullptr;
                 PAL_free(cgroup_path);
+                cgroup_path = nullptr;
                 subsystem_list = (char*)PAL_malloc(lineLen+1);
                 if (subsystem_list == nullptr)
                     goto done;
@@ -388,31 +416,50 @@ private:
         return result;
     }
 
-    static bool GetCGroupMemoryUsage(size_t *val, const char *filename)
+    static bool GetCGroupMemoryUsage(size_t *val)
     {
         if (s_memory_cgroup_path == nullptr)
             return false;
 
-        char* mem_usage_filename = nullptr;
-        if (asprintf(&mem_usage_filename, "%s%s", s_memory_cgroup_path, filename) < 0)
+        char* stat_filename = nullptr;
+        if (asprintf(&stat_filename, "%s%s", s_memory_cgroup_path, CGROUP_MEMORY_STAT_FILENAME) < 0)
             return false;
 
-        uint64_t temp = 0;
-        bool result = ReadMemoryValueFromFile(mem_usage_filename, &temp);
-        if (result)
+        FILE *stat_file = fopen(stat_filename, "r");
+        free(stat_filename);
+        if (stat_file == nullptr)
+            return false;
+
+        char *line = nullptr;
+        size_t lineLen = 0;
+        size_t readValues = 0;
+        char* endptr;
+
+        *val = 0;
+        while (getline(&line, &lineLen, stat_file) != -1 && readValues < s_mem_stat_n_keys)
         {
-            if (temp > std::numeric_limits<size_t>::max())
+            for (size_t i = 0; i < s_mem_stat_n_keys; i++)
             {
-                *val = std::numeric_limits<size_t>::max();
-            }
-            else
-            {
-                *val = (size_t)temp;
+                if (strncmp(line, s_mem_stat_key_names[i], s_mem_stat_key_lengths[i]) == 0)
+                {
+                    errno = 0;
+                    const char* startptr = line + s_mem_stat_key_lengths[i];
+                    *val += strtoll(startptr, &endptr, 10);
+                    if (endptr != startptr && errno == 0)
+                        readValues++;
+
+                    break;
+                }
             }
         }
 
-        free(mem_usage_filename);
-        return result;
+        fclose(stat_file);
+        free(line);
+
+        if (readValues == s_mem_stat_n_keys)
+            return true;
+
+        return false;
     }
 
     static bool ReadMemoryValueFromFile(const char* filename, uint64_t* val)
@@ -576,6 +623,10 @@ private:
 int CGroup::s_cgroup_version = 0;
 char *CGroup::s_memory_cgroup_path = nullptr;
 char *CGroup::s_cpu_cgroup_path = nullptr;
+
+const char *CGroup::s_mem_stat_key_names[4] = {};
+size_t CGroup::s_mem_stat_key_lengths[4] = {};
+size_t CGroup::s_mem_stat_n_keys = 0;
 
 void InitializeCGroup()
 {


### PR DESCRIPTION

Fixes Issue: https://github.com/dotnet/runtime/issues/49058

Main PR: https://github.com/dotnet/runtime/pull/51738

# Description

As reported in the https://github.com/dotnet/runtime/issues/49058 there are scenarios in which GC is too aggressive when the app runs inside a Linux container (cgroups v1 & cgroups v2). One of the factors considered for deciding whether it is necessary to run GC is a [memory load](https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/coreclr/vm/gcenv.os.cpp#L915-L989). A memory load value is supposed to mean the approximate percentage of physical memory that is in use. 
Unlike on Windows, memory load on Linux containers also includes a page cache (file cache) which makes the memory load value larger than it ought to be. This PR changes how the memory load is calculated on Linux containers to match Windows.
Instead of reading the memory usage from `memory.usage_in_bytes` / `memory.current` it is now being calculated from fields which are read from the `memory.stat` file.

# Customer Impact

@robertdavidsmith reports (https://github.com/dotnet/runtime/issues/49058) that this issue doubles runtime for some applications, and this makes running them on Linux impractical.

# Regression

No, this has always been the case.

# Testing

Manual testing using the [GcTesting](https://github.com/marcin-krystianc/runtime_49058/tree/8496a6051ba3f7174046d03f4286af8c98a1444c/GcTesting) app. This app creates GC pressure by continuously allocating new memory and performing I/O operations.  Before the fix, the reported value of `GCMemoryInfo.MemoryLoadBytes` was overestimated because it included the page cache. After the fix, the value of `GCMemoryInfo.MemoryLoadBytes` doesn't include page cache anymore and is more or less equal to the memory allocated by the app (heap size).

```
docker build -t gctesting -f Dockerfile_5 .
docker run  -it --rm --env COMPlus_gcServer=0 --memory=2gb gctesting --memorypressurerate=10mb --allocationunitsize=80Kb --minimummemoryusage=512mb --filepressuretask=true --filepressuresize=512mb
```
```
docker build -t gctesting -f Dockerfile_5_custom_build .
docker run  -it --rm --env COMPlus_gcServer=0 --memory=2gb gctesting --memorypressurerate=10mb --allocationunitsize=80Kb --minimummemoryusage=512mb --filepressuretask=true --filepressuresize=512mb
```

# Risk

According to this risk taxonomy (https://github.com/dotnet/runtime/pull/46867#issuecomment-759629458) I would say the risk of regressing is low. After this change, the GC is expected to run less often in some scenarios. This leads to better performance but can also lead to higher memory usage.