### PR TITLE
Add runtimeconfig.json support to AppleAppBuilder, reenable affected tests

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -14,10 +14,10 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Android' and '$(UseDefaultAndroidFeatureSwitches)' == 'true'">
     <DebuggerSupport>false</DebuggerSupport>
-    <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
     <EventSourceSupport>false</EventSourceSupport>
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
     <StartupHookSupport>false</StartupHookSupport>
     <UseNativeHttpHandler>true</UseNativeHttpHandler>
@@ -25,11 +25,11 @@
 
   <PropertyGroup Condition="('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator') and '$(UseDefaultiOSFeatureSwitches)' == 'true'">
     <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
-    <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <EventSourceSupport>false</EventSourceSupport>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
     <StartupHookSupport>false</StartupHookSupport>
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <UseNativeHttpHandler>true</UseNativeHttpHandler>
   </PropertyGroup>
 
@@ -58,15 +58,34 @@
 
   <Import Project="$(MSBuildThisFileDirectory)tests.wasm.targets" Condition="'$(TargetOS)' == 'Browser'" />
 
+  <UsingTask TaskName="RuntimeConfigParserTask"
+             AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)" />
+
+  <Target Name="GenerateRuntimeConfig">
+    <PropertyGroup>
+      <RuntimeConfigFilePath>$(PublishDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFilePath>
+      <ParsedRuntimeConfigFilePath>$(PublishDir)runtimeconfig.bin</ParsedRuntimeConfigFilePath>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(RunAOTCompilation)' == 'true'">
+      <RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER"/>
+      <RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY"/>
+    </ItemGroup>
+
+    <!-- Parse runtimeconfig.template.json file -->
+    <RuntimeConfigParserTask
+        RuntimeConfigFile="$(RuntimeConfigFilePath)"
+        OutputFile="$(ParsedRuntimeConfigFilePath)"
+        RuntimeConfigReservedProperties="@(RuntimeConfigReservedProperties)">
+    </RuntimeConfigParserTask>
+  </Target>
+
   <!-- Generate a self-contained app bundle for Android with tests. -->
   <UsingTask Condition="'$(TargetOS)' == 'Android'"
              TaskName="AndroidAppBuilderTask"
              AssemblyFile="$(AndroidAppBuilderTasksAssemblyPath)" />
-  <UsingTask Condition="'$(TargetOS)' == 'Android'"
-             TaskName="RuntimeConfigParserTask"
-             AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)" />
 
-  <Target Condition="'$(TargetOS)' == 'Android'" Name="BundleTestAndroidApp">
+  <Target Condition="'$(TargetOS)' == 'Android'" Name="BundleTestAndroidApp" DependsOnTargets="GenerateRuntimeConfig">
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
 
     <PropertyGroup>
@@ -76,16 +95,12 @@
       <AndroidAbi Condition="'$(TargetArchitecture)' == 'x86'">x86</AndroidAbi>
 
       <MainLibraryFileName Condition="'$(MainLibraryFileName)' == ''">AndroidTestRunner.dll</MainLibraryFileName>
-      <RuntimeConfigFilePath>$(PublishDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFilePath>
-      <ParsedRuntimeConfigFilePath>$(PublishDir)runtimeconfig.bin</ParsedRuntimeConfigFilePath>
     </PropertyGroup>
     <ItemGroup Condition="'$(RunAOTCompilation)' == 'true'">
       <AotInputAssemblies Include="$(PublishDir)\*.dll">
         <AotArguments>@(MonoAOTCompilerDefaultAotArguments, ';')</AotArguments>
         <ProcessArguments>@(MonoAOTCompilerDefaultProcessArguments, ';')</ProcessArguments>
       </AotInputAssemblies>
-      <RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER"/>
-      <RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY"/>
     </ItemGroup>
 
     <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(XunitExcludesTxtFileContent)" Overwrite="true" />
@@ -93,13 +108,6 @@
     <MakeDir Directories="$(_MobileIntermediateOutputPath)"
              Condition="'$(RunAOTCompilation)' == 'true'"/>
     <RemoveDir Directories="$(BundleDir)" />
-
-    <!-- Parse runtimeconfig.template.json file -->
-    <RuntimeConfigParserTask
-        RuntimeConfigFile="$(RuntimeConfigFilePath)"
-        OutputFile="$(ParsedRuntimeConfigFilePath)"
-        RuntimeConfigReservedProperties="@(RuntimeConfigReservedProperties)">
-    </RuntimeConfigParserTask>
 
     <MonoAOTCompiler Condition="'$(RunAOTCompilation)' == 'true'"
         CompilerBinaryPath="$(MonoAotCrossCompilerPath)"
@@ -147,7 +155,7 @@
     <DevTeamProvisioning Condition="'$(TargetOS)' == 'MacCatalyst' and '$(DevTeamProvisioning)' == ''">adhoc</DevTeamProvisioning>
   </PropertyGroup>
 
-  <Target Condition="'$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator'" Name="BundleTestAppleApp">
+  <Target Condition="'$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator'" Name="BundleTestAppleApp" DependsOnTargets="GenerateRuntimeConfig">
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <Error Condition="('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm' or '$(TargetOS)' == 'MacCatalyst') and '$(DevTeamProvisioning)' == ''"
            Text="'DevTeamProvisioning' needs to be set for device builds. Set it to 'UBF8T346G9' if you're part of the Microsoft team account, or 'adhoc' to sign with an adhoc key.." />

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -59,7 +59,8 @@
   <Import Project="$(MSBuildThisFileDirectory)tests.wasm.targets" Condition="'$(TargetOS)' == 'Browser'" />
 
   <UsingTask TaskName="RuntimeConfigParserTask"
-             AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)" />
+             AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)"
+             Condition="'$(RuntimeConfigParserTasksAssemblyPath)' != ''" />
 
   <Target Name="GenerateRuntimeConfig">
     <PropertyGroup>

--- a/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -67,8 +67,6 @@ namespace System.Text.Encodings.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Theory]
         [MemberData(nameof(Encoding_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void VerifyCodePageAttributes(int codepage, string name, string bodyName, string headerName, bool isBrowserDisplay,
                                             bool isBrowserSave, bool isMailNewsDisplay, bool isMailNewsSave, int windowsCodePage)
         {
@@ -86,8 +84,6 @@ namespace System.Text.Encodings.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Theory]
         [MemberData(nameof(Normalization_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void NormalizationTest(int codepage, bool normalized, bool normalizedC, bool normalizedD, bool normalizedKC, bool normalizedKD)
         {
             Encoding encoding = Encoding.GetEncoding(codepage);

--- a/src/libraries/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
@@ -90,8 +90,6 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void TestEncodingNameAndCopdepageNumber()
         {
             foreach (var map in s_mapping)
@@ -103,8 +101,6 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void GetEncoding_EncodingName()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -125,8 +121,6 @@ namespace System.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38433", TestPlatforms.Browser)] // wasm doesn't honor runtimeconfig.json
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void GetEncoding_WebName()
         {
             foreach (var mapping in s_codePageToWebNameMappings)

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <!-- Encoding.UTF7 and UTF7Encoding are obsolete, but we're the unit test project for it, so suppress warnings -->
     <NoWarn>$(NoWarn),SYSLIB0001</NoWarn>
+    <EnableUnsafeUTF7Encoding>true</EnableUnsafeUTF7Encoding>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ASCIIEncoding\ASCIIEncodingEncode.cs" />
@@ -84,9 +85,6 @@
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqVersion)" />

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
@@ -61,8 +61,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encode_Basic_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void Encode_Basic(string source, int index, int count, byte[] expected)
         {
             Encode_Advanced(true, source, index, count, expected);

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
@@ -52,10 +52,9 @@ namespace System.Text.Tests
             yield return new object[] { Encoding.UTF7 };
             yield return new object[] { Encoding.GetEncoding("utf-7") };
         }
+
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void WebName(UTF7Encoding encoding)
         {
             Assert.Equal("utf-7", encoding.WebName);
@@ -63,8 +62,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void CodePage(UTF7Encoding encoding)
         {
             Assert.Equal(65000, encoding.CodePage);
@@ -72,8 +69,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void EncodingName(UTF7Encoding encoding)
         {
             Assert.NotEmpty(encoding.EncodingName); // Unicode (UTF-7) in en-US
@@ -81,8 +76,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IsSingleByte(UTF7Encoding encoding)
         {
             Assert.False(encoding.IsSingleByte);
@@ -90,8 +83,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void Clone(UTF7Encoding encoding)
         {
             UTF7Encoding clone = (UTF7Encoding)encoding.Clone();
@@ -125,8 +116,6 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50573", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51394", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void EqualsTest(UTF7Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));

--- a/src/libraries/System.Text.Encoding/tests/runtimeconfig.template.json
+++ b/src/libraries/System.Text.Encoding/tests/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.Text.Encoding.EnableUnsafeUTF7Encoding": true
-  }
-}

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -239,6 +239,8 @@ mono_droid_runtime_init (const char* executable, int managed_argc, char* managed
         arg->kind = 0;
         arg->runtimeconfig.name.path = file_path;
         monovm_runtimeconfig_initialize (arg, cleanup_runtime_config, file_path);
+    } else {
+        free (file_path);
     }
 
     monovm_initialize(2, appctx_keys, appctx_values);

--- a/src/tasks/AppleAppBuilder/Templates/runtime.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime.m
@@ -26,6 +26,8 @@ static char *bundle_path;
 
 #define APPLE_RUNTIME_IDENTIFIER "//%APPLE_RUNTIME_IDENTIFIER%"
 
+#define RUNTIMECONFIG_BIN_FILE "runtimeconfig.bin"
+
 const char *
 get_bundle_path (void)
 {
@@ -205,6 +207,13 @@ register_dllmap (void)
 //%DllMap%
 }
 
+void
+cleanup_runtime_config (MonovmRuntimeConfigArguments *args, void *user_data)
+{
+    free (args);
+    free (user_data);
+}
+
 #if FORCE_INTERPRETER || FORCE_AOT || (!TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST)
 void mono_jit_set_aot_mode (MonoAotMode mode);
 void register_aot_modules (void);
@@ -257,6 +266,23 @@ mono_ios_runtime_init (void)
         icu_dat_path
 #endif
     };
+
+    char *file_name = RUNTIMECONFIG_BIN_FILE;
+    int str_len = strlen (bundle) + strlen (file_name) + 2;
+    char *file_path = (char *)malloc (sizeof (char) * str_len);
+    int num_char = snprintf (file_path, str_len, "%s/%s", bundle, file_name);
+    struct stat buffer;
+
+    assert (num_char > 0 && num_char < str_len);
+
+    if (stat (file_path, &buffer) == 0) {
+        MonovmRuntimeConfigArguments *arg = (MonovmRuntimeConfigArguments *)malloc (sizeof (MonovmRuntimeConfigArguments));
+        arg->kind = 0;
+        arg->runtimeconfig.name.path = file_path;
+        monovm_runtimeconfig_initialize (arg, cleanup_runtime_config, file_path);
+    } else {
+        free (file_path);
+    }
 
     monovm_initialize (sizeof (appctx_keys) / sizeof (appctx_keys [0]), appctx_keys, appctx_values);
 


### PR DESCRIPTION
Fixes #50573
Fixes #51394

It's quite unexpected to me that overriding methods through `runtimeconfig.template.json` doesn't work on WASM/iOS/Android. Some of the properties can be specified with both MSBuild properties and the JSON config file. The MSBuild properties take precedence over the user specified JSON file. Since the new SDKs specify defaults for the MSBuild properties the defaults always override the JSON config mechanism.