### PR TITLE
[wasm][testing] create dev cert via powershell on helix

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -106,7 +106,12 @@
     <HelixPreCommand Include="set XHARNESS_LOG_WITH_TIMESTAMPS=true" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
-    <!-- this is alternative to `dotnet dev-certs https` but we don't have SDK installed on helix -->
+    <!-- 
+      We are hosting the payloads for the WASM/browser on kestrel in the xharness process.
+      We also run some network tests to this server and so, we are running it on both HTTP and HTTPS.
+      For the HTTPS endpoint we need development SSL certificate.
+      Below is alternative to `dotnet dev-certs https` but we don't have full SDK installed on helix, so the tool is not available.
+    -->
     <HelixPreCommand Include="powershell -command &quot;New-SelfSignedCertificate -FriendlyName &#39;ASP.NET Core HTTPS development certificate&#39; -DnsName @(&#39;localhost&#39;) -Subject &#39;CN = localhost&#39; -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm sha256 -CertStoreLocation &#39;Cert:\CurrentUser\My&#39; -TextExtension @(&#39;2.5.29.37={text}1.3.6.1.5.5.7.3.1&#39;,&#39;1.3.6.1.4.1.311.84.1.1={hex}02&#39;,&#39;2.5.29.19={text}&#39;) -KeyUsage DigitalSignature,KeyEncipherment&quot;" />
   </ItemGroup>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -106,7 +106,8 @@
     <HelixPreCommand Include="set XHARNESS_LOG_WITH_TIMESTAMPS=true" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
-    <HelixPreCommand Include="dotnet dev-certs https" />
+    <!-- this is alternative to `dotnet dev-certs https` but we don't have SDK installed on helix -->
+    <HelixPreCommand Include="powershell -command &quot;New-SelfSignedCertificate -FriendlyName &#39;ASP.NET Core HTTPS development certificate&#39; -DnsName @(&#39;localhost&#39;) -Subject &#39;CN = localhost&#39; -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm sha256 -CertStoreLocation &#39;Cert:\CurrentUser\My&#39; -TextExtension @(&#39;2.5.29.37={text}1.3.6.1.5.5.7.3.1&#39;,&#39;1.3.6.1.4.1.311.84.1.1={hex}02&#39;,&#39;2.5.29.19={text}&#39;) -KeyUsage DigitalSignature,KeyEncipherment&quot;" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'BuildWasmApps'">


### PR DESCRIPTION
Caused by https://github.com/dotnet/runtime/pull/53180
The original approach to install certificates didn't work because we don't have dotnet SDK, just runtime.
Fixes https://github.com/dotnet/runtime/issues/53207
