### PR TITLE
Fix invoking of `FileSystemWatcher`

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -78,5 +78,22 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, 0, action, cleanup, dir.Path);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_Directory_Changed_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(dir.Path)))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                Action action = () => Directory.SetLastWriteTime(dir.Path, DateTime.Now + TimeSpan.FromSeconds(10));
+
+                ExpectEvent(watcher, WatcherChangeTypes.Changed, action, expectedPath: dir.Path);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
@@ -102,5 +102,25 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, symLinkPath);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_Directory_Create_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                string dirName = Path.Combine(testDirectory.Path, "dir");
+                watcher.Filter = Path.GetFileName(dirName);
+
+                Action action = () => Directory.CreateDirectory(dirName);
+                Action cleanup = () => Directory.Delete(dirName);
+
+                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, dirName);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
@@ -85,5 +85,26 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, expectedPath: symLinkPath);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_Directory_Delete_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                string dirName = Path.Combine(testDirectory.Path, "dir");
+                watcher.Filter = Path.GetFileName(dirName);
+
+                Action action = () => Directory.Delete(dirName);
+                Action cleanup = () => Directory.CreateDirectory(dirName);
+                cleanup();
+
+                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, dirName);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -93,6 +93,27 @@ namespace System.IO.Tests
             DirectoryMove_WithNotifyFilter(WatcherChangeTypes.Renamed);
         }
 
+        [Fact]
+        public void Directory_Move_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                string sourcePath = dir.Path;
+                string targetPath = Path.Combine(testDirectory.Path, "target");
+
+                Action action = () => Directory.Move(sourcePath, targetPath);
+                Action cleanup = () => Directory.Move(targetPath, sourcePath);
+
+                ExpectEvent(watcher, WatcherChangeTypes.Renamed, action, cleanup, targetPath);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
+
         #region Test Helpers
 
         private void DirectoryMove_SameDirectory(WatcherChangeTypes eventType)

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
@@ -82,5 +82,22 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, 0, action, cleanup, expectedPath: file.Path);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_File_Changed_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(file.Path)))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                Action action = () => Directory.SetLastWriteTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
+
+                ExpectEvent(watcher, WatcherChangeTypes.Changed, action, expectedPath: file.Path);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -141,5 +141,25 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, symLinkPath);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_File_Create_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                string fileName = Path.Combine(testDirectory.Path, "file");
+                watcher.Filter = Path.GetFileName(fileName);
+
+                Action action = () => File.Create(fileName).Dispose();
+                Action cleanup = () => File.Delete(fileName);
+
+                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, fileName);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -106,5 +106,26 @@ namespace System.IO.Tests
                 ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, symLinkPath);
             }
         }
+
+        [Fact]
+        public void FileSystemWatcher_File_Delete_SynchronizingObject()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                string fileName = Path.Combine(testDirectory.Path, "file");
+                watcher.Filter = Path.GetFileName(fileName);
+
+                Action action = () => File.Delete(fileName);
+                Action cleanup = () => File.Create(fileName).Dispose();
+                cleanup();
+
+                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, fileName);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.InternalBufferSize.cs
@@ -44,34 +44,19 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]  // Uses P/Invokes
         public void FileSystemWatcher_InternalBufferSize(bool setToHigherCapacity)
         {
+            ManualResetEvent unblockHandler = new ManualResetEvent(false);
             using (var testDirectory = new TempDirectory(GetTestFilePath()))
             using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))
-            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(file.Path)))
+            using (FileSystemWatcher watcher = CreateWatcher(testDirectory.Path, file.Path, unblockHandler))
             {
-                int internalBufferOperationCapacity = watcher.InternalBufferSize / (17 + Path.GetFileName(file.Path).Length);
+                int internalBufferOperationCapacity = CalculateInternalBufferOperationCapacity(watcher.InternalBufferSize, file.Path);
 
                 // Set the capacity high to ensure no error events arise.
                 if (setToHigherCapacity)
                     watcher.InternalBufferSize = watcher.InternalBufferSize * 12;
 
-                // block the handling thread
-                ManualResetEvent unblockHandler = new ManualResetEvent(false);
-                watcher.Changed += (o, e) =>
-                {
-                    unblockHandler.WaitOne();
-                };
-
-                // generate enough file change events to overflow the default buffer
-                Action action = () =>
-                {
-                    for (int i = 1; i < internalBufferOperationCapacity * 10; i++)
-                    {
-                        File.SetLastWriteTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(i));
-                    }
-
-                    unblockHandler.Set();
-                };
-                Action cleanup = () => unblockHandler.Reset();
+                Action action = GetAction(unblockHandler, internalBufferOperationCapacity, file.Path);
+                Action cleanup = GetCleanup(unblockHandler);
 
                 if (setToHigherCapacity)
                     ExpectNoError(watcher, action, cleanup);
@@ -79,5 +64,60 @@ namespace System.IO.Tests
                     ExpectError(watcher, action, cleanup);
             }
         }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void FileSystemWatcher_InternalBufferSize_SynchronizingObject()
+        {
+            ManualResetEvent unblockHandler = new ManualResetEvent(false);
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))
+            using (FileSystemWatcher watcher = CreateWatcher(testDirectory.Path, file.Path, unblockHandler))
+            {
+                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                watcher.SynchronizingObject = invoker;
+
+                int internalBufferOperationCapacity = CalculateInternalBufferOperationCapacity(watcher.InternalBufferSize, file.Path);
+
+                Action action = GetAction(unblockHandler, internalBufferOperationCapacity, file.Path);
+                Action cleanup = GetCleanup(unblockHandler);
+
+                ExpectError(watcher, action, cleanup);
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
+
+        #region Test Helpers
+
+        private FileSystemWatcher CreateWatcher(string testDirectoryPath, string filePath, ManualResetEvent unblockHandler)
+        {
+            var watcher = new FileSystemWatcher(testDirectoryPath, Path.GetFileName(filePath));
+
+            // block the handling thread
+            watcher.Changed += (o, e) => unblockHandler.WaitOne();
+
+            return watcher;
+        }
+
+        private int CalculateInternalBufferOperationCapacity(int internalBufferSize, string filePath) =>
+            internalBufferSize / (17 + Path.GetFileName(filePath).Length);
+
+        private Action GetAction(ManualResetEvent unblockHandler, int internalBufferOperationCapacity, string filePath)
+        {
+            return () =>
+            {
+                // generate enough file change events to overflow the default buffer
+                for (int i = 1; i < internalBufferOperationCapacity * 10; i++)
+                {
+                    File.SetLastWriteTime(filePath, DateTime.Now + TimeSpan.FromSeconds(i));
+                }
+
+                unblockHandler.Set();
+            };
+        }
+
+        private Action GetCleanup(ManualResetEvent unblockHandler) => () => unblockHandler.Reset();
+
+        #endregion
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -52,23 +52,6 @@ namespace System.IO.Tests
             }
         }
 
-        internal class TestISynchronizeInvoke : ISynchronizeInvoke
-        {
-            public bool BeginInvoke_Called;
-            public Delegate ExpectedDelegate;
-
-            public IAsyncResult BeginInvoke(Delegate method, object[] args)
-            {
-                Assert.Equal(ExpectedDelegate, method);
-                BeginInvoke_Called = true;
-                return null;
-            }
-
-            public bool InvokeRequired => true;
-            public object EndInvoke(IAsyncResult result) => null;
-            public object Invoke(Delegate method, object[] args) => null;
-        }
-
         [Fact]
         public void SynchronizingObject_GetSetRoundtrips()
         {
@@ -85,7 +68,7 @@ namespace System.IO.Tests
         }
 
         /// <summary>
-        /// Ensure that the SynchronizeObject is invoked when an event occurs
+        /// Ensure that the SynchronizingObject is invoked when an event occurs
         /// </summary>
         [Theory]
         [InlineData(WatcherChangeTypes.Changed)]
@@ -119,7 +102,7 @@ namespace System.IO.Tests
         }
 
         /// <summary>
-        /// Ensure that the SynchronizeObject is invoked when an Renamed event occurs
+        /// Ensure that the SynchronizingObject is invoked when a Renamed event occurs
         /// </summary>
         [Fact]
         public void SynchronizingObject_CalledOnRenamed()
@@ -131,13 +114,13 @@ namespace System.IO.Tests
             {
                 watcher.SynchronizingObject = invoker;
                 watcher.Renamed += dele;
-                watcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Changed, "test", "name", "oldname"));
+                watcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Renamed, "test", "name", "oldname"));
                 Assert.True(invoker.BeginInvoke_Called);
             }
         }
 
         /// <summary>
-        /// Ensure that the SynchronizeObject is invoked when an Error event occurs
+        /// Ensure that the SynchronizingObject is invoked when an Error event occurs
         /// </summary>
         [Fact]
         public void SynchronizingObject_CalledOnError()


### PR DESCRIPTION
Call `protected` `On...` event raising methods from `Notify...` methods,
to invoke `SynchronizingObject` when required.

Fix #52644