### PR TITLE
Optimise GetCustomAttributes - Part 1

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -8,6 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
+using Internal.Runtime.CompilerServices;
+
 namespace System.Reflection
 {
     public class CustomAttributeData
@@ -15,7 +17,7 @@ namespace System.Reflection
         #region Public Static Members
         public static IList<CustomAttributeData> GetCustomAttributes(MemberInfo target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -23,7 +25,7 @@ namespace System.Reflection
 
         public static IList<CustomAttributeData> GetCustomAttributes(Module target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -31,7 +33,7 @@ namespace System.Reflection
 
         public static IList<CustomAttributeData> GetCustomAttributes(Assembly target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -39,7 +41,7 @@ namespace System.Reflection
 
         public static IList<CustomAttributeData> GetCustomAttributes(ParameterInfo target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -49,55 +51,58 @@ namespace System.Reflection
         #region Internal Static Members
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeType target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), out RuntimeType.ListBuilder<Attribute> pcas);
-            return GetCombinedList(cad, ref pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
+            return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeFieldInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), out RuntimeType.ListBuilder<Attribute> pcas);
-            return GetCombinedList(cad, ref pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
+            return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeMethodInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), out RuntimeType.ListBuilder<Attribute> pcas);
-            return GetCombinedList(cad, ref pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
+            return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeConstructorInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             return GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeEventInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             return GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimePropertyInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             return GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeModule target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             if (target.IsResource())
                 return new List<CustomAttributeData>();
@@ -107,7 +112,7 @@ namespace System.Reflection
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeAssembly target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
             // No pseudo attributes for RuntimeAssembly
 
@@ -116,17 +121,17 @@ namespace System.Reflection
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeParameterInfo target)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(target is not null);
 
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule()!, target.MetadataToken);
-            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), out RuntimeType.ListBuilder<Attribute> pcas);
-            return GetCombinedList(cad, ref pcas);
+            PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
+            return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
 
         private static IList<CustomAttributeData> GetCombinedList(IList<CustomAttributeData> customAttributes, ref RuntimeType.ListBuilder<Attribute> pseudoAttributes)
         {
-            if (pseudoAttributes.Count == 0)
-                return customAttributes;
+            Debug.Assert(pseudoAttributes.Count != 0);
 
             CustomAttributeData[] pca = new CustomAttributeData[customAttributes.Count + pseudoAttributes.Count];
             customAttributes.CopyTo(pca, pseudoAttributes.Count);
@@ -376,12 +381,12 @@ namespace System.Reflection
             });
 
             int i = 3; // ArraySubType, SizeParamIndex, SizeConst
-            if (marshalAs.MarshalType != null) i++;
-            if (marshalAs.MarshalTypeRef != null) i++;
-            if (marshalAs.MarshalCookie != null) i++;
+            if (marshalAs.MarshalType is not null) i++;
+            if (marshalAs.MarshalTypeRef is not null) i++;
+            if (marshalAs.MarshalCookie is not null) i++;
             i++; // IidParameterIndex
             i++; // SafeArraySubType
-            if (marshalAs.SafeArrayUserDefinedSubType != null) i++;
+            if (marshalAs.SafeArrayUserDefinedSubType is not null) i++;
             CustomAttributeNamedArgument[] namedArgs = new CustomAttributeNamedArgument[i];
 
             // For compatibility with previous runtimes, we always include the following 5 attributes, regardless
@@ -392,13 +397,13 @@ namespace System.Reflection
             namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("SizeConst")!, marshalAs.SizeConst);
             namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("IidParameterIndex")!, marshalAs.IidParameterIndex);
             namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("SafeArraySubType")!, marshalAs.SafeArraySubType);
-            if (marshalAs.MarshalType != null)
+            if (marshalAs.MarshalType is not null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalType")!, marshalAs.MarshalType);
-            if (marshalAs.MarshalTypeRef != null)
+            if (marshalAs.MarshalTypeRef is not null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalTypeRef")!, marshalAs.MarshalTypeRef);
-            if (marshalAs.MarshalCookie != null)
+            if (marshalAs.MarshalCookie is not null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalCookie")!, marshalAs.MarshalCookie);
-            if (marshalAs.SafeArrayUserDefinedSubType != null)
+            if (marshalAs.SafeArrayUserDefinedSubType is not null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("SafeArrayUserDefinedSubType")!, marshalAs.SafeArrayUserDefinedSubType);
 
             m_namedArgs = Array.AsReadOnly(namedArgs);
@@ -481,7 +486,7 @@ namespace System.Reflection
         {
             get
             {
-                if (m_typedCtorArgs == null)
+                if (m_typedCtorArgs is null)
                 {
                     CustomAttributeTypedArgument[] typedCtorArgs = new CustomAttributeTypedArgument[m_ctorParams.Length];
 
@@ -503,9 +508,9 @@ namespace System.Reflection
         {
             get
             {
-                if (m_namedArgs == null)
+                if (m_namedArgs is null)
                 {
-                    if (m_namedParams == null)
+                    if (m_namedParams is null)
                         return null!;
 
                     int cNamedArgs = 0;
@@ -609,7 +614,7 @@ namespace System.Reflection
         {
             RuntimeType type = RuntimeTypeHandle.GetTypeByNameUsingCARules(typeName, scope);
 
-            if (type == null)
+            if (type is null)
                 throw new InvalidOperationException(
                     SR.Format(SR.Arg_CATypeResolutionFailed, typeName));
 
@@ -619,7 +624,7 @@ namespace System.Reflection
 
         private static object CanonicalizeValue(object value)
         {
-            Debug.Assert(value != null);
+            Debug.Assert(value is not null);
 
             if (value.GetType().IsEnum)
             {
@@ -651,7 +656,7 @@ namespace System.Reflection
 
                 m_value = null;
 
-                if (encodedArg.StringValue != null)
+                if (encodedArg.StringValue is not null)
                     m_value = ResolveType(scope, encodedArg.StringValue);
             }
             else if (encodedType == CustomAttributeEncoding.Array)
@@ -670,7 +675,7 @@ namespace System.Reflection
 
                 m_argumentType = elementType.MakeArrayType();
 
-                if (encodedArg.ArrayValue == null)
+                if (encodedArg.ArrayValue is null)
                 {
                     m_value = null;
                 }
@@ -749,11 +754,11 @@ namespace System.Reflection
             ref CustomAttributeNamedParameter[] customAttributeNamedParameters,
             RuntimeModule customAttributeModule)
         {
-            if (customAttributeModule == null)
+            if (customAttributeModule is null)
                 throw new ArgumentNullException(nameof(customAttributeModule));
 
-            Debug.Assert(customAttributeCtorParameters != null);
-            Debug.Assert(customAttributeNamedParameters != null);
+            Debug.Assert(customAttributeCtorParameters is not null);
+            Debug.Assert(customAttributeNamedParameters is not null);
 
             if (customAttributeCtorParameters.Length != 0 || customAttributeNamedParameters.Length != 0)
             {
@@ -783,7 +788,7 @@ namespace System.Reflection
 
         public CustomAttributeNamedParameter(string argumentName, CustomAttributeEncoding fieldOrProperty, CustomAttributeType type)
         {
-            if (argumentName == null)
+            if (argumentName is null)
                 throw new ArgumentNullException(nameof(argumentName));
 
             m_argumentName = argumentName;
@@ -845,9 +850,9 @@ namespace System.Reflection
         #region Internal Static Members
         internal static bool IsDefined(RuntimeType type, RuntimeType? caType, bool inherit)
         {
-            Debug.Assert(type != null);
+            Debug.Assert(type is not null);
 
-            if (type.GetElementType() != null)
+            if (type.GetElementType() is not null)
                 return false;
 
             if (PseudoCustomAttribute.IsDefined(type, caType))
@@ -861,7 +866,7 @@ namespace System.Reflection
 
             type = (type.BaseType as RuntimeType)!;
 
-            while (type != null)
+            while (type is not null)
             {
                 if (IsCustomAttributeDefined(type.GetRuntimeModule(), type.MetadataToken, caType, 0, inherit))
                     return true;
@@ -874,8 +879,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeMethodInfo method, RuntimeType caType, bool inherit)
         {
-            Debug.Assert(method != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(method is not null);
+            Debug.Assert(caType is not null);
 
             if (PseudoCustomAttribute.IsDefined(method, caType))
                 return true;
@@ -888,7 +893,7 @@ namespace System.Reflection
 
             method = method.GetParentDefinition()!;
 
-            while (method != null)
+            while (method is not null)
             {
                 if (IsCustomAttributeDefined(method.GetRuntimeModule(), method.MetadataToken, caType, 0, inherit))
                     return true;
@@ -901,8 +906,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeConstructorInfo ctor, RuntimeType caType)
         {
-            Debug.Assert(ctor != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(ctor is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeConstructorInfo
 
@@ -911,8 +916,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimePropertyInfo property, RuntimeType caType)
         {
-            Debug.Assert(property != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(property is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimePropertyInfo
 
@@ -921,8 +926,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeEventInfo e, RuntimeType caType)
         {
-            Debug.Assert(e != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(e is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeEventInfo
 
@@ -931,8 +936,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeFieldInfo field, RuntimeType caType)
         {
-            Debug.Assert(field != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(field is not null);
+            Debug.Assert(caType is not null);
 
             if (PseudoCustomAttribute.IsDefined(field, caType))
                 return true;
@@ -942,8 +947,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeParameterInfo parameter, RuntimeType caType)
         {
-            Debug.Assert(parameter != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(parameter is not null);
+            Debug.Assert(caType is not null);
 
             if (PseudoCustomAttribute.IsDefined(parameter, caType))
                 return true;
@@ -953,8 +958,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeAssembly assembly, RuntimeType caType)
         {
-            Debug.Assert(assembly != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(assembly is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeAssembly
             return IsCustomAttributeDefined((assembly.ManifestModule as RuntimeModule)!, RuntimeAssembly.GetToken(assembly.GetNativeHandle()), caType);
@@ -962,8 +967,8 @@ namespace System.Reflection
 
         internal static bool IsDefined(RuntimeModule module, RuntimeType caType)
         {
-            Debug.Assert(module != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(module is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeModule
 
@@ -972,16 +977,17 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeType type, RuntimeType caType, bool inherit)
         {
-            Debug.Assert(type != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(type is not null);
+            Debug.Assert(caType is not null);
 
-            if (type.GetElementType() != null)
+            if (type.GetElementType() is not null)
                 return (caType.IsValueType) ? Array.Empty<object>() : CreateAttributeArrayHelper(caType, 0);
 
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 type = (type.GetGenericTypeDefinition() as RuntimeType)!;
 
-            PseudoCustomAttribute.GetCustomAttributes(type, caType, out RuntimeType.ListBuilder<Attribute> pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(type, caType, ref pcas);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
             // attribute usage for the specific attribute because a derived attribute may override the usage...
@@ -1018,13 +1024,14 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeMethodInfo method, RuntimeType caType, bool inherit)
         {
-            Debug.Assert(method != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(method is not null);
+            Debug.Assert(caType is not null);
 
             if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
                 method = (method.GetGenericMethodDefinition() as RuntimeMethodInfo)!;
 
-            PseudoCustomAttribute.GetCustomAttributes(method, caType, out RuntimeType.ListBuilder<Attribute> pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(method, caType, ref pcas);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
             // attribute usage for the specific attribute because a derived attribute may override the usage...
@@ -1071,8 +1078,8 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimePropertyInfo property, RuntimeType caType)
         {
-            Debug.Assert(property != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(property is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimePropertyInfo
 
@@ -1081,8 +1088,8 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeEventInfo e, RuntimeType caType)
         {
-            Debug.Assert(e != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(e is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeEventInfo
 
@@ -1091,10 +1098,11 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType)
         {
-            Debug.Assert(field != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(field is not null);
+            Debug.Assert(caType is not null);
 
-            PseudoCustomAttribute.GetCustomAttributes(field, caType, out RuntimeType.ListBuilder<Attribute> pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(field, caType, ref pcas);
             object[] attributes = GetCustomAttributes(field.GetRuntimeModule(), field.MetadataToken, pcas.Count, caType);
             if (pcas.Count > 0) pcas.CopyTo(attributes, attributes.Length - pcas.Count);
             return attributes;
@@ -1102,10 +1110,11 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeParameterInfo parameter, RuntimeType caType)
         {
-            Debug.Assert(parameter != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(parameter is not null);
+            Debug.Assert(caType is not null);
 
-            PseudoCustomAttribute.GetCustomAttributes(parameter, caType, out RuntimeType.ListBuilder<Attribute> pcas);
+            RuntimeType.ListBuilder<Attribute> pcas = default;
+            PseudoCustomAttribute.GetCustomAttributes(parameter, caType, ref pcas);
             object[] attributes = GetCustomAttributes(parameter.GetRuntimeModule()!, parameter.MetadataToken, pcas.Count, caType);
             if (pcas.Count > 0) pcas.CopyTo(attributes, attributes.Length - pcas.Count);
             return attributes;
@@ -1113,8 +1122,8 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeAssembly assembly, RuntimeType caType)
         {
-            Debug.Assert(assembly != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(assembly is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeAssembly
 
@@ -1124,8 +1133,8 @@ namespace System.Reflection
 
         internal static object[] GetCustomAttributes(RuntimeModule module, RuntimeType caType)
         {
-            Debug.Assert(module != null);
-            Debug.Assert(caType != null);
+            Debug.Assert(module is not null);
+            Debug.Assert(caType is not null);
 
             // No pseudo attributes for RuntimeModule
 
@@ -1156,7 +1165,7 @@ namespace System.Reflection
             }
 
             CustomAttributeRecord record = default;
-            if (attributeFilterType != null)
+            if (attributeFilterType is not null)
             {
                 Debug.Assert(attributeCtorToken == 0);
 
@@ -1177,7 +1186,7 @@ namespace System.Reflection
             }
             else
             {
-                Debug.Assert(attributeFilterType == null);
+                Debug.Assert(attributeFilterType is null);
                 Debug.Assert(!MetadataToken.IsNullToken(attributeCtorToken));
 
                 for (int i = 0; i < attributeTokens.Length; i++)
@@ -1202,7 +1211,7 @@ namespace System.Reflection
 
             AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType, false, default);
 
-            bool useObjectArray = attributeFilterType == null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters;
+            bool useObjectArray = attributeFilterType is null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters;
             RuntimeType arrayType = useObjectArray ? (RuntimeType)typeof(object) : attributeFilterType!;
 
             object[] result = CreateAttributeArrayHelper(arrayType, attributes.Count + pcaCount);
@@ -1253,7 +1262,7 @@ namespace System.Reflection
                 // Create custom attribute object
                 int cNamedArgs;
                 object attribute;
-                if (ctorWithParameters != null)
+                if (ctorWithParameters is not null)
                 {
                     attribute = CreateCaObject(decoratedModule, attributeType, ctorWithParameters, ref blobStart, blobEnd, out cNamedArgs);
                 }
@@ -1269,25 +1278,20 @@ namespace System.Reflection
                     }
                     else
                     {
+                        int data = Unsafe.ReadUnaligned<int>((void*)blobStart);
+#if BIGENDIAN
                         // Metadata is always written in little-endian format. Must account for this on
                         // big-endian platforms.
-#if BIGENDIAN
-                        const int CustomAttributeVersion = 0x0100;
-#else
-                        const int CustomAttributeVersion = 0x0001;
+                        data = BinaryPrimitives.ReverseEndianness(data);
 #endif
-                        if (Marshal.ReadInt16(blobStart) != CustomAttributeVersion)
+                        const int CustomAttributeVersion = 0x0001;
+                        if ((data & 0xffff) != CustomAttributeVersion)
                         {
                             throw new CustomAttributeFormatException();
                         }
+                        cNamedArgs = data >> 16;
 
-                        blobStart = (IntPtr)((byte*)blobStart + 2); // skip version prefix
-
-                        cNamedArgs = Marshal.ReadInt16(blobStart);
-                        blobStart = (IntPtr)((byte*)blobStart + 2); // skip namedArgs count
-#if BIGENDIAN
-                        cNamedArgs = ((cNamedArgs & 0xff00) >> 8) | ((cNamedArgs & 0x00ff) << 8);
-#endif
+                        blobStart = (IntPtr)((byte*)blobStart + 4); // skip version and namedArgs count
                     }
                 }
 
@@ -1299,7 +1303,7 @@ namespace System.Reflection
                     {
                         if (isProperty)
                         {
-                            if (type is null && value != null)
+                            if (type is null && value is not null)
                             {
                                 type = (RuntimeType)value.GetType();
                                 if (type == Type_RuntimeType)
@@ -1313,10 +1317,9 @@ namespace System.Reflection
                                 attributeType.GetProperty(name, type, Type.EmptyTypes);
 
                             // Did we get a valid property reference?
-                            if (property == null)
+                            if (property is null)
                             {
-                                throw new CustomAttributeFormatException(
-                                    SR.Format(SR.RFLCT_InvalidPropFail, name));
+                                throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name));
                             }
 
                             MethodInfo setMethod = property.GetSetMethod(true)!;
@@ -1449,7 +1452,7 @@ namespace System.Reflection
             RuntimeTypeHandle attributeTypeHandle = attributeType.TypeHandle;
 
             bool result = RuntimeMethodHandle.IsCAVisibleFromDecoratedType(new QCallTypeHandle(ref attributeTypeHandle),
-                                                                    ctorWithParameters != null ? ctorWithParameters.Value : RuntimeMethodHandleInternal.EmptyHandle,
+                                                                    ctorWithParameters is not null ? ctorWithParameters.Value : RuntimeMethodHandleInternal.EmptyHandle,
                                                                     new QCallTypeHandle(ref parentTypeHandle),
                                                                     new QCallModule(ref decoratedModule)) != Interop.BOOL.FALSE;
 
@@ -1509,7 +1512,7 @@ namespace System.Reflection
                 if (attributeType != (RuntimeType)typeof(AttributeUsageAttribute))
                     continue;
 
-                if (attributeUsageAttribute != null)
+                if (attributeUsageAttribute is not null)
                     throw new FormatException(SR.Format(SR.Format_AttributeUsage, attributeType));
 
                 ParseAttributeUsageAttribute(caRecord.blob, out AttributeTargets targets, out bool inherited, out bool allowMultiple);
@@ -1576,11 +1579,11 @@ namespace System.Reflection
         // the only method that adds values to the Dictionary. For more details on
         // Dictionary versus Hashtable thread safety:
         // See code:Dictionary#DictionaryVersusHashtableThreadSafety
-        private static readonly Dictionary<RuntimeType, RuntimeType> s_pca = CreatePseudoCustomAttributeDictionary();
+        private static readonly HashSet<RuntimeType> s_pca = CreatePseudoCustomAttributeHashSet();
         #endregion
 
         #region Static Constructor
-        private static Dictionary<RuntimeType, RuntimeType> CreatePseudoCustomAttributeDictionary()
+        private static HashSet<RuntimeType> CreatePseudoCustomAttributeHashSet()
         {
             Type[] pcas = new Type[]
             {
@@ -1598,13 +1601,13 @@ namespace System.Reflection
                 typeof(TypeForwardedToAttribute), // assembly
             };
 
-            Dictionary<RuntimeType, RuntimeType> dict = new Dictionary<RuntimeType, RuntimeType>(pcas.Length);
+            HashSet<RuntimeType> set = new HashSet<RuntimeType>(pcas.Length);
             foreach (RuntimeType runtimeType in pcas)
             {
                 VerifyPseudoCustomAttribute(runtimeType);
-                dict[runtimeType] = runtimeType;
+                set.Add(runtimeType);
             }
-            return dict;
+            return set;
         }
 
         [Conditional("DEBUG")]
@@ -1621,14 +1624,13 @@ namespace System.Reflection
         #endregion
 
         #region Internal Static
-        internal static void GetCustomAttributes(RuntimeType type, RuntimeType caType, out RuntimeType.ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeType type, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
-            Debug.Assert(type != null);
-            Debug.Assert(caType != null);
-            pcas = default;
+            Debug.Assert(type is not null);
+            Debug.Assert(caType is not null);
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType))
+            if (!all && !s_pca.Contains(caType))
                 return;
 
             if (all || caType == typeof(SerializableAttribute))
@@ -1645,7 +1647,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeType type, RuntimeType? caType)
         {
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType!))
+            if (!all && !s_pca.Contains(caType!))
                 return false;
 
             if (all || caType == typeof(SerializableAttribute))
@@ -1662,20 +1664,19 @@ namespace System.Reflection
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeMethodInfo method, RuntimeType caType, out RuntimeType.ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeMethodInfo method, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
-            Debug.Assert(method != null);
-            Debug.Assert(caType != null);
-            pcas = default;
+            Debug.Assert(method is not null);
+            Debug.Assert(caType is not null);
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType))
+            if (!all && !s_pca.Contains(caType))
                 return;
 
             if (all || caType == typeof(DllImportAttribute))
             {
                 Attribute? pca = GetDllImportCustomAttribute(method);
-                if (pca != null) pcas.Add(pca);
+                if (pca is not null) pcas.Add(pca);
             }
             if (all || caType == typeof(PreserveSigAttribute))
             {
@@ -1686,7 +1687,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeMethodInfo method, RuntimeType? caType)
         {
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType!))
+            if (!all && !s_pca.Contains(caType!))
                 return false;
 
             if (all || caType == typeof(DllImportAttribute))
@@ -1703,14 +1704,13 @@ namespace System.Reflection
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeParameterInfo parameter, RuntimeType caType, out RuntimeType.ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeParameterInfo parameter, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
-            Debug.Assert(parameter != null);
-            Debug.Assert(caType != null);
-            pcas = default;
+            Debug.Assert(parameter is not null);
+            Debug.Assert(caType is not null);
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType))
+            if (!all && !s_pca.Contains(caType))
                 return;
 
             if (all || caType == typeof(InAttribute))
@@ -1731,13 +1731,13 @@ namespace System.Reflection
             if (all || caType == typeof(MarshalAsAttribute))
             {
                 Attribute? pca = GetMarshalAsCustomAttribute(parameter);
-                if (pca != null) pcas.Add(pca);
+                if (pca is not null) pcas.Add(pca);
             }
         }
         internal static bool IsDefined(RuntimeParameterInfo parameter, RuntimeType? caType)
         {
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType!))
+            if (!all && !s_pca.Contains(caType!))
                 return false;
 
             if (all || caType == typeof(InAttribute))
@@ -1754,21 +1754,19 @@ namespace System.Reflection
             }
             if (all || caType == typeof(MarshalAsAttribute))
             {
-                if (GetMarshalAsCustomAttribute(parameter) != null) return true;
+                if (GetMarshalAsCustomAttribute(parameter) is not null) return true;
             }
 
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType, out RuntimeType.ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
-            Debug.Assert(field != null);
-            Debug.Assert(caType != null);
-
-            pcas = default;
+            Debug.Assert(field is not null);
+            Debug.Assert(caType is not null);
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType))
+            if (!all && !s_pca.Contains(caType))
                 return;
 
             Attribute? pca;
@@ -1776,12 +1774,12 @@ namespace System.Reflection
             if (all || caType == typeof(MarshalAsAttribute))
             {
                 pca = GetMarshalAsCustomAttribute(field);
-                if (pca != null) pcas.Add(pca);
+                if (pca is not null) pcas.Add(pca);
             }
             if (all || caType == typeof(FieldOffsetAttribute))
             {
                 pca = GetFieldOffsetCustomAttribute(field);
-                if (pca != null) pcas.Add(pca);
+                if (pca is not null) pcas.Add(pca);
             }
             if (all || caType == typeof(NonSerializedAttribute))
             {
@@ -1792,16 +1790,16 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeFieldInfo field, RuntimeType? caType)
         {
             bool all = caType == typeof(object) || caType == typeof(Attribute);
-            if (!all && !s_pca.ContainsKey(caType!))
+            if (!all && !s_pca.Contains(caType!))
                 return false;
 
             if (all || caType == typeof(MarshalAsAttribute))
             {
-                if (GetMarshalAsCustomAttribute(field) != null) return true;
+                if (GetMarshalAsCustomAttribute(field) is not null) return true;
             }
             if (all || caType == typeof(FieldOffsetAttribute))
             {
-                if (GetFieldOffsetCustomAttribute(field) != null) return true;
+                if (GetFieldOffsetCustomAttribute(field) is not null) return true;
             }
             if (all || caType == typeof(NonSerializedAttribute))
             {
@@ -1891,13 +1889,13 @@ namespace System.Reflection
 
             try
             {
-                marshalTypeRef = marshalTypeName == null ? null : RuntimeTypeHandle.GetTypeByNameUsingCARules(marshalTypeName, scope);
+                marshalTypeRef = marshalTypeName is null ? null : RuntimeTypeHandle.GetTypeByNameUsingCARules(marshalTypeName, scope);
             }
             catch (TypeLoadException)
             {
                 // The user may have supplied a bad type name string causing this TypeLoadException
                 // Regardless, we return the bad type name
-                Debug.Assert(marshalTypeName != null);
+                Debug.Assert(marshalTypeName is not null);
             }
 
             MarshalAsAttribute attribute = new MarshalAsAttribute(unmanagedType);
@@ -1917,7 +1915,7 @@ namespace System.Reflection
 
         private static FieldOffsetAttribute? GetFieldOffsetCustomAttribute(RuntimeFieldInfo field)
         {
-            if (field.DeclaringType != null &&
+            if (field.DeclaringType is not null &&
                 field.GetRuntimeModule().MetadataImport.GetFieldOffset(field.DeclaringType.MetadataToken, field.MetadataToken, out int fieldOffset))
                 return new FieldOffsetAttribute(fieldOffset);
 


### PR DESCRIPTION
- Use is/is not instead of ==/!=. Avoids overhead from operator overloading
- Pass ListBuilder as ref instead of out. Avoids redundant initialization to default.
- Use HashSet instead of Dictionary.