### PR TITLE
Mono runtime dynamic component support.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -180,16 +180,16 @@
     <PlatformManifestFileEntry Include="mono-aot-cross.exe" IsNative="true" />
     <PlatformManifestFileEntry Include="opt" IsNative="true" />
     <!-- Mono components specific files -->
-    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-static.dll" IsNative="true" />
-    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-static.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-static.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-static.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-stub-static.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-static.lib" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-diagnostics_tracing-stub-static.lib" IsNative="true" />
-    <PlatformManifestFileEntry Include="libmono-component-hot_reload-static.dll" IsNative="true" />
-    <PlatformManifestFileEntry Include="libmono-component-hot_reload-static.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="libmono-component-hot_reload-static.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-hot_reload.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-hot_reload.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-component-hot_reload.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-hot_reload-static.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-hot_reload-stub-static.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-component-hot_reload-static.lib" IsNative="true" />

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -76,6 +76,7 @@
     <MonoComponentsStatic Condition="'$(TargetsBrowser)' == 'true' and '$(MonoComponentsStatic)' == ''">true</MonoComponentsStatic>
     <MonoComponentsStatic Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true' and '$(MonoComponentsStatic)' == ''">true</MonoComponentsStatic>
     <MonoComponentsStatic Condition="'$(TargetstvOS)' == 'true' and '$(TargetstvOSSimulator)' != 'true' and '$(MonoComponentsStatic)' == ''">true</MonoComponentsStatic>
+    <MonoComponentsStatic Condition="'$(TargetsAndroid)' == 'true' and '$(MonoComponentsStatic)' == ''">false</MonoComponentsStatic>
     <!-- by default, do dynamic components -->
     <!-- TODO: Change to dynamic as default once package/deploy is fixed for all targets -->
     <MonoComponentsStatic Condition="'$(MonoComponentsStatic)' == ''">true</MonoComponentsStatic>
@@ -419,10 +420,15 @@
       <_MonoCMakeArgs Include="-DENABLE_MSCORDBI=1" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true'">
+    <ItemGroup Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_PAL_TCP=1"/>
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_DEFAULT_LISTEN_PORT=1"/>
       <_MonoCMakeArgs Include="-DDISABLE_LINK_STATIC_COMPONENTS=1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetsAndroid)' == 'true'">
+      <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_PAL_TCP=1"/>
+      <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_DEFAULT_LISTEN_PORT=1"/>
     </ItemGroup>
 
     <!-- Components -->

--- a/src/mono/mono/component/CMakeLists.txt
+++ b/src/mono/mono/component/CMakeLists.txt
@@ -58,13 +58,27 @@ set(${MONO_DIAGNOSTICS_TRACING_COMPONENT_NAME}-dependencies
 
 # from here down, all the components are treated in the same way
 
+#define a library for each component and component stub
+function(define_component_libs)
+  if (NOT DISABLE_LIBS)
+    foreach(component IN LISTS components)
+      add_library("mono-component-${component}-static" STATIC $<TARGET_OBJECTS:${component}-objects>)
+      install(TARGETS "mono-component-${component}-static" LIBRARY)
+    endforeach()
+    foreach(component IN LISTS components)
+      add_library("mono-component-${component}-stub-static" STATIC $<TARGET_OBJECTS:${component}-stub-objects>)
+      install(TARGETS "mono-component-${component}-stub-static" LIBRARY)
+    endforeach()
+  endif()
+endfunction()
+
 # a generic component interface that all components implement
 add_library(component_base INTERFACE)
 target_sources(component_base INTERFACE
   ${MONO_COMPONENT_PATH}/component.h
 )
 
-if(DISABLE_COMPONENTS OR (NOT STATIC_COMPONENTS AND HOST_WIN32))
+if(DISABLE_COMPONENTS OR DISABLE_LIBS)
   set(DISABLE_COMPONENT_OBJECTS 1)
 endif()
 
@@ -90,6 +104,7 @@ if(NOT DISABLE_COMPONENTS AND NOT STATIC_COMPONENTS)
       target_compile_definitions("mono-component-${component}" PRIVATE -DCOMPILING_COMPONENT_DYNAMIC;-DMONO_DLL_IMPORT)
     else()
       add_library("mono-component-${component}" SHARED $<TARGET_OBJECTS:${component}-objects>)
+      target_compile_definitions("${component}-objects" PRIVATE -DCOMPILING_COMPONENT_DYNAMIC;-DMONO_DLL_IMPORT)
     endif()
     foreach(dependency IN LISTS "${component}-dependencies")
       add_dependencies("mono-component-${component}" "${dependency}")
@@ -111,17 +126,13 @@ if(NOT DISABLE_COMPONENTS AND NOT STATIC_COMPONENTS)
     install(TARGETS "mono-component-${component}" LIBRARY)
   endforeach()
 
+  #define a library for each component and component stub
+  define_component_libs()
+
 elseif(NOT DISABLE_COMPONENTS AND STATIC_COMPONENTS)
 
-  #define a static library for each component and component stub
-  foreach(component IN LISTS components)
-    add_library("mono-component-${component}-static" STATIC $<TARGET_OBJECTS:${component}-objects>)
-    install(TARGETS "mono-component-${component}-static" LIBRARY)
-  endforeach()
-  foreach(component IN LISTS components)
-    add_library("mono-component-${component}-stub-static" STATIC $<TARGET_OBJECTS:${component}-stub-objects>)
-    install(TARGETS "mono-component-${component}-stub-static" LIBRARY)
-  endforeach()
+  #define a library for each component and component stub
+  define_component_libs()
 
   # define a list of mono-components objects for mini if building a shared libmono with static-linked components
   set(mono-components-objects "")

--- a/src/mono/mono/component/diagnostics_server-stub.c
+++ b/src/mono/mono/component/diagnostics_server-stub.c
@@ -25,6 +25,9 @@ diagnostics_server_stub_pause_for_diagnostics_monitor (void);
 static void
 diagnostics_server_stub_disable (void);
 
+static MonoComponentDiagnosticsServer *
+component_diagnostics_server_stub_init (void);
+
 static MonoComponentDiagnosticsServer fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &diagnostics_server_stub_available },
 	&diagnostics_server_stub_init,
@@ -61,15 +64,15 @@ diagnostics_server_stub_disable (void)
 {
 }
 
+static MonoComponentDiagnosticsServer *
+component_diagnostics_server_stub_init (void)
+{
+	return &fn_table;
+}
+
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentDiagnosticsServer *
 mono_component_diagnostics_server_init (void)
 {
-	return mono_component_diagnostics_server_stub_init ();
-}
-
-MonoComponentDiagnosticsServer *
-mono_component_diagnostics_server_stub_init (void)
-{
-	return &fn_table;
+	return component_diagnostics_server_stub_init ();
 }

--- a/src/mono/mono/component/diagnostics_server-stub.c
+++ b/src/mono/mono/component/diagnostics_server-stub.c
@@ -61,14 +61,12 @@ diagnostics_server_stub_disable (void)
 {
 }
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentDiagnosticsServer *
 mono_component_diagnostics_server_init (void)
 {
 	return mono_component_diagnostics_server_stub_init ();
 }
-#endif
 
 MonoComponentDiagnosticsServer *
 mono_component_diagnostics_server_stub_init (void)

--- a/src/mono/mono/component/diagnostics_server.c
+++ b/src/mono/mono/component/diagnostics_server.c
@@ -8,12 +8,6 @@
 #include <mono/utils/mono-compiler.h>
 #include <eventpipe/ds-server.h>
 
-#ifndef STATIC_COMPONENTS
-MONO_COMPONENT_EXPORT_ENTRYPOINT
-MonoComponentDiagnosticsServer *
-mono_component_diagnostics_server_init (void);
-#endif
-
 static bool
 diagnostics_server_available (void);
 

--- a/src/mono/mono/component/diagnostics_server.h
+++ b/src/mono/mono/component/diagnostics_server.h
@@ -23,10 +23,8 @@ typedef struct _MonoComponentDiagnosticsServer {
 	void (*disable) (void);
 } MonoComponentDiagnosticsServer;
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentDiagnosticsServer *
 mono_component_diagnostics_server_init (void);
-#endif
 
 #endif /*_MONO_COMPONENT_DIAGNOSTICS_SERVER_H*/

--- a/src/mono/mono/component/event_pipe-stub.c
+++ b/src/mono/mono/component/event_pipe-stub.c
@@ -247,14 +247,12 @@ event_pipe_stub_write_event_ee_startup_start (void)
 	return true;
 }
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void)
 {
 	return mono_component_event_pipe_stub_init ();
 }
-#endif
 
 MonoComponentEventPipe *
 mono_component_event_pipe_stub_init (void)

--- a/src/mono/mono/component/event_pipe-stub.c
+++ b/src/mono/mono/component/event_pipe-stub.c
@@ -98,6 +98,8 @@ event_pipe_stub_thread_ctrl_activity_id (
 static bool
 event_pipe_stub_write_event_ee_startup_start (void);
 
+MonoComponentEventPipe *
+component_event_pipe_stub_init (void);
 
 static MonoComponentEventPipe fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &event_pipe_stub_available },
@@ -247,15 +249,15 @@ event_pipe_stub_write_event_ee_startup_start (void)
 	return true;
 }
 
+MonoComponentEventPipe *
+component_event_pipe_stub_init (void)
+{
+	return &fn_table;
+}
+
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void)
 {
-	return mono_component_event_pipe_stub_init ();
-}
-
-MonoComponentEventPipe *
-mono_component_event_pipe_stub_init (void)
-{
-	return &fn_table;
+	return component_event_pipe_stub_init ();
 }

--- a/src/mono/mono/component/event_pipe.c
+++ b/src/mono/mono/component/event_pipe.c
@@ -232,12 +232,6 @@ event_pipe_thread_ctrl_activity_id (
 	return result;
 }
 
-#ifndef STATIC_COMPONENTS
-MONO_COMPONENT_EXPORT_ENTRYPOINT
-MonoComponentEventPipe *
-mono_component_event_pipe_init (void);
-#endif
-
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void)
 {

--- a/src/mono/mono/component/event_pipe.h
+++ b/src/mono/mono/component/event_pipe.h
@@ -152,10 +152,8 @@ typedef struct _MonoComponentEventPipe {
 	event_pipe_component_write_event_ee_startup_start_func write_event_ee_startup_start;
 } MonoComponentEventPipe;
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void);
-#endif
 
 #endif /*_MONO_COMPONENT_EVENT_PIPE_H*/

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -16,33 +16,35 @@ hot_reload_stub_available (void);
 static void
 hot_reload_stub_apply_changes (MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, MonoError *error);
 
+static MonoComponentHotReload *
+component_hot_reload_stub_init (void);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_apply_changes,
 };
 
-MONO_COMPONENT_EXPORT_ENTRYPOINT
-MonoComponentHotReload *
-mono_component_hot_reload_init (void)
-{
-	return mono_component_hot_reload_stub_init ();
-}
-
-MonoComponentHotReload *
-mono_component_hot_reload_stub_init (void)
-{
-	return &fn_table;
-}
-
-bool
+static bool
 hot_reload_stub_available (void)
 {
 	return false;
 }
 
-void
+static void
 hot_reload_stub_apply_changes (MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, MonoError *error)
 {
 	mono_error_set_not_supported (error, "Hot reload not supported in this runtime.");
 }
 
+static MonoComponentHotReload *
+component_hot_reload_stub_init (void)
+{
+	return &fn_table;
+}
+
+MONO_COMPONENT_EXPORT_ENTRYPOINT
+MonoComponentHotReload *
+mono_component_hot_reload_init (void)
+{
+	return component_hot_reload_stub_init ();
+}

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -21,14 +21,12 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_apply_changes,
 };
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *
 mono_component_hot_reload_init (void)
 {
 	return mono_component_hot_reload_stub_init ();
 }
-#endif
 
 MonoComponentHotReload *
 mono_component_hot_reload_stub_init (void)

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -20,13 +20,6 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_apply_changes,
 };
 
-MonoComponentHotReload *
-mono_component_hot_reload_init (void)
-{
-	/* TODO: implement me */
-	return &fn_table;
-}
-
 static bool
 hot_reload_available (void)
 {
@@ -37,4 +30,11 @@ static void
 hot_reload_apply_changes (MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, MonoError *error)
 {
 	/* TODO: implement me */
+}
+
+MonoComponentHotReload *
+mono_component_hot_reload_init (void)
+{
+	/* TODO: implement me */
+	return &fn_table;
 }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -9,12 +9,6 @@
 
 #include <mono/utils/mono-compiler.h>
 
-#ifndef STATIC_COMPONENTS
-MONO_COMPONENT_EXPORT_ENTRYPOINT
-MonoComponentHotReload *
-mono_component_hot_reload_init (void);
-#endif
-
 static bool
 hot_reload_available (void);
 

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -16,10 +16,8 @@ typedef struct _MonoComponentHotReload {
 	void (*apply_changes) (MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, MonoError *error);
 } MonoComponentHotReload;
 
-#ifdef STATIC_COMPONENTS
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *
 mono_component_hot_reload_init (void);
-#endif
 
 #endif/*_MONO_COMPONENT_HOT_RELOAD_H*/

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -900,7 +900,7 @@ ep_rt_mono_init_finish (void)
 	// Managed init of diagnostics classes, like registration of RuntimeEventSource (if available).
 	ERROR_DECL (error);
 
-	MonoClass *runtime_event_source = mono_class_from_name_checked (mono_defaults.corlib, "System.Diagnostics.Tracing", "RuntimeEventSource", error);
+	MonoClass *runtime_event_source = mono_class_from_name_checked (mono_get_corlib (), "System.Diagnostics.Tracing", "RuntimeEventSource", error);
 	if (is_ok (error) && runtime_event_source) {
 		MonoMethod *init = mono_class_get_method_from_name_checked (runtime_event_source, "Initialize", -1, 0, error);
 		if (is_ok (error) && init) {

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1436,7 +1436,7 @@ mono_class_get_dim_conflicts (MonoClass *klass);
 MONO_COMPONENT_API MonoMethod *
 mono_class_get_method_from_name_checked (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 
-gboolean
+MONO_COMPONENT_API gboolean
 mono_method_has_no_body (MonoMethod *method);
 
 // FIXME Replace all internal callers of mono_method_get_header_checked with
@@ -1445,7 +1445,7 @@ mono_method_has_no_body (MonoMethod *method);
 // And then mark mono_method_get_header_checked as MONO_RT_EXTERNAL_ONLY MONO_API.
 //
 // Internal callers expected to use ERROR_DECL. External callers are not.
-MonoMethodHeader*
+MONO_COMPONENT_API MonoMethodHeader*
 mono_method_get_header_internal (MonoMethod *method, MonoError *error);
 
 MonoType*

--- a/src/mono/mono/metadata/components.c
+++ b/src/mono/mono/metadata/components.c
@@ -140,7 +140,7 @@ try_load (const char* dir, const MonoComponentEntry *component, const char* comp
 	path = g_module_build_path (dir, component_base_lib);
 	if (path) {
 		char *error_msg = NULL;
-		lib = mono_dl_open (path, MONO_DL_EAGER, &error_msg);
+		lib = mono_dl_open (path, MONO_DL_EAGER | MONO_DL_LOCAL, &error_msg);
 		if (!lib) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Component %s not found: %s", component->name, error_msg);
 		}

--- a/src/mono/mono/metadata/components.c
+++ b/src/mono/mono/metadata/components.c
@@ -25,11 +25,7 @@ typedef struct _MonoComponentEntry {
 	MonoDl *lib;
 } MonoComponentEntry;
 
-#ifdef STATIC_COMPONENTS
 #define COMPONENT_INIT_FUNC(name) (MonoComponentInitFn) mono_component_ ## name ## _init
-#else
-#define COMPONENT_INIT_FUNC(name) (MonoComponentInitFn) mono_component_ ## name ## _stub_init
-#endif
 
 #define HOT_RELOAD_LIBRARY_NAME "hot_reload"
 #define HOT_RELOAD_COMPONENT_NAME HOT_RELOAD_LIBRARY_NAME
@@ -140,16 +136,15 @@ static MonoDl*
 try_load (const char* dir, const MonoComponentEntry *component, const char* component_base_lib)
 {
 	MonoDl *lib = NULL;
-	void *iter = NULL;
 	char *path = NULL;
-	while ((path = mono_dl_build_path (dir, component_base_lib, &iter)) && !lib) {
+	path = g_module_build_path (dir, component_base_lib);
+	if (path) {
 		char *error_msg = NULL;
 		lib = mono_dl_open (path, MONO_DL_EAGER, &error_msg);
 		if (!lib) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Component %s not found: %s", component->name, error_msg);
-			g_free (error_msg);
-			continue;
 		}
+		g_free (error_msg);
 	}
 	if (lib)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Component %s found at %s", component->name, path);
@@ -160,6 +155,12 @@ try_load (const char* dir, const MonoComponentEntry *component, const char* comp
 static MonoComponentInitFn
 load_component (const MonoComponentEntry *component, MonoDl **lib_out)
 {
+	// If init method has been static linked not using stub library, use that instead of dynamic component.
+	if (component->init() && component->init()->available ()) {
+		*lib_out = NULL;
+		return component->init;
+	}
+
 	char *component_base_lib = component_library_base_name (component);
 	MonoComponentInitFn result = NULL;
 

--- a/src/mono/mono/metadata/components.h
+++ b/src/mono/mono/metadata/components.h
@@ -38,14 +38,4 @@ mono_component_diagnostics_server (void)
 	return diagnostics_server;
 }
 
-/* Declare each copomnents stub init function here */
-MonoComponentHotReload *
-mono_component_hot_reload_stub_init (void);
-
-MonoComponentEventPipe *
-mono_component_event_pipe_stub_init (void);
-
-MonoComponentDiagnosticsServer *
-mono_component_diagnostics_server_stub_init (void);
-
 #endif/*_MONO_METADATA_COMPONENTS_H*/

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -494,10 +494,10 @@ mono_thread_info_suspend_unlock (void);
 void
 mono_thread_info_abort_socket_syscall_for_close (MonoNativeThreadId tid);
 
-void
+MONO_COMPONENT_API void
 mono_thread_info_set_is_async_context (gboolean async_context);
 
-gboolean
+MONO_COMPONENT_API gboolean
 mono_thread_info_is_async_context (void);
 
 void

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -34,9 +34,14 @@ public class AndroidAppBuilderTask : Task
     public bool ForceAOT { get; set; }
 
     /// <summary>
-    /// List of components to static link, if available
+    /// Static linked runtime
     /// </summary>
-    public string? StaticLinkedComponentNames { get; set; } = ""!;
+    public bool StaticLinkedRuntime { get; set; }
+
+    /// <summary>
+    /// List of enabled runtime components
+    /// </summary>
+    public string? RuntimeComponents { get; set; } = ""!;
 
     [Required]
     public string RuntimeIdentifier { get; set; } = ""!;
@@ -95,7 +100,8 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.KeyStorePath = KeyStorePath;
         apkBuilder.ForceInterpreter = ForceInterpreter;
         apkBuilder.ForceAOT = ForceAOT;
-        apkBuilder.StaticLinkedComponentNames = StaticLinkedComponentNames;
+        apkBuilder.StaticLinkedRuntime = StaticLinkedRuntime;
+        apkBuilder.RuntimeComponents = RuntimeComponents;
         apkBuilder.Assemblies = Assemblies;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(abi, MainLibraryFileName, MonoRuntimeHeaders);
 

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -26,7 +26,8 @@ public class ApkBuilder
     public bool ForceAOT { get; set; }
     public bool InvariantGlobalization { get; set; }
     public bool EnableRuntimeLogging { get; set; }
-    public string? StaticLinkedComponentNames { get; set; }
+    public bool StaticLinkedRuntime { get; set; }
+    public string? RuntimeComponents { get; set; }
     public ITaskItem[] Assemblies { get; set; } = Array.Empty<ITaskItem>();
 
     public (string apk, string packageId) BuildApk(
@@ -175,62 +176,74 @@ public class ApkBuilder
         // 1. Build libmonodroid.so` via cmake
 
         string nativeLibraries = "";
-        string monoRuntimeLib = Path.Combine(AppDir, "libmonosgen-2.0.a");
+        string monoRuntimeLib = "";
+        if (StaticLinkedRuntime)
+        {
+            monoRuntimeLib = Path.Combine(AppDir, "libmonosgen-2.0.a");
+        }
+        else
+        {
+            monoRuntimeLib = Path.Combine(AppDir, "libmonosgen-2.0.so");
+        }
+
         if (!File.Exists(monoRuntimeLib))
         {
-            throw new ArgumentException($"libmonosgen-2.0.a was not found in {AppDir}");
+            throw new ArgumentException($"{monoRuntimeLib} was not found");
         }
         else
         {
             nativeLibraries += $"{monoRuntimeLib}{Environment.NewLine}";
         }
 
-        string[] staticComponentStubLibs = Directory.GetFiles(AppDir, "libmono-component-*-stub-static.a");
-        bool staticLinkAllComponents = false;
-        string[] componentNames = Array.Empty<string>();
-
-        if (!string.IsNullOrEmpty(StaticLinkedComponentNames) && StaticLinkedComponentNames.Equals("*", StringComparison.OrdinalIgnoreCase))
-            staticLinkAllComponents = true;
-        else if (!string.IsNullOrEmpty(StaticLinkedComponentNames))
-            componentNames = StaticLinkedComponentNames.Split(";");
-
-        // by default, component stubs will be linked and depending on how mono runtime has been build,
-        // stubs can disable or dynamic load components.
-        foreach (string staticComponentStubLib in staticComponentStubLibs)
+        if (StaticLinkedRuntime)
         {
-            string componentLibToLink = staticComponentStubLib;
-            if (staticLinkAllComponents)
+            string[] staticComponentStubLibs = Directory.GetFiles(AppDir, "libmono-component-*-stub-static.a");
+            bool staticLinkAllComponents = false;
+            string[] staticLinkedComponents = Array.Empty<string>();
+
+            if (!string.IsNullOrEmpty(RuntimeComponents) && RuntimeComponents.Equals("*", StringComparison.OrdinalIgnoreCase))
+                staticLinkAllComponents = true;
+            else if (!string.IsNullOrEmpty(RuntimeComponents))
+                staticLinkedComponents = RuntimeComponents.Split(";");
+
+            // by default, component stubs will be linked and depending on how mono runtime has been build,
+            // stubs can disable or dynamic load components.
+            foreach (string staticComponentStubLib in staticComponentStubLibs)
             {
-                // static link component.
-                componentLibToLink = componentLibToLink.Replace("-stub-static.a", "-static.a", StringComparison.OrdinalIgnoreCase);
-            }
-            else
-            {
-                foreach (string componentName in componentNames)
+                string componentLibToLink = staticComponentStubLib;
+                if (staticLinkAllComponents)
                 {
-                    if (componentLibToLink.Contains(componentName, StringComparison.OrdinalIgnoreCase))
+                    // static link component.
+                    componentLibToLink = componentLibToLink.Replace("-stub-static.a", "-static.a", StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    foreach (string staticLinkedComponent in staticLinkedComponents)
                     {
-                        // static link component.
-                        componentLibToLink = componentLibToLink.Replace("-stub-static.a", "-static.a", StringComparison.OrdinalIgnoreCase);
-                        break;
+                        if (componentLibToLink.Contains(staticLinkedComponent, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // static link component.
+                            componentLibToLink = componentLibToLink.Replace("-stub-static.a", "-static.a", StringComparison.OrdinalIgnoreCase);
+                            break;
+                        }
                     }
                 }
+
+                // if lib doesn't exist (primarly due to runtime build without static lib support), fallback linking stub lib.
+                if (!File.Exists(componentLibToLink))
+                {
+                    Utils.LogInfo($"\nCouldn't find static component library: {componentLibToLink}, linking static component stub library: {staticComponentStubLib}.\n");
+                    componentLibToLink = staticComponentStubLib;
+                }
+
+                nativeLibraries += $"    {componentLibToLink}{Environment.NewLine}";
             }
 
-            // if lib doesn't exist (primarly due to runtime build without static lib support), fallback linking stub lib.
-            if (!File.Exists(componentLibToLink))
-            {
-                Utils.LogInfo($"\nCouldn't find static component library: {componentLibToLink}, linking static component stub library: {staticComponentStubLib}.\n");
-                componentLibToLink = staticComponentStubLib;
-            }
-
-            nativeLibraries += $"    {componentLibToLink}{Environment.NewLine}";
+            // There's a circular dependecy between static mono runtime lib and static component libraries.
+            // Adding mono runtime lib before and after component libs will resolve issues with undefined symbols
+            // due to circular dependecy.
+            nativeLibraries += $"    {monoRuntimeLib}{Environment.NewLine}";
         }
-
-        // There's a circular dependecy between static mono runtime lib and static component libraries.
-        // Adding mono runtime lib before and after component libs will resolve issues with undefined symbols
-        // due to circular dependecy.
-        nativeLibraries += $"    {monoRuntimeLib}{Environment.NewLine}";
 
         string aotSources = "";
         foreach (string asm in assemblerFiles)
@@ -323,19 +336,54 @@ public class ApkBuilder
         dynamicLibs.AddRange(Directory.GetFiles(AppDir, "*.so").Where(file => Path.GetFileName(file) != "libmonodroid.so"));
 
         // add all *.so files to lib/%abi%/
+
+        string[] dynamicLinkedComponents = Array.Empty<string>();
+        bool dynamicLinkAllComponents = false;
+        if (!StaticLinkedRuntime && !string.IsNullOrEmpty(RuntimeComponents) && RuntimeComponents.Equals("*", StringComparison.OrdinalIgnoreCase))
+                dynamicLinkAllComponents = true;
+        if (!string.IsNullOrEmpty(RuntimeComponents) && !StaticLinkedRuntime)
+            dynamicLinkedComponents = RuntimeComponents.Split(";");
+
         Directory.CreateDirectory(Path.Combine(OutputDir, "lib", abi));
         foreach (var dynamicLib in dynamicLibs)
         {
             string dynamicLibName = Path.GetFileName(dynamicLib);
-            if (dynamicLibName == "libmonosgen-2.0.so")
+            string destRelative = Path.Combine("lib", abi, dynamicLibName);
+
+            if (dynamicLibName == "libmonosgen-2.0.so" && StaticLinkedRuntime)
             {
                 // we link mono runtime statically into libmonodroid.so
+                // make sure dynamic runtime is not included in package.
+                if (File.Exists(destRelative))
+                    File.Delete(destRelative);
                 continue;
+            }
+
+            if (dynamicLibName.Contains("libmono-component-", StringComparison.OrdinalIgnoreCase))
+            {
+                bool includeComponent = dynamicLinkAllComponents;
+                if (!StaticLinkedRuntime && !includeComponent)
+                {
+                    foreach (string dynamicLinkedComponent in dynamicLinkedComponents)
+                    {
+                        if (dynamicLibName.Contains(dynamicLinkedComponent, StringComparison.OrdinalIgnoreCase))
+                        {
+                            includeComponent = true;
+                            break;
+                        }
+                    }
+                }
+                if (!includeComponent)
+                {
+                    // make sure dynamic component is not included in package.
+                    if (File.Exists(destRelative))
+                        File.Delete(destRelative);
+                    continue;
+                }
             }
 
             // NOTE: we can run android-strip tool from NDK to shrink native binaries here even more.
 
-            string destRelative = Path.Combine("lib", abi, dynamicLibName);
             File.Copy(dynamicLib, Path.Combine(OutputDir, destRelative), true);
             Utils.RunProcess(aapt, $"add {apkFile} {destRelative}", workingDir: OutputDir);
         }

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -127,9 +127,9 @@ public class AppleAppBuilderTask : Task
     public bool ForceAOT { get; set; }
 
     /// <summary>
-    /// List of components to static link, if available
+    /// List of enabled runtime components
     /// </summary>
-    public string? StaticLinkedComponentNames { get; set; } = ""!;
+    public string? RuntimeComponents { get; set; } = ""!;
 
     /// <summary>
     /// Forces the runtime to use the invariant mode
@@ -204,7 +204,7 @@ public class AppleAppBuilderTask : Task
             generator.EnableRuntimeLogging = EnableRuntimeLogging;
 
             XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles,
-                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, StaticLinkedComponentNames, NativeMainSource);
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, RuntimeComponents, NativeMainSource);
 
             if (BuildAppBundle)
             {

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -55,7 +55,7 @@ internal class Xcode
         bool forceInterpreter,
         bool invariantGlobalization,
         bool stripDebugSymbols,
-        string? staticLinkedComponentNames=null,
+        string? runtimeComponents=null,
         string? nativeMainSource = null)
     {
         // bundle everything as resources excluding native files
@@ -110,12 +110,12 @@ internal class Xcode
         string[] allComponentLibs = Directory.GetFiles(workspace, "libmono-component-*-static.a");
         string[] staticComponentStubLibs = Directory.GetFiles(workspace, "libmono-component-*-stub-static.a");
         bool staticLinkAllComponents = false;
-        string[] componentNames = Array.Empty<string>();
+        string[] staticLinkedComponents = Array.Empty<string>();
 
-        if (!string.IsNullOrEmpty(staticLinkedComponentNames) && staticLinkedComponentNames.Equals("*", StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(runtimeComponents) && runtimeComponents.Equals("*", StringComparison.OrdinalIgnoreCase))
             staticLinkAllComponents = true;
-        else if (!string.IsNullOrEmpty(staticLinkedComponentNames))
-            componentNames = staticLinkedComponentNames.Split(";");
+        else if (!string.IsNullOrEmpty(runtimeComponents))
+            staticLinkedComponents = runtimeComponents.Split(";");
 
         // by default, component stubs will be linked and depending on how mono runtime has been build,
         // stubs can disable or dynamic load components.
@@ -129,9 +129,9 @@ internal class Xcode
             }
             else
             {
-                foreach (string componentName in componentNames)
+                foreach (string staticLinkedComponent in staticLinkedComponents)
                 {
-                    if (componentLibToLink.Contains(componentName, StringComparison.OrdinalIgnoreCase))
+                    if (componentLibToLink.Contains(staticLinkedComponent, StringComparison.OrdinalIgnoreCase))
                     {
                         // static link component.
                         componentLibToLink = componentLibToLink.Replace("-stub-static.a", "-static.a", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
So far only static component support have been used in Mono runtime. Android uses dynamic linked mono runtime and would need dynamic component support, https://github.com/dotnet/runtime/issues/52439.

PR adds dynamic component support (currently only enabled for Android). PR also adds dynamic runtime/component support into Android AppBuilder that previously only supported static linking, but since Xamarin Android will use dynamic linking it is better to align AppBuilder using same scenario. The static linking scenario is however still kept in Android AppBuilder, but its currently not the default, but can be enabled using a AndroidAppBuilderTask propert (StaticLinkedRuntime).

PR also adjust the dynamic component support build a little, instead of only build and include shared objects, build will also include component static libraries (including stubs). Since build already includes static version of libmonosgen-2.0.a it is possible to use that during build (as AppBuilder does in its static linking scenario), but that would also need the component libraries in order to build with or without (using stub libraries) component support.

Since AppBuild supports both dynamic as well as static linking, the property name used to pass what components to enable have been adjusted to work in both scenarios, StaticLinkedComponentNames has been renamed to RuntimeComponents for both Android and iOS AppBuilder. Android AppBuild also have StaticLinkedRuntime property (default to false) to switch from dynamic to static linked runtime and components.

All static Android libraries are build using -fPIC by default.