### PR TITLE
Add JsonPropertyDictionary and associated refactoring

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -50,6 +50,9 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Escaping.cs" />
+    <Compile Include="System\Text\Json\JsonPropertyDictionary.cs" />
+    <Compile Include="System\Text\Json\JsonPropertyDictionary.KeyCollection.cs" />
+    <Compile Include="System\Text\Json\JsonPropertyDictionary.ValueCollection.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.IList.cs" />
@@ -62,8 +65,6 @@
     <Compile Include="System\Text\Json\Nodes\JsonObject.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonObject.Dynamic.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonObject.IDictionary.cs" />
-    <Compile Include="System\Text\Json\Nodes\JsonObject.KeyCollection.cs" />
-    <Compile Include="System\Text\Json\Nodes\JsonObject.ValueCollection.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonValue.CreateOverloads.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonValue.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonValueNotTrimmable.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
@@ -4,34 +4,33 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace System.Text.Json.Nodes
+namespace System.Text.Json
 {
-    public partial class JsonObject
+    internal partial class JsonPropertyDictionary<T>
     {
         private KeyCollection? _keyCollection;
 
-        private KeyCollection GetKeyCollection(JsonObject jsonObject)
+        public ICollection<string> GetKeyCollection()
         {
-            CreateList();
-            return _keyCollection ??= new KeyCollection(jsonObject);
+            return _keyCollection ??= new KeyCollection(this);
         }
 
         private sealed class KeyCollection : ICollection<string>
         {
-            private readonly JsonObject _jObject;
+            private readonly JsonPropertyDictionary<T> _parent;
 
-            public KeyCollection(JsonObject jsonObject)
+            public KeyCollection(JsonPropertyDictionary<T> jsonObject)
             {
-                _jObject = jsonObject;
+                _parent = jsonObject;
             }
 
-            public int Count => _jObject.Count;
+            public int Count => _parent.Count;
 
             public bool IsReadOnly => true;
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     yield return item.Key;
                 }
@@ -39,12 +38,9 @@ namespace System.Text.Json.Nodes
 
             public void Add(string propertyName) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
 
-
             public void Clear() => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
 
-
-            public bool Contains(string propertyName) => _jObject.ContainsNode(propertyName);
-
+            public bool Contains(string propertyName) => _parent.ContainsProperty(propertyName);
 
             public void CopyTo(string[] propertyNameArray, int index)
             {
@@ -53,7 +49,7 @@ namespace System.Text.Json.Nodes
                     ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
                 }
 
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     if (index >= propertyNameArray.Length)
                     {
@@ -66,7 +62,7 @@ namespace System.Text.Json.Nodes
 
             public IEnumerator<string> GetEnumerator()
             {
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     yield return item.Key;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
@@ -4,55 +4,52 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace System.Text.Json.Nodes
+namespace System.Text.Json
 {
-    public partial class JsonObject
+    internal partial class JsonPropertyDictionary<T>
     {
         private ValueCollection? _valueCollection;
 
-        private ValueCollection GetValueCollection(JsonObject jsonObject)
+        public ICollection<T?> GetValueCollection()
         {
-            CreateList();
-            return _valueCollection ??= new ValueCollection(jsonObject);
+            return _valueCollection ??= new ValueCollection(this);
         }
 
-        private sealed class ValueCollection : ICollection<JsonNode?>
+        private sealed class ValueCollection : ICollection<T?>
         {
-            private readonly JsonObject _jObject;
+            private readonly JsonPropertyDictionary<T> _parent;
 
-            public ValueCollection(JsonObject jsonObject)
+            public ValueCollection(JsonPropertyDictionary<T> jsonObject)
             {
-                _jObject = jsonObject;
+                _parent = jsonObject;
             }
 
-            public int Count => _jObject.Count;
+            public int Count => _parent.Count;
 
             public bool IsReadOnly => true;
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     yield return item.Value;
                 }
             }
 
-            public void Add(JsonNode? jsonNode) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
-
+            public void Add(T? jsonNode) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
 
             public void Clear() => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
 
+            public bool Contains(T? jsonNode) => _parent.ContainsValue(jsonNode);
 
-            public bool Contains(JsonNode? jsonNode) => _jObject.ContainsNode(jsonNode);
-
-            public void CopyTo(JsonNode?[] nodeArray, int index)
+            public void CopyTo(T?[] nodeArray, int index)
             {
                 if (index < 0)
                 {
                     ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
                 }
 
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     if (index >= nodeArray.Length)
                     {
@@ -63,15 +60,15 @@ namespace System.Text.Json.Nodes
                 }
             }
 
-            public IEnumerator<JsonNode?> GetEnumerator()
+            public IEnumerator<T?> GetEnumerator()
             {
-                foreach (KeyValuePair<string, JsonNode?> item in _jObject)
+                foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     yield return item.Value;
                 }
             }
 
-            bool ICollection<JsonNode?>.Remove(JsonNode? node) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -1,0 +1,433 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Keeps both a List and Dictionary in sync to enable determinstic enumeration ordering of List
+    /// and performance benefits of Dictionary once a threshold is hit.
+    /// </summary>
+    internal partial class JsonPropertyDictionary<T> where T : class
+    {
+        private const int ListToDictionaryThreshold = 9;
+
+        private Dictionary<string, T?>? _dictionary;
+        private readonly List<KeyValuePair<string, T?>> _list;
+
+        private StringComparer _stringComparer;
+
+        public JsonPropertyDictionary(bool caseInsensitive)
+        {
+            _stringComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            _list = new List<KeyValuePair<string, T?>>();
+        }
+
+        public JsonPropertyDictionary(bool caseInsensitive, int capacity)
+        {
+            _stringComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            _list = new List<KeyValuePair<string, T?>>(capacity);
+        }
+
+        // Enable direct access to the List for performance reasons.
+        public List<KeyValuePair<string, T?>> List => _list;
+
+        public void Add(string propertyName, T? value)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            AddValue(propertyName, value);
+        }
+
+        public void Add(KeyValuePair<string, T?> property)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            Add(property.Key, property.Value);
+        }
+
+        public bool TryAdd(string propertyName, T value)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            // A check for a null propertyName is not required since this method is only called by internal code.
+            Debug.Assert(propertyName != null);
+
+            return TryAddValue(propertyName, value);
+        }
+
+        public void Clear()
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            _list.Clear();
+            _dictionary?.Clear();
+        }
+
+        public bool ContainsKey(string propertyName)
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            return ContainsProperty(propertyName);
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _list.Count;
+            }
+        }
+
+        public bool Remove(string propertyName)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            return TryRemoveProperty(propertyName, out T? removedValue);
+        }
+
+        public bool Contains(KeyValuePair<string, T?> item)
+        {
+            foreach (KeyValuePair<string, T?> existing in this)
+            {
+                if (ReferenceEquals(item.Value, existing.Value) && _stringComparer.Equals(item.Key, existing.Key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void CopyTo(KeyValuePair<string, T?>[] array, int index)
+        {
+            if (index < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
+            }
+
+            foreach (KeyValuePair<string, T?> item in _list)
+            {
+                if (index >= array.Length)
+                {
+                    ThrowHelper.ThrowArgumentException_NodeArrayTooSmall(nameof(array));
+                }
+
+                array[index++] = item;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, T?>> GetEnumerator()
+        {
+            foreach (KeyValuePair<string, T?> item in _list)
+            {
+                yield return item;
+            }
+        }
+
+        public ICollection<string> Keys => GetKeyCollection();
+
+        public ICollection<T?> Values => GetValueCollection();
+
+        public bool TryGetValue(string propertyName, out T? value)
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (_dictionary != null)
+            {
+                return _dictionary.TryGetValue(propertyName, out value);
+            }
+            else
+            {
+                foreach (KeyValuePair<string, T?> item in _list)
+                {
+                    if (_stringComparer.Equals(propertyName, item.Key))
+                    {
+                        value = item.Value;
+                        return true;
+                    }
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        public bool IsReadOnly { get; set; }
+
+        public T? this[string propertyName]
+        {
+            get
+            {
+                if (TryGetPropertyValue(propertyName, out T? value))
+                {
+                    return value;
+                }
+
+                // Return null for missing properties.
+                return null;
+            }
+
+            set
+            {
+                SetValue(propertyName, value, null);
+            }
+        }
+
+        public T? SetValue(string propertyName, T? value, Action? assignParent)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            CreateDictionaryIfThreshold();
+
+            T? existing = null;
+
+            if (_dictionary != null)
+            {
+                // Fast path if item doesn't exist in dictionary.
+                if (JsonHelpers.TryAdd(_dictionary, propertyName, value))
+                {
+                    assignParent?.Invoke();
+                    _list.Add(new KeyValuePair<string, T?>(propertyName, value));
+                    return null;
+                }
+
+                existing = _dictionary[propertyName];
+                if (ReferenceEquals(existing, value))
+                {
+                    // Ignore if the same value.
+                    return null;
+                }
+            }
+
+            int i = FindValueIndex(propertyName);
+            if (i >= 0)
+            {
+                if (_dictionary != null)
+                {
+                    _dictionary[propertyName] = value;
+                }
+                else
+                {
+                    KeyValuePair<string, T?> current = _list[i];
+                    if (ReferenceEquals(current.Value, value))
+                    {
+                        // Ignore if the same value.
+                        return null;
+                    }
+
+                    existing = current.Value;
+                }
+
+                assignParent?.Invoke();
+                _list[i] = new KeyValuePair<string, T?>(propertyName, value);
+            }
+            else
+            {
+                assignParent?.Invoke();
+                _dictionary?.Add(propertyName, value);
+                _list.Add(new KeyValuePair<string, T?>(propertyName, value));
+                Debug.Assert(existing == null);
+            }
+
+            return existing;
+        }
+
+        private void AddValue(string propertyName, T? value)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            CreateDictionaryIfThreshold();
+
+            if (_dictionary == null)
+            {
+                // Verify there are no duplicates before adding.
+                if (ContainsProperty(propertyName))
+                {
+                    ThrowHelper.ThrowArgumentException_DuplicateKey(propertyName);
+                }
+            }
+            else
+            {
+                _dictionary.Add(propertyName, value);
+            }
+
+            _list.Add(new KeyValuePair<string, T?>(propertyName, value));
+        }
+
+        private bool TryAddValue(string propertyName, T? value)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            CreateDictionaryIfThreshold();
+
+            if (_dictionary == null)
+            {
+                // Verify there are no duplicates before adding.
+                if (ContainsProperty(propertyName))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+               if (!JsonHelpers.TryAdd(_dictionary, propertyName, value))
+                {
+                    return false;
+                }
+            }
+
+            _list.Add(new KeyValuePair<string, T?>(propertyName, value));
+            return true;
+        }
+
+        public void CreateDictionaryIfThreshold()
+        {
+            if (_dictionary == null && _list.Count > ListToDictionaryThreshold)
+            {
+                _dictionary = JsonHelpers.CreateDictionaryFromCollection(_list, _stringComparer);
+            }
+        }
+
+        private bool ContainsValue(T? value)
+        {
+            foreach (T? item in GetValueCollection())
+            {
+                if (ReferenceEquals(item, value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public KeyValuePair<string, T?>? FindValue(T? value)
+        {
+            foreach (KeyValuePair<string, T?> item in this)
+            {
+                if (ReferenceEquals(item.Value, value))
+                {
+                    return item;
+                }
+            }
+
+            return null;
+        }
+
+        private bool ContainsProperty(string propertyName)
+        {
+            if (_dictionary != null)
+            {
+                return _dictionary.ContainsKey(propertyName);
+            }
+
+            foreach (KeyValuePair<string, T?> item in _list)
+            {
+                if (_stringComparer.Equals(propertyName, item.Key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private int FindValueIndex(string propertyName)
+        {
+            for (int i = 0; i < _list.Count; i++)
+            {
+                KeyValuePair<string, T?> current = _list[i];
+                if (_stringComparer.Equals(propertyName, current.Key))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public bool TryGetPropertyValue(string propertyName, out T? value) => TryGetValue(propertyName, out value);
+
+        public bool TryRemoveProperty(string propertyName, out T? existing)
+        {
+            if (IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            }
+
+            if (_dictionary != null)
+            {
+                if (!_dictionary.TryGetValue(propertyName, out existing))
+                {
+                    return false;
+                }
+
+                bool success = _dictionary.Remove(propertyName);
+                Debug.Assert(success);
+            }
+
+            for (int i = 0; i < _list.Count; i++)
+            {
+                KeyValuePair<string, T?> current = _list[i];
+
+                if (_stringComparer.Equals(current.Key, propertyName))
+                {
+                    _list.RemoveAt(i);
+                    existing = current.Value;
+                    return true;
+                }
+            }
+
+            existing = null;
+            return false;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -219,7 +219,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            CreateDictionaryIfThreshold();
+            CreateDictionaryIfThresholdMet();
 
             T? existing = null;
 
@@ -289,7 +289,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
             }
 
-            CreateDictionaryIfThreshold();
+            CreateDictionaryIfThresholdMet();
 
             if (_propertyDictionary == null)
             {
@@ -311,7 +311,7 @@ namespace System.Text.Json
             return true;
         }
 
-        private void CreateDictionaryIfThreshold()
+        private void CreateDictionaryIfThresholdMet()
         {
             if (_propertyDictionary == null && _propertyList.Count > ListToDictionaryThreshold)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
@@ -10,17 +10,7 @@ namespace System.Text.Json.Nodes
 {
     public partial class JsonObject : IDictionary<string, JsonNode?>
     {
-        private const int ListToDictionaryThreshold = 9;
-
-        private Dictionary<string, JsonNode?>? _dictionary;
-        private List<KeyValuePair<string, JsonNode?>>? _list;
-
-        /// We defer creating the comparer as long as possible in case no options were specified during creation.
-        /// In that case if later we are added to a parent with a non-null options, we use the parent options.
-        private StringComparer? _stringComparer;
-
-        private string? _lastKey;
-        private JsonNode? _lastValue;
+        private JsonPropertyDictionary<JsonNode>? _dictionary;
 
         /// <summary>
         ///   Adds an element with the provided property name and value to the <see cref="JsonObject"/>.
@@ -35,12 +25,9 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public void Add(string propertyName, JsonNode? value)
         {
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            AddNode(propertyName, value);
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            _dictionary.Add(propertyName, value);
             value?.AssignParent(this);
         }
 
@@ -68,20 +55,22 @@ namespace System.Text.Json.Nodes
         {
             if (_jsonElement != null)
             {
-                Debug.Assert(_list == null);
                 Debug.Assert(_dictionary == null);
                 _jsonElement = null;
                 return;
             }
 
-            foreach (JsonNode? node in GetValueCollection(this))
+            if (_dictionary == null)
+            {
+                return;
+            }
+
+            foreach (JsonNode? node in _dictionary.GetValueCollection())
             {
                 DetachParent(node);
             }
 
-            _list?.Clear();
-            _dictionary?.Clear();
-            ClearLastValueCache();
+            _dictionary.Clear();
         }
 
         /// <summary>
@@ -96,12 +85,9 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public bool ContainsKey(string propertyName)
         {
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            return ContainsNode(propertyName);
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            return _dictionary.ContainsKey(propertyName);
         }
 
         /// <summary>
@@ -111,9 +97,9 @@ namespace System.Text.Json.Nodes
         {
             get
             {
-                CreateList();
-                Debug.Assert(_list != null);
-                return _list.Count;
+                Initialize();
+                Debug.Assert(_dictionary != null);
+                return _dictionary.Count;
             }
         }
 
@@ -134,7 +120,10 @@ namespace System.Text.Json.Nodes
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            bool success = TryRemoveNode(propertyName, out JsonNode? removedNode);
+            Initialize();
+            Debug.Assert(_dictionary != null);
+
+            bool success = _dictionary.TryRemoveProperty(propertyName, out JsonNode? removedNode);
             if (success)
             {
                 DetachParent(removedNode);
@@ -152,16 +141,9 @@ namespace System.Text.Json.Nodes
         /// </returns>
         bool ICollection<KeyValuePair<string, JsonNode?>>.Contains(KeyValuePair<string, JsonNode?> item)
         {
-            foreach (KeyValuePair<string, JsonNode?> existing in this)
-            {
-                Debug.Assert(_stringComparer != null);
-                if (ReferenceEquals(item.Value, existing.Value) && _stringComparer.Equals(item.Key, existing.Key))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            return _dictionary.Contains(item);
         }
 
         /// <summary>
@@ -183,23 +165,9 @@ namespace System.Text.Json.Nodes
         /// </exception>
         void ICollection<KeyValuePair<string, JsonNode?>>.CopyTo(KeyValuePair<string, JsonNode?>[] array, int index)
         {
-            if (index < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
-            }
-
-            CreateList();
-            Debug.Assert(_list != null);
-
-            foreach (KeyValuePair<string, JsonNode?> item in _list)
-            {
-                if (index >= array.Length)
-                {
-                    ThrowHelper.ThrowArgumentException_NodeArrayTooSmall(nameof(array));
-                }
-
-                array[index++] = item;
-            }
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            _dictionary.CopyTo(array, index);
         }
 
         /// <summary>
@@ -210,13 +178,9 @@ namespace System.Text.Json.Nodes
         /// </returns>
         public IEnumerator<KeyValuePair<string, JsonNode?>> GetEnumerator()
         {
-            CreateList();
-            Debug.Assert(_list != null);
-
-            foreach (KeyValuePair<string, JsonNode?> item in _list)
-            {
-                yield return item;
-            }
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            return _dictionary.GetEnumerator();
         }
 
         /// <summary>
@@ -233,12 +197,28 @@ namespace System.Text.Json.Nodes
         /// <summary>
         ///   Gets a collection containing the property names in the <see cref="JsonObject"/>.
         /// </summary>
-        ICollection<string> IDictionary<string, JsonNode?>.Keys => GetKeyCollection(this);
+        ICollection<string> IDictionary<string, JsonNode?>.Keys
+        {
+            get
+            {
+                Initialize();
+                Debug.Assert(_dictionary != null);
+                return _dictionary.Keys;
+            }
+        }
 
         /// <summary>
         ///   Gets a collection containing the property values in the <see cref="JsonObject"/>.
         /// </summary>
-        ICollection<JsonNode?> IDictionary<string, JsonNode?>.Values => GetValueCollection(this);
+        ICollection<JsonNode?> IDictionary<string, JsonNode?>.Values
+        {
+            get
+            {
+                Initialize();
+                Debug.Assert(_dictionary != null);
+                return _dictionary.Values;
+            }
+        }
 
         /// <summary>
         ///   Gets the value associated with the specified property name.
@@ -256,51 +236,9 @@ namespace System.Text.Json.Nodes
         /// </exception>
         bool IDictionary<string, JsonNode?>.TryGetValue(string propertyName, out JsonNode? jsonNode)
         {
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            CreateList();
-            Debug.Assert(_list != null);
-            Debug.Assert(_stringComparer != null);
-
-            if (propertyName == _lastKey)
-            {
-                // Optimize for repeating sections in code:
-                // obj.Foo.Bar.FirstProperty = value1;
-                // obj.Foo.Bar.SecondProperty = value2;
-                jsonNode = _lastValue;
-                return true;
-            }
-
-            if (_dictionary != null)
-            {
-                bool success = _dictionary.TryGetValue(propertyName, out jsonNode);
-                if (success)
-                {
-                    _lastKey = propertyName;
-                    _lastValue = jsonNode;
-                }
-
-                return success;
-            }
-            else
-            {
-                foreach (KeyValuePair<string, JsonNode?> item in _list)
-                {
-                    if (_stringComparer.Equals(propertyName, item.Key))
-                    {
-                        jsonNode = item.Value;
-                        _lastKey = propertyName;
-                        _lastValue = jsonNode;
-                        return true;
-                    }
-                }
-            }
-
-            jsonNode = null;
-            return false;
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            return _dictionary.TryGetValue(propertyName, out jsonNode);
         }
 
         /// <summary>
@@ -316,63 +254,20 @@ namespace System.Text.Json.Nodes
         /// </returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            CreateList();
-            Debug.Assert(_list != null);
-
-            foreach (KeyValuePair<string, JsonNode?> item in _list)
-            {
-                yield return item;
-            }
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            return _dictionary.GetEnumerator();
         }
 
-        private void CreateStringComparer()
+        private void Initialize()
         {
-            bool caseInsensitive = Options?.PropertyNameCaseInsensitive == true;
-            if (caseInsensitive)
-            {
-                _stringComparer = StringComparer.OrdinalIgnoreCase;
-            }
-            else
-            {
-                _stringComparer = StringComparer.Ordinal;
-            }
-        }
-
-        private void AddNode(string propertyName, JsonNode? node)
-        {
-            CreateList();
-            Debug.Assert(_list != null);
-
-            CreateDictionaryIfThreshold();
-
-            if (_dictionary == null)
-            {
-                // Verify there are no duplicates before adding.
-                VerifyListItemMissing(propertyName);
-            }
-            else
-            {
-                _dictionary.Add(propertyName, node);
-            }
-
-            _list.Add(new KeyValuePair<string, JsonNode?>(propertyName, node));
-        }
-
-        private void ClearLastValueCache()
-        {
-            _lastKey = null;
-            _lastValue = null;
-        }
-
-        private void CreateList()
-        {
-            if (_list != null)
+            if (_dictionary != null)
             {
                 return;
             }
 
-            CreateStringComparer();
-            var list = new List<KeyValuePair<string, JsonNode?>>();
+            bool caseInsensitive = Options.HasValue ? Options.Value.PropertyNameCaseInsensitive : false;
+            var dictionary = new JsonPropertyDictionary<JsonNode>(caseInsensitive);
             if (_jsonElement.HasValue)
             {
                 JsonElement jElement = _jsonElement.Value;
@@ -385,202 +280,14 @@ namespace System.Text.Json.Nodes
                         node.Parent = this;
                     }
 
-                    list.Add(new KeyValuePair<string, JsonNode?>(jElementProperty.Name, node));
+                    dictionary.Add(new KeyValuePair<string, JsonNode?>(jElementProperty.Name, node));
                 }
 
                 _jsonElement = null;
             }
 
-            _list = list;
-            CreateDictionaryIfThreshold();
-        }
-
-        private JsonNode? SetNode(string propertyName, JsonNode? node)
-        {
-            CreateList();
-            Debug.Assert(_list != null);
-
-            CreateDictionaryIfThreshold();
-
-            JsonNode? existing = null;
-
-            if (_dictionary != null)
-            {
-                // Fast path if item doesn't exist in dictionary.
-                if (JsonHelpers.TryAdd(_dictionary, propertyName, node))
-                {
-                    node?.AssignParent(this);
-                    _list.Add(new KeyValuePair<string, JsonNode?>(propertyName, node));
-                    return null;
-                }
-
-                existing = _dictionary[propertyName];
-                if (ReferenceEquals(existing, node))
-                {
-                    _lastKey = propertyName;
-                    _lastValue = node;
-
-                    // Ignore if the same value.
-                    return null;
-                }
-            }
-
-            int i = FindNodeIndex(propertyName);
-            if (i >= 0)
-            {
-                if (_dictionary != null)
-                {
-                    _dictionary[propertyName] = node;
-                }
-                else
-                {
-                    KeyValuePair<string, JsonNode?> current = _list[i];
-                    if (ReferenceEquals(current.Value, node))
-                    {
-                        // Ignore if the same value.
-                        return null;
-                    }
-
-                    existing = current.Value;
-                }
-
-                node?.AssignParent(this);
-                _list[i] = new KeyValuePair<string, JsonNode?>(propertyName, node);
-            }
-            else
-            {
-                node?.AssignParent(this);
-                _dictionary?.Add(propertyName, node);
-                _list.Add(new KeyValuePair<string, JsonNode?>(propertyName, node));
-                Debug.Assert(existing == null);
-            }
-
-            _lastKey = propertyName;
-            _lastValue = node;
-
-            return existing;
-        }
-
-        private int FindNodeIndex(string propertyName)
-        {
-            Debug.Assert(_list != null);
-            Debug.Assert(_stringComparer != null);
-
-            for (int i = 0; i < _list.Count; i++)
-            {
-                KeyValuePair<string, JsonNode?> current = _list[i];
-                if (_stringComparer.Equals(propertyName, current.Key))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        private void CreateDictionaryIfThreshold()
-        {
-            Debug.Assert(_list != null);
-            Debug.Assert(_stringComparer != null);
-
-            if (_dictionary == null && _list.Count > ListToDictionaryThreshold)
-            {
-                _dictionary = JsonHelpers.CreateDictionaryFromCollection(_list, _stringComparer);
-            }
-        }
-
-        private bool ContainsNode(JsonNode? node)
-        {
-            CreateList();
-
-            foreach (JsonNode? item in GetValueCollection(this))
-            {
-                if (ReferenceEquals(item, node))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private KeyValuePair<string, JsonNode?>? FindNode(JsonNode? node)
-        {
-            CreateList();
-
-            foreach (KeyValuePair<string, JsonNode?> item in this)
-            {
-                if (ReferenceEquals(item.Value, node))
-                {
-                    return item;
-                }
-            }
-
-            return null;
-        }
-
-        private bool ContainsNode(string propertyName)
-        {
-            if (_dictionary != null)
-            {
-                return _dictionary.ContainsKey(propertyName);
-            }
-
-            foreach (string item in GetKeyCollection(this))
-            {
-                Debug.Assert(_stringComparer != null);
-                if (_stringComparer.Equals(item, propertyName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool TryRemoveNode(string propertyName, out JsonNode? existing)
-        {
-            CreateList();
-            Debug.Assert(_list != null);
-            Debug.Assert(_stringComparer != null);
-
-            if (_dictionary != null)
-            {
-                if (!_dictionary.TryGetValue(propertyName, out existing))
-                {
-                    return false;
-                }
-
-                bool success = _dictionary.Remove(propertyName);
-                Debug.Assert(success);
-            }
-
-            for (int i = 0; i < _list.Count; i++)
-            {
-                KeyValuePair<string, JsonNode?> current = _list[i];
-
-                if (_stringComparer.Equals(current.Key, propertyName))
-                {
-                    _list.RemoveAt(i);
-                    existing = current.Value;
-                    DetachParent(existing);
-                    return true;
-                }
-            }
-
-            existing = null;
-            return false;
-        }
-
-        private void VerifyListItemMissing(string propertyName)
-        {
-            Debug.Assert(_dictionary == null);
-            Debug.Assert(_list != null);
-
-            if (ContainsNode(propertyName))
-            {
-                ThrowHelper.ThrowArgumentException_DuplicateKey(propertyName);
-            }
+            dictionary.CreateDictionaryIfThreshold();
+            _dictionary = dictionary;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public void Add(string propertyName, JsonNode? value)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             _dictionary.Add(propertyName, value);
             value?.AssignParent(this);
@@ -85,7 +85,7 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public bool ContainsKey(string propertyName)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             return _dictionary.ContainsKey(propertyName);
         }
@@ -97,7 +97,7 @@ namespace System.Text.Json.Nodes
         {
             get
             {
-                Initialize();
+                InitializeIfRequired();
                 Debug.Assert(_dictionary != null);
                 return _dictionary.Count;
             }
@@ -120,7 +120,7 @@ namespace System.Text.Json.Nodes
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
 
             bool success = _dictionary.TryRemoveProperty(propertyName, out JsonNode? removedNode);
@@ -141,7 +141,7 @@ namespace System.Text.Json.Nodes
         /// </returns>
         bool ICollection<KeyValuePair<string, JsonNode?>>.Contains(KeyValuePair<string, JsonNode?> item)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             return _dictionary.Contains(item);
         }
@@ -165,7 +165,7 @@ namespace System.Text.Json.Nodes
         /// </exception>
         void ICollection<KeyValuePair<string, JsonNode?>>.CopyTo(KeyValuePair<string, JsonNode?>[] array, int index)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             _dictionary.CopyTo(array, index);
         }
@@ -178,7 +178,7 @@ namespace System.Text.Json.Nodes
         /// </returns>
         public IEnumerator<KeyValuePair<string, JsonNode?>> GetEnumerator()
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             return _dictionary.GetEnumerator();
         }
@@ -201,7 +201,7 @@ namespace System.Text.Json.Nodes
         {
             get
             {
-                Initialize();
+                InitializeIfRequired();
                 Debug.Assert(_dictionary != null);
                 return _dictionary.Keys;
             }
@@ -214,7 +214,7 @@ namespace System.Text.Json.Nodes
         {
             get
             {
-                Initialize();
+                InitializeIfRequired();
                 Debug.Assert(_dictionary != null);
                 return _dictionary.Values;
             }
@@ -236,7 +236,7 @@ namespace System.Text.Json.Nodes
         /// </exception>
         bool IDictionary<string, JsonNode?>.TryGetValue(string propertyName, out JsonNode? jsonNode)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             return _dictionary.TryGetValue(propertyName, out jsonNode);
         }
@@ -254,12 +254,12 @@ namespace System.Text.Json.Nodes
         /// </returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             return _dictionary.GetEnumerator();
         }
 
-        private void Initialize()
+        private void InitializeIfRequired()
         {
             if (_dictionary != null)
             {
@@ -286,7 +286,6 @@ namespace System.Text.Json.Nodes
                 _jsonElement = null;
             }
 
-            dictionary.CreateDictionaryIfThreshold();
             _dictionary = dictionary;
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -125,7 +125,9 @@ namespace System.Text.Json.Nodes
         {
             if (child != null)
             {
-                string propertyName = FindNode(child)!.Value.Key;
+                Initialize();
+                Debug.Assert(_dictionary != null);
+                string propertyName = _dictionary.FindValue(child)!.Value.Key;
                 if (propertyName.IndexOfAny(ReadStack.SpecialCharacters) != -1)
                 {
                     path.Add($"['{propertyName}']");
@@ -144,24 +146,21 @@ namespace System.Text.Json.Nodes
 
         internal void SetItem(string propertyName, JsonNode? value)
         {
-            if (propertyName == null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-
-            JsonNode? existing = SetNode(propertyName, value);
+            Initialize();
+            Debug.Assert(_dictionary != null);
+            JsonNode? existing = _dictionary.SetValue(propertyName, value, () => value?.AssignParent(this));
             DetachParent(existing);
         }
 
         private void DetachParent(JsonNode? item)
         {
+            Initialize();
+            Debug.Assert(_dictionary != null);
+
             if (item != null)
             {
                 item.Parent = null;
             }
-
-            // Prevent previous child from being returned from these cached variables.
-            ClearLastValueCache();
         }
 
         [ExcludeFromCodeCoverage] // Justification = "Design-time"

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json.Nodes
         {
             if (child != null)
             {
-                Initialize();
+                InitializeIfRequired();
                 Debug.Assert(_dictionary != null);
                 string propertyName = _dictionary.FindValue(child)!.Value.Key;
                 if (propertyName.IndexOfAny(ReadStack.SpecialCharacters) != -1)
@@ -146,7 +146,7 @@ namespace System.Text.Json.Nodes
 
         internal void SetItem(string propertyName, JsonNode? value)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
             JsonNode? existing = _dictionary.SetValue(propertyName, value, () => value?.AssignParent(this));
             DetachParent(existing);
@@ -154,7 +154,7 @@ namespace System.Text.Json.Nodes
 
         private void DetachParent(JsonNode? item)
         {
-            Initialize();
+            InitializeIfRequired();
             Debug.Assert(_dictionary != null);
 
             if (item != null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (_converterStrategy == ConverterStrategy.Object && jsonTypeInfo.PropertyCache == null)
             {
-                jsonTypeInfo.InitializeDeserializePropCache();
+                jsonTypeInfo.InitializePropCache();
             }
 
             return Converter.OnTryRead(ref reader, typeToConvert, options, ref state, out value);
@@ -79,9 +79,9 @@ namespace System.Text.Json.Serialization.Converters
                 return true;
             }
 
-            if (_converterStrategy == ConverterStrategy.Object && jsonTypeInfo.PropertyCacheArray == null)
+            if (_converterStrategy == ConverterStrategy.Object && jsonTypeInfo.PropertyCache == null)
             {
-                jsonTypeInfo.InitializeSerializePropCache();
+                jsonTypeInfo.InitializePropCache();
             }
 
             return Converter.OnTryWrite(writer, value, options, ref state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization.Metadata;
 
@@ -55,12 +56,16 @@ namespace System.Text.Json.Serialization.Converters
                 typeInfo.CreateObjectWithArgs = options.MemberAccessorStrategy.CreateParameterizedConstructor<T>(ConstructorInfo!);
             }
 
-            object[] arguments = ArrayPool<object>.Shared.Rent(typeInfo.ParameterCount);
-            foreach (JsonParameterInfo jsonParameterInfo in typeInfo.ParameterCache!.Values)
+            List<KeyValuePair<string, JsonParameterInfo?>> cache = typeInfo.ParameterCache!.List;
+            object[] arguments = ArrayPool<object>.Shared.Rent(cache.Count);
+            for (int i = 0; i < typeInfo.ParameterCount; i++)
             {
-                if (jsonParameterInfo.ShouldDeserialize)
+                JsonParameterInfo? parameterInfo = cache[i].Value;
+                Debug.Assert(parameterInfo != null);
+
+                if (parameterInfo.ShouldDeserialize)
                 {
-                    arguments[jsonParameterInfo.Position] = jsonParameterInfo.DefaultValue!;
+                    arguments[parameterInfo.Position] = parameterInfo.DefaultValue!;
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization.Metadata;
 
@@ -85,8 +86,12 @@ namespace System.Text.Json.Serialization.Converters
 
             var arguments = new Arguments<TArg0, TArg1, TArg2, TArg3>();
 
-            foreach (JsonParameterInfo parameterInfo in typeInfo.ParameterCache!.Values)
+            List<KeyValuePair<string, JsonParameterInfo?>> cache = typeInfo.ParameterCache!.List;
+            for (int i = 0; i < typeInfo.ParameterCount; i++)
             {
+                JsonParameterInfo? parameterInfo = cache[i].Value;
+                Debug.Assert(parameterInfo != null);
+
                 if (parameterInfo.ShouldDeserialize)
                 {
                     int position = parameterInfo.Position;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -570,10 +570,18 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal void InitializePropCache()
         {
-            Debug.Assert(PropInitFunc != null);
-            Debug.Assert(Options._context != null);
+            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
 
-            JsonPropertyInfo[] array = PropInitFunc(Options._context);
+            JsonSerializerContext? context = Options._context;
+            Debug.Assert(context != null);
+
+            if (PropInitFunc == null)
+            {
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(context, Type);
+                return;
+            }
+
+            JsonPropertyInfo[] array = PropInitFunc(context);
             var properties = new JsonPropertyDictionary<JsonPropertyInfo>(Options.PropertyNameCaseInsensitive, array.Length);
             for (int i = 0; i < array.Length; i++)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -32,15 +32,11 @@ namespace System.Text.Json.Serialization.Metadata
         internal int ParameterCount { get; private set; }
 
         // All of the serializable parameters on a POCO constructor keyed on parameter name.
-        // Only paramaters which bind to properties are cached.
-        internal Dictionary<string, JsonParameterInfo>? ParameterCache;
+        // Only parameters which bind to properties are cached.
+        internal JsonPropertyDictionary<JsonParameterInfo>? ParameterCache;
 
         // All of the serializable properties on a POCO (except the optional extension property) keyed on property name.
-        internal Dictionary<string, JsonPropertyInfo>? PropertyCache;
-
-        // All of the serializable properties on a POCO including the optional extension property.
-        // Used for performance during serialization instead of 'PropertyCache' above.
-        internal JsonPropertyInfo[]? PropertyCacheArray;
+        internal JsonPropertyDictionary<JsonPropertyInfo>? PropertyCache;
 
         // Fast cache of constructor parameters by first JSON ordering; may not contain all parameters. Accessed before ParameterCache.
         // Use an array (instead of List<T>) for highest performance.
@@ -208,6 +204,8 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (PropertyCache.TryGetValue(JsonHelpers.Utf8GetString(propertyName), out JsonPropertyInfo? info))
             {
+                Debug.Assert(info != null);
+
                 if (Options.PropertyNameCaseInsensitive)
                 {
                     if (propertyName.SequenceEqual(info.NameAsUtf8Bytes))
@@ -225,8 +223,8 @@ namespace System.Text.Json.Serialization.Metadata
                 }
                 else
                 {
-                    Debug.Assert(key == GetKey(info.NameAsUtf8Bytes!.AsSpan()));
-                    utf8PropertyName = info.NameAsUtf8Bytes!;
+                    Debug.Assert(key == GetKey(info.NameAsUtf8Bytes.AsSpan()));
+                    utf8PropertyName = info.NameAsUtf8Bytes;
                 }
             }
             else
@@ -345,6 +343,8 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (ParameterCache.TryGetValue(JsonHelpers.Utf8GetString(propertyName), out JsonParameterInfo? info))
             {
+                Debug.Assert(info != null);
+
                 if (Options.PropertyNameCaseInsensitive)
                 {
                     if (propertyName.SequenceEqual(info.NameAsUtf8Bytes))
@@ -472,6 +472,7 @@ namespace System.Text.Json.Serialization.Metadata
                 }
             }
 
+#if DEBUG
             // Verify key contains the embedded bytes as expected.
             // Note: the expected properties do not hold true on big-endian platforms
             if (BitConverter.IsLittleEndian)
@@ -490,6 +491,7 @@ namespace System.Text.Json.Serialization.Metadata
                     (name.Length >= 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == (ulong)name.Length) &&
                     (name.Length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF));
             }
+#endif
 
             return key;
         }
@@ -566,47 +568,24 @@ namespace System.Text.Json.Serialization.Metadata
             frame.CtorArgumentState.ParameterRefCache = null;
         }
 
-        internal void InitializeSerializePropCache()
+        internal void InitializePropCache()
         {
-            JsonSerializerContext? context = Options._context;
+            Debug.Assert(PropInitFunc != null);
+            Debug.Assert(Options._context != null);
 
-            Debug.Assert(context != null);
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
-
-            if (PropInitFunc == null)
+            JsonPropertyInfo[] array = PropInitFunc(Options._context);
+            var properties = new JsonPropertyDictionary<JsonPropertyInfo>(Options.PropertyNameCaseInsensitive, array.Length);
+            for (int i = 0; i < array.Length; i++)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(context, Type);
-                return;
-            }
-
-            PropertyCacheArray = PropInitFunc(context);
-        }
-
-        internal void InitializeDeserializePropCache()
-        {
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
-
-            if (PropertyCacheArray == null)
-            {
-                InitializeSerializePropCache();
-            }
-
-            Dictionary<string, JsonPropertyInfo> propertyCache = new(Options.PropertyNameCaseInsensitive
-                ? StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal);
-
-            for (int i = 0; i < PropertyCacheArray!.Length; i++)
-            {
-                JsonPropertyInfo jsonPropertyInfo = PropertyCacheArray[i];
-
-                if (!JsonHelpers.TryAdd(propertyCache, jsonPropertyInfo.NameAsString, jsonPropertyInfo))
+                JsonPropertyInfo property = array[i];
+                if (!properties.TryAdd(property.NameAsString, property))
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameConflict(Type, jsonPropertyInfo);
+                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameConflict(Type, property);
                 }
             }
 
             // Avoid threading issues by populating a local cache, and assigning it to the global cache after completion.
-            PropertyCache = propertyCache;
+            PropertyCache = properties;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -319,8 +319,8 @@ namespace System.Text.Json.Serialization.Metadata
             JsonNumberHandling? typeNumberHandling,
             ref Dictionary<string, MemberInfo>? ignoredMembers)
         {
-            bool hasExtensionAttribute = DoesPropertyHaveAttribute(memberType, typeof(JsonExtensionDataAttribute));
-            if (hasExtensionAttribute & DataExtensionProperty != null)
+            bool hasExtensionAttribute = memberInfo.GetCustomAttribute(typeof(JsonExtensionDataAttribute)) != null;
+            if (hasExtensionAttribute && DataExtensionProperty != null)
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type, typeof(JsonExtensionDataAttribute));
             }
@@ -515,7 +515,6 @@ namespace System.Text.Json.Serialization.Metadata
                 (memberType.FullName == JsonObjectTypeName && ReferenceEquals(memberType.Assembly, GetType().Assembly)))
             {
                 converter = Options.GetConverterInternal(memberType);
-                Debug.Assert(converter != null);
             }
 
             if (converter == null)
@@ -524,17 +523,6 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             DataExtensionProperty = jsonPropertyInfo;
-        }
-
-        private bool DoesPropertyHaveAttribute(MemberInfo memberInfo, Type attributeType)
-        {
-            Attribute? attribute = memberInfo.GetCustomAttribute(attributeType);
-            if (attribute != null)
-            {
-                return true;
-            }
-
-            return false;
         }
 
         private static JsonParameterInfo AddConstructorParameter(

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
@@ -152,26 +152,38 @@ namespace System.Text.Json.Nodes.Tests
             FieldInfo elementField = typeof(JsonObject).GetField("_jsonElement", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(elementField);
 
-            FieldInfo listField = typeof(JsonObject).GetField("_list", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo jsonDictionaryField = typeof(JsonObject).GetField("_dictionary", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(jsonDictionaryField);
+
+            Type jsonPropertyDictionaryType = typeof(JsonObject).Assembly.GetType("System.Text.Json.JsonPropertyDictionary`1");
+            Assert.NotNull(jsonPropertyDictionaryType);
+
+            jsonPropertyDictionaryType = jsonPropertyDictionaryType.MakeGenericType(new Type[] { typeof(JsonNode) });
+
+            FieldInfo listField = jsonPropertyDictionaryType.GetField("_list", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(listField);
 
-            FieldInfo dictionaryField = typeof(JsonObject).GetField("_dictionary", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo dictionaryField = jsonPropertyDictionaryType.GetField("_dictionary", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(dictionaryField);
 
             using (MemoryStream stream = new MemoryStream(SimpleTestClass.s_data))
             {
                 // Only JsonElement is present.
                 JsonNode node = JsonNode.Parse(stream);
+                object jsonDictionary = jsonDictionaryField.GetValue(node);
+                Assert.Null(jsonDictionary); // Value is null until converted from JsonElement.
                 Assert.NotNull(elementField.GetValue(node));
-                Assert.Null(listField.GetValue(node));
-                Assert.Null(dictionaryField.GetValue(node));
                 Test();
 
                 // Cause the single JsonElement to expand into individual JsonElement nodes.
                 Assert.Equal(1, node.AsObject()["MyInt16"].GetValue<int>());
                 Assert.Null(elementField.GetValue(node));
-                Assert.NotNull(listField.GetValue(node));
-                Assert.NotNull(dictionaryField.GetValue(node)); // The dictionary threshold was reached.
+
+                jsonDictionary = jsonDictionaryField.GetValue(node);
+                Assert.NotNull(jsonDictionary);
+
+                Assert.NotNull(listField.GetValue(jsonDictionary));
+                Assert.NotNull(dictionaryField.GetValue(jsonDictionary)); // The dictionary threshold was reached.
                 Test();
 
                 void Test()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
@@ -160,10 +160,10 @@ namespace System.Text.Json.Nodes.Tests
 
             jsonPropertyDictionaryType = jsonPropertyDictionaryType.MakeGenericType(new Type[] { typeof(JsonNode) });
 
-            FieldInfo listField = jsonPropertyDictionaryType.GetField("_list", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo listField = jsonPropertyDictionaryType.GetField("_propertyList", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(listField);
 
-            FieldInfo dictionaryField = jsonPropertyDictionaryType.GetField("_dictionary", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo dictionaryField = jsonPropertyDictionaryType.GetField("_propertyDictionary", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(dictionaryField);
 
             using (MemoryStream stream = new MemoryStream(SimpleTestClass.s_data))

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -123,7 +123,7 @@ namespace System.Text.Json.Serialization.Tests
         public async Task ExtensionDataProperty_CannotBindTo_CtorParam()
         {
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.DeserializeWrapper<Class_ExtData_CtorParam>("{}"));
-            string exStr = ex.ToString();
+            string exStr = ex.ToString(); // System.InvalidOperationException: 'The extension data property 'System.Collections.Generic.Dictionary`2[System.String,System.Text.Json.JsonElement] ExtensionData' on type 'System.Text.Json.Serialization.Tests.ConstructorTests+Class_ExtData_CtorParam' cannot bind with a parameter in constructor 'Void .ctor(System.Collections.Generic.Dictionary`2[System.String,System.Text.Json.JsonElement])'.'
             Assert.Contains("System.Collections.Generic.Dictionary`2[System.String,System.Text.Json.JsonElement] ExtensionData", exStr);
             Assert.Contains("System.Text.Json.Serialization.Tests.ConstructorTests+Class_ExtData_CtorParam", exStr);
             Assert.Contains("(System.Collections.Generic.Dictionary`2[System.String,System.Text.Json.JsonElement])", exStr);


### PR DESCRIPTION
Combines property creation and access logic from three locations:
- The new JsonObject class.
- The JsonTypeInfo for POCOs.
- The ParameterInfo used for calling constructors during deserialization.

The code now shared:
- The case-(in)sensitive creation of the dictionary.
- Deferred creation of the dictionary for a small number of properties (saves private bytes + faster startup + faster lookup).
- The ordered List so serialization of properties is deterministic.

This code is expected to be used shortly by a more extensible POCO hooks where the property list is exposed.

No known performance serialization CPU or alloc regressions; benchmarks show +- 1%, perhaps a bit on the faster side now due to other misc optimizations including avoiding a couple "if" statements per property during serialization.
