### PR TITLE
Optimize index bounds check for immutable sorted set and list

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -195,7 +195,6 @@ namespace System.Collections.Immutable
             internal ref readonly T ItemRef(int index)
             {
                 Requires.Range(index >= 0 && index < this.Count, nameof(index));
-                Debug.Assert(_left != null && _right != null);
 
                 return ref ItemRefUnchecked(index);
             }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -195,19 +195,9 @@ namespace System.Collections.Immutable
             internal ref readonly T ItemRef(int index)
             {
                 Requires.Range(index >= 0 && index < this.Count, nameof(index));
-
                 Debug.Assert(_left != null && _right != null);
-                if (index < _left._count)
-                {
-                    return ref _left.ItemRefUnchecked(index);
-                }
 
-                if (index > _left._count)
-                {
-                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
-                }
-
-                return ref _key;
+                return ref ItemRefUnchecked(index);
             }
 
             internal ref readonly T ItemRefUnchecked(int index)

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -199,7 +199,7 @@ namespace System.Collections.Immutable
                 return ref ItemRefUnchecked(index);
             }
 
-            internal ref readonly T ItemRefUnchecked(int index)
+            private ref readonly T ItemRefUnchecked(int index)
             {
                 Debug.Assert(_left != null && _right != null);
                 if (index < _left._count)

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -199,12 +199,28 @@ namespace System.Collections.Immutable
                 Debug.Assert(_left != null && _right != null);
                 if (index < _left._count)
                 {
-                    return ref _left.ItemRef(index);
+                    return ref _left.ItemRefUnchecked(index);
                 }
 
                 if (index > _left._count)
                 {
-                    return ref _right.ItemRef(index - _left._count - 1);
+                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
+                }
+
+                return ref _key;
+            }
+
+            internal ref readonly T ItemRefUnchecked(int index)
+            {
+                Debug.Assert(_left != null && _right != null);
+                if (index < _left._count)
+                {
+                    return ref _left.ItemRefUnchecked(index);
+                }
+
+                if (index > _left._count)
+                {
+                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
                 }
 
                 return ref _key;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -261,7 +261,6 @@ namespace System.Collections.Immutable
             internal ref readonly T ItemRef(int index)
             {
                 Requires.Range(index >= 0 && index < this.Count, nameof(index));
-                Debug.Assert(_left != null && _right != null);
 
                 return ref ItemRefUnchecked(index);
             }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -263,17 +263,7 @@ namespace System.Collections.Immutable
                 Requires.Range(index >= 0 && index < this.Count, nameof(index));
                 Debug.Assert(_left != null && _right != null);
 
-                if (index < _left._count)
-                {
-                    return ref _left.ItemRefUnchecked(index);
-                }
-
-                if (index > _left._count)
-                {
-                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
-                }
-
-                return ref _key;
+                return ref ItemRefUnchecked(index);
             }
 
             internal ref readonly T ItemRefUnchecked(int index)

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -265,7 +265,7 @@ namespace System.Collections.Immutable
                 return ref ItemRefUnchecked(index);
             }
 
-            internal ref readonly T ItemRefUnchecked(int index)
+            private ref readonly T ItemRefUnchecked(int index)
             {
                 Debug.Assert(_left != null && _right != null);
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -265,12 +265,29 @@ namespace System.Collections.Immutable
 
                 if (index < _left._count)
                 {
-                    return ref _left.ItemRef(index);
+                    return ref _left.ItemRefUnchecked(index);
                 }
 
                 if (index > _left._count)
                 {
-                    return ref _right.ItemRef(index - _left._count - 1);
+                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
+                }
+
+                return ref _key;
+            }
+
+            internal ref readonly T ItemRefUnchecked(int index)
+            {
+                Debug.Assert(_left != null && _right != null);
+
+                if (index < _left._count)
+                {
+                    return ref _left.ItemRefUnchecked(index);
+                }
+
+                if (index > _left._count)
+                {
+                    return ref _right.ItemRefUnchecked(index - _left._count - 1);
                 }
 
                 return ref _key;


### PR DESCRIPTION
- The bounds check to determine if a given index is >= 0 and < this.Count
  is only necessary on the first call to ItemRef.
- The recursive steps within ItemRef do not need to continuously
  do this bounds check on these immutable data structures.
- Proof:
  Elimination of index >= 0 bounds check:
    The first call to ItemRef checks if index >= 0.
    If we recurse on the left node, the index value does not change.
    If we recurse on the right node, index > _left._count. Then
    index - _left._count - 1 >= 0.

  Elimination of index < this.Count:
    The first call to ItemRef checks if index < this.Count. Then
    the given index must lie somewhere in this tree and
    (\*\*) index < this.Count == left.Count + right.Count + 1.
    If we recurse on the left node, the index value does not change
    and a check is already made to determine that index < _left.Count.
    If we recurse on the right node, then we need to be sure that
    index - _left.count - 1 < _right.Count. But this is just a
    rearrangement of (\*\*).