### PR TITLE
JIT into scratch buffer

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2680,7 +2680,11 @@ void EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t reserveFo
         pCodeHdr = ((CodeHeader *)pCode) - 1;
 
         *pAllocatedSize = sizeof(CodeHeader) + totalSize;
+#ifdef FEATURE_WXORX
         pCodeHdrRW = (CodeHeader *)new BYTE[*pAllocatedSize];
+#else
+        pCodeHdrRW = pCodeHdr;
+#endif
 
 #ifdef USE_INDIRECT_CODEHEADER
         if (requestInfo.IsDynamicDomain())

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -461,9 +461,9 @@ protected:
 // The number of code heaps at which we increase the size of new code heaps.
 #define CODE_HEAP_SIZE_INCREASE_THRESHOLD 5
 
-typedef DPTR(struct _HeapList) PTR_HeapList;
+typedef DPTR(struct HeapList) PTR_HeapList;
 
-typedef struct _HeapList
+struct HeapList
 {
     PTR_HeapList        hpNext;
 
@@ -497,7 +497,7 @@ typedef struct _HeapList
     void SetNext(PTR_HeapList next)
     { hpNext = next; }
 
-} HeapList;
+};
 
 //-----------------------------------------------------------------------------
 // Implementation of the standard CodeHeap.
@@ -974,12 +974,15 @@ public:
 
     BOOL                LoadJIT();
 
-    void                allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, CodeHeader** ppCodeHeader, CodeHeader** ppCodeHeaderRW, size_t* pAllocatedSize, BYTE** ppRealHeader
-#ifdef FEATURE_EH_FUNCLETS
-                                  , UINT nUnwindInfos
-                                  , TADDR * pModuleBase
+    void                allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, CodeHeader** ppCodeHeader, CodeHeader** ppCodeHeaderRW,
+                                  size_t* pAllocatedSize, HeapList** ppCodeHeap
+#ifdef USE_INDIRECT_CODEHEADER
+                                , BYTE** ppRealHeader
 #endif
-                                  );
+#ifdef FEATURE_EH_FUNCLETS
+                                , UINT nUnwindInfos
+#endif
+                                );
     BYTE *              allocGCInfo(CodeHeader* pCodeHeader, DWORD blockSize, size_t * pAllocationSize);
     EE_ILEXCEPTION*     allocEHInfo(CodeHeader* pCodeHeader, unsigned numClauses, size_t * pAllocationSize);
     JumpStubBlockHeader* allocJumpStubBlock(MethodDesc* pMD, DWORD numJumps,
@@ -1024,6 +1027,7 @@ public:
 #ifndef DACCESS_COMPILE
 	// Heap Management functions
     void NibbleMapSet(HeapList * pHp, TADDR pCode, BOOL bSet);
+    void NibbleMapSetUnlocked(HeapList * pHp, TADDR pCode, BOOL bSet);
 #endif  // !DACCESS_COMPILE
 
     static TADDR FindMethodCode(RangeSection * pRangeSection, PCODE currentPC);
@@ -1054,7 +1058,7 @@ private :
     bool        CanUseCodeHeap(CodeHeapRequestInfo *pInfo, HeapList *pCodeHeap);
     void*       allocCodeRaw(CodeHeapRequestInfo *pInfo,
                              size_t header, size_t blockSize, unsigned align,
-                             HeapList ** ppCodeHeap, size_t* pAllocatedSize);
+                             HeapList ** ppCodeHeap);
 
     DomainCodeHeapList *GetCodeHeapList(CodeHeapRequestInfo *pInfo, LoaderAllocator *pAllocator, BOOL fDynamicOnly = FALSE);
     DomainCodeHeapList *CreateCodeHeapList(CodeHeapRequestInfo *pInfo);

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -974,7 +974,7 @@ public:
 
     BOOL                LoadJIT();
 
-    CodeHeader*         allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, size_t* pAllocatedSize
+    void                allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, CodeHeader** ppCodeHeader, CodeHeader** ppCodeHeaderRW, size_t* pAllocatedSize, BYTE** ppRealHeader
 #ifdef FEATURE_EH_FUNCLETS
                                   , UINT nUnwindInfos
                                   , TADDR * pModuleBase

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -974,7 +974,7 @@ public:
 
     BOOL                LoadJIT();
 
-    CodeHeader*         allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag
+    CodeHeader*         allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, size_t* pAllocatedSize
 #ifdef FEATURE_EH_FUNCLETS
                                   , UINT nUnwindInfos
                                   , TADDR * pModuleBase
@@ -1054,7 +1054,7 @@ private :
     bool        CanUseCodeHeap(CodeHeapRequestInfo *pInfo, HeapList *pCodeHeap);
     void*       allocCodeRaw(CodeHeapRequestInfo *pInfo,
                              size_t header, size_t blockSize, unsigned align,
-                             HeapList ** ppCodeHeap);
+                             HeapList ** ppCodeHeap, size_t* pAllocatedSize);
 
     DomainCodeHeapList *GetCodeHeapList(CodeHeapRequestInfo *pInfo, LoaderAllocator *pAllocator, BOOL fDynamicOnly = FALSE);
     DomainCodeHeapList *CreateCodeHeapList(CodeHeapRequestInfo *pInfo);

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -5286,8 +5286,7 @@ void FixupPrecode::Init(MethodDesc* pMD, LoaderAllocator *pLoaderAllocator, int 
             *(void**)GetBase() = (BYTE*)pMD - (iMethodDescChunkIndex * MethodDesc::ALIGNMENT);
     }
 
-    MethodDesc* pPrecodeMD = (MethodDesc*)GetMethodDesc();
-    _ASSERTE((TADDR)pPrecodeMD == (TADDR)pMD);
+    _ASSERTE(GetMethodDesc() == (TADDR)pMD);
 
     PCODE target = (PCODE)GetEEFuncEntryPoint(PrecodeFixupThunk);
 #ifdef FIXUP_PRECODE_PREALLOCATE_DYNAMIC_METHOD_JUMP_STUBS

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -5286,7 +5286,8 @@ void FixupPrecode::Init(MethodDesc* pMD, LoaderAllocator *pLoaderAllocator, int 
             *(void**)GetBase() = (BYTE*)pMD - (iMethodDescChunkIndex * MethodDesc::ALIGNMENT);
     }
 
-    _ASSERTE(GetMethodDesc() == (TADDR)pMD);
+    MethodDesc* pPrecodeMD = (MethodDesc*)GetMethodDesc();
+    _ASSERTE((TADDR)pPrecodeMD == (TADDR)pMD);
 
     PCODE target = (PCODE)GetEEFuncEntryPoint(PrecodeFixupThunk);
 #ifdef FIXUP_PRECODE_PREALLOCATE_DYNAMIC_METHOD_JUMP_STUBS

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11209,7 +11209,10 @@ void CEEJitInfo::WriteCode(EEJitManager * jitMgr)
     }
 #endif // USE_INDIRECT_CODEHEADER
 
-    memcpy(m_CodeHeader, m_CodeHeaderRW, m_codeWriteBufferSize);
+    if (m_CodeHeaderRW != m_CodeHeader)
+    {
+        memcpy(m_CodeHeader, m_CodeHeaderRW, m_codeWriteBufferSize);
+    }
 
     // Now that the code header was written to the final location, publish the code via the nibble map
     jitMgr->NibbleMapSet(m_pCodeHeap, m_CodeHeader->GetCodeStartAddress(), TRUE);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11718,7 +11718,7 @@ void CEEJitInfo::recordRelocation(void * location,
             delta = (INT64)(branchTarget - fixupLocation);
             _ASSERTE((delta & 0x3) == 0);          // the low two bits must be zero
 
-            UINT32 branchInstr = *((UINT32*) fixupLocation);
+            UINT32 branchInstr = *((UINT32*) fixupLocationRW);
             branchInstr &= 0xFC000000;  // keep bits 31-26
             _ASSERTE((branchInstr & 0x7FFFFFFF) == 0x14000000);  // Must be B or BL
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11556,8 +11556,8 @@ void CEEJitInfo::allocUnwindInfo (
         for (ULONG iUnwindInfo = 0; iUnwindInfo < m_usedUnwindInfos - 1; iUnwindInfo++)
         {
             PT_RUNTIME_FUNCTION pOtherFunction = m_CodeHeaderRW->GetUnwindInfo(iUnwindInfo);
-            _ASSERTE((   RUNTIME_FUNCTION__BeginAddress(pOtherFunction) >= RUNTIME_FUNCTION__EndAddress(pRuntimeFunction, baseAddress)
-                     || RUNTIME_FUNCTION__EndAddress(pOtherFunction, baseAddress) <= RUNTIME_FUNCTION__BeginAddress(pRuntimeFunction)));
+            _ASSERTE((   RUNTIME_FUNCTION__BeginAddress(pOtherFunction) >= RUNTIME_FUNCTION__EndAddress(pRuntimeFunction, baseAddress + writeableOffset)
+                     || RUNTIME_FUNCTION__EndAddress(pOtherFunction, baseAddress + writeableOffset) <= RUNTIME_FUNCTION__BeginAddress(pRuntimeFunction)));
         }
     }
 #endif // _DEBUG

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11499,8 +11499,10 @@ void CEEJitInfo::allocUnwindInfo (
     // Make sure that the RUNTIME_FUNCTION is aligned on a DWORD sized boundary
     _ASSERTE(IS_ALIGNED(pRuntimeFunction, sizeof(DWORD)));
 
+
+    size_t writeableOffset = (BYTE *)m_CodeHeaderRW - (BYTE *)m_CodeHeader;
     UNWIND_INFO * pUnwindInfo = (UNWIND_INFO *) &(m_theUnwindBlock[m_usedUnwindSize]);
-    UNWIND_INFO * pUnwindInfoRW = (UNWIND_INFO *)((BYTE*)pUnwindInfo + m_writeableOffset);
+    UNWIND_INFO * pUnwindInfoRW = (UNWIND_INFO *)((BYTE*)pUnwindInfo + writeableOffset);
 
     m_usedUnwindSize += unwindSize;
 
@@ -12316,17 +12318,17 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
 #endif
 
     BYTE* current = (BYTE *)m_CodeHeader->GetCodeStartAddress();
-    m_writeableOffset = (BYTE *)m_CodeHeaderRW - (BYTE *)m_CodeHeader;
+    size_t writeableOffset = (BYTE *)m_CodeHeaderRW - (BYTE *)m_CodeHeader;
 
     *codeBlock = current;
-    *codeBlockRW = current + m_writeableOffset;
+    *codeBlockRW = current + writeableOffset;
     current += codeSize;
 
     if (pArgs->roDataSize > 0)
     {
         current = (BYTE *)ALIGN_UP(current, roDataAlignment);
         pArgs->roDataBlock = current;
-        pArgs->roDataBlockRW = current + m_writeableOffset;
+        pArgs->roDataBlockRW = current + writeableOffset;
         current += pArgs->roDataSize;
     }
     else

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11190,9 +11190,6 @@ void CEEJitInfo::BackoutJitData(EEJitManager * jitMgr)
     CodeHeader* pCodeHeader = m_CodeHeader;
     if (pCodeHeader)
         jitMgr->RemoveJitData(pCodeHeader, m_GCinfo_len, m_EHinfo_len);
-
-    delete [] (BYTE*)m_CodeHeaderRW;
-    m_CodeHeaderRW = NULL;
 }
 
 /*********************************************************************/
@@ -11213,13 +11210,9 @@ void CEEJitInfo::WriteCode(EEJitManager * jitMgr)
 #endif // USE_INDIRECT_CODEHEADER
 
     memcpy(m_CodeHeader, m_CodeHeaderRW, m_codeWriteBufferSize);
-    delete [] (BYTE*)m_CodeHeaderRW;
-    m_CodeHeaderRW = NULL;
-    m_codeWriteBufferSize = 0;
 
     // Now that the code header was written to the final location, publish the code via the nibble map
-    jitMgr->NibbleMapSetUnlocked(m_pCodeHeap, m_CodeHeader->GetCodeStartAddress(), TRUE);
-    m_pCodeHeap = NULL;
+    jitMgr->NibbleMapSet(m_pCodeHeap, m_CodeHeader->GetCodeStartAddress(), TRUE);
 
 #if defined(TARGET_AMD64)
     // Publish the new unwind information in a way that the ETW stack crawler can find

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -705,11 +705,12 @@ public:
             GC_NOTRIGGER;
         } CONTRACTL_END;
 
+        if (m_CodeHeaderRW != m_CodeHeader)
+        {
+            delete [] (BYTE*)m_CodeHeaderRW;
+        }
+
         m_CodeHeader = NULL;
-        
-#ifdef FEATURE_WXORX
-        delete [] (BYTE*)m_CodeHeaderRW;
-#endif
         m_CodeHeaderRW = NULL;
 
         m_codeWriteBufferSize = 0;
@@ -870,9 +871,11 @@ public:
             MODE_ANY;
         } CONTRACTL_END;
 
-#ifdef FEATURE_WXORX
-        delete [] (BYTE*)m_CodeHeaderRW;
-#endif
+        if (m_CodeHeaderRW != m_CodeHeader)
+        {
+            delete [] (BYTE*)m_CodeHeaderRW;
+        }
+
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
 

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -707,7 +707,9 @@ public:
 
         m_CodeHeader = NULL;
         
+#ifdef FEATURE_WXORX
         delete [] (BYTE*)m_CodeHeaderRW;
+#endif
         m_CodeHeaderRW = NULL;
 
         m_codeWriteBufferSize = 0;
@@ -868,8 +870,9 @@ public:
             MODE_ANY;
         } CONTRACTL_END;
 
+#ifdef FEATURE_WXORX
         delete [] (BYTE*)m_CodeHeaderRW;
-
+#endif
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
 

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -626,6 +626,7 @@ protected:
 /*********************************************************************/
 
 class  EEJitManager;
+struct  HeapList;
 struct _hpCodeHdr;
 typedef struct _hpCodeHdr CodeHeader;
 
@@ -711,8 +712,10 @@ public:
         m_CodeHeaderRW = NULL;
 
         m_codeWriteBufferSize = 0;
-
+#ifdef USE_INDIRECT_CODEHEADER
         m_pRealCodeHeader = NULL;
+#endif
+        m_pCodeHeap = NULL;
 
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
@@ -814,8 +817,11 @@ public:
           m_CodeHeader(NULL),
           m_CodeHeaderRW(NULL),
           m_codeWriteBufferSize(0),
+#ifdef USE_INDIRECT_CODEHEADER
           m_pRealCodeHeader(NULL),
+#endif
           m_writeableOffset(0),
+          m_pCodeHeap(NULL),
           m_ILHeader(header),
 #ifdef FEATURE_EH_FUNCLETS
           m_moduleBase(NULL),
@@ -921,7 +927,7 @@ public:
 
     void BackoutJitData(EEJitManager * jitMgr);
 
-    void WriteCode();
+    void WriteCode(EEJitManager * jitMgr);
 
     void setPatchpointInfo(PatchpointInfo* patchpointInfo) override final;
     PatchpointInfo* getOSRInfo(unsigned* ilOffset) override final;
@@ -950,8 +956,11 @@ protected :
     CodeHeader*             m_CodeHeader;   // descriptor for JITTED code
     CodeHeader*             m_CodeHeaderRW;
     size_t                  m_codeWriteBufferSize;
+#ifdef USE_INDIRECT_CODEHEADER
     BYTE*                   m_pRealCodeHeader;
+#endif
     size_t                  m_writeableOffset;
+    HeapList*               m_pCodeHeap;
     COR_ILMETHOD_DECODER *  m_ILHeader;     // the code header as exist in the file
 #ifdef FEATURE_EH_FUNCLETS
     TADDR                   m_moduleBase;       // Base for unwind Infos

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -707,8 +707,12 @@ public:
         m_CodeHeader = NULL;
         m_writeableOffset = 0;
         
-        delete [] m_codeWriteBuffer;
-        m_codeWriteBuffer = NULL;
+        delete [] (BYTE*)m_CodeHeaderRW;
+        m_CodeHeaderRW = NULL;
+
+        m_codeWriteBufferSize = 0;
+
+        m_pRealCodeHeader = NULL;
 
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
@@ -808,8 +812,9 @@ public:
         : CEEInfo(fd, fVerifyOnly, allowInlining),
           m_jitManager(jm),
           m_CodeHeader(NULL),
-          m_codeWriteBuffer(NULL),
+          m_CodeHeaderRW(NULL),
           m_codeWriteBufferSize(0),
+          m_pRealCodeHeader(NULL),
           m_writeableOffset(0),
           m_ILHeader(header),
 #ifdef FEATURE_EH_FUNCLETS
@@ -943,8 +948,9 @@ protected :
 
     EEJitManager*           m_jitManager;   // responsible for allocating memory
     CodeHeader*             m_CodeHeader;   // descriptor for JITTED code
-    BYTE*                   m_codeWriteBuffer;
+    CodeHeader*             m_CodeHeaderRW;
     size_t                  m_codeWriteBufferSize;
+    BYTE*                   m_pRealCodeHeader;
     size_t                  m_writeableOffset;
     COR_ILMETHOD_DECODER *  m_ILHeader;     // the code header as exist in the file
 #ifdef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -705,6 +705,10 @@ public:
         } CONTRACTL_END;
 
         m_CodeHeader = NULL;
+        m_writeableOffset = 0;
+        
+        delete [] m_codeWriteBuffer;
+        m_codeWriteBuffer = NULL;
 
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
@@ -804,6 +808,9 @@ public:
         : CEEInfo(fd, fVerifyOnly, allowInlining),
           m_jitManager(jm),
           m_CodeHeader(NULL),
+          m_codeWriteBuffer(NULL),
+          m_codeWriteBufferSize(0),
+          m_writeableOffset(0),
           m_ILHeader(header),
 #ifdef FEATURE_EH_FUNCLETS
           m_moduleBase(NULL),
@@ -909,6 +916,8 @@ public:
 
     void BackoutJitData(EEJitManager * jitMgr);
 
+    void WriteCode();
+
     void setPatchpointInfo(PatchpointInfo* patchpointInfo) override final;
     PatchpointInfo* getOSRInfo(unsigned* ilOffset) override final;
 
@@ -934,6 +943,9 @@ protected :
 
     EEJitManager*           m_jitManager;   // responsible for allocating memory
     CodeHeader*             m_CodeHeader;   // descriptor for JITTED code
+    BYTE*                   m_codeWriteBuffer;
+    size_t                  m_codeWriteBufferSize;
+    size_t                  m_writeableOffset;
     COR_ILMETHOD_DECODER *  m_ILHeader;     // the code header as exist in the file
 #ifdef FEATURE_EH_FUNCLETS
     TADDR                   m_moduleBase;       // Base for unwind Infos

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -706,7 +706,6 @@ public:
         } CONTRACTL_END;
 
         m_CodeHeader = NULL;
-        m_writeableOffset = 0;
         
         delete [] (BYTE*)m_CodeHeaderRW;
         m_CodeHeaderRW = NULL;
@@ -820,7 +819,6 @@ public:
 #ifdef USE_INDIRECT_CODEHEADER
           m_pRealCodeHeader(NULL),
 #endif
-          m_writeableOffset(0),
           m_pCodeHeap(NULL),
           m_ILHeader(header),
 #ifdef FEATURE_EH_FUNCLETS
@@ -959,7 +957,6 @@ protected :
 #ifdef USE_INDIRECT_CODEHEADER
     BYTE*                   m_pRealCodeHeader;
 #endif
-    size_t                  m_writeableOffset;
     HeapList*               m_pCodeHeap;
     COR_ILMETHOD_DECODER *  m_ILHeader;     // the code header as exist in the file
 #ifdef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -868,6 +868,8 @@ public:
             MODE_ANY;
         } CONTRACTL_END;
 
+        delete [] (BYTE*)m_CodeHeaderRW;
+
         if (m_pOffsetMapping != NULL)
             delete [] ((BYTE*) m_pOffsetMapping);
 


### PR DESCRIPTION
This change generates JITted code including the code header into a scratch buffer and copies it to its final location after the JITting is complete. This is another preparation step for the W^X work.

Contributes to #50391