### PR TITLE
Add missing space in xml description for IReadOnlySet<T>.Overlaps

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IReadOnlySet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IReadOnlySet.cs
@@ -47,7 +47,7 @@ namespace System.Collections.Generic
         /// Determines whether the current set overlaps with the specified collection.
         /// </summary>
         /// <param name="other">The collection to compare to the current set.</param>
-        /// <returns><see langword="true" />if the current set and other share at least one common element; otherwise, <see langword="false" />.</returns>
+        /// <returns><see langword="true" /> if the current set and other share at least one common element; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentNullException">other is <see langword="null" />.</exception>
         bool Overlaps(IEnumerable<T> other);
         /// <summary>


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/53147