### PR TITLE
Stringify RMWStatus for the dump

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -177,25 +177,6 @@ const char* GenTree::OpName(genTreeOps op)
 
 #endif
 
-#ifdef DEBUG
-
-static const char* RMWStatusStrings[] = {
-    "STATUS_UNKNOWN",
-    "DST_IS_OP1",
-    "DST_IS_OP2",
-    "UNSUPPORTED_ADDR",
-    "UNSUPPORTED_OPER",
-    "UNSUPPORTED_TYPE",
-    "INDIR_UNEQUAL"
-};
-
-const char* RMWStatusString(RMWStatus status)
-{
-    return RMWStatusStrings[(uint8_t)status];
-}
-
-#endif
-
 #if MEASURE_NODE_SIZE
 
 static const char* opStructNames[] = {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -177,6 +177,25 @@ const char* GenTree::OpName(genTreeOps op)
 
 #endif
 
+#ifdef DEBUG
+
+static const char* RMWStatusStrings[] = {
+    "STATUS_UNKNOWN",
+    "DST_IS_OP1",
+    "DST_IS_OP2",
+    "UNSUPPORTED_ADDR",
+    "UNSUPPORTED_OPER",
+    "UNSUPPORTED_TYPE",
+    "INDIR_UNEQUAL"
+};
+
+const char* RMWStatusString(RMWStatus status)
+{
+    return RMWStatusStrings[(uint8_t)status];
+}
+
+#endif
+
 #if MEASURE_NODE_SIZE
 
 static const char* opStructNames[] = {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5777,7 +5777,7 @@ protected:
 };
 
 // Read-modify-write status of a RMW memory op rooted at a storeInd
-enum RMWStatus : uint8_t
+enum RMWStatus
 {
     STOREIND_RMW_STATUS_UNKNOWN, // RMW status of storeInd unknown
                                  // Default status unless modified by IsRMWMemOpRootedAtStoreInd()
@@ -5794,7 +5794,28 @@ enum RMWStatus : uint8_t
 };
 
 #ifdef DEBUG
-const char* RMWStatusString(RMWStatus status);
+inline const char* RMWStatusString(RMWStatus status)
+{
+    switch (status)
+    {
+        case STOREIND_RMW_STATUS_UNKNOWN:
+            return "STATUS_UNKNOWN";
+        case STOREIND_RMW_DST_IS_OP1:
+            return "DST_IS_OP1";
+        case STOREIND_RMW_DST_IS_OP2:
+            return "DST_IS_OP2";
+        case STOREIND_RMW_UNSUPPORTED_ADDR:
+            return "UNSUPPORTED_ADDR";
+        case STOREIND_RMW_UNSUPPORTED_OPER:
+            return "UNSUPPORTED_OPER";
+        case STOREIND_RMW_UNSUPPORTED_TYPE:
+            return "UNSUPPORTED_TYPE";
+        case STOREIND_RMW_INDIR_UNEQUAL:
+            return "INDIR_UNEQUAL";
+        default:
+            unreached();
+    }
+}
 #endif
 
 // StoreInd is just a BinOp, with additional RMW status

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5777,7 +5777,7 @@ protected:
 };
 
 // Read-modify-write status of a RMW memory op rooted at a storeInd
-enum RMWStatus
+enum RMWStatus : uint8_t
 {
     STOREIND_RMW_STATUS_UNKNOWN, // RMW status of storeInd unknown
                                  // Default status unless modified by IsRMWMemOpRootedAtStoreInd()
@@ -5792,6 +5792,10 @@ enum RMWStatus
     STOREIND_RMW_UNSUPPORTED_TYPE, // Type is not supported for RMW memory
     STOREIND_RMW_INDIR_UNEQUAL     // Indir to read value is not equivalent to indir that writes the value
 };
+
+#ifdef DEBUG
+const char* RMWStatusString(RMWStatus status);
+#endif
 
 // StoreInd is just a BinOp, with additional RMW status
 struct GenTreeStoreInd : public GenTreeIndir

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5794,24 +5794,24 @@ enum RMWStatus
 };
 
 #ifdef DEBUG
-inline const char* RMWStatusString(RMWStatus status)
+inline const char* RMWStatusDescription(RMWStatus status)
 {
     switch (status)
     {
         case STOREIND_RMW_STATUS_UNKNOWN:
-            return "STATUS_UNKNOWN";
+            return "RMW status unknown";
         case STOREIND_RMW_DST_IS_OP1:
-            return "DST_IS_OP1";
+            return "dst candidate is op1";
         case STOREIND_RMW_DST_IS_OP2:
-            return "DST_IS_OP2";
+            return "dst candidate is op2";
         case STOREIND_RMW_UNSUPPORTED_ADDR:
-            return "UNSUPPORTED_ADDR";
+            return "address mode is not supported";
         case STOREIND_RMW_UNSUPPORTED_OPER:
-            return "UNSUPPORTED_OPER";
+            return "oper is not supported";
         case STOREIND_RMW_UNSUPPORTED_TYPE:
-            return "UNSUPPORTED_TYPE";
+            return "type is not supported";
         case STOREIND_RMW_INDIR_UNEQUAL:
-            return "INDIR_UNEQUAL";
+            return "read indir is not equivalent to write indir";
         default:
             unreached();
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5075,7 +5075,7 @@ bool Lowering::LowerRMWMemOp(GenTreeIndir* storeInd)
     if (!IsRMWMemOpRootedAtStoreInd(storeInd, &indirCandidate, &indirOpSource))
     {
         JITDUMP("Lower of StoreInd didn't mark the node as self contained for reason: %s\n",
-                RMWStatusString(storeInd->AsStoreInd()->GetRMWStatus()));
+                RMWStatusDescription(storeInd->AsStoreInd()->GetRMWStatus()));
         DISPTREERANGE(BlockRange(), storeInd);
         return false;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5074,8 +5074,8 @@ bool Lowering::LowerRMWMemOp(GenTreeIndir* storeInd)
 
     if (!IsRMWMemOpRootedAtStoreInd(storeInd, &indirCandidate, &indirOpSource))
     {
-        JITDUMP("Lower of StoreInd didn't mark the node as self contained for reason: %d\n",
-                storeInd->AsStoreInd()->GetRMWStatus());
+        JITDUMP("Lower of StoreInd didn't mark the node as self contained for reason: %s\n",
+                RMWStatusString(storeInd->AsStoreInd()->GetRMWStatus()));
         DISPTREERANGE(BlockRange(), storeInd);
         return false;
     }


### PR DESCRIPTION
Before:
```scala
Lower of StoreInd didn't mark the node as self contained for reason: 3
```
After:
```scala
Lower of StoreInd didn't mark the node as self contained for reason: oper is not supported
```

cc @tannergooding @kunalspathak