### PR TITLE
[Release/5.0] - Fix internal cache clean up for ComWrappers

### DIFF
--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -856,7 +856,7 @@ void* NativeObjectWrapperContext::GetRuntimeContext() const noexcept
 
 IReferenceTracker* NativeObjectWrapperContext::GetReferenceTracker() const noexcept
 {
-    return ((_trackerObjectState == TrackerObjectState_NotSet) ? nullptr : _trackerObject);
+    return ((_trackerObjectState == TrackerObjectState_NotSet || _trackerObjectDisconnected) ? nullptr : _trackerObject);
 }
 
 // See TrackerObjectManager::AfterWrapperCreated() for AddRefFromTrackerSource() usage.

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -66,6 +66,8 @@ VOID GCToEEInterface::AfterGcScanRoots (int condemned, int max_gen,
     // the RCW cache from resurrecting them.
     ::GetAppDomain()->DetachRCWs();
 #endif // FEATURE_COMINTEROP
+
+    Interop::OnAfterGCScanRoots();
 }
 
 /*

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -65,9 +65,9 @@ VOID GCToEEInterface::AfterGcScanRoots (int condemned, int max_gen,
     // Go through all the only app domain and detach all the *unmarked* RCWs to prevent
     // the RCW cache from resurrecting them.
     ::GetAppDomain()->DetachRCWs();
-#endif // FEATURE_COMINTEROP
 
     Interop::OnAfterGCScanRoots();
+#endif // FEATURE_COMINTEROP
 }
 
 /*

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -30,9 +30,15 @@ namespace
         enum
         {
             Flags_None = 0,
+
+            // The EOC has been collected and is no longer visible from managed code.
             Flags_Collected = 1,
+
             Flags_ReferenceTracker = 2,
             Flags_InCache = 4,
+
+            // The EOC is "detached" and no longer used to map between identity and a managed object.
+            Flags_Detached = 8,
         };
         DWORD Flags;
 
@@ -69,7 +75,7 @@ namespace
 
         bool IsActive() const
         {
-            return !IsSet(Flags_Collected)
+            return !IsSet(Flags_Collected | Flags_Detached)
                 && (SyncBlockIndex != InvalidSyncBlockIndex);
         }
 
@@ -78,6 +84,17 @@ namespace
             _ASSERTE(GCHeapUtilities::IsGCInProgress());
             SyncBlockIndex = InvalidSyncBlockIndex;
             Flags |= Flags_Collected;
+        }
+
+        void MarkDetached()
+        {
+            _ASSERTE(GCHeapUtilities::IsGCInProgress());
+            Flags |= Flags_Detached;
+        }
+
+        void MarkNotInCache()
+        {
+            ::InterlockedAnd((LONG*)&Flags, (~Flags_InCache));
         }
 
         OBJECTREF GetObjectRef()
@@ -432,6 +449,32 @@ namespace
 
             _hashMap.Remove(cxt->GetKey());
         }
+
+        void DetachNotPromotedEOCs()
+        {
+            CONTRACTL
+            {
+                NOTHROW;
+                GC_NOTRIGGER;
+                MODE_ANY;
+                PRECONDITION(GCHeapUtilities::IsGCInProgress()); // GC is in progress and the runtime is suspended
+            }
+            CONTRACTL_END;
+
+            Iterator curr = _hashMap.Begin();
+            Iterator end = _hashMap.End();
+
+            ExternalObjectContext* cxt;
+            for (; curr != end; ++curr)
+            {
+                cxt = *curr;
+                if (cxt->IsActive()
+                    && !GCHeapUtilities::GetGCHeap()->IsPromoted(OBJECTREFToObject(cxt->GetObjectRef())))
+                {
+                    cxt->MarkDetached();
+                }
+            }
+        }
     };
 
     // Global instance of the external object cache
@@ -730,6 +773,15 @@ namespace
                 {
                     handle = handleLocal;
                 }
+            }
+            else if (extObjCxt != NULL && extObjCxt->IsSet(ExternalObjectContext::Flags_Detached))
+            {
+                // If an EOC has been found but is marked detached, then we will remove it from the
+                // cache here instead of letting the GC do it later and pretend like it wasn't found.
+                STRESS_LOG1(LF_INTEROP, LL_INFO10, "Detached EOC requested: 0x%p\n", extObjCxt);
+                cache->Remove(extObjCxt);
+                extObjCxt->MarkNotInCache();
+                extObjCxt = NULL;
             }
         }
 
@@ -1825,5 +1877,21 @@ void Interop::OnGCFinished(_In_ int nCondemnedGeneration)
             STRESS_LOG0(LF_INTEROP, LL_INFO10000, "End Reference Tracking\n");
         }
     }
+#endif // FEATURE_COMWRAPPERS
+}
+
+void Interop::OnAfterGCScanRoots()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
+
+#ifdef FEATURE_COMWRAPPERS
+    ExtObjCxtCache* cache = ExtObjCxtCache::GetInstanceNoThrow();
+    if (cache != NULL)
+        cache->DetachNotPromotedEOCs();
 #endif // FEATURE_COMWRAPPERS
 }

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -38,6 +38,7 @@ namespace
             Flags_InCache = 4,
 
             // The EOC is "detached" and no longer used to map between identity and a managed object.
+            // This will only be set if the EOC was inserted into the cache.
             Flags_Detached = 8,
         };
         DWORD Flags;
@@ -75,7 +76,7 @@ namespace
 
         bool IsActive() const
         {
-            return !IsSet(Flags_Collected | Flags_Detached)
+            return !IsSet(Flags_Collected)
                 && (SyncBlockIndex != InvalidSyncBlockIndex);
         }
 
@@ -468,7 +469,7 @@ namespace
             for (; curr != end; ++curr)
             {
                 cxt = *curr;
-                if (cxt->IsActive()
+                if (!cxt->IsSet(ExternalObjectContext::Flags_Detached)
                     && !GCHeapUtilities::GetGCHeap()->IsPromoted(OBJECTREFToObject(cxt->GetObjectRef())))
                 {
                     cxt->MarkDetached();

--- a/src/coreclr/src/vm/interoplibinterface.h
+++ b/src/coreclr/src/vm/interoplibinterface.h
@@ -99,4 +99,6 @@ public:
 
     // Notify when GC finished
     static void OnGCFinished(_In_ int nCondemnedGeneration);
+
+    static void OnAfterGCScanRoots();
 };

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -261,6 +261,56 @@ namespace ComWrappersTests
                 });
         }
 
+        static void ValidateExternalWrapperCacheCleanUp()
+        {
+            Console.WriteLine($"Running {nameof(ValidateExternalWrapperCacheCleanUp)}...");
+
+            var cw = new TestComWrappers();
+
+            // Get an object from a tracker runtime.
+            IntPtr trackerObjRaw = MockReferenceTrackerRuntime.CreateTrackerObject();
+
+            // Create a wrapper for the object instance.
+            var weakRef1 = CreateAndRegisterWrapper(cw, trackerObjRaw);
+
+            // Run the GC to have the wrapper marked for collection.
+            ForceGC();
+
+            // Create a new wrapper for the same external object.
+            var weakRef2 = CreateAndRegisterWrapper(cw, trackerObjRaw);
+
+            // We are using a tracking resurrection WeakReference<T> so we should be able
+            // to get back the objects as they are all continually re-registering for Finalization.
+            Assert.IsTrue(weakRef1.TryGetTarget(out ITrackerObjectWrapper wrapper1));
+            Assert.IsTrue(weakRef2.TryGetTarget(out ITrackerObjectWrapper wrapper2));
+
+            // Check that the two wrappers aren't equal, meaning we created a new wrapper since
+            // the first wrapper was removed from the internal cache.
+            Assert.AreNotEqual(wrapper1, wrapper2);
+
+            // Let the wrappers Finalize.
+            wrapper1.ReregisterForFinalize = false;
+            wrapper2.ReregisterForFinalize = false;
+
+            static WeakReference<ITrackerObjectWrapper> CreateAndRegisterWrapper(ComWrappers cw, IntPtr trackerObjRaw)
+            {
+                // Manually create a wrapper
+                var iid = typeof(ITrackerObject).GUID;
+                IntPtr iTestComObject;
+                int hr = Marshal.QueryInterface(trackerObjRaw, ref iid, out iTestComObject);
+                Assert.AreEqual(0, hr);
+                var nativeWrapper = new ITrackerObjectWrapper(iTestComObject);
+
+                nativeWrapper = (ITrackerObjectWrapper)cw.GetOrRegisterObjectForComInstance(trackerObjRaw, CreateObjectFlags.None, nativeWrapper);
+
+                // Set this on the return instead of during creation since the returned wrapper may be the one from
+                // the internal cache and not the one passed in above.
+                nativeWrapper.ReregisterForFinalize = true;
+
+                return new WeakReference<ITrackerObjectWrapper>(nativeWrapper, trackResurrection: true);
+            }
+        }
+
         static void ValidateIUnknownImpls()
             => TestComWrappers.ValidateIUnknownImpls();
 
@@ -477,6 +527,7 @@ namespace ComWrappersTests
                 ValidateCreateObjectCachingScenario();
                 ValidateWrappersInstanceIsolation();
                 ValidatePrecreatedExternalWrapper();
+                ValidateExternalWrapperCacheCleanUp();
                 ValidateIUnknownImpls();
                 ValidateBadComWrapperImpl();
                 ValidateRuntimeTrackerScenario();

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -206,8 +206,17 @@ namespace ComWrappersTests.Common
 
         ~ITrackerObjectWrapper()
         {
-            ComWrappersHelper.Cleanup(ref this.classNative);
+            if (this.ReregisterForFinalize)
+            {
+                GC.ReRegisterForFinalize(this);
+            }
+            else
+            {
+                ComWrappersHelper.Cleanup(ref this.classNative);
+            }
         }
+
+        public bool ReregisterForFinalize { get; set; } = false;
 
         public int AddObjectRef(IntPtr obj)
         {


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/52771

## Customer Impact
Race condition between object resurrection and memory reuse of different `IUnknown*` instance. This is a precise fix for https://github.com/microsoft/CsWinRT/issues/762 and other related object resurrection issues we've been chasing for the past 2 months.

## Testing
Testing added in PR.
Partner team has run all C#/WinRT and WinUI tests and validated fix on all reported reproducing applications against a private build of runtime.

## Risk
Low, it only impacts C#/WinRT scenarios.

## Regression
This API was introduced in .NET 5 and is requested by the only official consumer.
