### PR TITLE
Revert "Allow TimeZoneInfo display names to use any of the installed Windows languages"

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MUI.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MUI.cs
@@ -7,10 +7,9 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        internal const uint MUI_USER_PREFERRED_UI_LANGUAGES = 0x10;
-        internal const uint MUI_USE_INSTALLED_LANGUAGES = 0x20;
+        internal const uint MUI_PREFERRED_UI_LANGUAGES = 0x10;
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        internal static extern unsafe bool GetFileMUIPath(uint dwFlags, string pcwszFilePath, char* pwszLanguage, ref uint pcchLanguage, char* pwszFileMUIPath, ref uint pcchFileMUIPath, ref ulong pululEnumerator);
+        internal static extern unsafe bool GetFileMUIPath(uint dwFlags, string pcwszFilePath, char* pwszLanguage, ref int pcchLanguage, char* pwszFileMUIPath, ref int pcchFileMUIPath, ref long pululEnumerator);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -37,8 +37,6 @@ namespace System
             "Zulu"
         };
 
-        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
-
         private TimeZoneInfo(byte[] data, string id, bool dstDisabled)
         {
             _id = id;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -36,9 +36,6 @@ namespace System
         private const int MaxKeyLength = 255;
         private const string InvariantUtcStandardDisplayName = "Coordinated Universal Time";
 
-        private static readonly Dictionary<string, string> s_FileMuiPathCache = new();
-        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
-
         private sealed partial class CachedData
         {
             private static TimeZoneInfo GetCurrentOneYearLocal()
@@ -740,106 +737,6 @@ namespace System
         }
 
         /// <summary>
-        /// Helper function for getting the MUI path for a given resource and culture, using a cache to prevent duplicating work.
-        /// Searches the installed OS languages for either an exact matching culture, or one that has the same parent.
-        /// If not found, uses the preferred default OS UI language, to align with prior behavior.
-        /// </summary>
-        private static string GetCachedFileMuiPath(string filePath, CultureInfo cultureInfo)
-        {
-            string? result;
-            string cacheKey = $"{cultureInfo.Name};{filePath}";
-
-            lock (s_FileMuiPathCache)
-            {
-                if (s_FileMuiPathCache.TryGetValue(cacheKey, out result))
-                {
-                    return result;
-                }
-            }
-
-            result = GetFileMuiPath(filePath, cultureInfo);
-
-            lock (s_FileMuiPathCache)
-            {
-                s_FileMuiPathCache.TryAdd(cacheKey, result);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Helper function for getting the MUI path for a given resource and culture.
-        /// Searches the installed OS languages for either an exact matching culture, or one that has the same parent.
-        /// If not found, uses the preferred default OS UI language, to align with prior behavior.
-        /// </summary>
-        private static unsafe string GetFileMuiPath(string filePath, CultureInfo cultureInfo)
-        {
-            char* fileMuiPath = stackalloc char[Interop.Kernel32.MAX_PATH + 1];
-            char* language = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1];
-            uint fileMuiPathLength = Interop.Kernel32.MAX_PATH;
-            uint languageLength = Interop.Kernel32.LOCALE_NAME_MAX_LENGTH;
-            ulong enumerator = 0;
-
-            while (true)
-            {
-                // Search all installed languages.  The enumerator is re-used between loop iterations.
-                bool succeeded = Interop.Kernel32.GetFileMUIPath(
-                    Interop.Kernel32.MUI_USE_INSTALLED_LANGUAGES,
-                    filePath, language, ref languageLength,
-                    fileMuiPath, ref fileMuiPathLength, ref enumerator);
-
-                if (!succeeded)
-                {
-                    // Recurse to search using the parent of the desired culture.
-                    if (cultureInfo.Parent.Name != string.Empty)
-                    {
-                        return GetFileMuiPath(filePath, cultureInfo.Parent);
-                    }
-
-                    // Final fallback, using the preferred installed UI language.
-                    enumerator = 0;
-                    succeeded = Interop.Kernel32.GetFileMUIPath(
-                        Interop.Kernel32.MUI_USER_PREFERRED_UI_LANGUAGES,
-                        filePath, language, ref languageLength,
-                        fileMuiPath, ref fileMuiPathLength, ref enumerator);
-
-                    if (succeeded)
-                    {
-                        fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
-                        return new string(fileMuiPath);
-                    }
-
-                    // Shouldn't get here, as there's always at least one language installed.
-                    return string.Empty;
-                }
-
-                // Lookup succeeded.  Check for exact match to the desired culture.
-                language[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH] = '\0';
-                var lang = new string(language);
-                if (string.Equals(lang, cultureInfo.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
-                    return new string(fileMuiPath);
-                }
-
-                // Check for match of any parent of the language returned to the desired culture.
-                var ci = CultureInfo.GetCultureInfo(lang);
-                while (ci.Parent.Name != string.Empty)
-                {
-                    if (ci.Parent.Name.Equals(cultureInfo.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        fileMuiPath[Interop.Kernel32.MAX_PATH] = '\0';
-                        return new string(fileMuiPath);
-                    }
-
-                    ci = ci.Parent;
-                }
-
-                // Not found yet.  Continue with next iteration.
-            }
-        }
-
-        /// <summary>
         /// Helper function for retrieving a localized string resource via MUI.
         /// The function expects a string in the form: "@resource.dll, -123"
         ///
@@ -849,15 +746,12 @@ namespace System
         /// If a localized resource file exists, we LoadString resource ID "123" and
         /// return it to our caller.
         /// </summary>
-        private static string GetLocalizedNameByMuiNativeResource(string resource, CultureInfo? cultureInfo = null)
+        private static string TryGetLocalizedNameByMuiNativeResource(string resource)
         {
             if (string.IsNullOrEmpty(resource))
             {
                 return string.Empty;
             }
-
-            // Use the current UI culture when culture not specified
-            cultureInfo ??= CultureInfo.CurrentUICulture;
 
             // parse "@tzres.dll, -100"
             //
@@ -888,23 +782,34 @@ namespace System
                 return string.Empty;
             }
 
-            // Get the MUI File Path
-            string fileMuiPath = GetCachedFileMuiPath(filePath, cultureInfo);
-            if (fileMuiPath == string.Empty)
-            {
-                // not likely, but we could not resolve a MUI path
-                return string.Empty;
-            }
-
-            // Get the resource ID
             if (!int.TryParse(resources[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int resourceId))
             {
                 return string.Empty;
             }
             resourceId = -resourceId;
 
-            // Finally, get the resource from the resource path
-            return GetLocalizedNameByNativeResource(fileMuiPath, resourceId);
+            try
+            {
+                unsafe
+                {
+                    char* fileMuiPath = stackalloc char[Interop.Kernel32.MAX_PATH];
+                    int fileMuiPathLength = Interop.Kernel32.MAX_PATH;
+                    int languageLength = 0;
+                    long enumerator = 0;
+
+                    bool succeeded = Interop.Kernel32.GetFileMUIPath(
+                                            Interop.Kernel32.MUI_PREFERRED_UI_LANGUAGES,
+                                            filePath, null /* language */, ref languageLength,
+                                            fileMuiPath, ref fileMuiPathLength, ref enumerator);
+                    return succeeded ?
+                        TryGetLocalizedNameByNativeResource(new string(fileMuiPath, 0, fileMuiPathLength), resourceId) :
+                        string.Empty;
+                }
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return string.Empty;
+            }
         }
 
         /// <summary>
@@ -914,7 +819,7 @@ namespace System
         /// "resource.dll" is a language-specific resource DLL.
         /// If the localized resource DLL exists, LoadString(resource) is returned.
         /// </summary>
-        private static unsafe string GetLocalizedNameByNativeResource(string filePath, int resource)
+        private static unsafe string TryGetLocalizedNameByNativeResource(string filePath, int resource)
         {
             IntPtr handle = IntPtr.Zero;
             try
@@ -964,17 +869,17 @@ namespace System
             // try to load the strings from the native resource DLL(s)
             if (!string.IsNullOrEmpty(displayNameMuiResource))
             {
-                displayName = GetLocalizedNameByMuiNativeResource(displayNameMuiResource);
+                displayName = TryGetLocalizedNameByMuiNativeResource(displayNameMuiResource);
             }
 
             if (!string.IsNullOrEmpty(standardNameMuiResource))
             {
-                standardName = GetLocalizedNameByMuiNativeResource(standardNameMuiResource);
+                standardName = TryGetLocalizedNameByMuiNativeResource(standardNameMuiResource);
             }
 
             if (!string.IsNullOrEmpty(daylightNameMuiResource))
             {
-                daylightName = GetLocalizedNameByMuiNativeResource(daylightNameMuiResource);
+                daylightName = TryGetLocalizedNameByMuiNativeResource(daylightNameMuiResource);
             }
 
             // fallback to using the standard registry keys
@@ -1098,7 +1003,7 @@ namespace System
                     // try to load the string from the native resource DLL(s)
                     if (!string.IsNullOrEmpty(standardNameMuiResource))
                     {
-                        standardDisplayName = GetLocalizedNameByMuiNativeResource(standardNameMuiResource);
+                        standardDisplayName = TryGetLocalizedNameByMuiNativeResource(standardNameMuiResource);
                     }
 
                     // fallback to using the standard registry key

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -54,6 +54,8 @@ namespace System
         private const string UtcId = "UTC";
         private const string LocalId = "Local";
 
+        private static readonly TimeZoneInfo s_utcTimeZone = CreateUtcTimeZone();
+
         private static CachedData s_cachedData = new CachedData();
 
         //


### PR DESCRIPTION
Reverts dotnet/runtime#52992

Need to fix the CI error created by the pinvoke in the test definitions.

Revert for now.  A new PR to replace will be sent when ready.