### PR TITLE
Use GeneratedDllImport in System.Security.Cryptography.Algorithms

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
         internal static extern int EvpDigestCurrent(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
         [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestOneShot")]
-        internal static unsafe extern int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, ref uint mdSize);
+        internal static unsafe extern int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, uint* mdSize);
 
         [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal static extern int EvpMdSize(IntPtr md);

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFArray.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFArray.cs
@@ -13,13 +13,13 @@ internal static partial class Interop
 {
     internal static partial class CoreFoundation
     {
-        [DllImport(Libraries.CoreFoundationLibrary, EntryPoint = "CFArrayGetCount")]
-        private static extern CFIndex _CFArrayGetCount(SafeCFArrayHandle cfArray);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary, EntryPoint = "CFArrayGetCount")]
+        private static partial CFIndex _CFArrayGetCount(SafeCFArrayHandle cfArray);
 
         // Follows the "Get" version of the "Create" rule, so needs to return an IntPtr to
         // prevent CFRelease from being called on the SafeHandle close.
-        [DllImport(Libraries.CoreFoundationLibrary, EntryPoint = "CFArrayGetValueAtIndex")]
-        private static extern IntPtr CFArrayGetValueAtIndex(SafeCFArrayHandle cfArray, CFIndex index);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary, EntryPoint = "CFArrayGetValueAtIndex")]
+        private static partial IntPtr CFArrayGetValueAtIndex(SafeCFArrayHandle cfArray, CFIndex index);
 
         internal static long CFArrayGetCount(SafeCFArrayHandle cfArray)
         {

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
@@ -13,11 +13,11 @@ internal static partial class Interop
 {
     internal static partial class CoreFoundation
     {
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern unsafe byte* CFDataGetBytePtr(SafeCFDataHandle cfData);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static unsafe partial byte* CFDataGetBytePtr(SafeCFDataHandle cfData);
 
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern CFIndex CFDataGetLength(SafeCFDataHandle cfData);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static partial CFIndex CFDataGetLength(SafeCFDataHandle cfData);
 
         internal static unsafe Span<byte> CFDataDangerousGetSpan(SafeCFDataHandle cfData)
         {

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
@@ -14,11 +14,11 @@ internal static partial class Interop
 {
     internal static partial class CoreFoundation
     {
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern CFIndex CFErrorGetCode(SafeCFErrorHandle cfError);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static partial CFIndex CFErrorGetCode(SafeCFErrorHandle cfError);
 
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern SafeCFStringHandle CFErrorCopyDescription(SafeCFErrorHandle cfError);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static partial SafeCFStringHandle CFErrorCopyDescription(SafeCFErrorHandle cfError);
 
         internal static int GetErrorCode(SafeCFErrorHandle cfError)
         {

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
@@ -15,13 +15,13 @@ internal static partial class Interop
         /// Returns the interior pointer of the cfString if it has the specified encoding.
         /// If it has the wrong encoding, or if the interior pointer isn't being shared for some reason, returns NULL
         /// </summary>
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern IntPtr CFStringGetCStringPtr(
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static partial IntPtr CFStringGetCStringPtr(
             SafeCFStringHandle cfString,
             CFStringBuiltInEncodings encoding);
 
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static extern SafeCFDataHandle CFStringCreateExternalRepresentation(
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static partial SafeCFDataHandle CFStringCreateExternalRepresentation(
             IntPtr alloc,
             SafeCFStringHandle theString,
             CFStringBuiltInEncodings encoding,

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -47,8 +47,8 @@ internal static partial class Interop
         /// <param name="encoding">The encoding type.</param>
         /// <param name="isExternalRepresentation">Whether or not a BOM is present.</param>
         /// <returns>A CFStringRef on success, otherwise a SafeCreateHandle(IntPtr.Zero).</returns>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        private static extern SafeCreateHandle CFStringCreateWithBytes(
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        private static partial SafeCreateHandle CFStringCreateWithBytes(
             IntPtr alloc,
             IntPtr bytes,
             CFIndex numBytes,
@@ -63,8 +63,8 @@ internal static partial class Interop
         /// <param name="encoding">The encoding of the str variable. This should be UTF 8 for OS X</param>
         /// <returns>Returns a pointer to a CFString on success; otherwise, returns IntPtr.Zero</returns>
         /// <remarks>For *nix systems, the CLR maps ANSI to UTF-8, so be explicit about that</remarks>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary, CharSet = CharSet.Ansi)]
-        private static extern SafeCreateHandle CFStringCreateWithCString(
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary, CharSet = CharSet.Ansi)]
+        private static partial SafeCreateHandle CFStringCreateWithCString(
             IntPtr allocator,
             string str,
             CFStringBuiltInEncodings encoding);
@@ -77,8 +77,8 @@ internal static partial class Interop
         /// <param name="encoding">The encoding of the str variable. This should be UTF 8 for OS X</param>
         /// <returns>Returns a pointer to a CFString on success; otherwise, returns IntPtr.Zero</returns>
         /// <remarks>For *nix systems, the CLR maps ANSI to UTF-8, so be explicit about that</remarks>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary, CharSet = CharSet.Ansi)]
-        private static extern SafeCreateHandle CFStringCreateWithCString(
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary, CharSet = CharSet.Ansi)]
+        private static partial SafeCreateHandle CFStringCreateWithCString(
             IntPtr allocator,
             IntPtr str,
             CFStringBuiltInEncodings encoding);
@@ -130,8 +130,8 @@ internal static partial class Interop
         /// <param name="numValues">The number of values in the array</param>
         /// <param name="callbacks">Should be IntPtr.Zero</param>
         /// <returns>Returns a pointer to a CFArray on success; otherwise, returns IntPtr.Zero</returns>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        private static extern SafeCreateHandle CFArrayCreate(
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        private static partial SafeCreateHandle CFArrayCreate(
             IntPtr allocator,
             [MarshalAs(UnmanagedType.LPArray)]
             IntPtr[] values,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -12,32 +12,32 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFree")]
         internal static extern void DigestFree(IntPtr handle);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
-        internal static extern SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
+        internal static partial SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
 
         internal static int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> data) =>
             DigestUpdate(ctx, ref MemoryMarshal.GetReference(data), data.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
-        private static extern int DigestUpdate(SafeDigestCtxHandle ctx, ref byte pbData, int cbData);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
+        private static partial int DigestUpdate(SafeDigestCtxHandle ctx, ref byte pbData, int cbData);
 
         internal static int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> output) =>
             DigestFinal(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
-        private static extern int DigestFinal(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
+        private static partial int DigestFinal(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
 
         internal static int DigestCurrent(SafeDigestCtxHandle ctx, Span<byte> output) =>
             DigestCurrent(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCurrent")]
-        private static extern int DigestCurrent(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCurrent")]
+        private static partial int DigestCurrent(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestOneShot")]
-        internal static unsafe extern int DigestOneShot(PAL_HashAlgorithm algorithm, byte* pbData, int cbData, byte* pbOutput, int cbOutput, out int cbDigest);
+        internal static unsafe extern int DigestOneShot(PAL_HashAlgorithm algorithm, byte* pbData, int cbData, byte* pbOutput, int cbOutput, int* cbDigest);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestReset")]
-        internal static extern int DigestReset(SafeDigestCtxHandle ctx);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestReset")]
+        internal static partial int DigestReset(SafeDigestCtxHandle ctx);
     }
 }
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
@@ -11,15 +11,15 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_EccGenerateKey(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_EccGenerateKey(
             int keySizeInBits,
             out SafeSecKeyRefHandle pPublicKey,
             out SafeSecKeyRefHandle pPrivateKey,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGetKeySizeInBits")]
-        internal static extern long EccGetKeySizeInBits(SafeSecKeyRefHandle publicKey);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGetKeySizeInBits")]
+        internal static partial long EccGetKeySizeInBits(SafeSecKeyRefHandle publicKey);
 
         internal static void EccGenerateKey(
             int keySizeInBits,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -12,29 +12,29 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFree")]
         internal static extern void HmacFree(IntPtr handle);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCreate")]
-        internal static extern SafeHmacHandle HmacCreate(PAL_HashAlgorithm algorithm, ref int cbDigest);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCreate")]
+        internal static partial SafeHmacHandle HmacCreate(PAL_HashAlgorithm algorithm, ref int cbDigest);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
-        internal static extern int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
+        internal static partial int HmacInit(SafeHmacHandle ctx, byte[] pbKey, int cbKey);
 
         internal static int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> data) =>
             HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), data.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
-        private static extern int HmacUpdate(SafeHmacHandle ctx, ref byte pbData, int cbData);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
+        private static partial int HmacUpdate(SafeHmacHandle ctx, ref byte pbData, int cbData);
 
         internal static int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> output) =>
             HmacFinal(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
-        private static extern int HmacFinal(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
+        private static partial int HmacFinal(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
 
         internal static int HmacCurrent(SafeHmacHandle ctx, ReadOnlySpan<byte> output) =>
             HmacCurrent(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCurrent")]
-        private static extern int HmacCurrent(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCurrent")]
+        private static partial int HmacCurrent(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
     }
 }
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyAgree.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyAgree.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_EcdhKeyAgree(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_EcdhKeyAgree(
             SafeSecKeyRefHandle privateKey,
             SafeSecKeyRefHandle publicKey,
             out SafeCFDataHandle cfDataOut,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Pbkdf2.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Pbkdf2.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
             fixed (byte* pSalt = salt)
             fixed (byte* pDestination = destination)
             {
+                int ccStatus;
                 int ret = AppleCryptoNative_Pbkdf2(
                     prfAlgorithm,
                     pPassword,
@@ -30,7 +31,7 @@ internal static partial class Interop
                     iterations,
                     pDestination,
                     destination.Length,
-                    out int ccStatus);
+                    &ccStatus);
 
                 if (ret == 0)
                 {
@@ -57,6 +58,6 @@ internal static partial class Interop
             int iterations,
             byte* derivedKey,
             int derivedKeyLen,
-            out int errorCode);
+            int* errorCode);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -12,31 +12,31 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_RsaGenerateKey(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_RsaGenerateKey(
             int keySizeInBits,
             out SafeSecKeyRefHandle pPublicKey,
             out SafeSecKeyRefHandle pPrivateKey,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_RsaSignaturePrimitive(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_RsaSignaturePrimitive(
             SafeSecKeyRefHandle privateKey,
             ref byte pbData,
             int cbData,
             out SafeCFDataHandle pDataOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_RsaVerificationPrimitive(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_RsaVerificationPrimitive(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,
             out SafeCFDataHandle pDataOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_RsaEncryptionPrimitive(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_RsaEncryptionPrimitive(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,
@@ -52,8 +52,8 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut) =>
             RsaEncryptOaep(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
-        private static extern int RsaEncryptOaep(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
+        private static partial int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,
@@ -69,8 +69,8 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut) =>
             RsaEncryptPkcs(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, out pEncryptedOut, out pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
-        private static extern int RsaEncryptPkcs(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
+        private static partial int RsaEncryptPkcs(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,
@@ -86,8 +86,8 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut) =>
             RsaDecryptOaep(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
-        private static extern int RsaDecryptOaep(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
+        private static partial int RsaDecryptOaep(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,
@@ -103,8 +103,8 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut) =>
             RsaDecryptPkcs(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, out pEncryptedOut, out pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
-        private static extern int RsaDecryptPkcs(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
+        private static partial int RsaDecryptPkcs(
             SafeSecKeyRefHandle publicKey,
             ref byte pbData,
             int cbData,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Random.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
             Debug.Assert(count >= 0);
 
             int errorCode;
-            int ret = AppleCryptoNative_GetRandomBytes(pbBuffer, count, out errorCode);
+            int ret = AppleCryptoNative_GetRandomBytes(pbBuffer, count, &errorCode);
 
             if (ret == 0)
             {
@@ -28,6 +28,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.AppleCryptoNative)]
-        private static extern unsafe int AppleCryptoNative_GetRandomBytes(byte* buf, int num, out int errorCode);
+        private static extern unsafe int AppleCryptoNative_GetRandomBytes(byte* buf, int num, int* errorCode);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecErrMessage.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecErrMessage.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern SafeCFStringHandle AppleCryptoNative_SecCopyErrorMessageString(int osStatus);
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial SafeCFStringHandle AppleCryptoNative_SecCopyErrorMessageString(int osStatus);
 
         internal static string? GetSecErrorString(int osStatus)
         {

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
@@ -23,8 +23,8 @@ internal static partial class Interop
             RSA = 2,
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyRefHandle publicKey);
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyRefHandle publicKey);
 
         private delegate int SecKeyTransform(ReadOnlySpan<byte> source, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle);
 
@@ -154,8 +154,8 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static unsafe extern int AppleCryptoNative_SecKeyCreateWithData(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static unsafe partial int AppleCryptoNative_SecKeyCreateWithData(
             byte* pKey,
             int cbKey,
             PAL_KeyAlgorithm keyAlgorithm,
@@ -163,14 +163,14 @@ internal static partial class Interop
             out SafeSecKeyRefHandle pDataKey,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static unsafe extern int AppleCryptoNative_SecKeyCopyExternalRepresentation(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static unsafe partial int AppleCryptoNative_SecKeyCopyExternalRepresentation(
             SafeSecKeyRefHandle key,
             out SafeCFDataHandle pDataOut,
             out SafeCFErrorHandle pErrorOut);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SecKeyCopyPublicKey")]
-        internal static unsafe extern SafeSecKeyRefHandle CopyPublicKey(SafeSecKeyRefHandle privateKey);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SecKeyCopyPublicKey")]
+        internal static unsafe partial SafeSecKeyRefHandle CopyPublicKey(SafeSecKeyRefHandle privateKey);
     }
 }
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.macOS.cs
@@ -26,8 +26,8 @@ internal static partial class Interop
                 out ppKeyOut,
                 out pOSStatus);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_SecKeyImportEphemeral(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_SecKeyImportEphemeral(
             ref byte pbKeyBlob,
             int cbKeyBlob,
             int isPrivateKey,
@@ -61,8 +61,8 @@ internal static partial class Interop
             throw new CryptographicException();
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_SecKeyExport(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_SecKeyExport(
             SafeSecKeyRefHandle? key,
             int exportPrivate,
             SafeCreateHandle cfExportPassphrase,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
@@ -47,8 +47,8 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static unsafe extern int AppleCryptoNative_SecKeyVerifySignature(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static unsafe partial int AppleCryptoNative_SecKeyVerifySignature(
             SafeSecKeyRefHandle publicKey,
             byte* pbDataHash,
             int cbDataHash,
@@ -79,8 +79,8 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static unsafe extern int AppleCryptoNative_SecKeyCreateSignature(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static unsafe partial int AppleCryptoNative_SecKeyCreateSignature(
             SafeSecKeyRefHandle privateKey,
             byte* pbDataHash,
             int cbDataHash,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
@@ -45,8 +45,8 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorFree")]
         internal static extern void CryptorFree(IntPtr handle);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorCreate")]
-        internal static extern unsafe int CryptorCreate(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorCreate")]
+        internal static unsafe partial int CryptorCreate(
             PAL_SymmetricOperation operation,
             PAL_SymmetricAlgorithm algorithm,
             PAL_ChainingMode chainingMode,
@@ -58,8 +58,8 @@ internal static partial class Interop
             out SafeAppleCryptorHandle cryptor,
             out int ccStatus);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorUpdate")]
-        internal static extern unsafe int CryptorUpdate(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorUpdate")]
+        internal static unsafe partial int CryptorUpdate(
             SafeAppleCryptorHandle cryptor,
             byte* pbData,
             int cbData,
@@ -68,16 +68,16 @@ internal static partial class Interop
             out int cbWritten,
             out int ccStatus);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorFinal")]
-        internal static extern unsafe int CryptorFinal(
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorFinal")]
+        internal static unsafe partial int CryptorFinal(
             SafeAppleCryptorHandle cryptor,
             byte* pbOutput,
             int cbOutput,
             out int cbWritten,
             out int ccStatus);
 
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorReset")]
-        internal static extern unsafe int CryptorReset(SafeAppleCryptorHandle cryptor, byte* pbIv, out int ccStatus);
+        [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_CryptorReset")]
+        internal static unsafe partial int CryptorReset(SafeAppleCryptorHandle cryptor, byte* pbIv, out int ccStatus);
     }
 }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Nid.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Nid.cs
@@ -15,11 +15,11 @@ internal static partial class Interop
 
         internal const int NID_undef = 0;
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjSn2Nid", CharSet = CharSet.Ansi)]
-        internal static extern int ObjSn2Nid(string sn);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjSn2Nid", CharSet = CharSet.Ansi)]
+        internal static partial int ObjSn2Nid(string sn);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjTxt2Nid", CharSet = CharSet.Ansi)]
-        private static extern int ObjTxt2Nid(string oid);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjTxt2Nid", CharSet = CharSet.Ansi)]
+        private static partial int ObjTxt2Nid(string oid);
 
         internal static int ResolveRequiredNid(string oid)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
@@ -16,11 +16,11 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumFromBinary")]
         private static extern unsafe IntPtr BigNumFromBinary(byte* s, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumToBinary")]
-        private static extern unsafe int BigNumToBinary(SafeBignumHandle a, byte* to);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumToBinary")]
+        private static unsafe partial int BigNumToBinary(SafeBignumHandle a, byte* to);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetBigNumBytes")]
-        private static extern int GetBigNumBytes(SafeBignumHandle a);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetBigNumBytes")]
+        private static partial int GetBigNumBytes(SafeBignumHandle a);
 
         private static unsafe IntPtr CreateBignumPtr(ReadOnlySpan<byte> bigEndianValue)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
@@ -12,18 +12,17 @@ internal static partial class Interop
     internal static partial class Crypto
     {
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaUpRef")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DsaUpRef(IntPtr dsa);
+        internal static extern int DsaUpRef(IntPtr dsa);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaDestroy")]
         internal static extern void DsaDestroy(IntPtr dsa);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaGenerateKey")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaGenerateKey")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DsaGenerateKey(out SafeDsaHandle dsa, int bits);
+        internal static partial bool DsaGenerateKey(out SafeDsaHandle dsa, int bits);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeSignature")]
-        private static extern int DsaSizeSignature(SafeDsaHandle dsa);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeSignature")]
+        private static partial int DsaSizeSignature(SafeDsaHandle dsa);
 
         /// <summary>
         /// Return the maximum size of the DER-encoded key in bytes.
@@ -34,8 +33,8 @@ internal static partial class Interop
             return size;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeQ")]
-        private static extern int DsaSizeQ(SafeDsaHandle dsa);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeQ")]
+        private static partial int DsaSizeQ(SafeDsaHandle dsa);
 
         /// <summary>
         /// Return the size of the 'r' or 's' signature fields in bytes.
@@ -47,8 +46,8 @@ internal static partial class Interop
             return size;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeP")]
-        private static extern int DsaSizeP(SafeDsaHandle dsa);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSizeP")]
+        private static partial int DsaSizeP(SafeDsaHandle dsa);
 
         /// <summary>
         /// Return the size of the key in bytes.
@@ -65,9 +64,9 @@ internal static partial class Interop
         internal static bool DsaSign(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, Span<byte> refSignature, out int outSignatureLength) =>
             DsaSign(dsa, ref MemoryMarshal.GetReference(hash), hash.Length, ref MemoryMarshal.GetReference(refSignature), out outSignatureLength);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSign")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DsaSign(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte refSignature, out int outSignatureLength);
+        private static partial bool DsaSign(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte refSignature, out int outSignatureLength);
 
         internal static bool DsaVerify(SafeDsaHandle dsa, ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
         {
@@ -83,9 +82,9 @@ internal static partial class Interop
             return ret;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaVerify")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DsaVerify(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte signature, int signatureLength);
+        private static partial bool DsaVerify(SafeDsaHandle dsa, ref byte hash, int hashLength, ref byte signature, int signatureLength);
 
         internal static DSAParameters ExportDsaParameters(SafeDsaHandle key, bool includePrivateParameters)
         {
@@ -144,9 +143,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetDsaParameters")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetDsaParameters")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetDsaParameters(
+        private static partial bool GetDsaParameters(
             SafeDsaHandle key,
             out IntPtr p, out int p_cb,
             out IntPtr q, out int q_cb,
@@ -154,9 +153,9 @@ internal static partial class Interop
             out IntPtr y, out int y_cb,
             out IntPtr x, out int x_cb);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaKeyCreateByExplicitParameters")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaKeyCreateByExplicitParameters")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DsaKeyCreateByExplicitParameters(
+        internal static partial bool DsaKeyCreateByExplicitParameters(
             out SafeDsaHandle dsa,
             byte[] p,
             int pLength,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreate2")]
-        internal static extern SafeEvpCipherCtxHandle EvpCipherCreate(
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreate2")]
+        internal static partial SafeEvpCipherCtxHandle EvpCipherCreate(
             IntPtr cipher,
             ref byte key,
             int keyLength,
@@ -18,13 +18,13 @@ internal static partial class Interop
             ref byte iv,
             int enc);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreatePartial")]
-        internal static extern SafeEvpCipherCtxHandle EvpCipherCreatePartial(
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreatePartial")]
+        internal static partial SafeEvpCipherCtxHandle EvpCipherCreatePartial(
             IntPtr cipher);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetKeyAndIV")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetKeyAndIV")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherSetKeyAndIV(
+        private static partial bool EvpCipherSetKeyAndIV(
             SafeEvpCipherCtxHandle ctx,
             ref byte key,
             ref byte iv,
@@ -46,9 +46,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetGcmNonceLength")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetGcmNonceLength")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CryptoNative_EvpCipherSetGcmNonceLength(
+        private static partial bool CryptoNative_EvpCipherSetGcmNonceLength(
             SafeEvpCipherCtxHandle ctx, int nonceLength);
 
         internal static void EvpCipherSetGcmNonceLength(SafeEvpCipherCtxHandle ctx, int nonceLength)
@@ -59,9 +59,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetCcmNonceLength")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetCcmNonceLength")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CryptoNative_EvpCipherSetCcmNonceLength(
+        private static partial bool CryptoNative_EvpCipherSetCcmNonceLength(
             SafeEvpCipherCtxHandle ctx, int nonceLength);
 
         internal static void EvpCipherSetCcmNonceLength(SafeEvpCipherCtxHandle ctx, int nonceLength)
@@ -75,21 +75,21 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherDestroy")]
         internal static extern void EvpCipherDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherReset")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherReset")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EvpCipherReset(SafeEvpCipherCtxHandle ctx);
+        internal static partial bool EvpCipherReset(SafeEvpCipherCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCtxSetPadding")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCtxSetPadding")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EvpCipherCtxSetPadding(SafeEvpCipherCtxHandle x, int padding);
+        internal static partial bool EvpCipherCtxSetPadding(SafeEvpCipherCtxHandle x, int padding);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherUpdate")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherUpdate")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherUpdate(
+        private static partial bool EvpCipherUpdate(
             SafeEvpCipherCtxHandle ctx,
-            ref byte @out,
+            ref byte output,
             out int outl,
-            ref byte @in,
+            ref byte input,
             int inl);
 
         internal static bool EvpCipherUpdate(
@@ -115,9 +115,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherFinalEx")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherFinalEx")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherFinalEx(
+        private static partial bool EvpCipherFinalEx(
             SafeEvpCipherCtxHandle ctx,
             ref byte outm,
             out int outl);
@@ -130,9 +130,9 @@ internal static partial class Interop
             return EvpCipherFinalEx(ctx, ref MemoryMarshal.GetReference(output), out bytesWritten);
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetGcmTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetGcmTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherGetGcmTag(
+        private static partial bool EvpCipherGetGcmTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);
@@ -145,9 +145,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetAeadTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetAeadTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherGetAeadTag(
+        private static partial bool EvpCipherGetAeadTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);
@@ -160,9 +160,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetGcmTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetGcmTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherSetGcmTag(
+        private static partial bool EvpCipherSetGcmTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);
@@ -175,9 +175,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetAeadTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetAeadTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherSetAeadTag(
+        private static partial bool EvpCipherSetAeadTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);
@@ -190,9 +190,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetCcmTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherGetCcmTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherGetCcmTag(
+        private static partial bool EvpCipherGetCcmTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);
@@ -205,9 +205,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetCcmTag")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherSetCcmTag")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EvpCipherSetCcmTag(
+        private static partial bool EvpCipherSetCcmTag(
             SafeEvpCipherCtxHandle ctx,
             ref byte tag,
             int tagLength);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -10,29 +10,29 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdCtxCreate")]
-        internal static extern SafeEvpMdCtxHandle EvpMdCtxCreate(IntPtr type);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdCtxCreate")]
+        internal static partial SafeEvpMdCtxHandle EvpMdCtxCreate(IntPtr type);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdCtxDestroy")]
         internal static extern void EvpMdCtxDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
-        internal static extern int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
+        internal static partial int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
         internal static int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt) =>
             EvpDigestUpdate(ctx, ref MemoryMarshal.GetReference(d), cnt);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
-        private static extern int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ref byte d, int cnt);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
+        private static partial int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ref byte d, int cnt);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
-        internal static extern int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
+        internal static partial int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestCurrent")]
-        internal static extern int EvpDigestCurrent(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestCurrent")]
+        internal static partial int EvpDigestCurrent(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestOneShot")]
-        internal static unsafe extern int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, ref uint mdSize);
+        internal static unsafe extern int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, uint* mdSize);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal static extern int EvpMdSize(IntPtr md);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByKeyParameters", CharSet = CharSet.Ansi)]
-        private static extern int EcKeyCreateByKeyParameters(
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByKeyParameters", CharSet = CharSet.Ansi)]
+        private static partial int EcKeyCreateByKeyParameters(
             out SafeEcKeyHandle key,
             string oid,
             byte[]? qx, int qxLength,
@@ -37,8 +37,8 @@ internal static partial class Interop
             return key;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByExplicitParameters")]
-        internal static extern SafeEcKeyHandle EcKeyCreateByExplicitParameters(
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByExplicitParameters")]
+        internal static partial SafeEcKeyHandle EcKeyCreateByExplicitParameters(
             ECCurve.ECCurveType curveType,
             byte[]? qx, int qxLength,
             byte[]? qy, int qyLength,
@@ -97,8 +97,8 @@ internal static partial class Interop
         }
 
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_GetECKeyParameters(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key,
             bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
@@ -166,8 +166,8 @@ internal static partial class Interop
             return parameters;
         }
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_GetECCurveParameters(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
             bool includePrivate,
             out ECCurve.ECCurveType curveType,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
@@ -12,9 +12,9 @@ internal static partial class Interop
         internal static bool EcDsaSign(ReadOnlySpan<byte> dgst, Span<byte> sig, out int siglen, SafeEcKeyHandle ecKey) =>
             EcDsaSign(ref MemoryMarshal.GetReference(dgst), dgst.Length, ref MemoryMarshal.GetReference(sig), out siglen, ecKey);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSign")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool EcDsaSign(ref byte dgst, int dlen, ref byte sig, out int siglen, SafeEcKeyHandle ecKey);
+        private static partial bool EcDsaSign(ref byte dgst, int dlen, ref byte sig, out int siglen, SafeEcKeyHandle ecKey);
 
         internal static int EcDsaVerify(ReadOnlySpan<byte> dgst, ReadOnlySpan<byte> sigbuf, SafeEcKeyHandle ecKey)
         {
@@ -39,12 +39,12 @@ internal static partial class Interop
          *      0: incorrect signature
          *     -1: error
          */
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaVerify")]
-        private static extern int EcDsaVerify(ref byte dgst, int dgst_len, ref byte sigbuf, int sig_len, SafeEcKeyHandle ecKey);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaVerify")]
+        private static partial int EcDsaVerify(ref byte dgst, int dgst_len, ref byte sigbuf, int sig_len, SafeEcKeyHandle ecKey);
 
         // returns the maximum length of a DER encoded ECDSA signature created with this key.
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSize")]
-        private static extern int CryptoNative_EcDsaSize(SafeEcKeyHandle ecKey);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSize")]
+        private static partial int CryptoNative_EcDsaSize(SafeEcKeyHandle ecKey);
 
         internal static int EcDsaSize(SafeEcKeyHandle ecKey)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
@@ -10,8 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
-        private static extern SafeEcKeyHandle CryptoNative_EcKeyCreateByOid(string oid);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid", CharSet = CharSet.Ansi)]
+        private static partial SafeEcKeyHandle CryptoNative_EcKeyCreateByOid(string oid);
         internal static SafeEcKeyHandle? EcKeyCreateByOid(string oid)
         {
             SafeEcKeyHandle handle = CryptoNative_EcKeyCreateByOid(oid);
@@ -26,16 +26,15 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
         internal static extern void EcKeyDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGenerateKey")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGenerateKey")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EcKeyGenerateKey(SafeEcKeyHandle eckey);
+        internal static partial bool EcKeyGenerateKey(SafeEcKeyHandle eckey);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyUpRef")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EcKeyUpRef(IntPtr r);
+        internal static extern int EcKeyUpRef(IntPtr r);
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_EcKeyGetSize(SafeEcKeyHandle ecKey, out int keySize);
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_EcKeyGetSize(SafeEcKeyHandle ecKey, out int keySize);
         internal static int EcKeyGetSize(SafeEcKeyHandle key)
         {
             int keySize;
@@ -47,8 +46,8 @@ internal static partial class Interop
             throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGetCurveName2")]
-        private static extern int CryptoNative_EcKeyGetCurveName(SafeEcKeyHandle ecKey, out int nid);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGetCurveName2")]
+        private static partial int CryptoNative_EcKeyGetCurveName(SafeEcKeyHandle ecKey, out int nid);
 
         internal static string EcKeyGetCurveName(SafeEcKeyHandle key)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.EcKey.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.EcKey.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetEcKey")]
-        internal static extern SafeEcKeyHandle EvpPkeyGetEcKey(SafeEvpPKeyHandle pkey);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetEcKey")]
+        internal static partial SafeEcKeyHandle EvpPkeyGetEcKey(SafeEvpPKeyHandle pkey);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetEcKey")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetEcKey")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EvpPkeySetEcKey(SafeEvpPKeyHandle pkey, SafeEcKeyHandle key);
+        internal static partial bool EvpPkeySetEcKey(SafeEvpPKeyHandle pkey, SafeEcKeyHandle key);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Ecdh.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Ecdh.cs
@@ -11,11 +11,11 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeyCtxCreate")]
-        internal static extern SafeEvpPKeyCtxHandle EvpPKeyCtxCreate(SafeEvpPKeyHandle pkey, SafeEvpPKeyHandle peerkey, out uint secretLength);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeyCtxCreate")]
+        internal static partial SafeEvpPKeyCtxHandle EvpPKeyCtxCreate(SafeEvpPKeyHandle pkey, SafeEvpPKeyHandle peerkey, out uint secretLength);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeyDeriveSecretAgreement")]
-        private static extern int EvpPKeyDeriveSecretAgreement(
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeyDeriveSecretAgreement")]
+        private static partial int EvpPKeyDeriveSecretAgreement(
             ref byte secret,
             uint secretLength,
             SafeEvpPKeyCtxHandle ctx);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Rsa.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Rsa.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
-        private static extern SafeEvpPKeyHandle CryptoNative_RsaGenerateKey(int keySize);
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial SafeEvpPKeyHandle CryptoNative_RsaGenerateKey(int keySize);
 
         internal static SafeEvpPKeyHandle RsaGenerateKey(int keySize)
         {
@@ -27,8 +27,8 @@ internal static partial class Interop
             return pkey;
         }
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_RsaDecrypt(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_RsaDecrypt(
             SafeEvpPKeyHandle pkey,
             ref byte source,
             int sourceLength,
@@ -62,8 +62,8 @@ internal static partial class Interop
             return written;
         }
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_RsaEncrypt(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_RsaEncrypt(
             SafeEvpPKeyHandle pkey,
             ref byte source,
             int sourceLength,
@@ -97,8 +97,8 @@ internal static partial class Interop
             return written;
         }
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_RsaSignHash(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_RsaSignHash(
             SafeEvpPKeyHandle pkey,
             RSASignaturePaddingMode paddingMode,
             IntPtr digestAlgorithm,
@@ -132,8 +132,8 @@ internal static partial class Interop
             return written;
         }
 
-        [DllImport(Libraries.CryptoNative)]
-        private static extern int CryptoNative_RsaVerifyHash(
+        [GeneratedDllImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_RsaVerifyHash(
             SafeEvpPKeyHandle pkey,
             RSASignaturePaddingMode paddingMode,
             IntPtr digestAlgorithm,
@@ -172,15 +172,15 @@ internal static partial class Interop
             throw CreateOpenSslCryptographicException();
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetRsa")]
-        internal static extern SafeRsaHandle EvpPkeyGetRsa(SafeEvpPKeyHandle pkey);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetRsa")]
+        internal static partial SafeRsaHandle EvpPkeyGetRsa(SafeEvpPKeyHandle pkey);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetRsa")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetRsa")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EvpPkeySetRsa(SafeEvpPKeyHandle pkey, SafeRsaHandle rsa);
+        internal static partial bool EvpPkeySetRsa(SafeEvpPKeyHandle pkey, SafeRsaHandle rsa);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetRsa")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetRsa")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool EvpPkeySetRsa(SafeEvpPKeyHandle pkey, IntPtr rsa);
+        internal static partial bool EvpPkeySetRsa(SafeEvpPKeyHandle pkey, IntPtr rsa);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
@@ -9,16 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyCreate")]
-        internal static extern SafeEvpPKeyHandle EvpPkeyCreate();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyCreate")]
+        internal static partial SafeEvpPKeyHandle EvpPkeyCreate();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyDestroy")]
         internal static extern void EvpPkeyDestroy(IntPtr pkey);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeySize")]
-        internal static extern int EvpPKeySize(SafeEvpPKeyHandle pkey);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPKeySize")]
+        internal static partial int EvpPKeySize(SafeEvpPKeyHandle pkey);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_UpRefEvpPkey")]
-        internal static extern int UpRefEvpPkey(SafeEvpPKeyHandle handle);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_UpRefEvpPkey")]
+        internal static partial int UpRefEvpPkey(SafeEvpPKeyHandle handle);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -9,25 +9,25 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCreate")]
-        internal static extern SafeHmacCtxHandle HmacCreate(ref byte key, int keyLen, IntPtr md);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCreate")]
+        internal static partial SafeHmacCtxHandle HmacCreate(ref byte key, int keyLen, IntPtr md);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacDestroy")]
         internal static extern void HmacDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
-        internal static extern int HmacReset(SafeHmacCtxHandle ctx);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
+        internal static partial int HmacReset(SafeHmacCtxHandle ctx);
 
         internal static int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len) =>
             HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        private static extern int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
+        private static partial int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
-        internal static extern int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
+        internal static partial int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCurrent")]
-        internal static extern int HmacCurrent(SafeHmacCtxHandle ctx, ref byte data, ref int len);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCurrent")]
+        internal static partial int HmacCurrent(SafeHmacCtxHandle ctx, ref byte data, ref int len);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
@@ -12,11 +12,10 @@ internal static partial class Interop
         {
             Debug.Assert(count >= 0);
 
-            return CryptoNative_GetRandomBytes(pbBuffer, count);
+            return CryptoNative_GetRandomBytes(pbBuffer, count) != 0;
         }
 
         [DllImport(Libraries.CryptoNative)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool CryptoNative_GetRandomBytes(byte* buf, int num);
+        private static extern unsafe int CryptoNative_GetRandomBytes(byte* buf, int num);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -11,12 +11,11 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaCreate")]
-        internal static extern SafeRsaHandle RsaCreate();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaCreate")]
+        internal static partial SafeRsaHandle RsaCreate();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaUpRef")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool RsaUpRef(IntPtr rsa);
+        internal static extern int RsaUpRef(IntPtr rsa);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaDestroy")]
         internal static extern void RsaDestroy(IntPtr rsa);
@@ -24,11 +23,11 @@ internal static partial class Interop
         internal static SafeRsaHandle DecodeRsaPublicKey(ReadOnlySpan<byte> buf) =>
             DecodeRsaPublicKey(ref MemoryMarshal.GetReference(buf), buf.Length);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeRsaPublicKey")]
-        private static extern SafeRsaHandle DecodeRsaPublicKey(ref byte buf, int len);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeRsaPublicKey")]
+        private static partial SafeRsaHandle DecodeRsaPublicKey(ref byte buf, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSize")]
-        internal static extern int RsaSize(SafeRsaHandle rsa);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSize")]
+        internal static partial int RsaSize(SafeRsaHandle rsa);
 
         internal static RSAParameters ExportRsaParameters(SafeEvpPKeyHandle key, bool includePrivateParameters)
         {
@@ -92,9 +91,9 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetRsaParameters")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetRsaParameters")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetRsaParameters(
+        private static partial bool GetRsaParameters(
             SafeRsaHandle key,
             out IntPtr n,
             out IntPtr e,
@@ -105,9 +104,9 @@ internal static partial class Interop
             out IntPtr dmq1,
             out IntPtr iqmp);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetRsaParameters")]
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetRsaParameters")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool SetRsaParameters(
+        internal static partial bool SetRsaParameters(
             SafeRsaHandle key,
             byte[]? n,
             int nLength,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
@@ -16,8 +16,8 @@ internal static partial class Interop
             return BCryptCreateHash(hAlgorithm, out phHash, pbHashObject, cbHashObject, ref MemoryMarshal.GetReference(secret), cbSecret, dwFlags);
         }
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ref byte pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static partial NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ref byte pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
 
         [Flags]
         internal enum BCryptCreateHashFlags : int

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDeriveKeyPBKDF2.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDeriveKeyPBKDF2.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe NTSTATUS BCryptDeriveKeyPBKDF2(
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial NTSTATUS BCryptDeriveKeyPBKDF2(
             SafeBCryptAlgorithmHandle hPrf,
             byte* pbPassword,
             int cbPassword,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDuplicateHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDuplicateHash.cs
@@ -23,8 +23,8 @@ internal static partial class Interop
             return newHash;
         }
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptDuplicateHash(
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static partial NTSTATUS BCryptDuplicateHash(
             SafeBCryptHashHandle hHash,
             out SafeBCryptHashHandle phNewHash,
             IntPtr pbHashObject,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.cs
@@ -53,10 +53,10 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        public static extern unsafe NTSTATUS BCryptEncrypt(SafeKeyHandle hKey, byte* pbInput, int cbInput, IntPtr paddingInfo, [In, Out] byte[]? pbIV, int cbIV, byte* pbOutput, int cbOutput, out int cbResult, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        public static unsafe partial NTSTATUS BCryptEncrypt(SafeKeyHandle hKey, byte* pbInput, int cbInput, IntPtr paddingInfo, byte[]? pbIV, int cbIV, byte* pbOutput, int cbOutput, out int cbResult, int dwFlags);
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        public static extern unsafe NTSTATUS BCryptDecrypt(SafeKeyHandle hKey, byte* pbInput, int cbInput, IntPtr paddingInfo, [In, Out] byte[]? pbIV, int cbIV, byte* pbOutput, int cbOutput, out int cbResult, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        public static unsafe partial NTSTATUS BCryptDecrypt(SafeKeyHandle hKey, byte* pbInput, int cbInput, IntPtr paddingInfo, byte[]? pbIV, int cbIV, byte* pbOutput, int cbOutput, out int cbResult, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal static NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags) =>
             BCryptFinishHash(hHash, ref MemoryMarshal.GetReference(pbOutput), cbOutput, dwFlags);
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, ref byte pbOutput, int cbOutput, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static partial NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, ref byte pbOutput, int cbOutput, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateSymmetricKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateSymmetricKey.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static unsafe extern NTSTATUS BCryptGenerateSymmetricKey(
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial NTSTATUS BCryptGenerateSymmetricKey(
             SafeBCryptAlgorithmHandle hAlgorithm,
             out SafeBCryptKeyHandle phKey,
             IntPtr pbKeyObject,
@@ -19,8 +19,8 @@ internal static partial class Interop
             int cbSecret,
             uint dwFlags);
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static unsafe extern NTSTATUS BCryptGenerateSymmetricKey(
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial NTSTATUS BCryptGenerateSymmetricKey(
             nuint hAlgorithm,
             out SafeBCryptKeyHandle phKey,
             IntPtr pbKeyObject,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGetProperty.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGetProperty.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern unsafe NTSTATUS BCryptGetProperty(SafeBCryptHandle hObject, string pszProperty, void* pbOutput, int cbOutput, out int pcbResult, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial NTSTATUS BCryptGetProperty(SafeBCryptHandle hObject, string pszProperty, void* pbOutput, int cbOutput, out int pcbResult, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags) =>
             BCryptHashData(hHash, ref MemoryMarshal.GetReference(pbInput), cbInput, dwFlags);
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ref byte pbInput, int cbInput, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static partial NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ref byte pbInput, int cbInput, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
@@ -47,7 +47,7 @@ internal static partial class Interop
             public const uint BCRYPT_KEY_DATA_BLOB_VERSION1 = 0x1;
         }
 
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptImportKey(SafeAlgorithmHandle hAlgorithm, IntPtr hImportKey, string pszBlobType, out SafeKeyHandle hKey, IntPtr pbKeyObject, int cbKeyObject, byte[] pbInput, int cbInput, int dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static partial NTSTATUS BCryptImportKey(SafeAlgorithmHandle hAlgorithm, IntPtr hImportKey, string pszBlobType, out SafeKeyHandle hKey, IntPtr pbKeyObject, int cbKeyObject, byte[] pbInput, int cbInput, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptKeyDerivation.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptKeyDerivation.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static unsafe extern NTSTATUS BCryptKeyDerivation(
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial NTSTATUS BCryptKeyDerivation(
             SafeBCryptKeyHandle hKey,
             BCryptBufferDesc* pParameterList,
             byte* pbDerivedKey,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptOpenAlgorithmProvider.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptOpenAlgorithmProvider.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern NTSTATUS BCryptOpenAlgorithmProvider(out SafeBCryptAlgorithmHandle phAlgorithm, string pszAlgId, string? pszImplementation, BCryptOpenAlgorithmProviderFlags dwFlags);
+        [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static partial NTSTATUS BCryptOpenAlgorithmProvider(out SafeBCryptAlgorithmHandle phAlgorithm, string pszAlgId, string? pszImplementation, BCryptOpenAlgorithmProviderFlags dwFlags);
 
         [Flags]
         internal enum BCryptOpenAlgorithmProviderFlags : int

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.HashIdAlg.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.HashIdAlg.cs
@@ -13,15 +13,19 @@ internal static partial class Interop
         /// Version used for a buffer containing a scalar integer (not an IntPtr)
         /// </summary>
         [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode)]
-        private static extern IntPtr CryptFindOIDInfo(CryptOidInfoKeyType dwKeyType, ref int pvKey, OidGroup group);
+        private static unsafe extern IntPtr CryptFindOIDInfo(CryptOidInfoKeyType dwKeyType, int* pvKey, OidGroup group);
 
         public static CRYPT_OID_INFO FindAlgIdOidInfo(Interop.BCrypt.ECC_CURVE_ALG_ID_ENUM algId)
         {
             int intAlgId = (int)algId;
-            IntPtr fullOidInfo = CryptFindOIDInfo(
-                CryptOidInfoKeyType.CRYPT_OID_INFO_ALGID_KEY,
-                ref intAlgId,
-                OidGroup.HashAlgorithm);
+            IntPtr fullOidInfo;
+            unsafe
+            {
+                fullOidInfo = CryptFindOIDInfo(
+                    CryptOidInfoKeyType.CRYPT_OID_INFO_ALGID_KEY,
+                    &intAlgId,
+                    OidGroup.HashAlgorithm);
+            }
 
             if (fullOidInfo != IntPtr.Zero)
             {

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
@@ -12,13 +12,13 @@ internal static partial class Interop
         internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
             NCryptEncrypt(hKey, ref MemoryMarshal.GetReference(pbInput), cbInput, pPaddingInfo, ref MemoryMarshal.GetReference(pbOutput), cbOutput, out pcbResult, dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static unsafe partial ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
             NCryptDecrypt(hKey, ref MemoryMarshal.GetReference(pbInput), cbInput, pPaddingInfo, ref MemoryMarshal.GetReference(pbOutput), cbOutput, out pcbResult, dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static unsafe partial ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Keys.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Keys.cs
@@ -13,32 +13,32 @@ internal static partial class Interop
     {
         internal const string NCRYPT_PKCS8_PRIVATE_KEY_BLOB = "PKCS8_PRIVATEKEY";
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptOpenKey(SafeNCryptProviderHandle hProvider, out SafeNCryptKeyHandle phKey, string pszKeyName, int dwLegacyKeySpec, CngKeyOpenOptions dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptOpenKey(SafeNCryptProviderHandle hProvider, out SafeNCryptKeyHandle phKey, string pszKeyName, int dwLegacyKeySpec, CngKeyOpenOptions dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptImportKey(SafeNCryptProviderHandle hProvider, IntPtr hImportKey, string pszBlobType, IntPtr pParameterList, [Out] out SafeNCryptKeyHandle phKey, ref byte pbData, int cbData, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptImportKey(SafeNCryptProviderHandle hProvider, IntPtr hImportKey, string pszBlobType, IntPtr pParameterList, out SafeNCryptKeyHandle phKey, ref byte pbData, int cbData, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptImportKey(SafeNCryptProviderHandle hProvider, IntPtr hImportKey, string pszBlobType, ref NCryptBufferDesc pParameterList, [Out] out SafeNCryptKeyHandle phKey, ref byte pbData, int cbData, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptImportKey(SafeNCryptProviderHandle hProvider, IntPtr hImportKey, string pszBlobType, ref NCryptBufferDesc pParameterList, out SafeNCryptKeyHandle phKey, ref byte pbData, int cbData, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, IntPtr pParameterList, [Out] byte[]? pbOutput, int cbOutput, [Out] out int pcbResult, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, IntPtr pParameterList, byte[]? pbOutput, int cbOutput, out int pcbResult, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, IntPtr pParameterList, ref byte pbOutput, int cbOutput, [Out] out int pcbResult, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, IntPtr pParameterList, ref byte pbOutput, int cbOutput, out int pcbResult, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, ref NCryptBufferDesc pParameterList, ref byte pbOutput, int cbOutput, [Out] out int pcbResult, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptExportKey(SafeNCryptKeyHandle hKey, IntPtr hExportKey, string pszBlobType, ref NCryptBufferDesc pParameterList, ref byte pbOutput, int cbOutput, out int pcbResult, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptDeleteKey(SafeNCryptKeyHandle hKey, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptDeleteKey(SafeNCryptKeyHandle hKey, int dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptCreatePersistedKey(SafeNCryptProviderHandle hProvider, out SafeNCryptKeyHandle phKey, string pszAlgId, string? pszKeyName, int dwLegacyKeySpec, CngKeyCreationOptions dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptCreatePersistedKey(SafeNCryptProviderHandle hProvider, out SafeNCryptKeyHandle phKey, string pszAlgId, string? pszKeyName, int dwLegacyKeySpec, CngKeyCreationOptions dwFlags);
 
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptFinalizeKey(SafeNCryptKeyHandle hKey, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptFinalizeKey(SafeNCryptKeyHandle hKey, int dwFlags);
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct CRYPT_PKCS12_PBE_PARAMS

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
@@ -15,14 +15,14 @@ internal static partial class Interop
         /// <summary>
         ///     Generate a key from a secret agreement
         /// </summary>
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern ErrorCode NCryptDeriveKey(
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static partial ErrorCode NCryptDeriveKey(
             SafeNCryptSecretHandle hSharedSecret,
             string pwszKDF,
-            [In] ref NCryptBufferDesc pParameterList,
-            [Out, MarshalAs(UnmanagedType.LPArray)] byte[]? pbDerivedKey,
+            ref NCryptBufferDesc pParameterList,
+            [MarshalAs(UnmanagedType.LPArray)] byte[]? pbDerivedKey,
             int cbDerivedKey,
-            [Out] out int pcbResult,
+            out int pcbResult,
             SecretAgreementFlags dwFlags);
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveSecretAgreement.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveSecretAgreement.cs
@@ -20,11 +20,11 @@ internal static partial class Interop
         /// <summary>
         ///     Generate a secret agreement for generating shared key material
         /// </summary>
-        [DllImport(Interop.Libraries.NCrypt)]
-        private static extern ErrorCode NCryptSecretAgreement(
+        [GeneratedDllImport(Interop.Libraries.NCrypt)]
+        private static partial ErrorCode NCryptSecretAgreement(
             SafeNCryptKeyHandle hPrivKey,
             SafeNCryptKeyHandle hPubKey,
-            [Out] out SafeNCryptSecretHandle phSecret,
+            out SafeNCryptSecretHandle phSecret,
             int dwFlags);
 
 

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptOpenStorageProvider.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptOpenStorageProvider.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        internal static extern ErrorCode NCryptOpenStorageProvider(out SafeNCryptProviderHandle phProvider, string pszProviderName, int dwFlags);
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static partial ErrorCode NCryptOpenStorageProvider(out SafeNCryptProviderHandle phProvider, string pszProviderName, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
@@ -13,11 +13,21 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
+#if DLLIMPORTGENERATOR_ENABLED
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial ErrorCode NCryptGetProperty(SafeNCryptHandle hObject, string pszProperty, void* pbOutput, int cbOutput, out int pcbResult, CngPropertyOptions dwFlags);
+#else
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static extern unsafe ErrorCode NCryptGetProperty(SafeNCryptHandle hObject, string pszProperty, [Out] void* pbOutput, int cbOutput, out int pcbResult, CngPropertyOptions dwFlags);
+#endif
 
+#if DLLIMPORTGENERATOR_ENABLED
+        [GeneratedDllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe partial ErrorCode NCryptSetProperty(SafeNCryptHandle hObject, string pszProperty, void* pbInput, int cbInput, CngPropertyOptions dwFlags);
+#else
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static extern unsafe ErrorCode NCryptSetProperty(SafeNCryptHandle hObject, string pszProperty, [In] void* pbInput, int cbInput, CngPropertyOptions dwFlags);
+#endif
 
         [SupportedOSPlatform("windows")]
         internal static unsafe ErrorCode NCryptGetByteProperty(SafeNCryptHandle hObject, string pszProperty, ref byte result, CngPropertyOptions options = CngPropertyOptions.None)

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
@@ -12,13 +12,13 @@ internal static partial class Interop
         internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
             NCryptSignHash(hKey, pPaddingInfo, ref MemoryMarshal.GetReference(pbHashValue), cbHashValue, ref MemoryMarshal.GetReference(pbSignature), cbSignature, out pcbResult, dwFlags);
 
-        [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        [GeneratedDllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static unsafe partial ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags) =>
             NCryptVerifySignature(hKey, pPaddingInfo, ref MemoryMarshal.GetReference(pbHashValue), cbHashValue, ref MemoryMarshal.GetReference(pbSignature), cbSignature, dwFlags);
 
-        [DllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
-        private static extern unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
+        [GeneratedDllImport(Libraries.NCrypt, CharSet = CharSet.Unicode)]
+        private static unsafe partial ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Win32.SafeHandles
             // that we don't lose a tracked reference in low-memory situations.
             SafeDsaHandle safeHandle = new SafeDsaHandle();
 
-            if (!Interop.Crypto.DsaUpRef(handle))
+            if (Interop.Crypto.DsaUpRef(handle) == 0)
             {
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Win32.SafeHandles
             // that we don't lose a tracked reference in low-memory situations.
             SafeEcKeyHandle safeHandle = new SafeEcKeyHandle();
 
-            if (!Interop.Crypto.EcKeyUpRef(handle))
+            if (Interop.Crypto.EcKeyUpRef(handle) == 0)
             {
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Win32.SafeHandles
             // that we don't lose a tracked reference in low-memory situations.
             SafeRsaHandle safeHandle = new SafeRsaHandle();
 
-            if (!Interop.Crypto.RsaUpRef(handle))
+            if (Interop.Crypto.RsaUpRef(handle) == 0)
             {
                 throw Interop.Crypto.CreateOpenSslCryptographicException();
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
@@ -40,13 +40,14 @@ namespace Internal.Cryptography
                 fixed (byte* pSource = source)
                 fixed (byte* pDestination = destination)
                 {
+                    int digestSize;
                     int ret = Interop.AppleCrypto.DigestOneShot(
                         algorithm,
                         pSource,
                         source.Length,
                         pDestination,
                         destination.Length,
-                        out int digestSize);
+                        &digestSize);
 
                     if (ret != 1)
                     {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -39,7 +39,7 @@ namespace Internal.Cryptography
                 fixed (byte* pDestination = destination)
                 {
                     uint length = (uint)destination.Length;
-                    Check(Interop.Crypto.EvpDigestOneShot(evpType, pSource, source.Length, pDestination, ref length));
+                    Check(Interop.Crypto.EvpDigestOneShot(evpType, pSource, source.Length, pDestination, &length));
                     Debug.Assert(length == hashSize);
                 }
 


### PR DESCRIPTION
| Library | Original (B) | Converted (B) | + (B) | + (%) |
| ------- | -----------: | ------------: | ----: | ----: |
| linux | 221696 | 249344 | 27648 | 12.47 |
| windows | 251392 | 264192 | 12800 | 5.09 |
| linux R2R | 692224 | 795648 | 103424 | 14.94 |
| windows R2R | 762880 | 814080 | 51200 | 6.71 |

We could probably get some size improvements by switching a few arguments to pointers, but I would rather first focus on getting through the initial conversion so we have a good sense of the overall impact (and then we can look to reduce the size impact).

Lots of great candidates in here for the (ReadOnly)Span support.

cc @AaronRobinsonMSFT @jkoritzinsky 