### PR TITLE
Parse `DOTNET_PROCESSOR_COUNT` with a 10 radix not 16

### DIFF
--- a/src/coreclr/inc/clrconfig.h
+++ b/src/coreclr/inc/clrconfig.h
@@ -31,7 +31,11 @@ public:
 
         // Remove any whitespace at beginning and end of value.  (Only applicable for
         // *string* configuration values.)
-        TrimWhiteSpaceFromStringValue = 0x2
+        TrimWhiteSpaceFromStringValue = 0x2,
+
+        // The configuration should be parsed using a 10 radix as opposed to the
+        // default of 16.
+        ParseIntegerAsBase10 = 0x4,
     };
 
     // Struct used to store information about where/how to find a Config DWORD.

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -555,7 +555,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_Thread_DeadThreadCountThresholdForGCTrigger, W
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_Thread_DeadThreadGCTriggerPeriodMilliseconds, W("Thread_DeadThreadGCTriggerPeriodMilliseconds"), 1000 * 60 * 30, "In the heuristics to clean up dead threads, this much time must have elapsed since the previous max-generation GC before triggering another GC will be considered")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_Thread_UseAllCpuGroups, W("Thread_UseAllCpuGroups"), 0, "Specifies whether to query and use CPU group information for determining the processor count.")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_Thread_AssignCpuGroups, W("Thread_AssignCpuGroups"), 1, "Specifies whether to automatically distribute threads created by the CLR across CPU Groups. Effective only when Thread_UseAllCpuGroups and GCCpuGroup are enabled.")
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProcessorCount, W("PROCESSOR_COUNT"), 0, "Specifies the number of processors available for the process, which is returned by Environment.ProcessorCount")
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_ProcessorCount, W("PROCESSOR_COUNT"), 0, "Specifies the number of processors available for the process, which is returned by Environment.ProcessorCount", CLRConfig::LookupOptions::ParseIntegerAsBase10)
 
 ///
 /// Threadpool

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -233,12 +233,16 @@ namespace
 
         FAULT_NOT_FATAL(); // We don't report OOM errors here, we return a default value.
 
+        int radix = CheckLookupOption(options, LookupOptions::ParseIntegerAsBase10)
+            ? 10
+            : 16; // Parse as hex by default.
+
         NewArrayHolder<WCHAR> val = EnvGetString(name, options);
         if (val != NULL)
         {
             errno = 0;
             LPWSTR endPtr;
-            DWORD configMaybe = wcstoul(val, &endPtr, 16); // treat it has hex
+            DWORD configMaybe = wcstoul(val, &endPtr, radix);
             BOOL fSuccess = ((errno != ERANGE) && (endPtr != val));
             if (fSuccess)
             {

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -30,7 +30,7 @@ namespace System.Tests
             fixed (char *ptr = settingValue)
             {
                 char *endptr;
-                int value = (int)wcstoul(ptr, &endptr, 16);
+                int value = (int)wcstoul(ptr, &endptr, 10);
 
                 if (0 < value && value <= MAX_PROCESSOR_COUNT)
                     return value;
@@ -69,7 +69,7 @@ namespace System.Tests
         [InlineData(8000, 2000, null)]
         [InlineData(8000, 0, "1")]
         [InlineData(2000, 0, null)]
-        [InlineData(2000, 0, " 0x11 ")]
+        [InlineData(2000, 0, " 17 ")]
         [InlineData(0, 0, "3")]
         public static unsafe void ProcessorCount_Windows_RespectsJobCpuRateAndConfigurationSetting(
             ushort maxRate, ushort minRate, string procCountConfig)


### PR DESCRIPTION
Fixes #53150 

/cc @richlander @AntonLapounov 