### PR TITLE
Fixed a few issues/assumptions relevant to MCJ recording and playing back R2R'ed code

### DIFF
--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2022,7 +2022,7 @@ private:
     PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier);
     PCODE GetPrecompiledNgenCode(PrepareCodeConfig* pConfig);
     PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig);
-    PCODE GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0Jit);
+    PCODE GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0);
     COR_ILMETHOD_DECODER* GetAndVerifyILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyNoMetadataILHeader();
@@ -2207,7 +2207,8 @@ public:
         }
     }
 
-    bool FinalizeOptimizationTierForTier0Jit();
+    bool FinalizeOptimizationTierForTier0Load();
+    bool FinalizeOptimizationTierForTier0LoadOrJit();
 #endif
 
 public:
@@ -2299,21 +2300,21 @@ public:
 class MulticoreJitPrepareCodeConfig : public PrepareCodeConfig
 {
 private:
-    bool m_wasTier0Jit;
+    bool m_wasTier0;
 
 public:
     MulticoreJitPrepareCodeConfig(MethodDesc* pMethod);
 
-    bool WasTier0Jit() const
+    bool WasTier0() const
     {
         LIMITED_METHOD_CONTRACT;
-        return m_wasTier0Jit;
+        return m_wasTier0;
     }
 
-    void SetWasTier0Jit()
+    void SetWasTier0()
     {
         LIMITED_METHOD_CONTRACT;
-        m_wasTier0Jit = true;
+        m_wasTier0 = true;
     }
 
     virtual BOOL SetNativeCode(PCODE pCode, PCODE * ppAlternateCodeToUse) override;

--- a/src/coreclr/vm/multicorejit.h
+++ b/src/coreclr/vm/multicorejit.h
@@ -62,6 +62,7 @@ struct MulticoreJitPlayerStat
     unsigned short    m_nTotalDelay;
     unsigned short    m_nDelayCount;
     unsigned short    m_nWalkBack;
+    unsigned short    m_nNoJitCount;
 
     HRESULT           m_hr;
 
@@ -282,6 +283,7 @@ public:
     MulticoreJitCodeInfo RequestMethodCode(MethodDesc * pMethod);
 
     void RecordMethodJit(MethodDesc * pMethod);
+    void RecordMethodLoad(MethodDesc * pMethod);
 
     MulticoreJitPlayerStat & GetStats()
     {

--- a/src/coreclr/vm/multicorejit.h
+++ b/src/coreclr/vm/multicorejit.h
@@ -85,9 +85,9 @@ private:
     enum class TierInfo : TADDR
     {
         None = 0,
-        WasTier0Jit = 1 << 0,
+        WasTier0 = 1 << 0,
         JitSwitchedToOptimized = 1 << 1,
-        Mask = None | WasTier0Jit | JitSwitchedToOptimized
+        Mask = None | WasTier0 | JitSwitchedToOptimized
     };
 
     TADDR m_entryPointAndTierInfo;
@@ -119,12 +119,12 @@ public:
         return IsNull() ? NULL : PINSTRToPCODE(m_entryPointAndTierInfo & ~(TADDR)TierInfo::Mask);
     }
 
-    bool WasTier0Jit() const
+    bool WasTier0() const
     {
         WRAPPER_NO_CONTRACT;
         VerifyIsNotNull();
 
-        return (m_entryPointAndTierInfo & (TADDR)TierInfo::WasTier0Jit) != 0;
+        return (m_entryPointAndTierInfo & (TADDR)TierInfo::WasTier0) != 0;
     }
 
     bool JitSwitchedToOptimized() const

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -23,7 +23,8 @@
 // Bits 0xff0000 are reserved method flags. Currently only first bit is used.
 const unsigned METHOD_FLAGS_MASK       = 0xff0000;
 const unsigned JIT_BY_APP_THREAD_TAG   = 0x10000;   // tag, that indicates whether method is jitted by application thread(1) or background thread(0)
-// Tags 0xfe0000 are currently free
+const unsigned NO_JIT_TAG              = 0x20000;   // tag, that indicates whether method should be jitted or simply loaded (i.e. related types are created, etc.)
+// Tags 0xfc0000 are currently free
 
 const unsigned RECORD_TYPE_OFFSET      = 24;        // offset of type of record
 
@@ -45,7 +46,7 @@ const int      MAX_WALKBACK      = 128;
 
 enum
 {
-    MULTICOREJIT_PROFILE_VERSION   = 102,
+    MULTICOREJIT_PROFILE_VERSION   = 103,
 
     MULTICOREJIT_HEADER_RECORD_ID           = 1,
     MULTICOREJIT_MODULE_RECORD_ID           = 2,
@@ -297,8 +298,8 @@ private:
 
     HRESULT HandleModuleRecord(const ModuleRecord * pMod);
     HRESULT HandleModuleInfoRecord(unsigned moduleTo, unsigned level);
-    HRESULT HandleNonGenericMethodInfoRecord(unsigned moduleIndex, unsigned token);
-    HRESULT HandleGenericMethodInfoRecord(unsigned moduleIndex, BYTE * signature, unsigned length);
+    HRESULT HandleNonGenericMethodInfoRecord(unsigned moduleIndex, unsigned token, bool dojit);
+    HRESULT HandleGenericMethodInfoRecord(unsigned moduleIndex, BYTE * signature, unsigned length, bool dojit);
     void CompileMethodInfoRecord(Module *pModule, MethodDesc *pMethod, bool isGeneric);
 
     bool CompileMethodDesc(Module * pModule, MethodDesc * pMD);
@@ -559,7 +560,7 @@ struct RecorderInfo
         _ASSERTE(IsFullyInitialized());
     }
 
-    void PackMethod(unsigned moduleIndex, MethodDesc * pMethod, bool application)
+    void PackMethod(unsigned moduleIndex, MethodDesc * pMethod, bool application, bool dojit)
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -584,6 +585,11 @@ struct RecorderInfo
         {
              // Jitted by application threads, not background thread
             data1 |= JIT_BY_APP_THREAD_TAG;
+        }
+
+        if (!dojit)
+        {
+            data1 |= NO_JIT_TAG;
         }
 
         data2 = 0;
@@ -639,7 +645,7 @@ private:
 
     HRESULT WriteModuleRecord(IStream * pStream,  const RecorderModuleInfo & module);
 
-    void RecordMethodInfo(unsigned moduleIndex, MethodDesc * pMethod, bool application);
+    void RecordMethodInfo(unsigned moduleIndex, MethodDesc * pMethod, bool application, bool dojit);
     unsigned RecordModuleInfo(Module * pModule);
     void RecordOrUpdateModuleInfo(FileLoadLevel needLevel, unsigned moduleIndex);
 
@@ -710,7 +716,7 @@ public:
                (m_ModuleCount  >= MAX_MODULES);
     }
 
-    void RecordMethodJit(MethodDesc * pMethod, bool application);
+    void RecordMethodJit(MethodDesc * pMethod, bool application, bool dojit);
 
     MulticoreJitCodeInfo RequestMethodCode(MethodDesc * pMethod, MulticoreJitManager * pManager);
 

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -87,7 +87,7 @@ void MulticoreJitCodeStorage::StoreMethodCode(MethodDesc * pMD, MulticoreJitCode
                 "%p %p %d %d StoredMethodCode",
                 pMD,
                 codeInfo.GetEntryPoint(),
-                (int)codeInfo.WasTier0Jit(),
+                (int)codeInfo.WasTier0(),
                 (int)codeInfo.JitSwitchedToOptimized()));
         }
 #endif
@@ -131,7 +131,7 @@ MulticoreJitCodeInfo MulticoreJitCodeStorage::QueryAndRemoveMethodCode(MethodDes
                     "%p %p %d %d QueryAndRemoveMethodCode",
                     pMethod,
                     codeInfo.GetEntryPoint(),
-                    (int)codeInfo.WasTier0Jit(),
+                    (int)codeInfo.WasTier0(),
                     (int)codeInfo.JitSwitchedToOptimized()));
             }
 #endif
@@ -521,7 +521,9 @@ HRESULT MulticoreJitProfilePlayer::HandleModuleRecord(const ModuleRecord * pMod)
 
 #ifndef DACCESS_COMPILE
 MulticoreJitPrepareCodeConfig::MulticoreJitPrepareCodeConfig(MethodDesc* pMethod) :
-    PrepareCodeConfig(NativeCodeVersion(pMethod), FALSE, FALSE), m_wasTier0Jit(false)
+    // Method code that was pregenerated and loaded is recorded in the multi-core JIT profile, so enable multi-core JIT to also
+    // look up pregenerated code to help parallelize the work
+    PrepareCodeConfig(NativeCodeVersion(pMethod), FALSE, TRUE), m_wasTier0(false)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -548,9 +550,9 @@ MulticoreJitCodeInfo::MulticoreJitCodeInfo(PCODE entryPoint, const MulticoreJitP
     _ASSERTE((m_entryPointAndTierInfo & (TADDR)TierInfo::Mask) == 0);
 
 #ifdef FEATURE_TIERED_COMPILATION
-    if (pConfig->WasTier0Jit())
+    if (pConfig->WasTier0())
     {
-        m_entryPointAndTierInfo |= (TADDR)TierInfo::WasTier0Jit;
+        m_entryPointAndTierInfo |= (TADDR)TierInfo::WasTier0;
     }
 
     if (pConfig->JitSwitchedToOptimized())

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -470,16 +470,41 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier
         {
             LOG_USING_R2R_CODE(this);
 
+#ifdef FEATURE_TIERED_COMPILATION
+            // Finalize the optimization tier before SetNativeCode() is called
+            bool shouldCountCalls = shouldTier && pConfig->FinalizeOptimizationTierForTier0Load();
+#endif
+
             if (pConfig->SetNativeCode(pCode, &pCode))
             {
 #ifdef FEATURE_CODE_VERSIONING
                 pConfig->SetGeneratedOrLoadedNewCode();
 #endif
 #ifdef FEATURE_TIERED_COMPILATION
-                if (shouldTier)
+                if (shouldCountCalls)
                 {
                     _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
                     pConfig->SetShouldCountCalls();
+                }
+#endif
+
+#ifdef FEATURE_MULTICOREJIT
+                // Multi-core JIT is only applicable to the default code version. A method is recorded in the profile only when
+                // SetNativeCode() above succeeds to avoid recording duplicates in the multi-core JIT profile. Successful loads
+                // of R2R code are also recorded.
+                if (pConfig->NeedsMulticoreJitNotification())
+                {
+                    _ASSERTE(pConfig->GetCodeVersion().IsDefaultVersion());
+                    _ASSERTE(!pConfig->IsForMulticoreJit());
+
+                    MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
+                    if (mcJitManager.IsRecorderActive())
+                    {
+                        if (MulticoreJitManager::IsMethodSupported(this))
+                        {
+                            mcJitManager.RecordMethodLoad(this);
+                        }
+                    }
                 }
 #endif
             }
@@ -603,33 +628,16 @@ PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
     }
 #endif
 
-#ifdef FEATURE_MULTICOREJIT
-    if (pCode != NULL && pConfig->NeedsMulticoreJitNotification())
-    {
-        _ASSERTE(pConfig->GetCodeVersion().IsDefaultVersion());
-        _ASSERTE(!pConfig->IsForMulticoreJit());
-
-        MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
-        if (mcJitManager.IsRecorderActive())
-        {
-            if (MulticoreJitManager::IsMethodSupported(this))
-            {
-                mcJitManager.RecordMethodLoad(this); // Tell multi-core JIT manager to record method on successful load from R2R
-            }
-        }
-    }
-#endif
-
     return pCode;
 }
 
-PCODE MethodDesc::GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0Jit)
+PCODE MethodDesc::GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(pConfig != NULL);
     _ASSERTE(pConfig->GetMethodDesc() == this);
-    _ASSERTE(pWasTier0Jit != NULL);
-    _ASSERTE(!*pWasTier0Jit);
+    _ASSERTE(pWasTier0 != NULL);
+    _ASSERTE(!*pWasTier0);
 
     MulticoreJitCodeInfo codeInfo;
 #ifdef FEATURE_MULTICOREJIT
@@ -643,9 +651,9 @@ PCODE MethodDesc::GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier
         #ifdef FEATURE_TIERED_COMPILATION
             if (!codeInfo.IsNull())
             {
-                if (codeInfo.WasTier0Jit())
+                if (codeInfo.WasTier0())
                 {
-                    *pWasTier0Jit = true;
+                    *pWasTier0 = true;
                 }
                 if (codeInfo.JitSwitchedToOptimized())
                 {
@@ -821,13 +829,13 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
             NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
             if (codeVersion.IsDefaultVersion())
             {
-                bool wasTier0Jit = false;
-                pCode = GetMulticoreJitCode(pConfig, &wasTier0Jit);
+                bool wasTier0 = false;
+                pCode = GetMulticoreJitCode(pConfig, &wasTier0);
                 if (pCode != NULL)
                 {
                 #ifdef FEATURE_TIERED_COMPILATION
                     // Finalize the optimization tier before SetNativeCode() is called
-                    bool shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit();
+                    bool shouldCountCalls = wasTier0 && pConfig->FinalizeOptimizationTierForTier0LoadOrJit();
                 #endif
 
                     if (pConfig->SetNativeCode(pCode, &pCode))
@@ -1097,7 +1105,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
 
 #ifdef FEATURE_TIERED_COMPILATION
     // Finalize the optimization tier before SetNativeCode() is called
-    bool shouldCountCalls = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0) && pConfig->FinalizeOptimizationTierForTier0Jit();
+    bool shouldCountCalls = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0) && pConfig->FinalizeOptimizationTierForTier0LoadOrJit();
 #endif
 
     // Aside from rejit, performing a SetNativeCodeInterlocked at this point
@@ -1343,10 +1351,27 @@ const char *PrepareCodeConfig::GetJitOptimizationTierStr(PrepareCodeConfig *conf
 }
 
 #ifdef FEATURE_TIERED_COMPILATION
+// This function should be called before SetNativeCode() for consistency with usage of FinalizeOptimizationTierForTier0Jit
+bool PrepareCodeConfig::FinalizeOptimizationTierForTier0Load()
+{
+    _ASSERTE(GetMethodDesc()->IsEligibleForTieredCompilation());
+    _ASSERTE(!JitSwitchedToOptimized());
+
+    if (!IsForMulticoreJit())
+    {
+        return true; // should count calls if SetNativeCode() succeeds
+    }
+
+    // When using multi-core JIT, the loaded code would not be used until the method is called. Record some information that may
+    // be used later when the method is called.
+    ((MulticoreJitPrepareCodeConfig *)this)->SetWasTier0();
+    return false; // don't count calls
+}
+
 // This function should be called before SetNativeCode() to update the optimization tier if necessary before SetNativeCode() is
 // called. As soon as SetNativeCode() is called, another thread may get the native code and the optimization tier for that code
 // version, and it should have already been finalized.
-bool PrepareCodeConfig::FinalizeOptimizationTierForTier0Jit()
+bool PrepareCodeConfig::FinalizeOptimizationTierForTier0LoadOrJit()
 {
     _ASSERTE(GetMethodDesc()->IsEligibleForTieredCompilation());
 
@@ -1354,7 +1379,7 @@ bool PrepareCodeConfig::FinalizeOptimizationTierForTier0Jit()
     {
         // When using multi-core JIT, the jitted code would not be used until the method is called. Don't make changes to the
         // optimization tier yet, just record some information that may be used later when the method is called.
-        ((MulticoreJitPrepareCodeConfig *)this)->SetWasTier0Jit();
+        ((MulticoreJitPrepareCodeConfig *)this)->SetWasTier0();
         return false; // don't count calls
     }
 
@@ -2247,19 +2272,6 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
         if (pCode == NULL)
         {
             pCode = GetStubForInteropMethod(this);
-#ifdef FEATURE_MULTICOREJIT
-            if (pCode)
-            {
-                MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
-                if (mcJitManager.IsRecorderActive())
-                {
-                    if (MulticoreJitManager::IsMethodSupported(this))
-                    {
-                        mcJitManager.RecordMethodJit(this); // Tell multi-core JIT manager to record method on successful JITting
-                    }
-                }
-            }
-#endif // FEATURE_MULTICOREJIT
         }
 
         GetOrCreatePrecode();

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -602,6 +602,24 @@ PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
         }
     }
 #endif
+
+#ifdef FEATURE_MULTICOREJIT
+    if (pCode != NULL && pConfig->NeedsMulticoreJitNotification())
+    {
+        _ASSERTE(pConfig->GetCodeVersion().IsDefaultVersion());
+        _ASSERTE(!pConfig->IsForMulticoreJit());
+
+        MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
+        if (mcJitManager.IsRecorderActive())
+        {
+            if (MulticoreJitManager::IsMethodSupported(this))
+            {
+                mcJitManager.RecordMethodLoad(this); // Tell multi-core JIT manager to record method on successful load from R2R
+            }
+        }
+    }
+#endif
+
     return pCode;
 }
 


### PR DESCRIPTION
- Renamed `*wasTier0Jit` to `wasTier0` to include pregenerated code that is loaded, which is considered tier 0
- Added a subset of `FinalizeOptimizationTierForTier0Jit` as `FinalizeOptimizationTierForTier0Load` to set the `wasTier0` flag so that those methods would be call-counted for tiering when MCJ-loaded code is used, and updated the relevant code
- Moved recording of loaded method code to after a successful `SetNativeCode()` to prevent duplicate recordings of the same method in multi-threaded races
- Enabled `MulticoreJitPrepareCodeConfig` to look up pregenerated code to parallelize that work

Intended to be incorporated into https://github.com/dotnet/runtime/pull/52595