### PR TITLE
Split 16-byte SIMD store around GC struct fields into two 8-byte SIMD stores (x86)/ two 8-byte mov-s (x64)

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5686,6 +5686,13 @@ public:
     bool gtBlkOpGcUnsafe;
 #endif
 
+#ifdef TARGET_XARCH
+    bool MustUsePointerSizeAtomicStores()
+    {
+        return (m_layout != nullptr) && m_layout->HasGCPtr() && !Addr()->OperIsLocalAddr();
+    }
+#endif
+
     GenTreeBlk(genTreeOps oper, var_types type, GenTree* addr, ClassLayout* layout)
         : GenTreeIndir(oper, type, addr, nullptr)
         , m_layout(layout)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5687,7 +5687,7 @@ public:
 #endif
 
 #ifdef TARGET_XARCH
-    bool MustUsePointerSizeAtomicStores()
+    bool IsOnHeapAndContainsReferences()
     {
         return (m_layout != nullptr) && m_layout->HasGCPtr() && !Addr()->OperIsLocalAddr();
     }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -16286,11 +16286,25 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                            "type operand incompatible with type of address");
                 }
 
-                size = info.compCompHnd->getClassSize(resolvedToken.hClass); // Size
-                op2  = gtNewIconNode(0);                                     // Value
-                op1  = impPopStack().val;                                    // Dest
-                op1  = gtNewBlockVal(op1, size);
-                op1  = gtNewBlkOpNode(op1, op2, (prefixFlags & PREFIX_VOLATILE) != 0, false);
+                op2 = gtNewIconNode(0);  // Value
+                op1 = impPopStack().val; // Dest
+
+                if (eeIsValueClass(resolvedToken.hClass))
+                {
+                    op1 = gtNewStructVal(resolvedToken.hClass, op1);
+                    if (op1->OperIs(GT_OBJ))
+                    {
+                        gtSetObjGcInfo(op1->AsObj());
+                    }
+                }
+                else
+                {
+                    size = info.compCompHnd->getClassSize(resolvedToken.hClass);
+                    assert(size == TARGET_POINTER_SIZE);
+                    op1 = gtNewBlockVal(op1, size);
+                }
+
+                op1 = gtNewBlkOpNode(op1, op2, (prefixFlags & PREFIX_VOLATILE) != 0, false);
                 goto SPILL_APPEND;
 
             case CEE_INITBLK:

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -216,13 +216,15 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 
                 if (fill == 0)
                 {
-                    // If the size is multiple of XMM register size there's no need to load 0 in a GPR,
-                    // codegen will use xorps to generate 0 directly in the temporary XMM register.
                     if (size >= XMM_REGSIZE_BYTES)
                     {
-                        const bool canUse16BytesSimdMov = !blkNode->MustUsePointerSizeAtomicStores();
-
-                        if (canUse16BytesSimdMov && (size % 16 == 0)X86_ONLY(|| (size % 8 == 0)))
+                        const bool canUse16BytesSimdMov = !blkNode->IsOnHeapAndContainsReferences();
+#ifdef TARGET_AMD64
+                        const bool willUseOnlySimdMov = canUse16BytesSimdMov && (size % 16 == 0);
+#else
+                        const bool willUseOnlySimdMov = (size % 8 == 0);
+#endif
+                        if (willUseOnlySimdMov)
                         {
                             src->SetContained();
                         }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -218,9 +218,14 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
                 {
                     // If the size is multiple of XMM register size there's no need to load 0 in a GPR,
                     // codegen will use xorps to generate 0 directly in the temporary XMM register.
-                    if ((size % XMM_REGSIZE_BYTES) == 0)
+                    if (size >= XMM_REGSIZE_BYTES)
                     {
-                        src->SetContained();
+                        const bool canUse16BytesSimdMov = !blkNode->MustUsePointerSizeAtomicStores();
+
+                        if (canUse16BytesSimdMov && (size % 16 == 0)X86_ONLY(|| (size % 8 == 0)))
+                        {
+                            src->SetContained();
+                        }
                     }
                 }
 #ifdef TARGET_AMD64

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1297,7 +1297,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         switch (blkNode->gtBlkOpKind)
         {
             case GenTreeBlk::BlkOpKindUnroll:
-                if (size >= XMM_REGSIZE_BYTES)
+                if (AMD64_ONLY(!blkNode->MustUsePointerSizeAtomicStores() &&)(size >= XMM_REGSIZE_BYTES))
                 {
                     buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
                     SetContainsAVXFlags();

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1069,7 +1069,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         // The return value will be on the X87 stack, and we will need to move it.
         dstCandidates = allRegs(registerType);
 #else  // !TARGET_X86
-        dstCandidates = RBM_FLOATRET;
+        dstCandidates                     = RBM_FLOATRET;
 #endif // !TARGET_X86
     }
     else if (registerType == TYP_LONG)
@@ -1297,7 +1297,14 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         switch (blkNode->gtBlkOpKind)
         {
             case GenTreeBlk::BlkOpKindUnroll:
-                if (AMD64_ONLY(!blkNode->MustUsePointerSizeAtomicStores() &&)(size >= XMM_REGSIZE_BYTES))
+            {
+#ifdef TARGET_AMD64
+                const bool canUse16BytesSimdMov = !blkNode->IsOnHeapAndContainsReferences();
+                const bool willUseSimdMov       = canUse16BytesSimdMov && (size >= 16);
+#else
+                const bool willUseSimdMov = (size >= 16);
+#endif
+                if (willUseSimdMov)
                 {
                     buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
                     SetContainsAVXFlags();
@@ -1310,7 +1317,8 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                     srcRegMask = allByteRegs();
                 }
 #endif
-                break;
+            }
+            break;
 
             case GenTreeBlk::BlkOpKindRepInstr:
                 dstAddrRegMask = RBM_RDI;


### PR DESCRIPTION
Fixes #51638 by using
1. a sequence of `mov [m64],r64` instead of `movdqu [m128],xmm` when zeroing structs with GC fields that are not guaranteed to be on the stack on win-x64 or linux-x64
2. a sequence of `movq [m64],xmm` when zeroing such structs on win-x86

**win-x64**

```diff
diff --git a/win-x64-base.txt b/win-x64-diff.txt
index 297bc49..3c5ce98 100644
--- a/win-x64-base.txt
+++ b/win-x64-diff.txt
@@ -12,19 +12,21 @@
 ; Lcl frame size = 0
 
 G_M32495_IG01:              ;; offset=0000H
-       C5F877               vzeroupper 
-						;; bbWeight=1    PerfScore 1.00
-G_M32495_IG02:              ;; offset=0003H
-       C5F857C0             vxorps   xmm0, xmm0
-       C5FA7F4108           vmovdqu  xmmword ptr [rcx+8], xmm0
-       C5FA7F4118           vmovdqu  xmmword ptr [rcx+24], xmm0
-       C5FA7F4128           vmovdqu  xmmword ptr [rcx+40], xmm0
-						;; bbWeight=1    PerfScore 3.33
-G_M32495_IG03:              ;; offset=0016H
+						;; bbWeight=1    PerfScore 0.00
+G_M32495_IG02:              ;; offset=0000H
+       33C0                 xor      eax, eax
+       48894108             mov      qword ptr [rcx+8], rax
+       48894110             mov      qword ptr [rcx+16], rax
+       48894118             mov      qword ptr [rcx+24], rax
+       48894120             mov      qword ptr [rcx+32], rax
+       48894128             mov      qword ptr [rcx+40], rax
+       48894130             mov      qword ptr [rcx+48], rax
+						;; bbWeight=1    PerfScore 6.25
+G_M32495_IG03:              ;; offset=001AH
        C3                   ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 23, prolog size 3, PerfScore 8.03, instruction count 6, allocated bytes for code 27 (MethodHash=80ac8110) for method MyClass1:Clear():this
+; Total bytes of code 27, prolog size 0, PerfScore 9.95, instruction count 8, allocated bytes for code 27 (MethodHash=80ac8110) for method MyClass1:Clear():this
 ; ============================================================
 
 ; Assembly listing for method MyClass2:Clear():this
@@ -41,19 +43,21 @@ G_M32495_IG03:              ;; offset=0016H
 ; Lcl frame size = 0
 
 G_M65228_IG01:              ;; offset=0000H
-       C5F877               vzeroupper 
-						;; bbWeight=1    PerfScore 1.00
-G_M65228_IG02:              ;; offset=0003H
-       C5F857C0             vxorps   xmm0, xmm0
-       C5FA7F4110           vmovdqu  xmmword ptr [rcx+16], xmm0
-       C5FA7F4120           vmovdqu  xmmword ptr [rcx+32], xmm0
-       C5FA7F4130           vmovdqu  xmmword ptr [rcx+48], xmm0
-						;; bbWeight=1    PerfScore 3.33
-G_M65228_IG03:              ;; offset=0016H
+						;; bbWeight=1    PerfScore 0.00
+G_M65228_IG02:              ;; offset=0000H
+       33C0                 xor      eax, eax
+       48894110             mov      qword ptr [rcx+16], rax
+       48894118             mov      qword ptr [rcx+24], rax
+       48894120             mov      qword ptr [rcx+32], rax
+       48894128             mov      qword ptr [rcx+40], rax
+       48894130             mov      qword ptr [rcx+48], rax
+       48894138             mov      qword ptr [rcx+56], rax
+						;; bbWeight=1    PerfScore 6.25
+G_M65228_IG03:              ;; offset=001AH
        C3                   ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 23, prolog size 3, PerfScore 8.03, instruction count 6, allocated bytes for code 27 (MethodHash=7d1f0133) for method MyClass2:Clear():this
+; Total bytes of code 27, prolog size 0, PerfScore 9.95, instruction count 8, allocated bytes for code 27 (MethodHash=7d1f0133) for method MyClass2:Clear():this
 ; ============================================================
 ```

**win-x86**

```diff
diff --git a/win-x86-base.txt b/win-x86-diff.txt
index 9bc9d86..141ada4 100644
--- a/win-x86-base.txt
+++ b/win-x86-diff.txt
@@ -14,17 +14,16 @@ G_M32495_IG01:              ;; offset=0000H
        C5F877       vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
 G_M32495_IG02:              ;; offset=0003H
-       33C0         xor      eax, eax
        C5F857C0     vxorps   xmm0, xmm0
-       C5FA7F4104   vmovdqu  xmmword ptr [ecx+4], xmm0
-       894114       mov      dword ptr [ecx+20], eax
-       894118       mov      dword ptr [ecx+24], eax
-						;; bbWeight=1    PerfScore 3.58
-G_M32495_IG03:              ;; offset=0014H
+       C5F9D64104   vmovq    qword ptr [ecx+4], xmm0
+       C5F9D6410C   vmovq    qword ptr [ecx+12], xmm0
+       C5F9D64114   vmovq    qword ptr [ecx+20], xmm0
+						;; bbWeight=1    PerfScore 3.33
+G_M32495_IG03:              ;; offset=0016H
        C3           ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.88, instruction count 7, allocated bytes for code 23 (MethodHash=80ac8110) for method MyClass1:Clear():this
+; Total bytes of code 23, prolog size 3, PerfScore 8.03, instruction count 6, allocated bytes for code 27 (MethodHash=80ac8110) for method MyClass1:Clear():this
 ; ============================================================
 
 ; Assembly listing for method MyClass2:Clear():this
@@ -43,17 +42,16 @@ G_M65228_IG01:              ;; offset=0000H
        C5F877       vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
 G_M65228_IG02:              ;; offset=0003H
-       33C0         xor      eax, eax
        C5F857C0     vxorps   xmm0, xmm0
-       C5FA7F4108   vmovdqu  xmmword ptr [ecx+8], xmm0
-       894118       mov      dword ptr [ecx+24], eax
-       89411C       mov      dword ptr [ecx+28], eax
-						;; bbWeight=1    PerfScore 3.58
-G_M65228_IG03:              ;; offset=0014H
+       C5F9D64108   vmovq    qword ptr [ecx+8], xmm0
+       C5F9D64110   vmovq    qword ptr [ecx+16], xmm0
+       C5F9D64118   vmovq    qword ptr [ecx+24], xmm0
+						;; bbWeight=1    PerfScore 3.33
+G_M65228_IG03:              ;; offset=0016H
        C3           ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.88, instruction count 7, allocated bytes for code 23 (MethodHash=7d1f0133) for method MyClass2:Clear():this
+; Total bytes of code 23, prolog size 3, PerfScore 8.03, instruction count 6, allocated bytes for code 27 (MethodHash=7d1f0133) for method MyClass2:Clear():this
 ; ============================================================
 
 Completed assembly Runtime_51638 - #types: 5, #methods: 7, skipped types: 0, skipped methods: 0
```

**asm.benchmarks.run.Linux.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 261749
Total bytes of diff: 261983
Total bytes of delta: 234 (0.09% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          54 : 13268.dasm (1.16% of base)
          53 : 18275.dasm (12.71% of base)
          45 : 21824.dasm (19.31% of base)
          37 : 11243.dasm (0.24% of base)
          32 : 18443.dasm (16.33% of base)
          31 : 18398.dasm (26.96% of base)
          29 : 5058.dasm (1.75% of base)
          29 : 2549.dasm (1.76% of base)
          18 : 17717.dasm (0.73% of base)
          17 : 3747.dasm (2.47% of base)
          16 : 2539.dasm (0.41% of base)
          16 : 5052.dasm (0.40% of base)
          15 : 22421.dasm (0.59% of base)
          14 : 4545.dasm (3.15% of base)
          13 : 11179.dasm (0.27% of base)
          11 : 3855.dasm (1.30% of base)
          11 : 23148.dasm (1.77% of base)
          10 : 15930.dasm (5.95% of base)
           8 : 3936.dasm (0.45% of base)
           8 : 12918.dasm (4.52% of base)

Top file improvements (bytes):
         -57 : 21624.dasm (-3.14% of base)
         -11 : 3731.dasm (-3.70% of base)
         -10 : 10557.dasm (-2.75% of base)
          -9 : 17565.dasm (-1.50% of base)
          -8 : 12958.dasm (-0.48% of base)
          -8 : 20770.dasm (-0.91% of base)
          -8 : 17571.dasm (-1.80% of base)
          -7 : 19201.dasm (-1.85% of base)
          -7 : 12959.dasm (-0.35% of base)
          -7 : 21682.dasm (-0.85% of base)
          -6 : 20590.dasm (-1.01% of base)
          -6 : 20332.dasm (-1.01% of base)
          -6 : 20520.dasm (-0.97% of base)
          -6 : 9695.dasm (-0.48% of base)
          -5 : 11165.dasm (-0.45% of base)
          -5 : 20469.dasm (-1.75% of base)
          -5 : 21790.dasm (-1.11% of base)
          -5 : 19501.dasm (-2.03% of base)
          -5 : 9689.dasm (-2.18% of base)
          -5 : 19457.dasm (-3.85% of base)

225 total files with Code Size differences (118 improved, 107 regressed), 8 unchanged.

Top method regressions (bytes):
          54 ( 1.16% of base) : 13268.dasm - <WriteHeadersAsync>d__53:MoveNext():this
          53 (12.71% of base) : 18275.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          45 (19.31% of base) : 21824.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          37 ( 0.24% of base) : 11243.dasm - <SendAsyncCore>d__57:MoveNext():this
          32 (16.33% of base) : 18443.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          31 (26.96% of base) : 18398.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          29 ( 1.75% of base) : 5058.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
          29 ( 1.76% of base) : 2549.dasm - <ReadAllAsync>d__29`1[SimpleStructWithProperties][MicroBenchmarks.Serializers.SimpleStructWithProperties]:MoveNext():this
          18 ( 0.73% of base) : 17717.dasm - <ReadAsync>d__7:MoveNext():this
          17 ( 2.47% of base) : 3747.dasm - System.Security.Cryptography.Asn1.Pkcs12.PfxAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          16 ( 0.41% of base) : 2539.dasm - <WriteAsyncCore>d__70`1[SimpleStructWithProperties][MicroBenchmarks.Serializers.SimpleStructWithProperties]:MoveNext():this
          16 ( 0.40% of base) : 5052.dasm - <WriteAsyncCore>d__70`1[__Canon][System.__Canon]:MoveNext():this
          15 ( 0.59% of base) : 22421.dasm - <ReadAsyncWithCancellationToken>d__11:MoveNext():this
          14 ( 3.15% of base) : 4545.dasm - AsyncStateMachineBox`1[__Canon,<ReceiveBlobAsync>d__174`1][System.__Canon,System.Net.Security.SslStream+<ReceiveBlobAsync>d__174`1[System.Net.Security.AsyncReadWriteAdapter]]:MoveNext(System.Threading.Thread):this
          13 ( 0.27% of base) : 11179.dasm - <ConnectAsync>d__89:MoveNext():this
          11 ( 1.30% of base) : 3855.dasm - System.Security.Cryptography.Asn1.Pkcs7.EncryptedDataAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          11 ( 1.77% of base) : 23148.dasm - procfs:TryParseStatFile(System.String,byref):bool
          10 ( 5.95% of base) : 15930.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
           8 ( 0.45% of base) : 3936.dasm - System.Security.Cryptography.Asn1.PrivateKeyInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
           8 ( 4.52% of base) : 12918.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this

Top method improvements (bytes):
         -57 (-3.14% of base) : 21624.dasm - <DescendantTriviaOnly>d__170:MoveNext():bool:this
         -11 (-3.70% of base) : 3731.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
         -10 (-2.75% of base) : 10557.dasm - <_Reverse>d__20`1[__Canon][System.__Canon]:MoveNext():bool:this
          -9 (-1.50% of base) : 17565.dasm - System.IO.Pipelines.Pipe:GetReadAsyncResult():System.IO.Pipelines.ReadResult:this
          -8 (-0.48% of base) : 12958.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,System.ReadOnlySpan`1[Char],byref):bool:this
          -8 (-0.91% of base) : 20770.dasm - Microsoft.Cci.MetadataWriter:SerializeMethodBodies(System.Reflection.Metadata.BlobBuilder,Microsoft.Cci.PdbWriter,byref):System.Int32[]:this
          -8 (-1.80% of base) : 17571.dasm - System.IO.Pipelines.Pipe:GetFlushAsyncResult():System.IO.Pipelines.FlushResult:this
          -7 (-1.85% of base) : 19201.dasm - <CreateNestedTypes>d__126:MoveNext():bool:this
          -7 (-0.35% of base) : 12959.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,int,System.ReadOnlySpan`1[Byte],byref):bool:this
          -7 (-0.85% of base) : 21682.dasm - <DescendantNodesOnly>d__167:MoveNext():bool:this
          -6 (-1.01% of base) : 20590.dasm - <GetCustomAttributesToEmitIterator>d__10:MoveNext():bool:this
          -6 (-1.01% of base) : 20332.dasm - <AddedModulesResourceNames>d__200:MoveNext():bool:this
          -6 (-0.97% of base) : 20520.dasm - <Microsoft-Cci-ITypeDefinition-GetNestedTypes>d__70:MoveNext():bool:this
          -6 (-0.48% of base) : 9695.dasm - System.Numerics.BigNumber:NumberToBigInteger(byref,byref):bool
          -5 (-0.45% of base) : 11165.dasm - <SendAndProcessAltSvcAsync>d__76:MoveNext():this
          -5 (-1.75% of base) : 20469.dasm - <GetEventsToEmit>d__30:MoveNext():bool:this
          -5 (-1.11% of base) : 21790.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):ubyte
          -5 (-2.03% of base) : 19501.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax:get_Parameters():Microsoft.CodeAnalysis.SeparatedSyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.ParameterSyntax, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -5 (-2.18% of base) : 9689.dasm - System.Numerics.BigNumber:TryParseBigInteger(System.ReadOnlySpan`1[Char],int,System.Globalization.NumberFormatInfo,byref):bool
          -5 (-3.85% of base) : 19457.dasm - Microsoft.CodeAnalysis.SyntaxNode:TryGetEofAt(int,byref):bool:this

Top method regressions (percentages):
          31 (26.96% of base) : 18398.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          45 (19.31% of base) : 21824.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          32 (16.33% of base) : 18443.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          53 (12.71% of base) : 18275.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          10 ( 5.95% of base) : 15930.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
           8 ( 4.52% of base) : 12918.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this
           4 ( 4.49% of base) : 2856.dasm - System.Collections.Generic.LargeArrayBuilder`1[__Canon][System.__Canon]:.ctor(int):this
           4 ( 4.08% of base) : 1249.dasm - System.Collections.Generic.LargeArrayBuilder`1[Double][System.Double]:.ctor(int):this
           5 ( 4.00% of base) : 2854.dasm - System.Collections.Generic.SparseArrayBuilder`1[__Canon][System.__Canon]:.ctor(bool):this
          14 ( 3.15% of base) : 4545.dasm - AsyncStateMachineBox`1[__Canon,<ReceiveBlobAsync>d__174`1][System.__Canon,System.Net.Security.SslStream+<ReceiveBlobAsync>d__174`1[System.Net.Security.AsyncReadWriteAdapter]]:MoveNext(System.Threading.Thread):this
          17 ( 2.47% of base) : 3747.dasm - System.Security.Cryptography.Asn1.Pkcs12.PfxAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
           6 ( 1.87% of base) : 21912.dasm - Microsoft.CodeAnalysis.CSharp.PreciseAbstractFlowPass`1[LocalState][Microsoft.CodeAnalysis.CSharp.DataFlowPass+LocalState]:VisitMethodBodies(Microsoft.CodeAnalysis.CSharp.BoundBlock,Microsoft.CodeAnalysis.CSharp.BoundBlock):this
          11 ( 1.77% of base) : 23148.dasm - procfs:TryParseStatFile(System.String,byref):bool
          29 ( 1.76% of base) : 2549.dasm - <ReadAllAsync>d__29`1[SimpleStructWithProperties][MicroBenchmarks.Serializers.SimpleStructWithProperties]:MoveNext():this
          29 ( 1.75% of base) : 5058.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
           3 ( 1.73% of base) : 21936.dasm - Microsoft.CodeAnalysis.CSharp.AbstractRegionDataFlowPass:Scan(byref):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.PreciseAbstractFlowPass`1+PendingBranch[[Microsoft.CodeAnalysis.CSharp.DataFlowPass+LocalState, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          11 ( 1.30% of base) : 3855.dasm - System.Security.Cryptography.Asn1.Pkcs7.EncryptedDataAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
           2 ( 1.21% of base) : 20352.dasm - Microsoft.CodeAnalysis.SyntaxToken:get_LeadingTrivia():Microsoft.CodeAnalysis.SyntaxTriviaList:this
          54 ( 1.16% of base) : 13268.dasm - <WriteHeadersAsync>d__53:MoveNext():this
           2 ( 1.12% of base) : 20354.dasm - Enumerator:.ctor(byref):this

Top method improvements (percentages):
          -5 (-10.87% of base) : 2278.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          -2 (-6.45% of base) : 12992.dasm - System.ReadOnlySpan`1[__Canon][System.__Canon]:.ctor(System.__Canon[]):this
          -4 (-6.35% of base) : 16776.dasm - System.IO.Pipelines.PipeAwaitable:.ctor(bool,bool):this
          -4 (-5.80% of base) : 2553.dasm - System.Text.Json.JsonReaderState:.ctor(System.Text.Json.JsonReaderOptions):this
          -4 (-5.80% of base) : 4532.dasm - System.Net.Sockets.SocketAsyncContext:ReturnOperation(BufferMemoryReceiveOperation):this
          -4 (-5.71% of base) : 8270.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableHashSet`1+HashBucket[System.Int32]]:TryGetValue(int,byref):bool:this
          -4 (-5.63% of base) : 11793.dasm - System.Diagnostics.Enumerator`1[KeyValuePair`2][System.Collections.Generic.KeyValuePair`2[System.__Canon,System.__Canon]]:MoveNext():bool:this
          -4 (-4.88% of base) : 4719.dasm - System.IO.StreamBuffer:.ctor(int,int):this
          -4 (-4.88% of base) : 5027.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableDictionary`2+HashBucket[System.__Canon,System.__Canon]]:TryGetValue(int,byref):bool:this
          -5 (-3.85% of base) : 19457.dasm - Microsoft.CodeAnalysis.SyntaxNode:TryGetEofAt(int,byref):bool:this
         -11 (-3.70% of base) : 3731.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
          -4 (-3.67% of base) : 5514.dasm - ObjectEnumerator:get_Current():System.Text.Json.JsonProperty:this
          -2 (-3.64% of base) : 6374.dasm - Newtonsoft.Json.JsonSerializerSettings:.cctor()
          -4 (-3.51% of base) : 7402.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:MoveNextRare():bool:this
          -4 (-3.33% of base) : 21755.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax:get_Modifiers():Microsoft.CodeAnalysis.SyntaxTokenList:this
         -57 (-3.14% of base) : 21624.dasm - <DescendantTriviaOnly>d__170:MoveNext():bool:this
          -5 (-2.99% of base) : 4770.dasm - ResettableValueTaskSource:System.Threading.Tasks.Sources.IValueTaskSource.GetResult(short):this
          -4 (-2.99% of base) : 3381.dasm - System.IO.MemoryStream:TryGetBuffer(byref):bool:this
          -4 (-2.96% of base) : 256.dasm - Enumerator[HostSignal,__Canon][BenchmarkDotNet.Engines.HostSignal,System.__Canon]:MoveNext():bool:this
          -4 (-2.82% of base) : 21713.dasm - Microsoft.CodeAnalysis.SeparatedSyntaxList`1[__Canon][System.__Canon]:.ctor(Microsoft.CodeAnalysis.SyntaxNodeOrTokenList):this

225 total methods with Code Size differences (118 improved, 107 regressed), 8 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.benchmarks.run.windows.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 238917
Total bytes of diff: 239198
Total bytes of delta: 281 (0.12% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          53 : 17178.dasm (12.44% of base)
          45 : 20814.dasm (20.93% of base)
          36 : 10171.dasm (0.24% of base)
          34 : 6112.dasm (2.16% of base)
          32 : 17346.dasm (16.33% of base)
          32 : 6025.dasm (2.04% of base)
          31 : 17301.dasm (27.93% of base)
          18 : 20307.dasm (0.77% of base)
          18 : 21805.dasm (0.75% of base)
          16 : 6018.dasm (0.43% of base)
          16 : 6107.dasm (0.43% of base)
          13 : 10115.dasm (0.28% of base)
          11 : 18790.dasm (0.82% of base)
          10 : 14947.dasm (6.54% of base)
           8 : 6156.dasm (4.94% of base)
           8 : 20620.dasm (0.47% of base)
           7 : 16208.dasm (0.66% of base)
           7 : 16699.dasm (0.54% of base)
           7 : 21242.dasm (0.62% of base)
           7 : 13581.dasm (0.16% of base)

Top file improvements (bytes):
          -8 : 8799.dasm (-2.29% of base)
          -8 : 16719.dasm (-1.83% of base)
          -8 : 16714.dasm (-1.29% of base)
          -8 : 5735.dasm (-0.47% of base)
          -7 : 10103.dasm (-0.29% of base)
          -7 : 18139.dasm (-2.01% of base)
          -7 : 20678.dasm (-0.89% of base)
          -7 : 5740.dasm (-0.36% of base)
          -5 : 3881.dasm (-0.77% of base)
          -5 : 5760.dasm (-10.87% of base)
          -5 : 10101.dasm (-0.42% of base)
          -5 : 13438.dasm (-0.09% of base)
          -5 : 18701.dasm (-0.33% of base)
          -5 : 16275.dasm (-0.75% of base)
          -5 : 19273.dasm (-0.85% of base)
          -5 : 19531.dasm (-0.87% of base)
          -5 : 4643.dasm (-5.81% of base)
          -5 : 8036.dasm (-6.76% of base)
          -5 : 10161.dasm (-0.51% of base)
          -5 : 19461.dasm (-0.89% of base)

201 total files with Code Size differences (93 improved, 108 regressed), 9 unchanged.

Top method regressions (bytes):
          53 (12.44% of base) : 17178.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          45 (20.93% of base) : 20814.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          36 ( 0.24% of base) : 10171.dasm - <SendAsyncCore>d__57:MoveNext():this
          34 ( 2.16% of base) : 6112.dasm - <ReadAllAsync>d__29`1[Int32][System.Int32]:MoveNext():this
          32 (16.33% of base) : 17346.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          32 ( 2.04% of base) : 6025.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
          31 (27.93% of base) : 17301.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          18 ( 0.77% of base) : 20307.dasm - <ReadAsync>d__7:MoveNext():this
          18 ( 0.75% of base) : 21805.dasm - <ReadAsyncWithCancellationToken>d__11:MoveNext():this
          16 ( 0.43% of base) : 6018.dasm - <WriteAsyncCore>d__70`1[__Canon][System.__Canon]:MoveNext():this
          16 ( 0.43% of base) : 6107.dasm - <WriteAsyncCore>d__70`1[Int32][System.Int32]:MoveNext():this
          13 ( 0.28% of base) : 10115.dasm - <ConnectAsync>d__89:MoveNext():this
          11 ( 0.82% of base) : 18790.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BinaryOperatorOverloadResolution(int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag,byref,byref):Microsoft.CodeAnalysis.CSharp.BinaryOperatorAnalysisResult:this
          10 ( 6.54% of base) : 14947.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
           8 ( 4.94% of base) : 6156.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this
           8 ( 0.47% of base) : 20620.dasm - <DescendantTriviaOnly>d__170:MoveNext():bool:this
           7 ( 0.66% of base) : 16208.dasm - <SyncReadAsync>d__5:MoveNext():this
           7 ( 0.54% of base) : 16699.dasm - <ParallelReader>d__14:MoveNext():this
           7 ( 0.62% of base) : 21242.dasm - <SyncReadAsyncWithCancellationToken>d__9:MoveNext():this
           7 ( 0.16% of base) : 13581.dasm - <WriteHeadersAsync>d__53:MoveNext():this

Top method improvements (bytes):
          -8 (-2.29% of base) : 8799.dasm - <_Reverse>d__20`1[__Canon][System.__Canon]:MoveNext():bool:this
          -8 (-1.83% of base) : 16719.dasm - System.IO.Pipelines.Pipe:GetFlushAsyncResult():System.IO.Pipelines.FlushResult:this
          -8 (-1.29% of base) : 16714.dasm - System.IO.Pipelines.Pipe:GetReadAsyncResult():System.IO.Pipelines.ReadResult:this
          -8 (-0.47% of base) : 5735.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,System.ReadOnlySpan`1[Char],byref):bool:this
          -7 (-0.29% of base) : 10103.dasm - <DetermineVersionAndSendAsync>d__75:MoveNext():this
          -7 (-2.01% of base) : 18139.dasm - <CreateNestedTypes>d__126:MoveNext():bool:this
          -7 (-0.89% of base) : 20678.dasm - <DescendantNodesOnly>d__167:MoveNext():bool:this
          -7 (-0.36% of base) : 5740.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,int,System.ReadOnlySpan`1[Byte],byref):bool:this
          -5 (-0.77% of base) : 3881.dasm - System.Collections.Generic.Dictionary`2[__Canon,ChainItemInfo][System.__Canon,Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteChain+ChainItemInfo]:Remove(System.__Canon):bool:this
          -5 (-10.87% of base) : 5760.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          -5 (-0.42% of base) : 10101.dasm - <SendAndProcessAltSvcAsync>d__76:MoveNext():this
          -5 (-0.09% of base) : 13438.dasm - <ForceAuthenticationAsync>d__173`1[AsyncReadWriteAdapter][System.Net.Security.AsyncReadWriteAdapter]:MoveNext():this
          -5 (-0.33% of base) : 18701.dasm - Microsoft.CodeAnalysis.CSharp.MethodCompiler:BindMethodBody(Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,Microsoft.CodeAnalysis.CSharp.TypeCompilationState,Microsoft.CodeAnalysis.DiagnosticBag,byref,byref,byref):Microsoft.CodeAnalysis.CSharp.BoundBlock
          -5 (-0.75% of base) : 16275.dasm - System.Buffers.SequenceReader`1[Int32][System.Int32]:TryReadToInternal(byref,int,bool,int):bool:this
          -5 (-0.85% of base) : 19273.dasm - <AddedModulesResourceNames>d__200:MoveNext():bool:this
          -5 (-0.87% of base) : 19531.dasm - <GetCustomAttributesToEmitIterator>d__10:MoveNext():bool:this
          -5 (-5.81% of base) : 4643.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableDictionary`2+HashBucket[System.__Canon,System.__Canon]]:TryGetValue(int,byref):bool:this
          -5 (-6.76% of base) : 8036.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableHashSet`1+HashBucket[System.Int32]]:TryGetValue(int,byref):bool:this
          -5 (-0.51% of base) : 10161.dasm - <ConstructHttp11ConnectionAsync>d__94:MoveNext():this
          -5 (-0.89% of base) : 19461.dasm - <Microsoft-Cci-ITypeDefinition-GetNestedTypes>d__70:MoveNext():bool:this

Top method regressions (percentages):
          31 (27.93% of base) : 17301.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          45 (20.93% of base) : 20814.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          32 (16.33% of base) : 17346.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          53 (12.44% of base) : 17178.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          10 ( 6.54% of base) : 14947.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
           8 ( 4.94% of base) : 6156.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this
           4 ( 4.76% of base) : 1237.dasm - System.Collections.Generic.LargeArrayBuilder`1[__Canon][System.__Canon]:.ctor(int):this
           5 ( 4.13% of base) : 1905.dasm - System.Collections.Generic.SparseArrayBuilder`1[__Canon][System.__Canon]:.ctor(bool):this
           4 ( 4.00% of base) : 926.dasm - System.Collections.Generic.LargeArrayBuilder`1[Double][System.Double]:.ctor(int):this
           6 ( 3.17% of base) : 20925.dasm - Microsoft.CodeAnalysis.CSharp.AbstractRegionDataFlowPass:Scan(byref):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.PreciseAbstractFlowPass`1+PendingBranch[[Microsoft.CodeAnalysis.CSharp.DataFlowPass+LocalState, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          34 ( 2.16% of base) : 6112.dasm - <ReadAllAsync>d__29`1[Int32][System.Int32]:MoveNext():this
          32 ( 2.04% of base) : 6025.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
           6 ( 1.90% of base) : 20901.dasm - Microsoft.CodeAnalysis.CSharp.PreciseAbstractFlowPass`1[LocalState][Microsoft.CodeAnalysis.CSharp.DataFlowPass+LocalState]:VisitMethodBodies(Microsoft.CodeAnalysis.CSharp.BoundBlock,Microsoft.CodeAnalysis.CSharp.BoundBlock):this
           2 ( 1.23% of base) : 19293.dasm - Microsoft.CodeAnalysis.SyntaxToken:get_LeadingTrivia():Microsoft.CodeAnalysis.SyntaxTriviaList:this
           2 ( 1.11% of base) : 19295.dasm - Enumerator:.ctor(byref):this
           3 ( 1.06% of base) : 12894.dasm - System.Text.ValueStringBuilder:TryCopyTo(System.Span`1[Char],byref):bool:this
           4 ( 0.84% of base) : 9679.dasm - System.Diagnostics.ActivityCreationOptions`1[ActivityContext][System.Diagnostics.ActivityContext]:.ctor(System.Diagnostics.ActivitySource,System.String,System.Diagnostics.ActivityContext,int,System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],System.Collections.Generic.IEnumerable`1[ActivityLink],int):this
          11 ( 0.82% of base) : 18790.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BinaryOperatorOverloadResolution(int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag,byref,byref):Microsoft.CodeAnalysis.CSharp.BinaryOperatorAnalysisResult:this
           2 ( 0.79% of base) : 20633.dasm - Microsoft.CodeAnalysis.SyntaxToken:get_TrailingTrivia():Microsoft.CodeAnalysis.SyntaxTriviaList:this
          18 ( 0.77% of base) : 20307.dasm - <ReadAsync>d__7:MoveNext():this

Top method improvements (percentages):
          -5 (-10.87% of base) : 5760.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          -4 (-6.90% of base) : 16190.dasm - System.IO.Pipelines.PipeAwaitable:.ctor(bool,bool):this
          -5 (-6.76% of base) : 8036.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableHashSet`1+HashBucket[System.Int32]]:TryGetValue(int,byref):bool:this
          -4 (-6.06% of base) : 5707.dasm - System.Text.Json.JsonReaderState:.ctor(System.Text.Json.JsonReaderOptions):this
          -5 (-5.81% of base) : 4643.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket][System.Collections.Immutable.ImmutableDictionary`2+HashBucket[System.__Canon,System.__Canon]]:TryGetValue(int,byref):bool:this
          -4 (-5.19% of base) : 11583.dasm - System.Diagnostics.Enumerator`1[KeyValuePair`2][System.Collections.Generic.KeyValuePair`2[System.__Canon,System.__Canon]]:MoveNext():bool:this
          -4 (-4.40% of base) : 22410.dasm - System.IO.StreamBuffer:.ctor(int,int):this
          -4 (-3.64% of base) : 18397.dasm - Microsoft.CodeAnalysis.SyntaxNode:TryGetEofAt(int,byref):bool:this
          -4 (-3.64% of base) : 4631.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:MoveNextRare():bool:this
          -4 (-3.54% of base) : 20746.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax:get_Modifiers():Microsoft.CodeAnalysis.SyntaxTokenList:this
          -4 (-3.51% of base) : 22544.dasm - ObjectEnumerator:get_Current():System.Text.Json.JsonProperty:this
          -4 (-3.39% of base) : 2635.dasm - System.IO.MemoryStream:TryGetBuffer(byref):bool:this
          -1 (-3.12% of base) : 12722.dasm - System.ReadOnlySpan`1[__Canon][System.__Canon]:.ctor(System.__Canon[]):this
          -4 (-3.10% of base) : 20709.dasm - Microsoft.CodeAnalysis.SeparatedSyntaxList`1[__Canon][System.__Canon]:.ctor(Microsoft.CodeAnalysis.SyntaxNodeOrTokenList):this
          -2 (-3.08% of base) : 2677.dasm - Newtonsoft.Json.JsonSerializerSettings:.cctor()
          -2 (-3.03% of base) : 6374.dasm - Enumerator[Byte][System.Byte]:.ctor(byref):this
          -4 (-2.92% of base) : 163.dasm - Enumerator[HostSignal,__Canon][BenchmarkDotNet.Engines.HostSignal,System.__Canon]:MoveNext():bool:this
          -4 (-2.67% of base) : 17602.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax:get_Modifiers():Microsoft.CodeAnalysis.SyntaxTokenList:this
          -4 (-2.58% of base) : 22434.dasm - ResettableValueTaskSource:System.Threading.Tasks.Sources.IValueTaskSource.GetResult(short):this
          -2 (-2.50% of base) : 26139.dasm - System.ReadOnlySpan`1[__Canon][System.__Canon]:.ctor(System.__Canon[],int,int):this

201 total methods with Code Size differences (93 improved, 108 regressed), 9 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.benchmarks.run.windows.x86.checked**
```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 112368
Total bytes of diff: 112739
Total bytes of delta: 371 (0.33% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         120 : 5917.dasm (9.10% of base)
         117 : 6003.dasm (8.92% of base)
          50 : 19166.dasm (30.67% of base)
          32 : 15820.dasm (20.78% of base)
          30 : 15652.dasm (9.87% of base)
          21 : 5910.dasm (0.71% of base)
          21 : 5998.dasm (0.67% of base)
          20 : 9859.dasm (0.16% of base)
          15 : 9803.dasm (0.39% of base)
          15 : 17263.dasm (1.29% of base)
          15 : 19132.dasm (3.80% of base)
          15 : 15775.dasm (18.52% of base)
          12 : 13852.dasm (8.76% of base)
          12 : 6025.dasm (8.76% of base)
          10 : 8549.dasm (3.31% of base)
          10 : 9919.dasm (10.31% of base)
          10 : 12213.dasm (4.65% of base)
           9 : 9801.dasm (0.69% of base)
           8 : 10557.dasm (1.26% of base)
           8 : 18724.dasm (0.48% of base)

Top file improvements (bytes):
        -159 : 10200.dasm (-1.05% of base)
         -13 : 10059.dasm (-1.46% of base)
         -12 : 9728.dasm (-0.64% of base)
         -11 : 9365.dasm (-0.45% of base)
         -10 : 15813.dasm (-0.45% of base)
          -9 : 4256.dasm (-2.35% of base)
          -9 : 3086.dasm (-0.28% of base)
          -9 : 16821.dasm (-0.77% of base)
          -8 : 16393.dasm (-0.69% of base)
          -6 : 9691.dasm (-2.11% of base)
          -4 : 11800.dasm (-2.96% of base)
          -4 : 20570.dasm (-3.20% of base)
          -4 : 12761.dasm (-1.30% of base)
          -4 : 10238.dasm (-0.70% of base)
          -4 : 12038.dasm (-2.08% of base)
          -4 : 9734.dasm (-0.78% of base)
          -4 : 12111.dasm (-3.77% of base)
          -4 : 2583.dasm (-0.21% of base)
          -4 : 10380.dasm (-0.56% of base)
          -3 : 10107.dasm (-0.67% of base)

127 total files with Code Size differences (64 improved, 63 regressed), 1 unchanged.

Top method regressions (bytes):
         120 ( 9.10% of base) : 5917.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
         117 ( 8.92% of base) : 6003.dasm - <ReadAllAsync>d__29`1[Int32][System.Int32]:MoveNext():this
          50 (30.67% of base) : 19166.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          32 (20.78% of base) : 15820.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          30 ( 9.87% of base) : 15652.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          21 ( 0.71% of base) : 5910.dasm - <WriteAsyncCore>d__70`1[__Canon][System.__Canon]:MoveNext():this
          21 ( 0.67% of base) : 5998.dasm - <WriteAsyncCore>d__70`1[Int32][System.Int32]:MoveNext():this
          20 ( 0.16% of base) : 9859.dasm - <SendAsyncCore>d__57:MoveNext():this
          15 ( 0.39% of base) : 9803.dasm - <ConnectAsync>d__89:MoveNext():this
          15 ( 1.29% of base) : 17263.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BinaryOperatorOverloadResolution(int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag,byref,byref):Microsoft.CodeAnalysis.CSharp.BinaryOperatorAnalysisResult:this
          15 ( 3.80% of base) : 19132.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):ubyte
          15 (18.52% of base) : 15775.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          12 ( 8.76% of base) : 13852.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
          12 ( 8.76% of base) : 6025.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this
          10 ( 3.31% of base) : 8549.dasm - <_Reverse>d__20`1[__Canon][System.__Canon]:MoveNext():bool:this
          10 (10.31% of base) : 9919.dasm - System.Net.Http.HttpConnection:ConsumeReadAheadTask():System.Nullable`1[ValueTask`1]:this
          10 ( 4.65% of base) : 12213.dasm - System.Text.ValueStringBuilder:TryCopyTo(System.Span`1[Char],byref):bool:this
           9 ( 0.69% of base) : 9801.dasm - <CreateHttp11ConnectionAsync>d__91:MoveNext():this
           8 ( 1.26% of base) : 10557.dasm - System.Text.Json.Utf8JsonReader:ReadMultiSegment():bool:this
           8 ( 0.48% of base) : 18724.dasm - <ReadAsync>d__7:MoveNext():this

Top method improvements (bytes):
        -159 (-1.05% of base) : 10200.dasm - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -13 (-1.46% of base) : 10059.dasm - System.Diagnostics.StackTraceSymbols:GetSourceLineInfo(System.Reflection.Assembly,System.String,int,int,bool,int,int,int,int,byref,byref,byref):this
         -12 (-0.64% of base) : 9728.dasm - System.Net.Http.HttpWindowsProxy:GetMultiProxy(System.Uri):System.Net.Http.MultiProxy:this
         -11 (-0.45% of base) : 9365.dasm - System.Diagnostics.Perf_Activity:.cctor()
         -10 (-0.45% of base) : 15813.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.LanguageParser:ParseMemberName(byref,byref,byref,bool):this
          -9 (-2.35% of base) : 4256.dasm - FloatingPointInfo:.cctor()
          -9 (-0.28% of base) : 3086.dasm - Newtonsoft.Json.JsonWriter:WriteValue(Newtonsoft.Json.JsonWriter,int,System.Object)
          -9 (-0.77% of base) : 16821.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:CheckInterfaces(Microsoft.CodeAnalysis.DiagnosticBag):this
          -8 (-0.69% of base) : 16393.dasm - Microsoft.CodeAnalysis.CSharp.Imports:Validate():this
          -6 (-2.11% of base) : 9691.dasm - ILStubClass:IL_STUB_StructMarshal(byref,int,int,byref)
          -4 (-2.96% of base) : 11800.dasm - System.Numerics.Tests.Perf_Matrix3x2:CreateFromScalars():System.Numerics.Matrix3x2:this
          -4 (-3.20% of base) : 20570.dasm - MicroBenchmarks.Serializers.DataGenerator:CreateLargeStructWithProperties():MicroBenchmarks.Serializers.LargeStructWithProperties
          -4 (-1.30% of base) : 12761.dasm - System.Net.Security.SslStreamPal:QueryContextConnectionInfo(System.Net.Security.SafeDeleteContext,byref)
          -4 (-0.70% of base) : 10238.dasm - Enumerator:MoveNext():bool:this
          -4 (-2.08% of base) : 12038.dasm - System.Collections.Immutable.ImmutableHashSet`1[Int32][System.Int32]:GetEnumerator():Enumerator[Int32]:this
          -4 (-0.78% of base) : 9734.dasm - ILStubClass:IL_STUB_StructMarshal(byref,int,int,byref)
          -4 (-3.77% of base) : 12111.dasm - System.Diagnostics.DiagLinkedList`1[ActivityLink][System.Diagnostics.ActivityLink]:System.Collections.Generic.IEnumerable<T>.GetEnumerator():System.Collections.Generic.IEnumerator`1[ActivityLink]:this
          -4 (-0.21% of base) : 2583.dasm - System.Reflection.Emit.MethodBuilder:CreateMethodBodyHelper(System.Reflection.Emit.ILGenerator):this
          -4 (-0.56% of base) : 10380.dasm - System.TimeZoneInfo:.ctor(byref,bool):this
          -3 (-0.67% of base) : 10107.dasm - System.Reflection.PortableExecutable.PEReader:ReadDebugDirectoryEntries(System.Reflection.Metadata.BlobReader):System.Collections.Immutable.ImmutableArray`1[DebugDirectoryEntry]

Top method regressions (percentages):
          50 (30.67% of base) : 19166.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(ValueSet[__Canon,__Canon]):this
          32 (20.78% of base) : 15820.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          15 (18.52% of base) : 15775.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
           5 (10.42% of base) : 5652.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          10 (10.31% of base) : 9919.dasm - System.Net.Http.HttpConnection:ConsumeReadAheadTask():System.Nullable`1[ValueTask`1]:this
          30 ( 9.87% of base) : 15652.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
         120 ( 9.10% of base) : 5917.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
         117 ( 8.92% of base) : 6003.dasm - <ReadAllAsync>d__29`1[Int32][System.Int32]:MoveNext():this
          12 ( 8.76% of base) : 13852.dasm - Enumerator[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon]):this
          12 ( 8.76% of base) : 6025.dasm - Enumerator[__Canon,__Canon][System.__Canon,System.__Canon]:.ctor(System.Collections.Immutable.SortedInt32KeyNode`1[HashBucket],Builder[__Canon,__Canon]):this
           5 ( 8.06% of base) : 20459.dasm - System.IO.StreamBuffer:.ctor(int,int):this
           5 ( 7.14% of base) : 5597.dasm - System.Text.Json.JsonReaderState:.ctor(System.Text.Json.JsonReaderOptions):this
           5 ( 7.04% of base) : 19098.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax:get_Modifiers():Microsoft.CodeAnalysis.SyntaxTokenList:this
           7 ( 6.31% of base) : 1891.dasm - System.Collections.Generic.SparseArrayBuilder`1[__Canon][System.__Canon]:.ctor(bool):this
           5 ( 6.25% of base) : 16870.dasm - Microsoft.CodeAnalysis.SyntaxNode:TryGetEofAt(int,byref):bool:this
           4 ( 5.80% of base) : 921.dasm - System.Collections.Generic.LargeArrayBuilder`1[Double][System.Double]:.ctor(int):this
           4 ( 5.63% of base) : 1224.dasm - System.Collections.Generic.LargeArrayBuilder`1[__Canon][System.__Canon]:.ctor(int):this
           4 ( 4.94% of base) : 12112.dasm - System.Diagnostics.Enumerator`1[ActivityLink][System.Diagnostics.ActivityLink]:MoveNext():bool:this
           5 ( 4.90% of base) : 19061.dasm - Microsoft.CodeAnalysis.SeparatedSyntaxList`1[__Canon][System.__Canon]:.ctor(Microsoft.CodeAnalysis.SyntaxNodeOrTokenList):this
          10 ( 4.65% of base) : 12213.dasm - System.Text.ValueStringBuilder:TryCopyTo(System.Span`1[Char],byref):bool:this

Top method improvements (percentages):
          -4 (-3.77% of base) : 12111.dasm - System.Diagnostics.DiagLinkedList`1[ActivityLink][System.Diagnostics.ActivityLink]:System.Collections.Generic.IEnumerable<T>.GetEnumerator():System.Collections.Generic.IEnumerator`1[ActivityLink]:this
          -1 (-3.23% of base) : 19627.dasm - DecCalc:DebugPoison(byref)
          -4 (-3.20% of base) : 20570.dasm - MicroBenchmarks.Serializers.DataGenerator:CreateLargeStructWithProperties():MicroBenchmarks.Serializers.LargeStructWithProperties
          -4 (-2.96% of base) : 11800.dasm - System.Numerics.Tests.Perf_Matrix3x2:CreateFromScalars():System.Numerics.Matrix3x2:this
          -3 (-2.63% of base) : 23936.dasm - System.Numerics.Tests.Perf_Matrix3x2:LerpBenchmark():System.Numerics.Matrix3x2:this
          -9 (-2.35% of base) : 4256.dasm - FloatingPointInfo:.cctor()
          -3 (-2.19% of base) : 5494.dasm - System.Numerics.Matrix3x2:.cctor()
          -6 (-2.11% of base) : 9691.dasm - ILStubClass:IL_STUB_StructMarshal(byref,int,int,byref)
          -4 (-2.08% of base) : 12038.dasm - System.Collections.Immutable.ImmutableHashSet`1[Int32][System.Int32]:GetEnumerator():Enumerator[Int32]:this
          -3 (-1.63% of base) : 10114.dasm - System.Reflection.Internal.EnumerableExtensions:FirstOrDefault(System.Collections.Immutable.ImmutableArray`1[DebugDirectoryEntry],System.Func`2[DebugDirectoryEntry,Boolean]):System.Reflection.PortableExecutable.DebugDirectoryEntry
          -3 (-1.62% of base) : 18346.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddModule(int,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.GuidHandle,System.Reflection.Metadata.GuidHandle,System.Reflection.Metadata.GuidHandle):System.Reflection.Metadata.ModuleDefinitionHandle:this
          -3 (-1.55% of base) : 18265.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddAssembly(System.Reflection.Metadata.StringHandle,System.Version,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.BlobHandle,int,int):System.Reflection.Metadata.AssemblyDefinitionHandle:this
         -13 (-1.46% of base) : 10059.dasm - System.Diagnostics.StackTraceSymbols:GetSourceLineInfo(System.Reflection.Assembly,System.String,int,int,bool,int,int,int,int,byref,byref,byref):this
          -3 (-1.46% of base) : 18356.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddTypeDefinition(int,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.EntityHandle,System.Reflection.Metadata.FieldDefinitionHandle,System.Reflection.Metadata.MethodDefinitionHandle):System.Reflection.Metadata.TypeDefinitionHandle:this
          -3 (-1.45% of base) : 18256.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddAssemblyReference(System.Reflection.Metadata.StringHandle,System.Version,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.BlobHandle,int,System.Reflection.Metadata.BlobHandle):System.Reflection.Metadata.AssemblyReferenceHandle:this
          -3 (-1.40% of base) : 5993.dasm - System.Text.Json.JsonSerializer:WriteUsingMetadata(System.Text.Json.Utf8JsonWriter,byref,System.Text.Json.Serialization.Metadata.JsonTypeInfo)
          -3 (-1.32% of base) : 5842.dasm - System.Text.Json.JsonSerializer:WriteUsingMetadata(System.Text.Json.Utf8JsonWriter,byref,System.Text.Json.Serialization.Metadata.JsonTypeInfo)
          -4 (-1.30% of base) : 12761.dasm - System.Net.Security.SslStreamPal:QueryContextConnectionInfo(System.Net.Security.SafeDeleteContext,byref)
          -3 (-1.10% of base) : 23701.dasm - System.Numerics.Matrix3x2:Invert(System.Numerics.Matrix3x2,byref):bool
          -3 (-1.08% of base) : 23875.dasm - System.Collections.IterateForEach`1[Int32][System.Int32]:ImmutableHashSet():int:this

127 total methods with Code Size differences (64 improved, 63 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.Linux.arm.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 310
Total bytes of diff: 324
Total bytes of delta: 14 (4.52% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          14 : 252614.dasm (4.52% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          14 ( 4.52% of base) : 252614.dasm - Test.AA:Main():int

Top method regressions (percentages):
          14 ( 4.52% of base) : 252614.dasm - Test.AA:Main():int

1 total methods with Code Size differences (0 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.Linux.arm64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 360
Total bytes of diff: 372
Total bytes of delta: 12 (3.33% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 252330.dasm (3.33% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          12 ( 3.33% of base) : 252330.dasm - Test.AA:Main():int

Top method regressions (percentages):
          12 ( 3.33% of base) : 252330.dasm - Test.AA:Main():int

1 total methods with Code Size differences (0 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.Linux.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 16843
Total bytes of diff: 17063
Total bytes of delta: 220 (1.31% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         313 : 236060.dasm (25.30% of base)
          18 : 251256.dasm (5.00% of base)
           8 : 2849.dasm (1.66% of base)
           2 : 81547.dasm (0.23% of base)
           1 : 100211.dasm (0.16% of base)
           1 : 100218.dasm (0.13% of base)
           1 : 100225.dasm (0.16% of base)
           1 : 2747.dasm (0.07% of base)
           1 : 2764.dasm (0.11% of base)
           1 : 2708.dasm (0.50% of base)
           1 : 249588.dasm (0.40% of base)
           1 : 106.dasm (0.50% of base)

Top file improvements (bytes):
         -23 : 99991.dasm (-2.99% of base)
         -20 : 99992.dasm (-2.70% of base)
         -11 : 2817.dasm (-3.70% of base)
          -8 : 100245.dasm (-1.08% of base)
          -8 : 100237.dasm (-1.08% of base)
          -8 : 100253.dasm (-1.14% of base)
          -5 : 2677.dasm (-1.13% of base)
          -5 : 99671.dasm (-1.02% of base)
          -5 : 99668.dasm (-1.03% of base)
          -5 : 99669.dasm (-1.02% of base)
          -4 : 2839.dasm (-5.80% of base)
          -4 : 100231.dasm (-1.18% of base)
          -4 : 248830.dasm (-2.88% of base)
          -3 : 82986.dasm (-2.31% of base)
          -2 : 172.dasm (-0.49% of base)
          -2 : 223504.dasm (-2.04% of base)
          -2 : 223505.dasm (-2.13% of base)
          -2 : 223506.dasm (-2.02% of base)
          -2 : 223507.dasm (-2.11% of base)
          -2 : 249986.dasm (-1.96% of base)

35 total files with Code Size differences (23 improved, 12 regressed), 0 unchanged.

Top method regressions (bytes):
         313 (25.30% of base) : 236060.dasm - Test:Main():int
          18 ( 5.00% of base) : 251256.dasm - Test.AA:Main():int
           8 ( 1.66% of base) : 2849.dasm - AsyncStateMachineBox`1[Int32,<ReadAsyncCore>d__82][System.Int32,System.IO.Pipes.PipeStream+<ReadAsyncCore>d__82]:MoveNext(System.Threading.Thread):this
           2 ( 0.23% of base) : 81547.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object
           1 ( 0.16% of base) : 100211.dasm - <GetMethods>d__38:MoveNext():bool:this
           1 ( 0.13% of base) : 100218.dasm - <GetVirtualMethods>d__39:MoveNext():bool:this
           1 ( 0.16% of base) : 100225.dasm - <GetFields>d__44:MoveNext():bool:this
           1 ( 0.07% of base) : 2747.dasm - <ReadBufferAsync>d__16:MoveNext():this
           1 ( 0.11% of base) : 2764.dasm - <ReadAsyncCore>d__82:MoveNext():this
           1 ( 0.50% of base) : 2708.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           1 ( 0.40% of base) : 249588.dasm - Runtime_45557.ObjectBinder:.cctor()
           1 ( 0.50% of base) : 106.dasm - System.Text.ValueStringBuilder:ToString():System.String:this

Top method improvements (bytes):
         -23 (-2.99% of base) : 99991.dasm - ILVerify.Verifier:VerifyMethod(Internal.TypeSystem.Ecma.EcmaModule,Internal.IL.MethodIL,System.Reflection.Metadata.MethodDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
         -20 (-2.70% of base) : 99992.dasm - ILVerify.Verifier:VerifyType(Internal.TypeSystem.Ecma.EcmaModule,System.Reflection.Metadata.TypeDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
         -11 (-3.70% of base) : 2817.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
          -8 (-1.08% of base) : 100245.dasm - <GetDecodedCustomAttributes>d__4:MoveNext():bool:this
          -8 (-1.08% of base) : 100237.dasm - <GetDecodedCustomAttributes>d__2:MoveNext():bool:this
          -8 (-1.14% of base) : 100253.dasm - <GetDecodedCustomAttributes>d__5:MoveNext():bool:this
          -5 (-1.13% of base) : 2677.dasm - procfs:TryParseMapsEntry(System.String,byref):bool
          -5 (-1.02% of base) : 99671.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaField,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -5 (-1.03% of base) : 99668.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaType,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -5 (-1.02% of base) : 99669.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaMethod,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -4 (-5.80% of base) : 2839.dasm - System.Net.Sockets.SocketAsyncContext:ReturnOperation(BufferMemoryReceiveOperation):this
          -4 (-1.18% of base) : 100231.dasm - <GetNestedTypes>d__46:MoveNext():bool:this
          -4 (-2.88% of base) : 248830.dasm - Test.App:Main():int
          -3 (-2.31% of base) : 82986.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -2 (-0.49% of base) : 172.dasm - System.Text.SegmentStringBuilder:ToString():System.String:this
          -2 (-2.04% of base) : 223504.dasm - C`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.13% of base) : 223505.dasm - C`1[Byte][System.Byte]:.cctor()
          -2 (-2.02% of base) : 223506.dasm - S`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.11% of base) : 223507.dasm - S`1[Byte][System.Byte]:.cctor()
          -2 (-1.96% of base) : 249986.dasm - MS.VT:Main():int

Top method regressions (percentages):
         313 (25.30% of base) : 236060.dasm - Test:Main():int
          18 ( 5.00% of base) : 251256.dasm - Test.AA:Main():int
           8 ( 1.66% of base) : 2849.dasm - AsyncStateMachineBox`1[Int32,<ReadAsyncCore>d__82][System.Int32,System.IO.Pipes.PipeStream+<ReadAsyncCore>d__82]:MoveNext(System.Threading.Thread):this
           1 ( 0.50% of base) : 2708.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           1 ( 0.50% of base) : 106.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           1 ( 0.40% of base) : 249588.dasm - Runtime_45557.ObjectBinder:.cctor()
           2 ( 0.23% of base) : 81547.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object
           1 ( 0.16% of base) : 100211.dasm - <GetMethods>d__38:MoveNext():bool:this
           1 ( 0.16% of base) : 100225.dasm - <GetFields>d__44:MoveNext():bool:this
           1 ( 0.13% of base) : 100218.dasm - <GetVirtualMethods>d__39:MoveNext():bool:this
           1 ( 0.11% of base) : 2764.dasm - <ReadAsyncCore>d__82:MoveNext():this
           1 ( 0.07% of base) : 2747.dasm - <ReadBufferAsync>d__16:MoveNext():this

Top method improvements (percentages):
          -4 (-5.80% of base) : 2839.dasm - System.Net.Sockets.SocketAsyncContext:ReturnOperation(BufferMemoryReceiveOperation):this
         -11 (-3.70% of base) : 2817.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
         -23 (-2.99% of base) : 99991.dasm - ILVerify.Verifier:VerifyMethod(Internal.TypeSystem.Ecma.EcmaModule,Internal.IL.MethodIL,System.Reflection.Metadata.MethodDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -4 (-2.88% of base) : 248830.dasm - Test.App:Main():int
         -20 (-2.70% of base) : 99992.dasm - ILVerify.Verifier:VerifyType(Internal.TypeSystem.Ecma.EcmaModule,System.Reflection.Metadata.TypeDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -3 (-2.31% of base) : 82986.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -2 (-2.13% of base) : 223505.dasm - C`1[Byte][System.Byte]:.cctor()
          -2 (-2.11% of base) : 223507.dasm - S`1[Byte][System.Byte]:.cctor()
          -2 (-2.04% of base) : 223504.dasm - C`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.02% of base) : 223506.dasm - S`1[__Canon][System.__Canon]:.cctor()
          -2 (-1.96% of base) : 249986.dasm - MS.VT:Main():int
          -2 (-1.74% of base) : 252826.dasm - Test.BB:Main1()
          -4 (-1.18% of base) : 100231.dasm - <GetNestedTypes>d__46:MoveNext():bool:this
          -8 (-1.14% of base) : 100253.dasm - <GetDecodedCustomAttributes>d__5:MoveNext():bool:this
          -5 (-1.13% of base) : 2677.dasm - procfs:TryParseMapsEntry(System.String,byref):bool
          -8 (-1.08% of base) : 100245.dasm - <GetDecodedCustomAttributes>d__4:MoveNext():bool:this
          -8 (-1.08% of base) : 100237.dasm - <GetDecodedCustomAttributes>d__2:MoveNext():bool:this
          -5 (-1.03% of base) : 99668.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaType,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -5 (-1.02% of base) : 99671.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaField,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -5 (-1.02% of base) : 99669.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaMethod,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]

35 total methods with Code Size differences (23 improved, 12 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.windows.arm64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 712
Total bytes of diff: 724
Total bytes of delta: 12 (1.69% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 252607.dasm (3.33% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 1 unchanged.

Top method regressions (bytes):
          12 ( 3.33% of base) : 252607.dasm - Test.AA:Main():int

Top method regressions (percentages):
          12 ( 3.33% of base) : 252607.dasm - Test.AA:Main():int

1 total methods with Code Size differences (0 improved, 1 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.windows.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 15776
Total bytes of diff: 16023
Total bytes of delta: 247 (1.57% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         313 : 243625.dasm (24.80% of base)
          18 : 252923.dasm (5.23% of base)
           6 : 252939.dasm (1.50% of base)
           4 : 247129.dasm (0.69% of base)
           4 : 79943.dasm (0.54% of base)
           1 : 205.dasm (0.07% of base)
           1 : 54.dasm (0.55% of base)
           1 : 251142.dasm (0.40% of base)
           1 : 120.dasm (0.29% of base)
           1 : 167616.dasm (0.13% of base)

Top file improvements (bytes):
         -24 : 167391.dasm (-3.22% of base)
         -21 : 167392.dasm (-2.84% of base)
          -7 : 167651.dasm (-1.06% of base)
          -7 : 167635.dasm (-1.00% of base)
          -7 : 167643.dasm (-1.00% of base)
          -4 : 167070.dasm (-0.66% of base)
          -4 : 167629.dasm (-1.30% of base)
          -4 : 248477.dasm (-2.86% of base)
          -4 : 167071.dasm (-0.65% of base)
          -4 : 167073.dasm (-0.65% of base)
          -2 : 232668.dasm (-2.02% of base)
          -2 : 232669.dasm (-2.11% of base)
          -2 : 232666.dasm (-2.04% of base)
          -2 : 232667.dasm (-2.13% of base)
          -2 : 250583.dasm (-2.06% of base)
          -2 : 85464.dasm (-1.30% of base)
          -2 : 252945.dasm (-1.80% of base)
          -1 : 85417.dasm (-0.40% of base)
          -1 : 249086.dasm (-0.09% of base)
          -1 : 213.dasm (-0.22% of base)

30 total files with Code Size differences (20 improved, 10 regressed), 2 unchanged.

Top method regressions (bytes):
         313 (24.80% of base) : 243625.dasm - Test:Main():int
          18 ( 5.23% of base) : 252923.dasm - Test.AA:Main():int
           6 ( 1.50% of base) : 252939.dasm - Test.BB:Static1(byref)
           4 ( 0.69% of base) : 247129.dasm - Test:Main():int
           4 ( 0.54% of base) : 79943.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object
           1 ( 0.07% of base) : 205.dasm - <ReadBufferAsync>d__16:MoveNext():this
           1 ( 0.55% of base) : 54.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           1 ( 0.40% of base) : 251142.dasm - Runtime_45557.ObjectBinder:.cctor()
           1 ( 0.29% of base) : 120.dasm - System.Text.SegmentStringBuilder:ToString():System.String:this
           1 ( 0.13% of base) : 167616.dasm - <GetVirtualMethods>d__39:MoveNext():bool:this

Top method improvements (bytes):
         -24 (-3.22% of base) : 167391.dasm - ILVerify.Verifier:VerifyMethod(Internal.TypeSystem.Ecma.EcmaModule,Internal.IL.MethodIL,System.Reflection.Metadata.MethodDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
         -21 (-2.84% of base) : 167392.dasm - ILVerify.Verifier:VerifyType(Internal.TypeSystem.Ecma.EcmaModule,System.Reflection.Metadata.TypeDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -7 (-1.06% of base) : 167651.dasm - <GetDecodedCustomAttributes>d__5:MoveNext():bool:this
          -7 (-1.00% of base) : 167635.dasm - <GetDecodedCustomAttributes>d__2:MoveNext():bool:this
          -7 (-1.00% of base) : 167643.dasm - <GetDecodedCustomAttributes>d__4:MoveNext():bool:this
          -4 (-0.66% of base) : 167070.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaType,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -4 (-1.30% of base) : 167629.dasm - <GetNestedTypes>d__46:MoveNext():bool:this
          -4 (-2.86% of base) : 248477.dasm - Test.App:Main():int
          -4 (-0.65% of base) : 167071.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaMethod,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -4 (-0.65% of base) : 167073.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaField,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -2 (-2.02% of base) : 232668.dasm - S`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.11% of base) : 232669.dasm - S`1[Byte][System.Byte]:.cctor()
          -2 (-2.04% of base) : 232666.dasm - C`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.13% of base) : 232667.dasm - C`1[Byte][System.Byte]:.cctor()
          -2 (-2.06% of base) : 250583.dasm - MS.VT:Main():int
          -2 (-1.30% of base) : 85464.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -2 (-1.80% of base) : 252945.dasm - Test.BB:Main1()
          -1 (-0.40% of base) : 85417.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -1 (-0.09% of base) : 249086.dasm - <Main>d__0:MoveNext():this
          -1 (-0.22% of base) : 213.dasm - AsyncStateMachineBox`1[VoidTaskResult,<ReadBufferAsync>d__16][System.Threading.Tasks.VoidTaskResult,System.Diagnostics.AsyncStreamReader+<ReadBufferAsync>d__16]:MoveNext(System.Threading.Thread):this

Top method regressions (percentages):
         313 (24.80% of base) : 243625.dasm - Test:Main():int
          18 ( 5.23% of base) : 252923.dasm - Test.AA:Main():int
           6 ( 1.50% of base) : 252939.dasm - Test.BB:Static1(byref)
           4 ( 0.69% of base) : 247129.dasm - Test:Main():int
           1 ( 0.55% of base) : 54.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           4 ( 0.54% of base) : 79943.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object
           1 ( 0.40% of base) : 251142.dasm - Runtime_45557.ObjectBinder:.cctor()
           1 ( 0.29% of base) : 120.dasm - System.Text.SegmentStringBuilder:ToString():System.String:this
           1 ( 0.13% of base) : 167616.dasm - <GetVirtualMethods>d__39:MoveNext():bool:this
           1 ( 0.07% of base) : 205.dasm - <ReadBufferAsync>d__16:MoveNext():this

Top method improvements (percentages):
         -24 (-3.22% of base) : 167391.dasm - ILVerify.Verifier:VerifyMethod(Internal.TypeSystem.Ecma.EcmaModule,Internal.IL.MethodIL,System.Reflection.Metadata.MethodDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -4 (-2.86% of base) : 248477.dasm - Test.App:Main():int
         -21 (-2.84% of base) : 167392.dasm - ILVerify.Verifier:VerifyType(Internal.TypeSystem.Ecma.EcmaModule,System.Reflection.Metadata.TypeDefinitionHandle):System.Collections.Generic.IEnumerable`1[[ILVerify.VerificationResult, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -2 (-2.13% of base) : 232667.dasm - C`1[Byte][System.Byte]:.cctor()
          -2 (-2.11% of base) : 232669.dasm - S`1[Byte][System.Byte]:.cctor()
          -2 (-2.06% of base) : 250583.dasm - MS.VT:Main():int
          -2 (-2.04% of base) : 232666.dasm - C`1[__Canon][System.__Canon]:.cctor()
          -2 (-2.02% of base) : 232668.dasm - S`1[__Canon][System.__Canon]:.cctor()
          -2 (-1.80% of base) : 252945.dasm - Test.BB:Main1()
          -4 (-1.30% of base) : 167629.dasm - <GetNestedTypes>d__46:MoveNext():bool:this
          -2 (-1.30% of base) : 85464.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -7 (-1.06% of base) : 167651.dasm - <GetDecodedCustomAttributes>d__5:MoveNext():bool:this
          -7 (-1.00% of base) : 167635.dasm - <GetDecodedCustomAttributes>d__2:MoveNext():bool:this
          -7 (-1.00% of base) : 167643.dasm - <GetDecodedCustomAttributes>d__4:MoveNext():bool:this
          -4 (-0.66% of base) : 167070.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaType,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -4 (-0.65% of base) : 167071.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaMethod,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -4 (-0.65% of base) : 167073.dasm - Internal.TypeSystem.Ecma.MetadataExtensions:GetDecodedCustomAttribute(Internal.TypeSystem.Ecma.EcmaField,System.String,System.String):System.Nullable`1[[System.Reflection.Metadata.CustomAttributeValue`1[[Internal.TypeSystem.TypeDesc, ILVerification.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -1 (-0.40% of base) : 85417.dasm - JitTest.LargeVT:callee(int):JitTest.LargeVT
          -1 (-0.22% of base) : 213.dasm - AsyncStateMachineBox`1[VoidTaskResult,<ReadBufferAsync>d__16][System.Threading.Tasks.VoidTaskResult,System.Diagnostics.AsyncStreamReader+<ReadBufferAsync>d__16]:MoveNext(System.Threading.Thread):this
          -1 (-0.09% of base) : 249086.dasm - <Main>d__0:MoveNext():this

30 total methods with Code Size differences (20 improved, 10 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.coreclr_tests.pmi.windows.x86.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 570111
Total bytes of diff: 567840
Total bytes of delta: -2271 (-0.40% of base)
    diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         399 : 243251.dasm (35.91% of base)
          37 : 252524.dasm (12.21% of base)
           8 : 252508.dasm (3.08% of base)
           5 : 53.dasm (3.65% of base)
           5 : 248102.dasm (5.88% of base)
           5 : 250733.dasm (2.75% of base)
           4 : 79939.dasm (0.60% of base)
           4 : 209.dasm (1.12% of base)

Top file improvements (bytes):
        -216 : 218532.dasm (-1.70% of base)
        -216 : 218124.dasm (-1.68% of base)
        -210 : 218559.dasm (-1.69% of base)
        -210 : 218213.dasm (-1.67% of base)
        -183 : 194692.dasm (-2.63% of base)
        -171 : 226799.dasm (-2.44% of base)
        -100 : 134036.dasm (-0.16% of base)
        -100 : 131334.dasm (-0.16% of base)
         -95 : 232576.dasm (-1.11% of base)
         -89 : 226856.dasm (-1.15% of base)
         -89 : 225802.dasm (-1.04% of base)
         -83 : 225741.dasm (-0.98% of base)
         -77 : 226875.dasm (-1.02% of base)
         -54 : 225270.dasm (-2.64% of base)
         -54 : 225262.dasm (-2.60% of base)
         -39 : 218095.dasm (-3.83% of base)
         -39 : 232598.dasm (-3.93% of base)
         -39 : 226777.dasm (-3.85% of base)
         -39 : 225714.dasm (-3.93% of base)
         -39 : 218525.dasm (-3.83% of base)

162 total files with Code Size differences (154 improved, 8 regressed), 0 unchanged.

Top method regressions (bytes):
         399 (35.91% of base) : 243251.dasm - Test:Main():int
          37 (12.21% of base) : 252524.dasm - Test.BB:Static1(byref)
           8 ( 3.08% of base) : 252508.dasm - Test.AA:Main():int
           5 ( 3.65% of base) : 53.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           5 ( 5.88% of base) : 248102.dasm - Test.App:Main():int
           5 ( 2.75% of base) : 250733.dasm - Runtime_45557.ObjectBinder:.cctor()
           4 ( 0.60% of base) : 79939.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object
           4 ( 1.12% of base) : 209.dasm - AsyncStateMachineBox`1[VoidTaskResult,<ReadBufferAsync>d__16][System.Threading.Tasks.VoidTaskResult,System.Diagnostics.AsyncStreamReader+<ReadBufferAsync>d__16]:MoveNext(System.Threading.Thread):this

Top method improvements (bytes):
        -216 (-1.70% of base) : 218532.dasm - TestApp:Main():int
        -216 (-1.68% of base) : 218124.dasm - TestApp:Main():int
        -210 (-1.69% of base) : 218559.dasm - TestApp:Main():int
        -210 (-1.67% of base) : 218213.dasm - TestApp:Main():int
        -183 (-2.63% of base) : 194692.dasm - testout1:.cctor()
        -171 (-2.44% of base) : 226799.dasm - TestApp:Main():int
        -100 (-0.16% of base) : 134036.dasm - testout1:.cctor()
        -100 (-0.16% of base) : 131334.dasm - testout1:.cctor()
         -95 (-1.11% of base) : 232576.dasm - TestApp:Main():int
         -89 (-1.15% of base) : 226856.dasm - TestApp:Main():int
         -89 (-1.04% of base) : 225802.dasm - TestApp:Main():int
         -83 (-0.98% of base) : 225741.dasm - TestApp:Main():int
         -77 (-1.02% of base) : 226875.dasm - TestApp:Main():int
         -54 (-2.64% of base) : 225270.dasm - IntelHardwareIntrinsicTest.Program:.cctor()
         -54 (-2.60% of base) : 225262.dasm - IntelHardwareIntrinsicTest.Program:.cctor()
         -39 (-3.83% of base) : 218095.dasm - AA:reset()
         -39 (-3.93% of base) : 232598.dasm - AA:reset()
         -39 (-3.85% of base) : 226777.dasm - AA:reset()
         -39 (-3.93% of base) : 225714.dasm - AA:reset()
         -39 (-3.83% of base) : 218525.dasm - AA:reset()

Top method regressions (percentages):
         399 (35.91% of base) : 243251.dasm - Test:Main():int
          37 (12.21% of base) : 252524.dasm - Test.BB:Static1(byref)
           5 ( 5.88% of base) : 248102.dasm - Test.App:Main():int
           5 ( 3.65% of base) : 53.dasm - System.Text.ValueStringBuilder:ToString():System.String:this
           8 ( 3.08% of base) : 252508.dasm - Test.AA:Main():int
           5 ( 2.75% of base) : 250733.dasm - Runtime_45557.ObjectBinder:.cctor()
           4 ( 1.12% of base) : 209.dasm - AsyncStateMachineBox`1[VoidTaskResult,<ReadBufferAsync>d__16][System.Threading.Tasks.VoidTaskResult,System.Diagnostics.AsyncStreamReader+<ReadBufferAsync>d__16]:MoveNext(System.Threading.Thread):this
           4 ( 0.60% of base) : 79939.dasm - SinCalc.SinCalc:mySin(System.Object):System.Object

Top method improvements (percentages):
          -3 (-13.04% of base) : 81000.dasm - S1:.ctor(int):this
          -3 (-9.68% of base) : 81017.dasm - S24:.ctor(int,S4):this
          -6 (-8.96% of base) : 252470.dasm - DefaultNamespace.jitBug:Main(System.String[]):int
          -3 (-6.52% of base) : 81018.dasm - S24W:.ctor(S24):this
          -3 (-5.88% of base) : 81342.dasm - Runtime_39403:TestLclVarAddr():System.Numerics.Vector`1[Int32]
          -6 (-5.45% of base) : 251763.dasm - TestReadIntAsDouble:Main():int
          -6 (-4.35% of base) : 81080.dasm - GitHub_19256:.cctor()
          -3 (-4.11% of base) : 81171.dasm - Program:Main():int
         -39 (-3.93% of base) : 232598.dasm - AA:reset()
         -39 (-3.93% of base) : 225714.dasm - AA:reset()
         -39 (-3.85% of base) : 226777.dasm - AA:reset()
         -39 (-3.83% of base) : 218095.dasm - AA:reset()
         -39 (-3.83% of base) : 218525.dasm - AA:reset()
          -4 (-3.81% of base) : 232804.dasm - RefInst:SMi(int,byref):S:this
          -4 (-3.77% of base) : 232820.dasm - RefStat:SMi(int,byref):S
          -4 (-3.57% of base) : 232823.dasm - RefStat:oMi(int,byref):System.Object
          -4 (-3.57% of base) : 232822.dasm - RefStat:IMi(int,byref):I
          -4 (-3.42% of base) : 232807.dasm - RefInst:oMi(int,byref):System.Object:this
          -4 (-3.42% of base) : 232806.dasm - RefInst:IMi(int,byref):I:this
          -7 (-3.08% of base) : 232805.dasm - RefInst:NSMi(int,byref):System.Nullable`1[S]:this

162 total methods with Code Size differences (154 improved, 8 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.crossgen2.Linux.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 21222
Total bytes of diff: 21313
Total bytes of delta: 91 (0.43% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 2937.dasm (1.12% of base)
          11 : 1259.dasm (0.71% of base)
           9 : 3622.dasm (0.49% of base)
           9 : 1307.dasm (0.90% of base)
           6 : 1302.dasm (0.71% of base)
           5 : 1630.dasm (0.60% of base)
           5 : 815.dasm (1.66% of base)
           3 : 3971.dasm (0.50% of base)
           3 : 658.dasm (8.82% of base)
           3 : 3627.dasm (0.28% of base)
           3 : 3992.dasm (0.49% of base)
           3 : 727.dasm (5.56% of base)
           3 : 1628.dasm (0.55% of base)
           3 : 1634.dasm (0.62% of base)
           3 : 1662.dasm (0.40% of base)
           3 : 2935.dasm (0.77% of base)
           3 : 3512.dasm (2.59% of base)
           3 : 3985.dasm (0.39% of base)
           1 : 1148.dasm (0.18% of base)
           1 : 863.dasm (0.13% of base)

Top file improvements (bytes):
          -2 : 1201.dasm (-0.41% of base)

22 total files with Code Size differences (1 improved, 21 regressed), 8 unchanged.

Top method regressions (bytes):
          12 ( 1.12% of base) : 2937.dasm - <DisposeAsync>d__15:MoveNext():this
          11 ( 0.71% of base) : 1259.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this
           9 ( 0.49% of base) : 3622.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this
           9 ( 0.90% of base) : 1307.dasm - <RunAsync>d__4:MoveNext():this
           6 ( 0.71% of base) : 1302.dasm - <WaitForShutdownAsync>d__5:MoveNext():this
           5 ( 0.60% of base) : 1630.dasm - <WriteAsync>d__21:MoveNext():this
           5 ( 1.66% of base) : 815.dasm - <get_Values>d__26:MoveNext():bool:this
           3 ( 0.50% of base) : 3971.dasm - <GetOrCreateAsync>d__9`1:MoveNext():this
           3 ( 8.82% of base) : 658.dasm - TemporaryStringBuilder:.ctor(int):this
           3 ( 0.28% of base) : 3627.dasm - <<ForEachAsync>b__50_0>d:MoveNext():this
           3 ( 0.49% of base) : 3992.dasm - <SendAsync>d__5:MoveNext():this
           3 ( 5.56% of base) : 727.dasm - System.Collections.Generic.ArrayBuilder`1:.ctor(int):this
           3 ( 0.55% of base) : 1628.dasm - <WriteAsync>d__24:MoveNext():this
           3 ( 0.62% of base) : 1634.dasm - <ReadAsync>d__14:MoveNext():this
           3 ( 0.40% of base) : 1662.dasm - <IterateAsync>d__5:MoveNext():this
           3 ( 0.77% of base) : 2935.dasm - <<DisposeAsync>g__DisposeAsync|15_0>d:MoveNext():this
           3 ( 2.59% of base) : 3512.dasm - Enumerator:.ctor(byref):this
           3 ( 0.39% of base) : 3985.dasm - <SendAsync>d__5:MoveNext():this
           1 ( 0.18% of base) : 1148.dasm - <GetNestedTypesCore>d__5:MoveNext():bool:this
           1 ( 0.13% of base) : 863.dasm - <ExecuteFilter>d__4:MoveNext():bool:this

Top method improvements (bytes):
          -2 (-0.41% of base) : 1201.dasm - <ToTrueCustomAttributes>d__0:MoveNext():bool:this

Top method regressions (percentages):
           3 ( 8.82% of base) : 658.dasm - TemporaryStringBuilder:.ctor(int):this
           3 ( 5.56% of base) : 727.dasm - System.Collections.Generic.ArrayBuilder`1:.ctor(int):this
           3 ( 2.59% of base) : 3512.dasm - Enumerator:.ctor(byref):this
           5 ( 1.66% of base) : 815.dasm - <get_Values>d__26:MoveNext():bool:this
          12 ( 1.12% of base) : 2937.dasm - <DisposeAsync>d__15:MoveNext():this
           9 ( 0.90% of base) : 1307.dasm - <RunAsync>d__4:MoveNext():this
           3 ( 0.77% of base) : 2935.dasm - <<DisposeAsync>g__DisposeAsync|15_0>d:MoveNext():this
           6 ( 0.71% of base) : 1302.dasm - <WaitForShutdownAsync>d__5:MoveNext():this
          11 ( 0.71% of base) : 1259.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this
           3 ( 0.62% of base) : 1634.dasm - <ReadAsync>d__14:MoveNext():this
           5 ( 0.60% of base) : 1630.dasm - <WriteAsync>d__21:MoveNext():this
           3 ( 0.55% of base) : 1628.dasm - <WriteAsync>d__24:MoveNext():this
           3 ( 0.50% of base) : 3971.dasm - <GetOrCreateAsync>d__9`1:MoveNext():this
           9 ( 0.49% of base) : 3622.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this
           3 ( 0.49% of base) : 3992.dasm - <SendAsync>d__5:MoveNext():this
           3 ( 0.40% of base) : 1662.dasm - <IterateAsync>d__5:MoveNext():this
           3 ( 0.39% of base) : 3985.dasm - <SendAsync>d__5:MoveNext():this
           3 ( 0.28% of base) : 3627.dasm - <<ForEachAsync>b__50_0>d:MoveNext():this
           1 ( 0.22% of base) : 1507.dasm - <<BeginSendRequest>g__ResponseCallback|43_0>d:MoveNext():this
           1 ( 0.18% of base) : 1148.dasm - <GetNestedTypesCore>d__5:MoveNext():bool:this

Top method improvements (percentages):
          -2 (-0.41% of base) : 1201.dasm - <ToTrueCustomAttributes>d__0:MoveNext():bool:this

22 total methods with Code Size differences (1 improved, 21 regressed), 8 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.crossgen2.windows.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 24095
Total bytes of diff: 24235
Total bytes of delta: 140 (0.58% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 1202.dasm (1.45% of base)
          11 : 1350.dasm (0.74% of base)
           9 : 1662.dasm (1.31% of base)
           9 : 2607.dasm (1.11% of base)
           9 : 667.dasm (0.56% of base)
           6 : 2602.dasm (0.78% of base)
           6 : 1124.dasm (0.77% of base)
           5 : 1681.dasm (0.95% of base)
           5 : 1656.dasm (0.44% of base)
           5 : 1235.dasm (1.70% of base)
           5 : 570.dasm (0.69% of base)
           4 : 1326.dasm (0.28% of base)
           3 : 581.dasm (10.34% of base)
           3 : 2304.dasm (5.45% of base)
           3 : 672.dasm (0.32% of base)
           3 : 2793.dasm (0.42% of base)
           3 : 1126.dasm (0.54% of base)
           3 : 2538.dasm (0.53% of base)
           3 : 1444.dasm (2.91% of base)
           3 : 340.dasm (7.14% of base)

36 total files with Code Size differences (0 improved, 36 regressed), 3 unchanged.

Top method regressions (bytes):
          12 ( 1.45% of base) : 1202.dasm - <DisposeAsync>d__15:MoveNext():this
          11 ( 0.74% of base) : 1350.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this
           9 ( 1.31% of base) : 1662.dasm - System.Security.Cryptography.Asn1.SubjectPublicKeyInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           9 ( 1.11% of base) : 2607.dasm - <RunAsync>d__4:MoveNext():this
           9 ( 0.56% of base) : 667.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this
           6 ( 0.78% of base) : 2602.dasm - <WaitForShutdownAsync>d__5:MoveNext():this
           6 ( 0.77% of base) : 1124.dasm - <GetAddressAndSendAsync>d__53:MoveNext():this
           5 ( 0.95% of base) : 1681.dasm - System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           5 ( 0.44% of base) : 1656.dasm - System.Security.Cryptography.Asn1.X509ExtensionAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           5 ( 1.70% of base) : 1235.dasm - <get_Values>d__26:MoveNext():bool:this
           5 ( 0.69% of base) : 570.dasm - <WriteAsync>d__21:MoveNext():this
           4 ( 0.28% of base) : 1326.dasm - <ReadAsyncCore>d__24:MoveNext():this
           3 (10.34% of base) : 581.dasm - System.Net.Quic.Implementations.Mock.MockStream:ShutdownCompleted(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask:this
           3 ( 5.45% of base) : 2304.dasm - System.Collections.Generic.ArrayBuilder`1:.ctor(int):this
           3 ( 0.32% of base) : 672.dasm - <<ForEachAsync>b__50_0>d:MoveNext():this
           3 ( 0.42% of base) : 2793.dasm - <SendAsync>d__5:MoveNext():this
           3 ( 0.54% of base) : 1126.dasm - <SendPingAsyncInternal>d__49:MoveNext():this
           3 ( 0.53% of base) : 2538.dasm - <GetOrCreateAsync>d__9`1:MoveNext():this
           3 ( 2.91% of base) : 1444.dasm - PERF_INSTANCE_DEFINITION:GetName(byref,System.ReadOnlySpan`1[System.Byte]):System.ReadOnlySpan`1[System.Char]
           3 ( 7.14% of base) : 340.dasm - TemporaryStringBuilder:.ctor(int):this

Top method regressions (percentages):
           3 (10.34% of base) : 581.dasm - System.Net.Quic.Implementations.Mock.MockStream:ShutdownCompleted(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask:this
           3 ( 7.14% of base) : 340.dasm - TemporaryStringBuilder:.ctor(int):this
           3 ( 6.38% of base) : 577.dasm - System.Net.Quic.Implementations.Mock.MockStream:DisposeAsync():System.Threading.Tasks.ValueTask:this
           3 ( 5.45% of base) : 2304.dasm - System.Collections.Generic.ArrayBuilder`1:.ctor(int):this
           3 ( 4.92% of base) : 811.dasm - Enumerator:.ctor(byref):this
           3 ( 2.91% of base) : 1444.dasm - PERF_INSTANCE_DEFINITION:GetName(byref,System.ReadOnlySpan`1[System.Byte]):System.ReadOnlySpan`1[System.Char]
           5 ( 1.70% of base) : 1235.dasm - <get_Values>d__26:MoveNext():bool:this
          12 ( 1.45% of base) : 1202.dasm - <DisposeAsync>d__15:MoveNext():this
           9 ( 1.31% of base) : 1662.dasm - System.Security.Cryptography.Asn1.SubjectPublicKeyInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           9 ( 1.11% of base) : 2607.dasm - <RunAsync>d__4:MoveNext():this
           5 ( 0.95% of base) : 1681.dasm - System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           3 ( 0.91% of base) : 1200.dasm - <<DisposeAsync>g__DisposeAsync|15_0>d:MoveNext():this
           6 ( 0.78% of base) : 2602.dasm - <WaitForShutdownAsync>d__5:MoveNext():this
           6 ( 0.77% of base) : 1124.dasm - <GetAddressAndSendAsync>d__53:MoveNext():this
          11 ( 0.74% of base) : 1350.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this
           5 ( 0.69% of base) : 570.dasm - <WriteAsync>d__21:MoveNext():this
           3 ( 0.68% of base) : 575.dasm - <ReadAsync>d__14:MoveNext():this
           3 ( 0.64% of base) : 568.dasm - <WriteAsync>d__24:MoveNext():this
           9 ( 0.56% of base) : 667.dasm - <<ForEachAsync>b__54_0>d:MoveNext():this
           3 ( 0.54% of base) : 1126.dasm - <SendPingAsyncInternal>d__49:MoveNext():this

36 total methods with Code Size differences (0 improved, 36 regressed), 3 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.crossgen2.windows.x86.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 5310
Total bytes of diff: 5358
Total bytes of delta: 48 (0.90% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 2706.dasm (3.05% of base)
          12 : 1350.dasm (1.74% of base)
           6 : 2700.dasm (0.73% of base)
           6 : 88.dasm (0.96% of base)
           6 : 3526.dasm (2.61% of base)
           6 : 2725.dasm (1.79% of base)
           5 : 260.dasm (0.30% of base)

Top file improvements (bytes):
          -3 : 1235.dasm (-5.88% of base)
          -1 : 3156.dasm (-0.31% of base)
          -1 : 341.dasm (-0.51% of base)

10 total files with Code Size differences (3 improved, 7 regressed), 0 unchanged.

Top method regressions (bytes):
          12 ( 3.05% of base) : 2706.dasm - System.Security.Cryptography.Asn1.SubjectPublicKeyInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
          12 ( 1.74% of base) : 1350.dasm - <Merge>d__1:MoveNext():bool:this
           6 ( 0.73% of base) : 2700.dasm - System.Security.Cryptography.Asn1.X509ExtensionAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           6 ( 0.96% of base) : 88.dasm - <ExecuteFilter>d__4:MoveNext():bool:this
           6 ( 2.61% of base) : 3526.dasm - <get_Values>d__26:MoveNext():bool:this
           6 ( 1.79% of base) : 2725.dasm - System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           5 ( 0.30% of base) : 260.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this

Top method improvements (bytes):
          -3 (-5.88% of base) : 1235.dasm - Microsoft.Diagnostics.Tracing.Extensions.ETWKernelControl:IsWin8orNewer():bool
          -1 (-0.31% of base) : 3156.dasm - System.Net.NameResolutionPal:GetAddrInfoAsync(System.String,bool,int,System.Threading.CancellationToken):System.Threading.Tasks.Task
          -1 (-0.51% of base) : 341.dasm - Internal.Runtime.InteropServices.ComActivationContext:Create(byref):Internal.Runtime.InteropServices.ComActivationContext

Top method regressions (percentages):
          12 ( 3.05% of base) : 2706.dasm - System.Security.Cryptography.Asn1.SubjectPublicKeyInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           6 ( 2.61% of base) : 3526.dasm - <get_Values>d__26:MoveNext():bool:this
           6 ( 1.79% of base) : 2725.dasm - System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
          12 ( 1.74% of base) : 1350.dasm - <Merge>d__1:MoveNext():bool:this
           6 ( 0.96% of base) : 88.dasm - <ExecuteFilter>d__4:MoveNext():bool:this
           6 ( 0.73% of base) : 2700.dasm - System.Security.Cryptography.Asn1.X509ExtensionAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[System.Byte],byref)
           5 ( 0.30% of base) : 260.dasm - <ParsePgoData>d__6`1:MoveNext():bool:this

Top method improvements (percentages):
          -3 (-5.88% of base) : 1235.dasm - Microsoft.Diagnostics.Tracing.Extensions.ETWKernelControl:IsWin8orNewer():bool
          -1 (-0.51% of base) : 341.dasm - Internal.Runtime.InteropServices.ComActivationContext:Create(byref):Internal.Runtime.InteropServices.ComActivationContext
          -1 (-0.31% of base) : 3156.dasm - System.Net.NameResolutionPal:GetAddrInfoAsync(System.String,bool,int,System.Threading.CancellationToken):System.Threading.Tasks.Task

10 total methods with Code Size differences (3 improved, 7 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.pmi.Linux.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1679335
Total bytes of diff: 1680305
Total bytes of delta: 970 (0.06% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          87 : 73382.dasm (4.11% of base)
          55 : 34699.dasm (1.14% of base)
          53 : 73955.dasm (12.71% of base)
          48 : 8882.dasm (11.11% of base)
          48 : 8886.dasm (11.03% of base)
          42 : 64503.dasm (5.11% of base)
          37 : 34706.dasm (0.23% of base)
          32 : 73928.dasm (17.78% of base)
          31 : 73947.dasm (27.19% of base)
          29 : 73373.dasm (23.58% of base)
          29 : 73374.dasm (31.52% of base)
          29 : 73375.dasm (38.16% of base)
          29 : 73387.dasm (13.12% of base)
          29 : 73388.dasm (13.12% of base)
          29 : 110769.dasm (1.75% of base)
          29 : 110771.dasm (1.72% of base)
          29 : 73389.dasm (4.52% of base)
          29 : 73395.dasm (6.17% of base)
          29 : 73396.dasm (7.51% of base)
          29 : 73397.dasm (6.22% of base)

Top file improvements (bytes):
         -54 : 7835.dasm (-2.99% of base)
         -45 : 61040.dasm (-1.01% of base)
         -27 : 189145.dasm (-1.85% of base)
         -24 : 41445.dasm (-0.70% of base)
         -21 : 189148.dasm (-1.39% of base)
         -17 : 198364.dasm (-2.24% of base)
         -13 : 203195.dasm (-1.54% of base)
         -12 : 34701.dasm (-0.44% of base)
         -11 : 185799.dasm (-0.39% of base)
         -11 : 85693.dasm (-0.67% of base)
         -11 : 85686.dasm (-0.57% of base)
         -11 : 29388.dasm (-3.70% of base)
         -10 : 214475.dasm (-1.65% of base)
         -10 : 8690.dasm (-1.71% of base)
         -10 : 109999.dasm (-0.62% of base)
         -10 : 195110.dasm (-2.31% of base)
          -9 : 8317.dasm (-0.91% of base)
          -9 : 110000.dasm (-2.59% of base)
          -9 : 210638.dasm (-1.35% of base)
          -9 : 200850.dasm (-1.49% of base)

1475 total files with Code Size differences (657 improved, 818 regressed), 163 unchanged.

Top method regressions (bytes):
          87 ( 4.11% of base) : 73382.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlElement():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlNodeSyntax:this
          55 ( 1.14% of base) : 34699.dasm - <WriteHeadersAsync>d__53:MoveNext():this
          53 (12.71% of base) : 73955.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          48 (11.11% of base) : 8882.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (11.03% of base) : 8886.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          42 ( 5.11% of base) : 64503.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetForEachStatementInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:this
          37 ( 0.23% of base) : 34706.dasm - <SendAsyncCore>d__57:MoveNext():this
          32 (17.78% of base) : 73928.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          31 (27.19% of base) : 73947.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          29 (23.58% of base) : 73373.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ReInitialize(int):this
          29 (31.52% of base) : 73374.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:SetMode(int):int:this
          29 (38.16% of base) : 73375.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ResetMode(int):this
          29 (13.12% of base) : 73387.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseCrefAttribute(byref,byref,byref):this
          29 (13.12% of base) : 73388.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseNameAttribute(byref,byref,byref):this
          29 ( 1.75% of base) : 110769.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
          29 ( 1.72% of base) : 110771.dasm - <ReadAllAsync>d__29`1[Byte][System.Byte]:MoveNext():this
          29 ( 4.52% of base) : 73389.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlAttributeText(byref,Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxListBuilder`1[[Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref):this
          29 ( 6.17% of base) : 73395.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlComment():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlCommentSyntax:this
          29 ( 7.51% of base) : 73396.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlCDataSection():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlCDataSectionSyntax:this
          29 ( 6.22% of base) : 73397.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlProcessingInstruction():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlProcessingInstructionSyntax:this

Top method improvements (bytes):
         -54 (-2.99% of base) : 7835.dasm - <DescendantTriviaOnly>d__160:MoveNext():bool:this
         -45 (-1.01% of base) : 61040.dasm - System.Data.Common.DbDataAdapter:Update(System.Data.DataRow[],System.Data.Common.DataTableMapping):int:this
         -27 (-1.85% of base) : 189145.dasm - System.Buffers.SequenceReader`1[Int16][System.Int16]:TryReadToSlow(byref,short,short,int,bool):bool:this
         -24 (-0.70% of base) : 41445.dasm - <RunTestCollectionsAsync>d__14:MoveNext():this
         -21 (-1.39% of base) : 189148.dasm - System.Buffers.SequenceReader`1[Int16][System.Int16]:TryReadTo(byref,short,short,bool):bool:this
         -17 (-2.24% of base) : 198364.dasm - System.Net.Mail.MailAddressParser:TryParseAddress(System.String,bool,byref,byref,bool):bool
         -13 (-1.54% of base) : 203195.dasm - <Merge>d__1:MoveNext():bool:this
         -12 (-0.44% of base) : 34701.dasm - <WriteHostHeaderAsync>d__54:MoveNext():this
         -11 (-0.39% of base) : 185799.dasm - <BuildCommandLineArguments>d__15:MoveNext():bool:this
         -11 (-0.67% of base) : 85693.dasm - <GetMethodsToEmit>d__68:MoveNext():bool:this
         -11 (-0.57% of base) : 85686.dasm - <GetEnumFieldsToEmit>d__66:MoveNext():bool:this
         -11 (-3.70% of base) : 29388.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
         -10 (-1.65% of base) : 214475.dasm - OrderedPipeliningMergeEnumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:TryWaitForElement(int,byref):bool:this
         -10 (-1.71% of base) : 8690.dasm - <GetEnumerator>d__9:MoveNext():bool:this
         -10 (-0.62% of base) : 109999.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,System.ReadOnlySpan`1[Char],byref):bool:this
         -10 (-2.31% of base) : 195110.dasm - RunningInstance:TryReadEvent(byref):bool:this
          -9 (-0.91% of base) : 8317.dasm - TargetSymbolResolver:ParseNamedType(Microsoft.CodeAnalysis.ISymbol):System.Nullable`1[TypeInfo]:this
          -9 (-2.59% of base) : 110000.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,System.ReadOnlySpan`1[Byte],byref):bool:this
          -9 (-1.35% of base) : 210638.dasm - <GetOrCreateAsync>d__9`1[__Canon][System.__Canon]:MoveNext():this
          -9 (-1.49% of base) : 200850.dasm - System.IO.Pipelines.Pipe:GetReadAsyncResult():System.IO.Pipelines.ReadResult:this

Top method regressions (percentages):
          29 (38.16% of base) : 73375.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ResetMode(int):this
          29 (38.16% of base) : 73933.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:set_Mode(int):this
          29 (31.52% of base) : 73374.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:SetMode(int):int:this
           7 (29.17% of base) : 141640.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:MoveToNextSyntaxNodeInTrivia():this
          31 (27.19% of base) : 73947.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          29 (23.58% of base) : 73373.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ReInitialize(int):this
          10 (17.86% of base) : 158305.dasm - CandidateAnalysisResult:.ctor(Candidate):this
          32 (17.78% of base) : 73928.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          10 (14.49% of base) : 158304.dasm - CandidateAnalysisResult:.ctor(Candidate,ubyte):this
           7 (13.46% of base) : 141639.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:MoveToNextSyntaxNode():this
          29 (13.12% of base) : 73387.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseCrefAttribute(byref,byref,byref):this
          29 (13.12% of base) : 73388.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseNameAttribute(byref,byref,byref):this
          53 (12.71% of base) : 73955.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
           7 (12.28% of base) : 141539.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Blender:MoveToNextSyntaxNodeInTrivia():this
          48 (11.11% of base) : 8882.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (11.03% of base) : 8886.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          11 ( 9.73% of base) : 64598.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxTreeSemanticModel:GetForEachStatementInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:this
          10 ( 9.71% of base) : 29907.dasm - Enumerator[Byte][System.Byte]:Reset():this
          11 ( 9.57% of base) : 64933.dasm - Microsoft.CodeAnalysis.CSharp.CSharpExtensions:GetForEachStatementInfo(Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo
          10 ( 8.70% of base) : 29900.dasm - Enumerator[__Canon][System.__Canon]:Reset():this

Top method improvements (percentages):
          -4 (-28.57% of base) : 49338.dasm - System.Buffers.MemoryManager`1[Int16][System.Int16]:TryGetArray(byref):bool:this
          -4 (-22.22% of base) : 207879.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 33833.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-19.05% of base) : 153155.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
          -4 (-19.05% of base) : 68942.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
          -4 (-19.05% of base) : 80325.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.LabelSymbol:get_IdentifierNodeOrToken():Microsoft.CodeAnalysis.SyntaxNodeOrToken:this
          -4 (-19.05% of base) : 136260.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.LabelSymbol:get_LabelName():Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 82248.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SynthesizedLocal:get_IdentifierToken():Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 128752.dasm - System.Xml.Xsl.IlGen.StorageDescriptor:None():System.Xml.Xsl.IlGen.StorageDescriptor
          -4 (-14.29% of base) : 4192.dasm - Microsoft.CodeAnalysis.SyntaxToken:.ctor(Microsoft.CodeAnalysis.GreenNode):this
          -4 (-12.50% of base) : 183621.dasm - System.Xml.Linq.ElementWriter:.ctor(System.Xml.XmlWriter):this
          -4 (-12.12% of base) : 196902.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:Reset():this
          -2 (-11.76% of base) : 203747.dasm - System.IO.ReadOnlyMemoryStream:Dispose(bool):this
          -2 (-11.76% of base) : 33776.dasm - System.IO.ReadOnlyMemoryStream:Dispose(bool):this
          -2 (-11.76% of base) : 206298.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[__Canon][System.__Canon]:ClearReservation():this
          -2 (-11.76% of base) : 206318.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[Byte][System.Byte]:ClearReservation():this
          -5 (-10.87% of base) : 111285.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          -4 (-10.81% of base) : 138316.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterConstraint:.ctor(int,Microsoft.CodeAnalysis.Location):this
          -4 (-10.00% of base) : 53019.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:System.Collections.IEnumerator.Reset():this
          -4 (-10.00% of base) : 158620.dasm - DocWriter:.ctor(System.IO.TextWriter):this

1475 total methods with Code Size differences (657 improved, 818 regressed), 163 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.pmi.windows.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1657664
Total bytes of diff: 1659617
Total bytes of delta: 1953 (0.12% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          87 : 32560.dasm (4.29% of base)
          58 : 191105.dasm (1.24% of base)
          53 : 33133.dasm (12.44% of base)
          48 : 81480.dasm (10.50% of base)
          48 : 81484.dasm (10.48% of base)
          42 : 23578.dasm (5.53% of base)
          40 : 191112.dasm (0.26% of base)
          34 : 218872.dasm (2.15% of base)
          32 : 218870.dasm (2.03% of base)
          31 : 33125.dasm (28.18% of base)
          29 : 32551.dasm (23.97% of base)
          29 : 32552.dasm (29.90% of base)
          29 : 32553.dasm (38.16% of base)
          29 : 32565.dasm (13.94% of base)
          29 : 32566.dasm (13.94% of base)
          29 : 32567.dasm (5.00% of base)
          29 : 32573.dasm (6.33% of base)
          29 : 32574.dasm (7.80% of base)
          29 : 32575.dasm (6.62% of base)
          29 : 33111.dasm (38.16% of base)

Top file improvements (bytes):
         -33 : 106875.dasm (-0.71% of base)
         -24 : 230551.dasm (-0.72% of base)
         -18 : 188067.dasm (-1.59% of base)
         -18 : 188025.dasm (-1.59% of base)
         -13 : 189900.dasm (-0.71% of base)
         -12 : 116378.dasm (-0.21% of base)
         -12 : 193991.dasm (-1.74% of base)
         -11 : 230958.dasm (-1.36% of base)
         -11 : 45146.dasm (-0.57% of base)
         -11 : 45153.dasm (-0.68% of base)
         -10 : 145962.dasm (-0.37% of base)
         -10 : 193291.dasm (-1.31% of base)
          -8 : 134176.dasm (-1.27% of base)
          -8 : 218111.dasm (-0.47% of base)
          -8 : 223689.dasm (-2.88% of base)
          -8 : 175853.dasm (-1.32% of base)
          -8 : 181571.dasm (-1.41% of base)
          -8 : 214360.dasm (-1.06% of base)
          -8 : 175856.dasm (-1.84% of base)
          -8 : 81294.dasm (-1.40% of base)

1619 total files with Code Size differences (611 improved, 1008 regressed), 33 unchanged.

Top method regressions (bytes):
          87 ( 4.29% of base) : 32560.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlElement():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlNodeSyntax:this
          58 ( 1.24% of base) : 191105.dasm - <WriteHeadersAsync>d__53:MoveNext():this
          53 (12.44% of base) : 33133.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          48 (10.50% of base) : 81480.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (10.48% of base) : 81484.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          42 ( 5.53% of base) : 23578.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetForEachStatementInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:this
          40 ( 0.26% of base) : 191112.dasm - <SendAsyncCore>d__57:MoveNext():this
          34 ( 2.15% of base) : 218872.dasm - <ReadAllAsync>d__29`1[Byte][System.Byte]:MoveNext():this
          32 ( 2.03% of base) : 218870.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
          31 (28.18% of base) : 33125.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          29 (23.97% of base) : 32551.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ReInitialize(int):this
          29 (29.90% of base) : 32552.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:SetMode(int):int:this
          29 (38.16% of base) : 32553.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ResetMode(int):this
          29 (13.94% of base) : 32565.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseCrefAttribute(byref,byref,byref):this
          29 (13.94% of base) : 32566.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseNameAttribute(byref,byref,byref):this
          29 ( 5.00% of base) : 32567.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlAttributeText(byref,Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxListBuilder`1[[Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref):this
          29 ( 6.33% of base) : 32573.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlComment():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlCommentSyntax:this
          29 ( 7.80% of base) : 32574.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlCDataSection():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlCDataSectionSyntax:this
          29 ( 6.62% of base) : 32575.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlProcessingInstruction():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlProcessingInstructionSyntax:this
          29 (38.16% of base) : 33111.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:set_Mode(int):this

Top method improvements (bytes):
         -33 (-0.71% of base) : 106875.dasm - System.Data.Common.DbDataAdapter:Update(System.Data.DataRow[],System.Data.Common.DataTableMapping):int:this
         -24 (-0.72% of base) : 230551.dasm - <RunTestCollectionsAsync>d__14:MoveNext():this
         -18 (-1.59% of base) : 188067.dasm - System.Buffers.SequenceReader`1[Int64][System.Int64]:TryReadTo(byref,long,long,bool):bool:this
         -18 (-1.59% of base) : 188025.dasm - System.Buffers.SequenceReader`1[Int32][System.Int32]:TryReadTo(byref,int,int,bool):bool:this
         -13 (-0.71% of base) : 189900.dasm - <ReadAsyncCore>d__24:MoveNext():this
         -12 (-0.21% of base) : 116378.dasm - <ReadAsync>d__35:MoveNext():this
         -12 (-1.74% of base) : 193991.dasm - <<GetAddrInfoWithTelemetryAsync>g__CompleteAsync|34_0>d`1[__Canon][System.__Canon]:MoveNext():this
         -11 (-1.36% of base) : 230958.dasm - <Merge>d__1:MoveNext():bool:this
         -11 (-0.57% of base) : 45146.dasm - <GetEnumFieldsToEmit>d__66:MoveNext():bool:this
         -11 (-0.68% of base) : 45153.dasm - <GetMethodsToEmit>d__68:MoveNext():bool:this
         -10 (-0.37% of base) : 145962.dasm - <BuildCommandLineArguments>d__15:MoveNext():bool:this
         -10 (-1.31% of base) : 193291.dasm - System.Net.Mail.MailAddressParser:TryParseAddress(System.String,bool,byref,byref,bool):bool
          -8 (-1.27% of base) : 134176.dasm - <GetOrCreateAsync>d__9`1[__Canon][System.__Canon]:MoveNext():this
          -8 (-0.47% of base) : 218111.dasm - System.Text.Json.JsonDocument:TryGetNamedPropertyValue(int,System.ReadOnlySpan`1[Char],byref):bool:this
          -8 (-2.88% of base) : 223689.dasm - System.Threading.Tasks.Dataflow.Internal.TargetCore`1[__Canon][System.__Canon]:TryGetNextMessageForNewAsyncOperation(byref):bool:this
          -8 (-1.32% of base) : 175853.dasm - System.IO.Pipelines.Pipe:GetReadAsyncResult():System.IO.Pipelines.ReadResult:this
          -8 (-1.41% of base) : 181571.dasm - OrderedPipeliningMergeEnumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:TryWaitForElement(int,byref):bool:this
          -8 (-1.06% of base) : 214360.dasm - <get_Claims>d__90:MoveNext():bool:this
          -8 (-1.84% of base) : 175856.dasm - System.IO.Pipelines.Pipe:GetFlushAsyncResult():System.IO.Pipelines.FlushResult:this
          -8 (-1.40% of base) : 81294.dasm - <GetEnumerator>d__9:MoveNext():bool:this

Top method regressions (percentages):
          29 (38.16% of base) : 32553.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ResetMode(int):this
          29 (38.16% of base) : 33111.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:set_Mode(int):this
          29 (29.90% of base) : 32552.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:SetMode(int):int:this
           7 (29.17% of base) : 55714.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:MoveToNextSyntaxNodeInTrivia():this
          31 (28.18% of base) : 33125.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:MoveToNextToken():this
          29 (23.97% of base) : 32551.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ReInitialize(int):this
          10 (17.86% of base) : 72483.dasm - CandidateAnalysisResult:.ctor(Candidate):this
          10 (14.93% of base) : 72482.dasm - CandidateAnalysisResult:.ctor(Candidate,ubyte):this
          29 (13.94% of base) : 32565.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseCrefAttribute(byref,byref,byref):this
          29 (13.94% of base) : 32566.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseNameAttribute(byref,byref,byref):this
           7 (13.46% of base) : 55713.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:MoveToNextSyntaxNode():this
          53 (12.44% of base) : 33133.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
           7 (11.67% of base) : 55613.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Blender:MoveToNextSyntaxNodeInTrivia():this
          48 (10.50% of base) : 81480.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (10.48% of base) : 81484.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          10 (10.10% of base) : 148553.dasm - Enumerator[Byte][System.Byte]:Reset():this
          11 ( 9.65% of base) : 23675.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxTreeSemanticModel:GetForEachStatementInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:this
          11 ( 9.48% of base) : 24010.dasm - Microsoft.CodeAnalysis.CSharp.CSharpExtensions:GetForEachStatementInfo(Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo
          10 ( 9.35% of base) : 148546.dasm - Enumerator[__Canon][System.__Canon]:Reset():this
          16 ( 8.94% of base) : 33106.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this

Top method improvements (percentages):
          -4 (-28.57% of base) : 16315.dasm - System.Buffers.MemoryManager`1[Int16][System.Int16]:TryGetArray(byref):bool:this
          -4 (-22.22% of base) : 190229.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 194976.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-19.05% of base) : 41702.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SynthesizedLocal:get_IdentifierToken():Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 125534.dasm - System.Xml.Xsl.IlGen.StorageDescriptor:None():System.Xml.Xsl.IlGen.StorageDescriptor
          -4 (-19.05% of base) : 28031.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
          -4 (-19.05% of base) : 50269.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.LabelSymbol:get_LabelName():Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 67310.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
          -4 (-19.05% of base) : 39765.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.LabelSymbol:get_IdentifierNodeOrToken():Microsoft.CodeAnalysis.SyntaxNodeOrToken:this
          -4 (-14.29% of base) : 76839.dasm - Microsoft.CodeAnalysis.SyntaxToken:.ctor(Microsoft.CodeAnalysis.GreenNode):this
          -4 (-12.50% of base) : 200183.dasm - System.Xml.Linq.ElementWriter:.ctor(System.Xml.XmlWriter):this
          -4 (-12.12% of base) : 147751.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:Reset():this
          -2 (-11.76% of base) : 187682.dasm - System.IO.ReadOnlyMemoryStream:Dispose(bool):this
          -2 (-11.76% of base) : 190158.dasm - System.IO.ReadOnlyMemoryStream:Dispose(bool):this
          -2 (-11.76% of base) : 223253.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[__Canon][System.__Canon]:ClearReservation():this
          -2 (-11.76% of base) : 223273.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[Byte][System.Byte]:ClearReservation():this
          -5 (-10.87% of base) : 219381.dasm - System.Text.Json.Utf8JsonWriter:ResetHelper():this
          -4 (-10.81% of base) : 52376.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterConstraint:.ctor(int,Microsoft.CodeAnalysis.Location):this
          -4 (-10.81% of base) : 190555.dasm - System.Net.Http.HttpContent:TryGetBuffer(byref):bool:this
          -4 (-10.00% of base) : 72801.dasm - DocWriter:.ctor(System.IO.TextWriter):this

1619 total methods with Code Size differences (611 improved, 1008 regressed), 33 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries.pmi.windows.x86.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 715965
Total bytes of diff: 716622
Total bytes of delta: 657 (0.09% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         120 : 159514.dasm (9.09% of base)
         117 : 159516.dasm (8.86% of base)
          51 : 33946.dasm (3.04% of base)
          49 : 82798.dasm (13.54% of base)
          49 : 82794.dasm (13.54% of base)
          42 : 24978.dasm (6.65% of base)
          36 : 130545.dasm (0.28% of base)
          35 : 213177.dasm (4.75% of base)
          35 : 213972.dasm (4.75% of base)
          34 : 215741.dasm (1.52% of base)
          34 : 215571.dasm (1.54% of base)
          32 : 34494.dasm (23.36% of base)
          30 : 34517.dasm (9.87% of base)
          30 : 215610.dasm (3.21% of base)
          29 : 159524.dasm (1.76% of base)
          29 : 213977.dasm (1.07% of base)
          29 : 213221.dasm (1.07% of base)
          28 : 174995.dasm (11.38% of base)
          28 : 175003.dasm (7.09% of base)
          28 : 174974.dasm (11.43% of base)

Top file improvements (bytes):
       -2151 : 83680.dasm (-5.46% of base)
        -159 : 154198.dasm (-1.05% of base)
         -50 : 120317.dasm (-1.10% of base)
         -23 : 45282.dasm (-1.12% of base)
         -22 : 68857.dasm (-1.46% of base)
         -20 : 80227.dasm (-1.26% of base)
         -18 : 52461.dasm (-1.42% of base)
         -18 : 68895.dasm (-1.04% of base)
         -17 : 44987.dasm (-2.24% of base)
         -17 : 72870.dasm (-2.23% of base)
         -16 : 77882.dasm (-0.66% of base)
         -16 : 141688.dasm (-0.38% of base)
         -15 : 215313.dasm (-0.46% of base)
         -14 : 28605.dasm (-1.42% of base)
         -14 : 28606.dasm (-1.81% of base)
         -14 : 68855.dasm (-1.43% of base)
         -14 : 68856.dasm (-1.83% of base)
         -14 : 62176.dasm (-1.53% of base)
         -14 : 62177.dasm (-1.65% of base)
         -14 : 30274.dasm (-1.49% of base)

961 total files with Code Size differences (422 improved, 539 regressed), 4 unchanged.

Top method regressions (bytes):
         120 ( 9.09% of base) : 159514.dasm - <ReadAllAsync>d__29`1[__Canon][System.__Canon]:MoveNext():this
         117 ( 8.86% of base) : 159516.dasm - <ReadAllAsync>d__29`1[Byte][System.Byte]:MoveNext():this
          51 ( 3.04% of base) : 33946.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ParseXmlElement():Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.XmlNodeSyntax:this
          49 (13.54% of base) : 82798.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          49 (13.54% of base) : 82794.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          42 ( 6.65% of base) : 24978.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetForEachStatementInfo(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax):Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo:this
          36 ( 0.28% of base) : 130545.dasm - <SendAsyncCore>d__57:MoveNext():this
          35 ( 4.75% of base) : 213177.dasm - System.Security.Cryptography.Asn1.ECDomainParameters:DecodeCore(byref,System.ReadOnlyMemory`1[Byte],byref)
          35 ( 4.75% of base) : 213972.dasm - System.Security.Cryptography.Asn1.ECDomainParameters:DecodeCore(byref,System.ReadOnlyMemory`1[Byte],byref)
          34 ( 1.52% of base) : 215741.dasm - System.Security.Cryptography.Pkcs.Asn1.SignerInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          34 ( 1.54% of base) : 215571.dasm - System.Security.Cryptography.Pkcs.Asn1.KeyAgreeRecipientInfoAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          32 (23.36% of base) : 34494.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
          30 ( 9.87% of base) : 34517.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:.ctor(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer,int,Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,System.Collections.Generic.IEnumerable`1[TextChangeRange],bool,bool,System.Threading.CancellationToken):this
          30 ( 3.21% of base) : 215610.dasm - System.Security.Cryptography.Pkcs.Asn1.RecipientEncryptedKeyAsn:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          29 ( 1.76% of base) : 159524.dasm - <<DeserializeAsyncEnumerable>g__CreateAsyncEnumerableDeserializer|27_0>d`1[__Canon][System.__Canon]:MoveNext():this
          29 ( 1.07% of base) : 213977.dasm - System.Security.Cryptography.Asn1.SpecifiedECDomain:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          29 ( 1.07% of base) : 213221.dasm - System.Security.Cryptography.Asn1.SpecifiedECDomain:DecodeCore(byref,System.Formats.Asn1.Asn1Tag,System.ReadOnlyMemory`1[Byte],byref)
          28 (11.38% of base) : 174995.dasm - <get_Values>d__22[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:MoveNext():bool:this
          28 ( 7.09% of base) : 175003.dasm - <get_Values>d__22[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:MoveNext():bool:this
          28 (11.43% of base) : 174974.dasm - <get_Keys>d__18[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:MoveNext():bool:this

Top method improvements (bytes):
       -2151 (-5.46% of base) : 83680.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
        -159 (-1.05% of base) : 154198.dasm - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -50 (-1.10% of base) : 120317.dasm - System.DirectoryServices.DirectorySearcher:SetSearchPreferences(IDirectorySearch,bool):this
         -23 (-1.12% of base) : 45282.dasm - InterpolatedStringScanner:ScanInterpolatedStringLiteralHoleBalancedText(ushort,bool,byref):this
         -22 (-1.46% of base) : 68857.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:FindTriviaByOffset(Microsoft.CodeAnalysis.SyntaxNode,int,System.Func`2[SyntaxTrivia,Boolean]):Microsoft.CodeAnalysis.SyntaxTrivia
         -20 (-1.26% of base) : 80227.dasm - Microsoft.CodeAnalysis.CodeGen.SequencePointList:GetSequencePoints(Microsoft.CodeAnalysis.CodeGen.DebugDocumentProvider):System.Collections.Immutable.ImmutableArray`1[SequencePoint]:this
         -18 (-1.42% of base) : 52461.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberContainerTypeSymbol:CheckInterfaceUnificationAndVariance(Microsoft.CodeAnalysis.DiagnosticBag):this
         -18 (-1.04% of base) : 68895.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:DoGetSyntaxErrors(Microsoft.CodeAnalysis.SyntaxTree,Microsoft.CodeAnalysis.SyntaxNodeOrToken):System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]
         -17 (-2.24% of base) : 44987.dasm - Analysis:ComputeLambdaScopesAndFrameCaptures():this
         -17 (-2.23% of base) : 72870.dasm - Analysis:ComputeLambdaScopesAndFrameCaptures():this
         -16 (-0.66% of base) : 77882.dasm - Microsoft.CodeAnalysis.SyntaxDiffer:GetSimilarity(Microsoft.CodeAnalysis.SyntaxNodeOrToken,Microsoft.CodeAnalysis.SyntaxNodeOrToken):int:this
         -16 (-0.38% of base) : 141688.dasm - <_ParseTextAsync>d__534:MoveNext():this
         -15 (-0.46% of base) : 215313.dasm - System.Security.Cryptography.Pkcs.CmsSigner:Sign(System.ReadOnlyMemory`1[Byte],System.String,bool,byref):System.Security.Cryptography.Pkcs.Asn1.SignerInfoAsn:this
         -14 (-1.42% of base) : 28605.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode:GetFirstDirective(System.Func`2[[Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.81% of base) : 28606.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode:GetLastDirective(System.Func`2[[Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.43% of base) : 68855.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:GetFirstDirective(System.Func`2[[Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.83% of base) : 68856.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:GetLastDirective(System.Func`2[[Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.53% of base) : 62176.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:GetNextDirective(System.Func`2[[Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.65% of base) : 62177.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:GetPreviousDirective(System.Func`2[[Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.DirectiveTriviaSyntax:this
         -14 (-1.49% of base) : 30274.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax:GetNextDirective(System.Func`2[[Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Boolean, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax:this

Top method regressions (percentages):
           5 (41.67% of base) : 149692.dasm - System.Xml.Xsl.IlGen.StorageDescriptor:None():System.Xml.Xsl.IlGen.StorageDescriptor
           5 (41.67% of base) : 68670.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
           5 (41.67% of base) : 201996.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 51618.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.LabelSymbol:get_LabelName():Microsoft.CodeAnalysis.SyntaxToken:this
           5 (41.67% of base) : 129657.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 41141.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.LabelSymbol:get_IdentifierNodeOrToken():Microsoft.CodeAnalysis.SyntaxNodeOrToken:this
           5 (41.67% of base) : 29433.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxFactory:TokenList():Microsoft.CodeAnalysis.SyntaxTokenList
           5 (41.67% of base) : 43077.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SynthesizedLocal:get_IdentifierToken():Microsoft.CodeAnalysis.SyntaxToken:this
          15 (35.71% of base) : 73823.dasm - CandidateAnalysisResult:.ctor(Candidate):this
          17 (29.82% of base) : 34499.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:set_Mode(int):this
          17 (29.82% of base) : 33939.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:ResetMode(int):this
          15 (27.27% of base) : 73824.dasm - CandidateAnalysisResult:.ctor(Candidate,ubyte):this
           5 (25.00% of base) : 23121.dasm - Microsoft.CodeAnalysis.CSharp.Conversion:.ctor(ubyte):this
           5 (23.81% of base) : 57044.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:MoveToNextSyntaxNodeInTrivia():this
           5 (23.81% of base) : 213304.dasm - Internal.Cryptography.CngAlgorithmCore:.ctor(System.String):this
          32 (23.36% of base) : 34494.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxParser:Reset(byref):this
           5 (22.73% of base) : 78169.dasm - Microsoft.CodeAnalysis.SyntaxToken:.ctor(Microsoft.CodeAnalysis.GreenNode):this
          17 (22.08% of base) : 33938.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentParser:SetMode(int):int:this
           5 (20.00% of base) : 78083.dasm - Microsoft.CodeAnalysis.SyntaxNodeOrTokenList:FirstOrDefault():Microsoft.CodeAnalysis.SyntaxNodeOrToken:this
          10 (20.00% of base) : 48487.dasm - Microsoft.CodeAnalysis.VisualBasic.RegionAnalysisContext:.ctor(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation):this

Top method improvements (percentages):
          -3 (-11.54% of base) : 154542.dasm - Enumerator:Reset():this
          -4 (-5.48% of base) : 190565.dasm - System.IO.Hashing.XxHash32:Reset():this
       -2151 (-5.46% of base) : 83680.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
          -3 (-5.45% of base) : 169599.dasm - Microsoft.Diagnostics.Tracing.Extensions.ETWKernelControl:IsWin8orNewer():bool
          -4 (-4.82% of base) : 190575.dasm - System.IO.Hashing.XxHash32:.ctor(int):this
          -4 (-4.82% of base) : 193228.dasm - System.Linq.Parallel.ConcatKey`2[Double,Nullable`1][System.Double,System.Nullable`1[System.Int32]]:MakeLeft(double):System.Linq.Parallel.ConcatKey`2[Double,Nullable`1]
          -4 (-4.60% of base) : 225936.dasm - Microsoft.DiaSymReader.ComMemoryStream:Microsoft.DiaSymReader.IUnsafeComStream.Stat(byref,int):this
          -4 (-4.60% of base) : 80877.dasm - Roslyn.Utilities.ComMemoryStream:Roslyn.Utilities.IUnsafeComStream.Stat(byref,int):this
          -4 (-4.49% of base) : 193232.dasm - System.Linq.Parallel.ConcatKey`2[Int64,Nullable`1][System.Int64,System.Nullable`1[System.Int32]]:MakeLeft(long):System.Linq.Parallel.ConcatKey`2[Int64,Nullable`1]
          -4 (-4.30% of base) : 163510.dasm - <>c__DisplayClass9_0`1[Vector`1][System.Numerics.Vector`1[System.Single]]:<Index>b__0(System.Numerics.Vector`1[Single],int):System.Collections.Generic.KeyValuePair`2[Int32,Vector`1]:this
          -4 (-3.92% of base) : 193297.dasm - System.Linq.Parallel.HashLookupValueList`2[Vector`1,Nullable`1][System.Numerics.Vector`1[System.Single],System.Nullable`1[System.Int32]]:CreatePair(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Linq.Parallel.Pair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 21980.dasm - Microsoft.CSharp.RuntimeBinder.Semantics.TypeTable:MakeKey(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):KeyPair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 19744.dasm - System.Collections.Generic.KeyValuePair:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 193275.dasm - System.Linq.Parallel.PairOutputKeyBuilder`2[Vector`1,Nullable`1][System.Numerics.Vector`1[System.Single],System.Nullable`1[System.Int32]]:Combine(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Linq.Parallel.Pair`2[Vector`1,Nullable`1]:this
          -4 (-3.92% of base) : 15662.dasm - System.ValueTuple:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.ValueTuple`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 80642.dasm - Roslyn.Utilities.KeyValuePair:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 80835.dasm - Roslyn.Utilities.ValueTuple:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):Roslyn.Utilities.ValueTuple`2[Vector`1,Nullable`1]
          -6 (-3.87% of base) : 160114.dasm - System.Text.Json.Nodes.JsonNode:op_Explicit(System.Text.Json.Nodes.JsonNode):System.Nullable`1[Decimal]
          -4 (-3.74% of base) : 193298.dasm - System.Linq.Parallel.HashLookupValueList`2[Vector`1,Nullable`1][System.Numerics.Vector`1[System.Single],System.Nullable`1[System.Int32]]:.ctor(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):this
          -4 (-3.10% of base) : 224949.dasm - Internal.TypeSystem.UniversalCanonLayoutAlgorithm:ComputeInstanceLayout(Internal.TypeSystem.DefType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this

961 total methods with Code Size differences (422 improved, 539 regressed), 4 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries_tests.pmi.Linux.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3059536
Total bytes of diff: 3061552
Total bytes of delta: 2016 (0.07% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          48 : 49139.dasm (11.11% of base)
          48 : 49143.dasm (11.03% of base)
          39 : 49433.dasm (0.38% of base)
          36 : 293205.dasm (0.64% of base)
          32 : 193663.dasm (0.71% of base)
          28 : 49429.dasm (0.40% of base)
          28 : 193982.dasm (0.51% of base)
          26 : 193720.dasm (0.85% of base)
          25 : 32730.dasm (0.32% of base)
          22 : 193718.dasm (0.80% of base)
          21 : 193523.dasm (0.66% of base)
          20 : 195123.dasm (2.03% of base)
          19 : 194071.dasm (0.39% of base)
          19 : 194069.dasm (0.43% of base)
          19 : 32839.dasm (0.16% of base)
          18 : 193687.dasm (0.21% of base)
          16 : 46385.dasm (1.52% of base)
          16 : 103122.dasm (0.37% of base)
          15 : 48124.dasm (0.43% of base)
          15 : 47830.dasm (0.45% of base)

Top file improvements (bytes):
         -18 : 215081.dasm (-0.88% of base)
         -18 : 233914.dasm (-0.88% of base)
         -17 : 229639.dasm (-2.24% of base)
         -16 : 277547.dasm (-0.92% of base)
         -14 : 277549.dasm (-0.76% of base)
         -14 : 26741.dasm (-1.04% of base)
         -14 : 26743.dasm (-0.54% of base)
         -13 : 200339.dasm (-0.36% of base)
         -13 : 136975.dasm (-0.49% of base)
         -13 : 136977.dasm (-0.56% of base)
         -13 : 253125.dasm (-0.62% of base)
         -12 : 48160.dasm (-1.82% of base)
         -12 : 32486.dasm (-0.82% of base)
         -12 : 253127.dasm (-0.64% of base)
         -11 : 237698.dasm (-1.14% of base)
         -11 : 137000.dasm (-0.36% of base)
         -11 : 46362.dasm (-2.42% of base)
         -11 : 319.dasm (-3.70% of base)
         -11 : 159103.dasm (-0.83% of base)
         -10 : 301520.dasm (-0.65% of base)

2023 total files with Code Size differences (536 improved, 1487 regressed), 88 unchanged.

Top method regressions (bytes):
          48 (11.11% of base) : 49139.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (11.03% of base) : 49143.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          39 ( 0.38% of base) : 49433.dasm - <IdentifyConflictsAsync>d__19:MoveNext():this
          36 ( 0.64% of base) : 293205.dasm - <RunAnalyzerAndFixer>d__9:MoveNext():this
          32 ( 0.71% of base) : 193663.dasm - <AdvanceResetsCommitHeadIndex>d__5:MoveNext():this
          28 ( 0.40% of base) : 49429.dasm - <ResolveConflictsAsync>d__18:MoveNext():this
          28 ( 0.51% of base) : 193982.dasm - <ConsumingSegmentsReturnsMemoryToPool>d__18:MoveNext():this
          26 ( 0.85% of base) : 193720.dasm - <ReadAsyncReturnsDataAfterCanceledRead>d__42:MoveNext():this
          25 ( 0.32% of base) : 32730.dasm - <Http2_MultipleConnectionsEnabled_IdleConnectionTimeoutExpired_ConnectionRemovedAndNewCreated>d__4:MoveNext():this
          22 ( 0.80% of base) : 193718.dasm - <EmptyFlushAsyncDoesntWakeUpReaderAfterAdvance>d__41:MoveNext():this
          21 ( 0.66% of base) : 193523.dasm - <ReadAtLeastShouldNotCompleteIfWriterWroteLessThanMinimum>d__10:MoveNext():this
          20 ( 2.03% of base) : 195123.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeWorker(Microsoft.CodeAnalysis.SyntaxToken,bool):System.Nullable`1[ValueTuple`2]
          19 ( 0.39% of base) : 194071.dasm - <PooledSegmentsDontAffectLastExaminedSegmentEmptyGapWithDifferentBlocks>d__12:MoveNext():this
          19 ( 0.43% of base) : 194069.dasm - <PooledSegmentsDontAffectLastExaminedSegment>d__11:MoveNext():this
          19 ( 0.16% of base) : 32839.dasm - <ProcessSocks5Request>d__16:MoveNext():this
          18 ( 0.21% of base) : 193687.dasm - <ReaderShouldNotGetUnflushedBytesWithAppend>d__17:MoveNext():this
          16 ( 1.52% of base) : 46385.dasm - <ConvertToTokenPairs>d__2:MoveNext():bool:this
          16 ( 0.37% of base) : 103122.dasm - <BinaryOperators>d__4:MoveNext():bool:this
          15 ( 0.43% of base) : 48124.dasm - <FindIndexerReferencesAsync>d__7:MoveNext():this
          15 ( 0.45% of base) : 47830.dasm - <FindImplementedInterfaceMembersArrayAsync>d__53:MoveNext():this

Top method improvements (bytes):
         -18 (-0.88% of base) : 215081.dasm - System.Data.SqlClient.SqlBulkCopy:WriteToServerInternalRestAsync(System.Threading.CancellationToken,System.Threading.Tasks.TaskCompletionSource`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
         -18 (-0.88% of base) : 233914.dasm - System.Data.SqlClient.SqlBulkCopy:WriteToServerInternalRestAsync(System.Threading.CancellationToken,System.Threading.Tasks.TaskCompletionSource`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
         -17 (-2.24% of base) : 229639.dasm - System.Net.Mail.MailAddressParser:TryParseAddress(System.String,bool,byref,byref,bool):bool
         -16 (-0.92% of base) : 277547.dasm - <MoveNextAsync>d__9[__Canon][System.__Canon]:MoveNext():this
         -14 (-0.76% of base) : 277549.dasm - <MoveNextAsync>d__9[Byte][System.Byte]:MoveNext():this
         -14 (-1.04% of base) : 26741.dasm - <FlushEmptyAsync>d__41:MoveNext():this
         -14 (-0.54% of base) : 26743.dasm - <FlushMultipleTimesAsync>d__43:MoveNext():this
         -13 (-0.36% of base) : 200339.dasm - <UnaryOperators>d__245:MoveNext():bool:this
         -13 (-0.49% of base) : 136975.dasm - <SendReceive_PartialMessageDueToSmallReceiveBuffer_Success>d__3:MoveNext():this
         -13 (-0.56% of base) : 136977.dasm - <SendReceive_PartialMessageBeforeCompleteMessageArrives_Success>d__4:MoveNext():this
         -13 (-0.62% of base) : 253125.dasm - <Write_Memory_WritesExpectedData>d__19:MoveNext():this
         -12 (-1.82% of base) : 48160.dasm - <PerformFunctionAsync>d__3`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-0.82% of base) : 32486.dasm - <ReadAsStreamAsync_ReadByte_MatchesInput>d__7:MoveNext():this
         -12 (-0.64% of base) : 253127.dasm - <WriteLineAsync_Memory_WritesExpectedData>d__21:MoveNext():this
         -11 (-1.14% of base) : 237698.dasm - <InvalidClientHelloDataTruncatedBytes>d__9:MoveNext():bool:this
         -11 (-0.36% of base) : 137000.dasm - <TestEcho>d__3:MoveNext():this
         -11 (-2.42% of base) : 46362.dasm - <PerformIOAsync>d__2`1[__Canon][System.__Canon]:MoveNext():this
         -11 (-3.70% of base) : 319.dasm - System.Collections.Concurrent.ConcurrentQueueSegment`1[SocketIOEvent][System.Net.Sockets.SocketAsyncEngine+SocketIOEvent]:TryDequeue(byref):bool:this
         -11 (-0.83% of base) : 159103.dasm - <FindVariables>d__34:MoveNext():bool:this
         -10 (-0.65% of base) : 301520.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this

Top method regressions (percentages):
          13 (30.23% of base) : 40147.dasm - Microsoft.CodeAnalysis.Rename.ConflictResolution:.ctor(System.String):this
           4 (16.00% of base) : 194137.dasm - BuggyPipeReader:ReadAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[ReadResult]:this
           4 (16.00% of base) : 240330.dasm - _Closure$__:_Lambda$__40-3(Microsoft.CodeAnalysis.SyntaxNode):System.ValueTuple`2[SyntaxToken,SyntaxToken]:this
          48 (11.11% of base) : 49139.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (11.03% of base) : 49143.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          14 ( 7.78% of base) : 240568.dasm - CodeShapeAnalyzer:.ctor(Microsoft.CodeAnalysis.Formatting.FormattingContext,bool,Microsoft.CodeAnalysis.Formatting.TriviaList):this
           2 ( 6.25% of base) : 49491.dasm - Enumerator:System.Collections.IEnumerator.Reset():this
          10 ( 5.52% of base) : 42048.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.IAliasSymbol,Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.SymbolUsageInfo,System.Collections.Immutable.ImmutableDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int,Microsoft.CodeAnalysis.Location):this
           2 ( 5.41% of base) : 49488.dasm - Enumerator:MoveNextRare():bool:this
           4 ( 5.13% of base) : 142156.dasm - System.Collections.Generic.LargeArrayBuilder`1[Byte][System.Byte]:.ctor(int):this
          11 ( 4.80% of base) : 195199.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.CSharpUseImplicitTypeHelper:AnalyzeTypeName(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax,Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.Options.OptionSet,System.Threading.CancellationToken):Microsoft.CodeAnalysis.CSharp.Utilities.TypeStyleResult:this
           4 ( 4.49% of base) : 142141.dasm - System.Collections.Generic.LargeArrayBuilder`1[__Canon][System.__Canon]:.ctor(int):this
          10 ( 4.31% of base) : 42050.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.Location):this
          10 ( 4.20% of base) : 42049.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.IAliasSymbol,Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.SymbolUsageInfo,System.Collections.Immutable.ImmutableDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int):this
           2 ( 4.00% of base) : 190425.dasm - System.Collections.ObjectModel.Tests.Named`1[Vector`1][System.Numerics.Vector`1[System.Single]]:.ctor(System.String,System.Numerics.Vector`1[Single]):this
          11 ( 3.90% of base) : 187467.dasm - <System-Collections-Generic-IReadOnlyDictionary<System-String,System-Net-Http-Headers-HeaderStringValues>-get_Keys>d__14:MoveNext():bool:this
          11 ( 3.72% of base) : 187473.dasm - <System-Collections-Generic-IReadOnlyDictionary<System-String,System-Net-Http-Headers-HeaderStringValues>-get_Values>d__16:MoveNext():bool:this
          11 ( 3.70% of base) : 186490.dasm - System.Net.Http.Headers.HttpHeadersNonValidated:GetEnumerator():Enumerator:this
           2 ( 3.57% of base) : 49492.dasm - Enumerator:.ctor(System.Collections.Generic.List`1[SyntaxToken]):this
           8 ( 3.33% of base) : 239890.dasm - Microsoft.CodeAnalysis.VisualBasic.LanguageServices.VisualBasicSyntaxFacts:GetNameOfParameter(Microsoft.CodeAnalysis.SyntaxNode):System.Nullable`1[SyntaxToken]:this

Top method improvements (percentages):
          -4 (-28.57% of base) : 161258.dasm - System.Numerics.Tensors.Tests.NativeMemory`1[__Canon][System.__Canon]:TryGetArray(byref):bool:this
          -4 (-28.57% of base) : 161271.dasm - System.Numerics.Tensors.Tests.NativeMemory`1[Byte][System.Byte]:TryGetArray(byref):bool:this
          -4 (-22.22% of base) : 236708.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 294367.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 252247.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 268263.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 27992.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 260180.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 141729.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 111869.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-19.05% of base) : 32693.dasm - <>c:<ConnectCallback_GetSet_Roundtrips>b__17_0(System.Net.Http.SocketsHttpConnectionContext,System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[[System.IO.Stream, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]:this
          -4 (-19.05% of base) : 46811.dasm - <>c:<FindTokenOnRightOfPosition>b__34_0(Microsoft.CodeAnalysis.SyntaxTriviaList,int):Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 275837.dasm - <>c:<FromPipe_LeaveOpen_PipeDisposed>b__11_2(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -2 (-16.67% of base) : 88096.dasm - ByRefLikeStruct:.ctor(int):this
          -4 (-16.00% of base) : 194095.dasm - TestPipeWriter:FlushAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -4 (-16.00% of base) : 194096.dasm - TestPipeWriter:WriteAsync(System.ReadOnlyMemory`1[Byte],System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -4 (-16.00% of base) : 275849.dasm - <>c__DisplayClass9_0:<FromPipe_CloseMethod_Flushed>b__1(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -4 (-11.43% of base) : 49144.dasm - BuilderNode:.ctor(Microsoft.CodeAnalysis.Text.TextSpan):this
          -4 (-9.30% of base) : 184403.dasm - System.Net.Http.HttpContent:TryGetBuffer(byref):bool:this
          -4 (-5.80% of base) : 334.dasm - System.Net.Sockets.SocketAsyncContext:ReturnOperation(BufferMemoryReceiveOperation):this

2023 total methods with Code Size differences (536 improved, 1487 regressed), 88 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries_tests.pmi.windows.x64.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3237312
Total bytes of diff: 3239919
Total bytes of delta: 2607 (0.08% of base)
    diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          50 : 22798.dasm (0.50% of base)
          48 : 22504.dasm (10.43% of base)
          48 : 22508.dasm (10.43% of base)
          37 : 260327.dasm (0.66% of base)
          36 : 68102.dasm (0.47% of base)
          32 : 22794.dasm (0.47% of base)
          28 : 173378.dasm (0.52% of base)
          26 : 173117.dasm (0.90% of base)
          26 : 173060.dasm (0.60% of base)
          22 : 173115.dasm (0.85% of base)
          21 : 172919.dasm (0.70% of base)
          21 : 67451.dasm (0.44% of base)
          20 : 122134.dasm (2.18% of base)
          19 : 173466.dasm (0.44% of base)
          19 : 173468.dasm (0.40% of base)
          19 : 68211.dasm (0.16% of base)
          18 : 173084.dasm (0.23% of base)
          18 : 67456.dasm (0.35% of base)
          16 : 68098.dasm (0.20% of base)
          16 : 157864.dasm (0.38% of base)

Top file improvements (bytes):
         -17 : 243303.dasm (-0.86% of base)
         -17 : 238972.dasm (-0.86% of base)
         -14 : 299469.dasm (-0.46% of base)
         -14 : 264594.dasm (-0.80% of base)
         -14 : 264596.dasm (-0.77% of base)
         -13 : 172173.dasm (-0.64% of base)
         -13 : 293768.dasm (-0.71% of base)
         -13 : 176361.dasm (-0.64% of base)
         -12 : 290280.dasm (-0.83% of base)
         -12 : 65087.dasm (-0.83% of base)
         -12 : 299256.dasm (-0.83% of base)
         -12 : 172393.dasm (-1.09% of base)
         -12 : 195320.dasm (-0.83% of base)
         -12 : 172391.dasm (-1.12% of base)
         -12 : 228913.dasm (-0.83% of base)
         -12 : 176745.dasm (-1.12% of base)
         -12 : 199850.dasm (-0.83% of base)
         -12 : 176747.dasm (-1.09% of base)
         -12 : 292583.dasm (-0.83% of base)
         -12 : 292710.dasm (-0.83% of base)

2258 total files with Code Size differences (566 improved, 1692 regressed), 41 unchanged.

Top method regressions (bytes):
          50 ( 0.50% of base) : 22798.dasm - <IdentifyConflictsAsync>d__19:MoveNext():this
          48 (10.43% of base) : 22504.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (10.43% of base) : 22508.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          37 ( 0.66% of base) : 260327.dasm - <RunAnalyzerAndFixer>d__9:MoveNext():this
          36 ( 0.47% of base) : 68102.dasm - <Http2_MultipleConnectionsEnabled_IdleConnectionTimeoutExpired_ConnectionRemovedAndNewCreated>d__4:MoveNext():this
          32 ( 0.47% of base) : 22794.dasm - <ResolveConflictsAsync>d__18:MoveNext():this
          28 ( 0.52% of base) : 173378.dasm - <ConsumingSegmentsReturnsMemoryToPool>d__18:MoveNext():this
          26 ( 0.90% of base) : 173117.dasm - <ReadAsyncReturnsDataAfterCanceledRead>d__42:MoveNext():this
          26 ( 0.60% of base) : 173060.dasm - <AdvanceResetsCommitHeadIndex>d__5:MoveNext():this
          22 ( 0.85% of base) : 173115.dasm - <EmptyFlushAsyncDoesntWakeUpReaderAfterAdvance>d__41:MoveNext():this
          21 ( 0.70% of base) : 172919.dasm - <ReadAtLeastShouldNotCompleteIfWriterWroteLessThanMinimum>d__10:MoveNext():this
          21 ( 0.44% of base) : 67451.dasm - <GetAsync_SettingsFrameNotSentOnNewConnection_ClientApplies100StreamLimit>d__22:MoveNext():this
          20 ( 2.18% of base) : 122134.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeWorker(Microsoft.CodeAnalysis.SyntaxToken,bool):System.Nullable`1[ValueTuple`2]
          19 ( 0.44% of base) : 173466.dasm - <PooledSegmentsDontAffectLastExaminedSegment>d__11:MoveNext():this
          19 ( 0.40% of base) : 173468.dasm - <PooledSegmentsDontAffectLastExaminedSegmentEmptyGapWithDifferentBlocks>d__12:MoveNext():this
          19 ( 0.16% of base) : 68211.dasm - <ProcessSocks5Request>d__16:MoveNext():this
          18 ( 0.23% of base) : 173084.dasm - <ReaderShouldNotGetUnflushedBytesWithAppend>d__17:MoveNext():this
          18 ( 0.35% of base) : 67456.dasm - <GetAsync_ServerSendSettingsWithoutMaxConcurrentStreams_ClientAppliesInfiniteLimit>d__24:MoveNext():this
          16 ( 0.20% of base) : 68098.dasm - <Http2_MultipleConnectionsEnabled_OpenAndCloseMultipleConnections_Success>d__3:MoveNext():this
          16 ( 0.38% of base) : 157864.dasm - <BinaryOperators>d__4:MoveNext():bool:this

Top method improvements (bytes):
         -17 (-0.86% of base) : 243303.dasm - System.Data.SqlClient.SqlBulkCopy:WriteToServerInternalRestAsync(System.Threading.CancellationToken,System.Threading.Tasks.TaskCompletionSource`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
         -17 (-0.86% of base) : 238972.dasm - System.Data.SqlClient.SqlBulkCopy:WriteToServerInternalRestAsync(System.Threading.CancellationToken,System.Threading.Tasks.TaskCompletionSource`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
         -14 (-0.46% of base) : 299469.dasm - <TestEcho>d__3:MoveNext():this
         -14 (-0.80% of base) : 264594.dasm - <MoveNextAsync>d__9[__Canon][System.__Canon]:MoveNext():this
         -14 (-0.77% of base) : 264596.dasm - <MoveNextAsync>d__9[Byte][System.Byte]:MoveNext():this
         -13 (-0.64% of base) : 172173.dasm - <Write_Memory_WritesExpectedData>d__19:MoveNext():this
         -13 (-0.71% of base) : 293768.dasm - <ReadAsyncCore>d__24:MoveNext():this
         -13 (-0.64% of base) : 176361.dasm - <Write_Memory_WritesExpectedData>d__19:MoveNext():this
         -12 (-0.83% of base) : 290280.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-0.83% of base) : 65087.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-0.83% of base) : 299256.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-1.09% of base) : 172393.dasm - <WriteLineCharMemoryTest>d__47:MoveNext():this
         -12 (-0.83% of base) : 195320.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-1.12% of base) : 172391.dasm - <WriteCharMemoryTest>d__46:MoveNext():this
         -12 (-0.83% of base) : 228913.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-1.12% of base) : 176745.dasm - <WriteCharMemoryTest>d__46:MoveNext():this
         -12 (-0.83% of base) : 199850.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-1.09% of base) : 176747.dasm - <WriteLineCharMemoryTest>d__47:MoveNext():this
         -12 (-0.83% of base) : 292583.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this
         -12 (-0.83% of base) : 292710.dasm - <WaitAsync>d__5`1[__Canon][System.__Canon]:MoveNext():this

Top method regressions (percentages):
          13 (30.23% of base) : 13462.dasm - Microsoft.CodeAnalysis.Rename.ConflictResolution:.ctor(System.String):this
           4 (16.00% of base) : 127684.dasm - _Closure$__:_Lambda$__40-3(Microsoft.CodeAnalysis.SyntaxNode):System.ValueTuple`2[SyntaxToken,SyntaxToken]:this
           4 (16.00% of base) : 173533.dasm - BuggyPipeReader:ReadAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[ReadResult]:this
          48 (10.43% of base) : 22504.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          48 (10.43% of base) : 22508.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          14 ( 8.24% of base) : 127923.dasm - CodeShapeAnalyzer:.ctor(Microsoft.CodeAnalysis.Formatting.FormattingContext,bool,Microsoft.CodeAnalysis.Formatting.TriviaList):this
           2 ( 6.25% of base) : 22856.dasm - Enumerator:System.Collections.IEnumerator.Reset():this
           4 ( 5.56% of base) : 248190.dasm - System.Collections.Generic.LargeArrayBuilder`1[Byte][System.Byte]:.ctor(int):this
           2 ( 5.41% of base) : 22853.dasm - Enumerator:MoveNextRare():bool:this
          10 ( 5.18% of base) : 15375.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.IAliasSymbol,Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.SymbolUsageInfo,System.Collections.Immutable.ImmutableDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int,Microsoft.CodeAnalysis.Location):this
          11 ( 5.07% of base) : 122211.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.CSharpUseImplicitTypeHelper:AnalyzeTypeName(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax,Microsoft.CodeAnalysis.SemanticModel,Microsoft.CodeAnalysis.Options.OptionSet,System.Threading.CancellationToken):Microsoft.CodeAnalysis.CSharp.Utilities.TypeStyleResult:this
           4 ( 4.76% of base) : 248175.dasm - System.Collections.Generic.LargeArrayBuilder`1[__Canon][System.__Canon]:.ctor(int):this
          10 ( 4.39% of base) : 15377.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.Location):this
          10 ( 4.03% of base) : 15376.dasm - Microsoft.CodeAnalysis.FindSymbols.ReferenceLocation:.ctor(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.IAliasSymbol,Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.SymbolUsageInfo,System.Collections.Immutable.ImmutableDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int):this
           2 ( 3.92% of base) : 242654.dasm - System.Text.ValueStringBuilder:Dispose():this
           2 ( 3.92% of base) : 193749.dasm - System.Text.ValueStringBuilder:Dispose():this
           2 ( 3.92% of base) : 247654.dasm - System.Text.ValueStringBuilder:Dispose():this
          11 ( 3.91% of base) : 194330.dasm - <System-Collections-Generic-IReadOnlyDictionary<System-String,System-Net-Http-Headers-HeaderStringValues>-get_Keys>d__14:MoveNext():bool:this
           2 ( 3.77% of base) : 303272.dasm - System.Collections.ObjectModel.Tests.Named`1[Vector`1][System.Numerics.Vector`1[System.Single]]:.ctor(System.String,System.Numerics.Vector`1[Single]):this
           2 ( 3.57% of base) : 22857.dasm - Enumerator:.ctor(System.Collections.Generic.List`1[SyntaxToken]):this

Top method improvements (percentages):
          -4 (-28.57% of base) : 300858.dasm - System.Numerics.Tensors.Tests.NativeMemory`1[__Canon][System.__Canon]:TryGetArray(byref):bool:this
          -4 (-28.57% of base) : 300871.dasm - System.Numerics.Tensors.Tests.NativeMemory`1[Byte][System.Byte]:TryGetArray(byref):bool:this
          -4 (-22.22% of base) : 224198.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 287022.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 297488.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 63364.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 170972.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 247756.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-22.22% of base) : 70143.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          -4 (-19.05% of base) : 68065.dasm - <>c:<ConnectCallback_GetSet_Roundtrips>b__17_0(System.Net.Http.SocketsHttpConnectionContext,System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[[System.IO.Stream, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]:this
          -4 (-19.05% of base) : 20168.dasm - <>c:<FindTokenOnRightOfPosition>b__34_0(Microsoft.CodeAnalysis.SyntaxTriviaList,int):Microsoft.CodeAnalysis.SyntaxToken:this
          -4 (-19.05% of base) : 292503.dasm - <>c:<FromPipe_LeaveOpen_PipeDisposed>b__11_2(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -2 (-16.67% of base) : 86517.dasm - ByRefLikeStruct:.ctor(int):this
          -4 (-16.00% of base) : 173492.dasm - TestPipeWriter:FlushAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -4 (-16.00% of base) : 173493.dasm - TestPipeWriter:WriteAsync(System.ReadOnlyMemory`1[Byte],System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -4 (-16.00% of base) : 292515.dasm - <>c__DisplayClass9_0:<FromPipe_CloseMethod_Flushed>b__1(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[FlushResult]:this
          -2 (-13.33% of base) : 312574.dasm - TryPeekNoOverrideReader`1[__Canon][System.__Canon]:WaitToReadAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[Boolean]:this
          -2 (-13.33% of base) : 312576.dasm - TryPeekNoOverrideReader`1[Byte][System.Byte]:WaitToReadAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[Boolean]:this
          -2 (-13.33% of base) : 298126.dasm - System.Net.Security.SslStream:ReadAsyncInternal(System.__Canon,System.Memory`1[Byte]):System.Threading.Tasks.ValueTask`1[Int32]:this
          -2 (-13.33% of base) : 298127.dasm - System.Net.Security.SslStream:ReadAsyncInternal(ubyte,System.Memory`1[Byte]):System.Threading.Tasks.ValueTask`1[Int32]:this

2258 total methods with Code Size differences (566 improved, 1692 regressed), 41 unchanged.

```

</details>

--------------------------------------------------------------------------------

**asm.libraries_tests.pmi.windows.x86.checked**

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1190715
Total bytes of diff: 1187590
Total bytes of delta: -3125 (-0.26% of base)
    diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          49 : 22421.dasm (13.39% of base)
          49 : 22425.dasm (13.39% of base)
          48 : 135004.dasm (4.86% of base)
          40 : 121258.dasm (7.04% of base)
          30 : 20986.dasm (1.95% of base)
          25 : 127039.dasm (16.78% of base)
          24 : 22747.dasm (3.96% of base)
          22 : 20418.dasm (1.52% of base)
          20 : 121259.dasm (0.97% of base)
          20 : 121260.dasm (0.60% of base)
          20 : 121261.dasm (5.04% of base)
          20 : 172101.dasm (0.57% of base)
          19 : 293439.dasm (3.29% of base)
          18 : 247137.dasm (2.45% of base)
          16 : 172419.dasm (0.35% of base)
          16 : 124015.dasm (1.93% of base)
          16 : 172156.dasm (0.83% of base)
          16 : 172158.dasm (0.74% of base)
          15 : 13406.dasm (48.39% of base)
          15 : 192363.dasm (7.65% of base)

Top file improvements (bytes):
        -568 : 56118.dasm (-2.04% of base)
        -216 : 56218.dasm (-0.86% of base)
        -144 : 58729.dasm (-0.65% of base)
        -119 : 183802.dasm (-2.86% of base)
        -115 : 183926.dasm (-2.81% of base)
        -108 : 301015.dasm (-2.71% of base)
         -84 : 315316.dasm (-2.27% of base)
         -69 : 315317.dasm (-1.50% of base)
         -54 : 125704.dasm (-1.98% of base)
         -49 : 182697.dasm (-2.54% of base)
         -42 : 301032.dasm (-1.67% of base)
         -39 : 301031.dasm (-1.74% of base)
         -37 : 125455.dasm (-1.80% of base)
         -36 : 120219.dasm (-1.87% of base)
         -35 : 120220.dasm (-0.88% of base)
         -33 : 122072.dasm (-1.53% of base)
         -30 : 78423.dasm (-0.70% of base)
         -28 : 35804.dasm (-1.40% of base)
         -27 : 301014.dasm (-1.48% of base)
         -26 : 78419.dasm (-0.63% of base)

1060 total files with Code Size differences (667 improved, 393 regressed), 7 unchanged.

Top method regressions (bytes):
          49 (13.39% of base) : 22421.dasm - Enumerator[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:.ctor(ValueSet[__Canon,Nullable`1]):this
          49 (13.39% of base) : 22425.dasm - Enumerator[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:.ctor(ValueSet[Byte,Nullable`1]):this
          48 ( 4.86% of base) : 135004.dasm - NuGet.Packaging.Signing.NativeCms:GetRepositoryCountersignature(NuGet.Packaging.Signing.HeapBlockRetainer):System.Nullable`1[RepositoryCounterSignerInfo]:this
          40 ( 7.04% of base) : 121258.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeWorker(Microsoft.CodeAnalysis.SyntaxToken,bool):System.Nullable`1[ValueTuple`2]
          30 ( 1.95% of base) : 20986.dasm - <ProcessDocumentQueueAsync>d__12:MoveNext():this
          25 (16.78% of base) : 127039.dasm - CodeShapeAnalyzer:.ctor(Microsoft.CodeAnalysis.Formatting.FormattingContext,bool,Microsoft.CodeAnalysis.Formatting.TriviaList):this
          24 ( 3.96% of base) : 22747.dasm - <GetChangedOptions>d__9:MoveNext():bool:this
          22 ( 1.52% of base) : 20418.dasm - <FindAsync>d__10:MoveNext():this
          20 ( 0.97% of base) : 121259.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeForSemicolon(Microsoft.CodeAnalysis.SyntaxToken):System.Nullable`1[ValueTuple`2]
          20 ( 0.60% of base) : 121260.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeForCloseBrace(Microsoft.CodeAnalysis.SyntaxToken):System.Nullable`1[ValueTuple`2]
          20 ( 5.04% of base) : 121261.dasm - Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper:FindAppropriateRangeForColon(Microsoft.CodeAnalysis.SyntaxToken):System.Nullable`1[ValueTuple`2]
          20 ( 0.57% of base) : 172101.dasm - <AdvanceResetsCommitHeadIndex>d__5:MoveNext():this
          19 ( 3.29% of base) : 293439.dasm - System.Net.Mail.MailAddress:TryParse(System.String,System.String,System.Text.Encoding,byref,bool):bool
          18 ( 2.45% of base) : 247137.dasm - procfs:TryParseStatFile(System.String,byref):bool
          16 ( 0.35% of base) : 172419.dasm - <ConsumingSegmentsReturnsMemoryToPool>d__18:MoveNext():this
          16 ( 1.93% of base) : 124015.dasm - <GetAllTrailingTrivia>d__19:MoveNext():bool:this
          16 ( 0.83% of base) : 172156.dasm - <EmptyFlushAsyncDoesntWakeUpReaderAfterAdvance>d__41:MoveNext():this
          16 ( 0.74% of base) : 172158.dasm - <ReadAsyncReturnsDataAfterCanceledRead>d__42:MoveNext():this
          15 (48.39% of base) : 13406.dasm - Microsoft.CodeAnalysis.Rename.ConflictResolution:.ctor(System.String):this
          15 ( 7.65% of base) : 192363.dasm - System.Net.Http.Headers.HttpHeadersNonValidated:GetEnumerator():Enumerator:this

Top method improvements (bytes):
        -568 (-2.04% of base) : 56118.dasm - System.Linq.Expressions.Tests.Compiler_Tests:BinaryOperators(bool)
        -216 (-0.86% of base) : 56218.dasm - System.Linq.Expressions.Tests.Compiler_Tests:Conversions(bool)
        -144 (-0.65% of base) : 58729.dasm - <TestData>d__0:MoveNext():bool:this
        -119 (-2.86% of base) : 183802.dasm - <Max_NullableDecimal_TestData>d__41:MoveNext():bool:this
        -115 (-2.81% of base) : 183926.dasm - <Min_NullableDecimal_TestData>d__35:MoveNext():bool:this
        -108 (-2.71% of base) : 301015.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2EqualsNanTest():this
         -84 (-2.27% of base) : 315316.dasm - System.Tests.ValueTupleTests:SixTuples()
         -69 (-1.50% of base) : 315317.dasm - System.Tests.ValueTupleTests:SevenTuples()
         -54 (-1.98% of base) : 125704.dasm - Microsoft.CodeAnalysis.VisualBasic.Formatting.VisualBasicTriviaFormatter:GetLineColumnRuleBetween(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.Formatting.LineColumnDelta,bool,Microsoft.CodeAnalysis.SyntaxTrivia):Microsoft.CodeAnalysis.Formatting.LineColumnRule:this
         -49 (-2.54% of base) : 182697.dasm - <NullableDecimal_TestData>d__49:MoveNext():bool:this
         -42 (-1.67% of base) : 301032.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateRotationRightAngleCenterTest():this
         -39 (-1.74% of base) : 301031.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateRotationRightAngleTest():this
         -37 (-1.80% of base) : 125455.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.SyntaxTreeExtensions:FindTriviaToLeft(Microsoft.CodeAnalysis.SyntaxNodeOrToken,int):Microsoft.CodeAnalysis.SyntaxTrivia
         -36 (-1.87% of base) : 120219.dasm - Microsoft.CSharp.RuntimeBinder.Tests.ImplicitConversionTests:NumericNullableConversions():this
         -35 (-0.88% of base) : 120220.dasm - Microsoft.CSharp.RuntimeBinder.Tests.ImplicitConversionTests:NumericNullableToNullableConversions():this
         -33 (-1.53% of base) : 122072.dasm - Microsoft.CodeAnalysis.CSharp.Formatting.CSharpTriviaFormatter:GetLineColumnRuleBetween(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.Formatting.LineColumnDelta,bool,Microsoft.CodeAnalysis.SyntaxTrivia):Microsoft.CodeAnalysis.Formatting.LineColumnRule:this
         -30 (-0.70% of base) : 78423.dasm - System.Tests.DateTimeTests:ParseExact_String_String_FormatProvider_DateTimeStyles_O(System.DateTime,System.String)
         -28 (-1.40% of base) : 35804.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.basic.operate013a.operate013a.Test:Test5():bool
         -27 (-1.48% of base) : 301014.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2IsIdentityTest():this
         -26 (-0.63% of base) : 78419.dasm - System.Tests.DateTimeTests:ParseExact_String_String_FormatProvider_DateTimeStyles_R(System.DateTime,System.String)

Top method regressions (percentages):
          10 (52.63% of base) : 126789.dasm - _Closure$__:_Lambda$__41-17(Microsoft.CodeAnalysis.SyntaxNode):System.ValueTuple`2[SyntaxToken,SyntaxToken]:this
          15 (48.39% of base) : 13406.dasm - Microsoft.CodeAnalysis.Rename.ConflictResolution:.ctor(System.String):this
           5 (41.67% of base) : 285725.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 62927.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 296189.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 223139.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 246661.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 170014.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
           5 (41.67% of base) : 69706.dasm - System.Net.MultiArrayBuffer:.ctor(int):this
          10 (38.46% of base) : 22773.dasm - Enumerator:System.Collections.IEnumerator.Reset():this
           5 (35.71% of base) : 20085.dasm - <>c:<FindTokenOnRightOfPosition>b__34_0(Microsoft.CodeAnalysis.SyntaxTriviaList,int):Microsoft.CodeAnalysis.SyntaxToken:this
          10 (33.33% of base) : 22770.dasm - Enumerator:MoveNextRare():bool:this
          10 (22.73% of base) : 22774.dasm - Enumerator:.ctor(System.Collections.Generic.List`1[SyntaxToken]):this
          10 (21.28% of base) : 301962.dasm - System.Collections.ObjectModel.Tests.Named`1[Vector`1][System.Numerics.Vector`1[System.Single]]:.ctor(System.String,System.Numerics.Vector`1[Single]):this
           5 (17.86% of base) : 22426.dasm - BuilderNode:.ctor(Microsoft.CodeAnalysis.Text.TextSpan):this
          25 (16.78% of base) : 127039.dasm - CodeShapeAnalyzer:.ctor(Microsoft.CodeAnalysis.Formatting.FormattingContext,bool,Microsoft.CodeAnalysis.Formatting.TriviaList):this
           4 (16.00% of base) : 172574.dasm - BuggyPipeReader:ReadAsync(System.Threading.CancellationToken):System.Threading.Tasks.ValueTask`1[ReadResult]:this
           5 (15.62% of base) : 192738.dasm - System.Text.ValueStringBuilder:Dispose():this
           5 (15.62% of base) : 241556.dasm - System.Text.ValueStringBuilder:Dispose():this
           5 (15.62% of base) : 246539.dasm - System.Text.ValueStringBuilder:Dispose():this

Top method improvements (percentages):
          -3 (-13.64% of base) : 178609.dasm - <>c:<Average_Decimal_AllNull>b__21_0(int):System.Nullable`1[Decimal]:this
          -3 (-5.88% of base) : 39288.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.regclass.regclassregindexer.regclassregindexer.MemberClass:get_Item(ushort):System.Nullable`1[Decimal]:this
          -3 (-5.88% of base) : 39333.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.regclass.regclassregindexer.regclassregindexer.MemberClass:get_Item(int,System.Nullable`1[Char],System.Nullable`1[Single]):System.Nullable`1[Decimal]:this
          -4 (-4.60% of base) : 37250.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct:op_UnaryPlus(ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct):System.Nullable`1[Decimal]
          -4 (-4.49% of base) : 37234.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct:op_Equality(ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct,System.Object):System.Nullable`1[Decimal]
          -4 (-4.40% of base) : 37233.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct:op_Inequality(ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclass.regstrctoperate.regstrctoperate.MyStruct,System.Object):System.Nullable`1[Decimal]
          -6 (-4.23% of base) : 15024.dasm - Microsoft.CodeAnalysis.Formatting.LineColumnRule:.cctor()
          -4 (-3.92% of base) : 110844.dasm - genKeyValuePair@904[Vector`1,Nullable`1][System.Numerics.Vector`1[System.Single],System.Nullable`1[System.Int32]]:Invoke(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]:this
          -4 (-3.92% of base) : 176369.dasm - System.Linq.Parallel.Tests.KeyValuePair:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 287364.dasm - System.IO.Hashing.Tests.XxHash32Tests_Seeded_007:CreateInstance():System.IO.Hashing.NonCryptographicHashAlgorithm:this
          -4 (-3.92% of base) : 8427.dasm - Roslyn.Utilities.KeyValuePairUtil:Create(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 102555.dasm - ImTools.KeyValuePair:Pair(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):System.Collections.Generic.KeyValuePair`2[Vector`1,Nullable`1]
          -4 (-3.92% of base) : 287372.dasm - System.IO.Hashing.Tests.XxHash32Tests_Seeded_f00d:CreateInstance():System.IO.Hashing.NonCryptographicHashAlgorithm:this
          -4 (-3.57% of base) : 97256.dasm - <>c:<.cctor>b__92_10(System.Decimal):System.Nullable`1[Decimal]:this
          -4 (-3.17% of base) : 38138.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth.MemberClass:Method_ReturnDecimalNullable(byref,byref,byref):System.Nullable`1[Decimal]:this
          -4 (-3.03% of base) : 38135.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth.MemberClass:Method_ReturnDecimalNullable():System.Nullable`1[Decimal]:this
          -4 (-2.99% of base) : 38137.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth.MemberClass:Method_ReturnDecimalNullable(System.Int32[]):System.Nullable`1[Decimal]:this
          -6 (-2.99% of base) : 15014.dasm - Microsoft.CodeAnalysis.Formatting.LineColumnRule:With(System.Nullable`1[Int32],System.Nullable`1[Int32],System.Nullable`1[Int32],System.Nullable`1[LineOperations],System.Nullable`1[SpaceOperations],System.Nullable`1[IndentationOperations]):Microsoft.CodeAnalysis.Formatting.LineColumnRule:this
         -18 (-2.86% of base) : 53907.dasm - System.Linq.Expressions.Tests.ConvertTests:ConvertNullableDecimalToULongTest(bool)
         -18 (-2.86% of base) : 53908.dasm - System.Linq.Expressions.Tests.ConvertTests:ConvertNullableDecimalToNullableULongTest(bool)

1060 total methods with Code Size differences (667 improved, 393 regressed), 7 unchanged.

```

</details>

--------------------------------------------------------------------------------