### PR TITLE
Fix formatting of CircularDependencyException error message

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteChain.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteChain.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private string CreateCircularDependencyExceptionMessage(Type type)
         {
             var messageBuilder = new StringBuilder();
-            messageBuilder.AppendFormat(SR.CircularDependencyException, TypeNameHelper.GetTypeDisplayName(type));
+            messageBuilder.Append(SR.Format(CircularDependencyException, TypeNameHelper.GetTypeDisplayName(type)));
             messageBuilder.AppendLine();
 
             AppendResolutionPath(messageBuilder, type);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteChain.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteChain.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private string CreateCircularDependencyExceptionMessage(Type type)
         {
             var messageBuilder = new StringBuilder();
-            messageBuilder.Append(SR.Format(CircularDependencyException, TypeNameHelper.GetTypeDisplayName(type)));
+            messageBuilder.Append(SR.Format(SR.CircularDependencyException, TypeNameHelper.GetTypeDisplayName(type)));
             messageBuilder.AppendLine();
 
             AppendResolutionPath(messageBuilder, type);


### PR DESCRIPTION
to work with trimmed resources