### PR TITLE
Rename superpmi tests collection names

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -118,7 +118,7 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
       collectionType: pmi
-      collectionName: tests
+      collectionName: coreclr_tests
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -140,7 +140,7 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
       collectionType: pmi
-      collectionName: tests_libraries
+      collectionName: libraries_tests
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -46,9 +46,9 @@ jobs:
       displayName: '${{ parameters.jobName }}'
 
     # tests collection takes longer so increase timeout to 8 hours
-    ${{ if or(eq(parameters.collectionName, 'tests'), eq(parameters.collectionName, 'tests_libraries')) }}:
+    ${{ if or(eq(parameters.collectionName, 'coreclr_tests'), eq(parameters.collectionName, 'libraries_tests')) }}:
       timeoutInMinutes: 480
-    ${{ if and(ne(parameters.collectionName, 'tests'), ne(parameters.collectionName, 'tests_libraries')) }}:
+    ${{ if and(ne(parameters.collectionName, 'coreclr_tests'), ne(parameters.collectionName, 'libraries_tests')) }}:
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     variables:
@@ -98,10 +98,10 @@ jobs:
     - ${{ if eq(parameters.collectionName, 'benchmarks') }}:
       - name: InputDirectory
         value: '$(Core_Root_Dir)'
-    - ${{ if eq(parameters.collectionName, 'tests') }}:
+    - ${{ if eq(parameters.collectionName, 'coreclr_tests') }}:
       - name: InputDirectory
         value: '$(managedTestArtifactRootFolderPath)'
-    - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
+    - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:
       - name: InputDirectory
         value: '$(Build.SourcesDirectory)/artifacts/tests/libraries/$(osGroup).$(archType).$(buildConfigUpper)'
     workspace:

--- a/eng/pipelines/coreclr/templates/superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-job.yml
@@ -53,7 +53,7 @@ jobs:
        - ${{ format('coreclr_{0}_product_build_{1}{2}_x64_{3}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.buildConfig) }}
      - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
        - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
-     - ${{ if eq(parameters.collectionName, 'tests') }}:
+     - ${{ if eq(parameters.collectionName, 'coreclr_tests') }}:
         - '${{ parameters.runtimeType }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
 
     variables: ${{ parameters.variables }}
@@ -91,7 +91,7 @@ jobs:
           displayName: 'Coreclr product build (x64)'
 
     # Download and unzip managed test artifacts
-    - ${{ if eq(parameters.collectionName, 'tests') }}:
+    - ${{ if eq(parameters.collectionName, 'coreclr_tests') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(managedTestArtifactRootFolderPath)'
@@ -100,7 +100,7 @@ jobs:
           displayName: 'generic managed test artifacts'
 
     # Download and unzip libraries test artifacts
-    - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
+    - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(Build.SourcesDirectory)/artifacts/tests/libraries_zipped/$(osGroup).$(archType).$(buildConfigUpper)'
@@ -109,7 +109,7 @@ jobs:
           displayName: 'generic libraries test artifacts'
 
     # Unzip individual test projects
-    - ${{ if eq(parameters.collectionName, 'tests_libraries') }}:
+    - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:
       - task: ExtractFiles@1
         displayName: 'Unzip Tests.zip'
         inputs:

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -464,7 +464,7 @@ def main(main_args):
     # The reason is there are lot of dependencies with *.Tests.dll and to ensure we do not get
     # Reflection errors, just copy everything to CORE_ROOT so for all individual partitions, the
     # references will be present in CORE_ROOT.
-    if coreclr_args.collection_name == "tests_libraries":
+    if coreclr_args.collection_name == "libraries_tests":
         print('Copying {} -> {}'.format(coreclr_args.input_directory, superpmi_dst_directory))
 
         def make_readable(folder_name):
@@ -546,15 +546,15 @@ def main(main_args):
         # payload
         pmiassemblies_directory = path.join(workitem_directory, "pmiAssembliesDirectory")
         input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)
-        exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "tests" else []
+        exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "coreclr_tests" else []
         exclude_files = native_binaries_to_ignore
         if coreclr_args.collection_type == "crossgen2":
             print('Adding exclusions for crossgen2')
             # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.
             exclude_files += ["Microsoft.Build.dll"]
 
-        if coreclr_args.collection_name == "tests_libraries":
-            # tests_libraries artifacts contains files from core_root folder. Exclude them.
+        if coreclr_args.collection_name == "libraries_tests":
+            # libraries_tests artifacts contains files from core_root folder. Exclude them.
             core_root_dir = coreclr_args.core_root_directory
             exclude_files += [item for item in os.listdir(core_root_dir)
                               if isfile(join(core_root_dir, item)) and (item.endswith(".dll") or item.endswith(".exe"))]


### PR DESCRIPTION
After introducing libraries tests collection, whenever I filter the collection to `-f libraries.pmi` , the `tests_libraries.pmi` also gets picked up, downloaded and ran. To differentiate, I have renamed the libraries tests collection to `libraries_tests.pmi` and for consistency, the `tests.pmi` to `coreclr_tests.pmi`. That way, if someone specified `-f tests.pmi` , both libraries and coreclr collection can be downloaded and run.

- Rename `tests.pmi` to `coreclr_tests.pmi`
- Rename `tests_libraries.pmi` to `libraries_tests.pmi`