### PR TITLE
Fix #53181. AssemblyLoadContext incorrectly validates name of dynamiс assembly when returned from Load

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -147,7 +147,7 @@ namespace System.Runtime.Loader
 
             AssemblyLoadContext? loadContextForAssembly = null;
 
-            RuntimeAssembly? rtAsm = assembly as RuntimeAssembly;
+            RuntimeAssembly? rtAsm = GetRuntimeAssembly(assembly);
 
             // We only support looking up load context for runtime assemblies.
             if (rtAsm != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -657,7 +657,7 @@ namespace System.Runtime.Loader
             // Derived type's Load implementation is expected to use one of the LoadFrom* methods to get the assembly
             // which is a RuntimeAssembly instance. However, since Assembly type can be used build any other artifact (e.g. AssemblyBuilder),
             // we need to check for RuntimeAssembly.
-            RuntimeAssembly? rtLoadedAssembly = assembly as RuntimeAssembly;
+            RuntimeAssembly? rtLoadedAssembly = GetRuntimeAssembly(assembly);
             if (rtLoadedAssembly != null)
             {
                 loadedSimpleName = rtLoadedAssembly.GetSimpleName();

--- a/src/tests/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.cs
+++ b/src/tests/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.Loader;
 using System.IO;
+using System.Linq;
+using My;
 
 namespace My
 {
@@ -200,6 +203,33 @@ public class Program
         }
     }
 
+    public static void GetLoadContextForDynamicAssembly(bool isCollectible)
+    {
+        try
+        {
+            Console.WriteLine($"{nameof(GetLoadContextForDynamicAssembly)}; isCollectible={isCollectible}");
+
+            AssemblyLoadContext alc = new AssemblyLoadContext($"ALC - {isCollectible}", isCollectible);
+            AssemblyBuilder assemblyBuilder;
+            AssemblyName assemblyName = new AssemblyName($"DynamicAssembly_{Guid.NewGuid():N}");
+
+            using (alc.EnterContextualReflection())
+            {
+                assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
+            }
+
+            AssemblyLoadContext? context = AssemblyLoadContext.GetLoadContext(assemblyBuilder);
+
+            Assert(context != null);
+            Assert(alc == context);
+            Assert(alc.Assemblies.Any(a => AssemblyName.ReferenceMatchesDefinition(a.GetName(), assemblyName)));
+        }
+        catch (Exception e)
+        {
+            Assert(false, e.ToString());
+        }
+    }
+
     public static int Main()
     {
         foreach (AssemblyLoadContext alc in AssemblyLoadContext.All)
@@ -216,6 +246,8 @@ public class Program
         AssemblyLoadByteArrayName();
         CustomWOName();
         CustomName();
+        GetLoadContextForDynamicAssembly(true);
+        GetLoadContextForDynamicAssembly(false);
 
         foreach (AssemblyLoadContext alc in AssemblyLoadContext.All)
         {


### PR DESCRIPTION
See #53181