### PR TITLE
Remove "armv7" architecture from iOS fat binaries

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -332,7 +332,7 @@
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x64'" Include="-DCMAKE_OSX_ARCHITECTURES=x86_64"/>
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x86'" Include="-DCMAKE_OSX_ARCHITECTURES=i386"/>
       <_MonoCMakeArgs Condition="'$(Platform)' == 'arm64'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64"/>
-      <_MonoCMakeArgs Condition="'$(Platform)' == 'arm'" Include="&quot;-DCMAKE_OSX_ARCHITECTURES=armv7%3Barmv7s&quot;"/>
+      <_MonoCMakeArgs Condition="'$(Platform)' == 'arm'" Include="-DCMAKE_OSX_ARCHITECTURES=armv7s"/>
       <_MonoCFLAGS Include="-Wl,-application_extension" />
       <_MonoCXXFLAGS Include="-Wl,-application_extension" />
     </ItemGroup>


### PR DESCRIPTION
This reverts commit 477363b27c658bc4f89bab3995386760e95ee8ef.

Our support matrix marks iOS as the minimum supported version. This means iPhone 5 as a minimum, and the "armv7s" architecture in Cmake. This means we don't need to support "armv7" (iPhone 3GS, 4, 4S)