### PR TITLE
Fix platform-specific substitutions

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
+    <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml"
+                             Condition="Exists('$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml')" />
   </ItemGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -24,8 +24,7 @@
 
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
-    <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml"
-                             Condition="Exists('$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml')" />
+    <ILLinkSubstitutionsXmls Condition="'$(TargetsWindows)' == 'true'" Include="$(ILLinkDirectory)ILLink.Substitutions.Windows.xml" />
   </ItemGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Windows.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader" feature="System.Runtime.InteropServices.EnableCppCLIHostActivation" featurevalue="false">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.InteropServices.Marshal" feature="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" featurevalue="false">
+      <method signature="System.Boolean get_IsBuiltInComSupported()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
@@ -6,11 +6,5 @@
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator" feature="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting" featurevalue="false">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
-    <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader" feature="System.Runtime.InteropServices.EnableCppCLIHostActivation" featurevalue="false">
-      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
-    </type>
-    <type fullname="System.Runtime.InteropServices.Marshal" feature="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" featurevalue="false">
-      <method signature="System.Boolean get_IsBuiltInComSupported()" body="stub" value="false" />
-    </type>
   </assembly>
 </linker>

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -12,9 +12,11 @@ namespace Internal.Runtime.InteropServices
     /// </summary>
     public static class InMemoryAssemblyLoader
     {
+#if TARGET_WINDOWS
         private static bool IsSupported { get; } = InitializeIsSupported();
 
         private static bool InitializeIsSupported() => AppContext.TryGetSwitch("System.Runtime.InteropServices.EnableCppCLIHostActivation", out bool isSupported) ? isSupported : true;
+#endif
 
         /// <summary>
         /// Loads into an isolated AssemblyLoadContext an assembly that has already been loaded into memory by the OS loader as a native module.

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -195,9 +195,6 @@ namespace System.Runtime.InteropServices
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void InternalPrelink(RuntimeMethodHandleInternal m);
 
-        [DllImport(RuntimeHelpers.QCall)]
-        private static extern bool IsBuiltInComSupportedInternal();
-
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern /* struct _EXCEPTION_POINTERS* */ IntPtr GetExceptionPointers();
 
@@ -236,9 +233,12 @@ namespace System.Runtime.InteropServices
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsPinnable(object? obj);
 
+#if TARGET_WINDOWS
         internal static bool IsBuiltInComSupported { get; } = IsBuiltInComSupportedInternal();
 
-#if TARGET_WINDOWS
+        [DllImport(RuntimeHelpers.QCall)]
+        private static extern bool IsBuiltInComSupportedInternal();
+
         /// <summary>
         /// Returns the HInstance for this module.  Returns -1 if the module doesn't have
         /// an HInstance.  In Memory (Dynamic) Modules won't have an HInstance.


### PR DESCRIPTION
These feature switches are dead code on non-windows. They were causing
linker warnings because the substitutions weren't being resolved.

See https://github.com/dotnet/sdk/pull/17676