### PR TITLE
Generate targets files that throws for unsupported netstandard applicable tfms

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -256,6 +256,7 @@
     <GeneratePackage Condition="(('$(PreReleaseVersionLabel)' == 'servicing' or
                                   '$(GitHubRepositoryName)' == 'runtimelab') and
                                  '$(MSBuildProjectExtension)' != '.sfxproj')">false</GeneratePackage>
+    <PlaceholderFile>$(RepositoryEngineeringDir)_._</PlaceholderFile>
   </PropertyGroup>
 
   <!-- Language configuration -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -80,7 +80,7 @@
           BeforeTargets="GetFiles">
     <PropertyGroup>
       <_NETStandardCompatErrorFilePath>$(BaseIntermediateOutputPath)netstandardcompaterrors\%(NETStandardCompatError.Identity)\$(PackageId).targets</_NETStandardCompatErrorFilePath>
-      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_%(NETStandardCompatError.Supported.Trim('.'))</_NETStandardCompatErrorFileTarget>
+      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_$([System.String]::new('%(NETStandardCompatError.Supported)').Replace('.', '_'))</_NETStandardCompatErrorFileTarget>
       <_NETStandardCompatErrorFileContent>
 <![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
   <Target Name="$(_NETStandardCompatErrorFileTarget)"
@@ -93,8 +93,8 @@
 
     <WriteLinesToFile File="$(_NETStandardCompatErrorFilePath)"
                       Lines="$(_NETStandardCompatErrorFileContent)"
-                      WriteOnlyWhenDifferent="true"
-                      Encoding="Unicode" />
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
       <None Include="$(_NETStandardCompatErrorFilePath)"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -80,7 +80,7 @@
           BeforeTargets="GetFiles">
     <PropertyGroup>
       <_NETStandardCompatErrorFilePath>$(BaseIntermediateOutputPath)netstandardcompaterrors\%(NETStandardCompatError.Identity)\$(PackageId).targets</_NETStandardCompatErrorFilePath>
-      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_$([System.String]::new('%(NETStandardCompatError.Supported)').Replace('.', '_'))</_NETStandardCompatErrorFileTarget>
+      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId.Replace('.', '_'))_$([System.String]::new('%(NETStandardCompatError.Supported)').Replace('.', '_'))</_NETStandardCompatErrorFileTarget>
       <_NETStandardCompatErrorFileContent>
 <![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
   <Target Name="$(_NETStandardCompatErrorFileTarget)"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -80,7 +80,7 @@
           BeforeTargets="GetFiles">
     <PropertyGroup>
       <_NETStandardCompatErrorFilePath>$(BaseIntermediateOutputPath)netstandardcompaterrors\%(NETStandardCompatError.Identity)\$(PackageId).targets</_NETStandardCompatErrorFilePath>
-      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_%(NETStandardCompatError.Supported)</_NETStandardCompatErrorFileTarget>
+      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_%(NETStandardCompatError.Supported.Trim('.'))</_NETStandardCompatErrorFileTarget>
       <_NETStandardCompatErrorFileContent>
 <![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
   <Target Name="$(_NETStandardCompatErrorFileTarget)"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -54,6 +54,7 @@
     <PackageDescription Condition="'$(PackageDescription)' == '' and '$(UseRuntimePackageDisclaimer)' == 'true'">$(RuntimePackageDisclaimer)</PackageDescription>
     <!-- Keep in sync as required by the Packaging SDK in Arcade. -->
     <Description>$(PackageDescription)</Description>
+    <BeforePack>$(BeforePack);AddNETStandardCompatErrorFileForPackaging</BeforePack>
   </PropertyGroup>
 
   <!-- Remove when https://github.com/NuGet/Home/issues/10405 is implemented and consumed. -->
@@ -69,5 +70,40 @@
     <PropertyGroup>
       <PackDependsOn />
     </PropertyGroup>
+  </Target>
+
+  <!-- Add targets file that marks a .NETStandard applicable tfm as unsupported. -->
+  <Target Name="AddNETStandardCompatErrorFileForPackaging"
+          Condition="'@(NETStandardCompatError)' != ''"
+          Inputs="%(NETStandardCompatError.Identity)"
+          Outputs="unused"
+          BeforeTargets="GetFiles">
+    <PropertyGroup>
+      <_NETStandardCompatErrorFilePath>$(BaseIntermediateOutputPath)netstandardcompaterrors\%(NETStandardCompatError.Identity)\$(PackageId).targets</_NETStandardCompatErrorFilePath>
+      <_NETStandardCompatErrorFileTarget>NETStandardCompatError_$(PackageId)_%(NETStandardCompatError.Supported)</_NETStandardCompatErrorFileTarget>
+      <_NETStandardCompatErrorFileContent>
+<![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
+  <Target Name="$(_NETStandardCompatErrorFileTarget)"
+          Condition="'%24(SuppressTfmSupportBuildWarnings)' == ''">
+    <Error Text="$(PackageId) doesn't support %24(TargetFramework). Consider updating your TargetFramework to %(NETStandardCompatError.Supported) or later." />
+  </Target>
+</Project>]]>
+      </_NETStandardCompatErrorFileContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(_NETStandardCompatErrorFilePath)"
+                      Lines="$(_NETStandardCompatErrorFileContent)"
+                      Overwrite="true"
+                      Encoding="Unicode" />
+
+    <ItemGroup>
+      <None Include="$(_NETStandardCompatErrorFilePath)"
+            PackagePath="buildTransitive\%(NETStandardCompatError.Identity)"
+            Pack="true" />
+      <None Include="$(PlaceholderFile)"
+            PackagePath="buildTransitive\%(NETStandardCompatError.Supported)"
+            Pack="true" />
+      <FileWrites Include="$(_NETStandardCompatErrorFilePath)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -93,7 +93,7 @@
 
     <WriteLinesToFile File="$(_NETStandardCompatErrorFilePath)"
                       Lines="$(_NETStandardCompatErrorFileContent)"
-                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true"
                       Encoding="Unicode" />
 
     <ItemGroup>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
     <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(IntermediateOutputPath)runtime.json" PackagePath="/" />
-    <Content Include="_._" PackagePath="lib/netstandard1.0" />
+    <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Drawing.Common/pkg/System.Drawing.Common.pkgproj
+++ b/src/libraries/System.Drawing.Common/pkg/System.Drawing.Common.pkgproj
@@ -6,10 +6,7 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Drawing.Common.csproj" />
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
-    <PackageFile Include="buildTransitive\System.Drawing.Common.targets"
-                 TargetPath="buildTransitive\netcoreapp2.0" />
-    <File Include="$(PlaceHolderFile)"
-          TargetPath="buildTransitive\netcoreapp3.0" />
+    <NETStandardCompatError Include="netcoreapp2.0" Supported="netcoreapp3.1" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Drawing.Common/pkg/buildTransitive/System.Drawing.Common.targets
+++ b/src/libraries/System.Drawing.Common/pkg/buildTransitive/System.Drawing.Common.targets
@@ -1,6 +1,0 @@
-<Project InitialTargets="_ErrorForSystemDrawingCommonOnNetCoreApp2x">
-  <Target Name="_ErrorForSystemDrawingCommonOnNetCoreApp2x"
-          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
-    <Error Text="System.Drawing.Common doesn't support $(TargetFramework). Consider updating your TargetFramework to netcoreapp3.1 or later." />
-  </Target>
-</Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -5,10 +5,7 @@
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.csproj" />
-    <PackageFile Include="buildTransitive\System.Security.Cryptography.Pkcs.targets"
-                 TargetPath="buildTransitive\netcoreapp2.0" />
-    <File Include="$(PlaceholderFile)"
-          TargetPath="buildTransitive\netcoreapp3.0" />
+    <NETStandardCompatError Include="netcoreapp2.0" Supported="netcoreapp3.1" />
     <!-- Exclude TFMs that aren't supported by the package anymore from validation. -->
     <ExcludeHarvestedSupportedFramework Include="netcoreapp1.0;netcoreapp1.1;netcore50;uap10.0;net46" />
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Pkcs/pkg/buildTransitive/System.Security.Cryptography.Pkcs.targets
+++ b/src/libraries/System.Security.Cryptography.Pkcs/pkg/buildTransitive/System.Security.Cryptography.Pkcs.targets
@@ -1,6 +1,0 @@
-<Project InitialTargets="_ErrorForSystemSecurityCryptographyPkcsOnNetCoreApp20">
-  <Target Name="_ErrorForSystemSecurityCryptographyPkcsOnNetCoreApp20"
-          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
-    <Error Text="System.Security.Cryptography.Pkcs doesn't support netcoreapp2.0. Consider updating your TargetFramework to netcoreapp3.1 or later." />
-  </Target>
-</Project>

--- a/src/libraries/System.Speech/pkg/System.Speech.pkgproj
+++ b/src/libraries/System.Speech/pkg/System.Speech.pkgproj
@@ -8,10 +8,7 @@
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
-    <PackageFile Include="buildTransitive\System.Speech.targets"
-                 TargetPath="buildTransitive\netcoreapp2.0" />
-    <File Include="$(PlaceholderFile)"
-          TargetPath="buildTransitive\netcoreapp2.1" />
+    <NETStandardCompatError Include="netcoreapp2.0" Supported="netcoreapp3.1" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Speech/pkg/buildTransitive/System.Speech.targets
+++ b/src/libraries/System.Speech/pkg/buildTransitive/System.Speech.targets
@@ -1,7 +1,0 @@
-<Project InitialTargets="_ErrorForSystemSpeechOnNetCoreApp20">
-  <Target Name="_ErrorForSystemSpeechOnNetCoreApp20"
-          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
-    <Error Text="System.Speech doesn't support netcoreapp2.0. Consider updating your TargetFramework to netcoreapp2.1 or later."
-           Code="SYSLIB9000" />
-  </Target>
-</Project>


### PR DESCRIPTION
For S.D.Common, S.Speech and S.Sec.Crypto.Pkcs we manually added a
targets file to mark the .NETStandard asset as not applicable.
This was done to allow defining a minimum supported .NETCoreApp
version, even though a compatible .NETStandard asset is available.
This commit automatically generates that targets file based on
items.

This is a port of the commit from https://github.com/dotnet/runtime/pull/53023.