### PR TITLE
support ServerCertificateContext in quic

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -15,6 +16,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal sealed class SafeMsQuicConfigurationHandle : SafeHandle
     {
+        private static readonly FieldInfo _contextCertificate = typeof(SslStreamCertificateContext).GetField("Certificate", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly FieldInfo _contextChain= typeof(SslStreamCertificateContext).GetField("IntermediateCertificates", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         private SafeMsQuicConfigurationHandle()
@@ -31,18 +35,18 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         public static unsafe SafeMsQuicConfigurationHandle Create(QuicClientConnectionOptions options)
         {
             // TODO: lots of ClientAuthenticationOptions are not yet supported by MsQuic.
-            return Create(options, QUIC_CREDENTIAL_FLAGS.CLIENT, certificate: null, options.ClientAuthenticationOptions?.ApplicationProtocols);
+            return Create(options, QUIC_CREDENTIAL_FLAGS.CLIENT, certificate: null, certificateContext: null, options.ClientAuthenticationOptions?.ApplicationProtocols);
         }
 
         public static unsafe SafeMsQuicConfigurationHandle Create(QuicListenerOptions options)
         {
             // TODO: lots of ServerAuthenticationOptions are not yet supported by MsQuic.
-            return Create(options, QUIC_CREDENTIAL_FLAGS.NONE, options.ServerAuthenticationOptions?.ServerCertificate, options.ServerAuthenticationOptions?.ApplicationProtocols);
+            return Create(options, QUIC_CREDENTIAL_FLAGS.NONE, options.ServerAuthenticationOptions?.ServerCertificate, options.ServerAuthenticationOptions?.ServerCertificateContext, options.ServerAuthenticationOptions?.ApplicationProtocols);
         }
 
         // TODO: this is called from MsQuicListener and when it fails it wreaks havoc in MsQuicListener finalizer.
         //       Consider moving bigger logic like this outside of constructor call chains.
-        private static unsafe SafeMsQuicConfigurationHandle Create(QuicOptions options, QUIC_CREDENTIAL_FLAGS flags, X509Certificate? certificate, List<SslApplicationProtocol>? alpnProtocols)
+        private static unsafe SafeMsQuicConfigurationHandle Create(QuicOptions options, QUIC_CREDENTIAL_FLAGS flags, X509Certificate? certificate, SslStreamCertificateContext? certificateContext, List<SslApplicationProtocol>? alpnProtocols)
         {
             // TODO: some of these checks should be done by the QuicOptions type.
             if (alpnProtocols == null || alpnProtocols.Count == 0)
@@ -62,7 +66,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             if ((flags & QUIC_CREDENTIAL_FLAGS.CLIENT) == 0)
             {
-                if (certificate == null)
+                if (certificate == null && certificateContext == null)
                 {
                     throw new Exception("Server must provide certificate");
                 }
@@ -101,6 +105,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             uint status;
             SafeMsQuicConfigurationHandle? configurationHandle;
+            X509Certificate2[]? intermediates = null;
 
             MemoryHandle[]? handles = null;
             QuicBuffer[]? buffers = null;
@@ -121,6 +126,17 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 CredentialConfig config = default;
                 config.Flags = flags; // TODO: consider using LOAD_ASYNCHRONOUS with a callback.
 
+                if (certificateContext != null)
+                {
+                    certificate = (X509Certificate2?) _contextCertificate.GetValue(certificateContext);
+                    intermediates = (X509Certificate2[]?) _contextChain.GetValue(certificateContext);
+
+                    if (certificate == null || intermediates == null)
+                    {
+                        throw new ArgumentException(nameof(certificateContext));
+                    }
+                }
+
                 if (certificate != null)
                 {
                     if (OperatingSystem.IsWindows())
@@ -132,7 +148,24 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     else
                     {
                         CredentialConfigCertificatePkcs12 pkcs12Config;
-                        byte[] asn1 = certificate.Export(X509ContentType.Pkcs12);
+                        byte[] asn1;
+
+                        if (intermediates?.Length > 0)
+                        {
+                            X509Certificate2Collection collection = new X509Certificate2Collection();
+                            collection.Add(certificate);
+                            for (int i= 0; i < intermediates?.Length; i++)
+                            {
+                                collection.Add(intermediates[i]);
+                            }
+
+                            asn1 = collection.Export(X509ContentType.Pkcs12)!;
+                        }
+                        else
+                        {
+                            asn1 = certificate.Export(X509ContentType.Pkcs12);
+                        }
+
                         fixed (void* ptr = asn1)
                         {
                             pkcs12Config.Asn1Blob = (IntPtr)ptr;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -235,7 +235,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                                     additionalCertificates.Import(asn1);
                                     if (additionalCertificates.Count > 0)
                                     {
-                                        certificate = additionalCertificates[0];
+                                        certificate = additionalCertificates[additionalCertificates.Count - 1];
                                     }
                                 }
                             }
@@ -263,7 +263,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                     if (additionalCertificates != null && additionalCertificates.Count > 1)
                     {
-                        for (int i = 1; i < additionalCertificates.Count; i++)
+                        for (int i = 0; i < additionalCertificates.Count - 1; i++)
                         {
                             chain.ChainPolicy.ExtraStore.Add(additionalCertificates[i]);
                         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -8,13 +8,21 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs" Link="TestCommon\System\Net\Configuration.Certificates.cs" />
-    <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs" Link="TestCommon\System\Security\Cryptography\PlatformSupport.cs" />
-    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="TestCommon\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs" Link="Common\System\Net\Capability.Security.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs" Link="Common\System\Net\Configuration.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs" Link="TestCommon\System\Net\Configuration.Certificates.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs" Link="Common\System\Net\Configuration.Http.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs" Link="Common\System\Net\Configuration.Security.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs" Link="TestCommon\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" Link="CommonTest\System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\RevocationResponder.cs" Link="CommonTest\System\Security\Cryptography\X509Certificates\RevocationResponder.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="TestCommon\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
+    <Compile Include="..\..\..\System.Net.Security\tests\FunctionalTests\TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />


### PR DESCRIPTION
This contributes to  #49574 and adds support for ServerCertificateContext and fixes certificate chain handling (seems like the certificates come out in revers order that originally expected) 
ServerCertificateContext is used primarily by Kestrel as comparing to plain certificate saves repeating operations.
The type does not expose some of the private parts we need so this change uses reflection.
We may keep it as such since this happens only once per server instance or we can decide to expose it via API change later. I wanted to plug the missing functionality and add tests for chain handling in QUIC.
