### PR TITLE
[wasm][xharness] install development SSL certificate on Helix agent before xharness run

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -105,6 +105,9 @@
     <HelixPreCommand Include="set XHARNESS_DISABLE_COLORED_OUTPUT=true" />
     <HelixPreCommand Include="set XHARNESS_LOG_WITH_TIMESTAMPS=true" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <HelixPreCommand Include="dotnet dev-certs https" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'BuildWasmApps'">
     <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/chromedriver_linux64:$PATH" />


### PR DESCRIPTION
I added HTTPS listener to existing kestrel server in the xharness last week. 
After the change propagated to this repo, I can see following [issue on Helix](<https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1621860942987?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&amp;groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&amp;parentMessageId=1621860942987&amp;teamName=.NET Core Eng Services Partners&amp;channelName=First Responders&amp;createdTime=1621860942987>)
```
crit: System.InvalidOperationException: Unable to configure HTTPS endpoint. 
No server certificate was specified, and the default developer certificate could not be found or is out of date. 
To generate a developer certificate run 'dotnet dev-certs https'.
```

