### PR TITLE
Remove phi nodes during rationalize.

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -951,7 +951,7 @@ bool BasicBlock::isEmpty()
     }
     else
     {
-        for (GenTree* node : LIR::AsRange(this).NonPhiNodes())
+        for (GenTree* node : LIR::AsRange(this))
         {
             if (node->OperGet() != GT_IL_OFFSET)
             {

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -403,7 +403,7 @@ void CodeGen::genCodeForBBlist()
         // Set the use-order numbers for each node.
         {
             int useNum = 0;
-            for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
+            for (GenTree* node : LIR::AsRange(block))
             {
                 assert((node->gtDebugFlags & GTF_DEBUG_NODE_CG_CONSUMED) == 0);
 
@@ -422,7 +422,7 @@ void CodeGen::genCodeForBBlist()
 #endif // DEBUG
 
         IL_OFFSETX currentILOffset = BAD_IL_OFFSET;
-        for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
+        for (GenTree* node : LIR::AsRange(block))
         {
             // Do we have a new IL offset?
             if (node->OperGet() == GT_IL_OFFSET)

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -408,8 +408,7 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
 
     GenTree* tree = use.Def();
     GenTree* rhs  = tree->gtGetOp1();
-    if ((rhs->OperGet() == GT_PHI) || (rhs->OperGet() == GT_CALL) ||
-        ((rhs->OperGet() == GT_MUL_LONG) && (rhs->gtFlags & GTF_MUL_64RSLT) != 0))
+    if (rhs->OperIs(GT_CALL) || (rhs->OperIs(GT_MUL_LONG) && (rhs->gtFlags & GTF_MUL_64RSLT) != 0))
     {
         // GT_CALLs are not decomposed, so will not be converted to GT_LONG
         // GT_STORE_LCL_VAR = GT_CALL are handled in genMultiRegCallStoreToLocal

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -101,7 +101,7 @@ void DecomposeLongs::DecomposeRangeHelper()
 {
     assert(m_range != nullptr);
 
-    GenTree* node = Range().FirstNonPhiNode();
+    GenTree* node = Range().FirstNode();
     while (node != nullptr)
     {
         node = DecomposeNode(node);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1659,25 +1659,12 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         LIR::Range& nextRange  = LIR::AsRange(bNext);
 
         // Does the next block have any phis?
-        GenTree*           nextFirstNonPhi = nullptr;
-        LIR::ReadOnlyRange nextPhis        = nextRange.PhiNodes();
-        if (!nextPhis.IsEmpty())
-        {
-            GenTree* blockLastPhi = blockRange.LastPhiNode();
-            nextFirstNonPhi       = nextPhis.LastNode()->gtNext;
+        GenTree* nextNode = nextRange.FirstNode();
 
-            LIR::Range phisToMove = nextRange.Remove(std::move(nextPhis));
-            blockRange.InsertAfter(blockLastPhi, std::move(phisToMove));
-        }
-        else
+        // Does the block have any code?
+        if (nextNode != nullptr)
         {
-            nextFirstNonPhi = nextRange.FirstNode();
-        }
-
-        // Does the block have any other code?
-        if (nextFirstNonPhi != nullptr)
-        {
-            LIR::Range nextNodes = nextRange.Remove(nextFirstNonPhi, nextRange.LastNode());
+            LIR::Range nextNodes = nextRange.Remove(nextNode, nextRange.LastNode());
             blockRange.InsertAtEnd(std::move(nextNodes));
         }
     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4518,7 +4518,7 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
             assert(isRecompute);
 
             const BasicBlock::weight_t weight = block->getBBWeight(this);
-            for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
+            for (GenTree* node : LIR::AsRange(block))
             {
                 switch (node->OperGet())
                 {

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1548,8 +1548,7 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
 
     SmallHashTable<GenTree*, bool, 32> unusedDefs(compiler->getAllocatorDebugOnly());
 
-    bool     pastPhis = false;
-    GenTree* prev     = nullptr;
+    GenTree* prev = nullptr;
     for (Iterator node = begin(), end = this->end(); node != end; prev = *node, ++node)
     {
         // Verify that the node is allowed in LIR.
@@ -1566,16 +1565,6 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         assert((node->gtFlags & GTF_REVERSE_OPS) == 0);
 
         // TODO: validate catch arg stores
-
-        // Check that all phi nodes (if any) occur at the start of the range.
-        if ((node->OperGet() == GT_PHI_ARG) || (node->OperGet() == GT_PHI) || node->IsPhiDefn())
-        {
-            assert(!pastPhis);
-        }
-        else
-        {
-            pastPhis = true;
-        }
 
         for (GenTree** useEdge : node->UseEdges())
         {

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -432,57 +432,17 @@ LIR::Range::Range(GenTree* firstNode, GenTree* lastNode) : ReadOnlyRange(firstNo
 }
 
 //------------------------------------------------------------------------
-// LIR::Range::LastPhiNode: Returns the last phi node in the range or
-//                          `nullptr` if no phis exist.
+// LIR::Range::FirstNonCatchArgNode: Returns the first node after all catch arg nodes in this range.
 //
-GenTree* LIR::Range::LastPhiNode() const
-{
-    GenTree* lastPhiNode = nullptr;
-    for (GenTree* node : *this)
-    {
-        if (!node->IsPhiNode())
-        {
-            break;
-        }
-
-        lastPhiNode = node;
-    }
-
-    return lastPhiNode;
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::FirstNonPhiNode: Returns the first non-phi node in the
-//                              range or `nullptr` if no non-phi nodes
-//                              exist.
-//
-GenTree* LIR::Range::FirstNonPhiNode() const
+GenTree* LIR::Range::FirstNonCatchArgNode() const
 {
     for (GenTree* node : *this)
     {
-        if (!node->IsPhiNode())
-        {
-            return node;
-        }
-    }
-
-    return nullptr;
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::FirstNonPhiOrCatchArgNode: Returns the first node after all
-//                                        phi or catch arg nodes in this
-//                                        range.
-//
-GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
-{
-    for (GenTree* node : NonPhiNodes())
-    {
-        if (node->OperGet() == GT_CATCH_ARG)
+        if (node->OperIs(GT_CATCH_ARG))
         {
             continue;
         }
-        else if ((node->OperGet() == GT_STORE_LCL_VAR) && (node->gtGetOp1()->OperGet() == GT_CATCH_ARG))
+        else if ((node->OperIs(GT_STORE_LCL_VAR)) && (node->gtGetOp1()->OperIs(GT_CATCH_ARG)))
         {
             continue;
         }
@@ -491,35 +451,6 @@ GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
     }
 
     return nullptr;
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::PhiNodes: Returns the range of phi nodes inside this range.
-//
-LIR::ReadOnlyRange LIR::Range::PhiNodes() const
-{
-    GenTree* lastPhiNode = LastPhiNode();
-    if (lastPhiNode == nullptr)
-    {
-        return ReadOnlyRange();
-    }
-
-    return ReadOnlyRange(m_firstNode, lastPhiNode);
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::PhiNodes: Returns the range of non-phi nodes inside this
-//                       range.
-//
-LIR::ReadOnlyRange LIR::Range::NonPhiNodes() const
-{
-    GenTree* firstNonPhiNode = FirstNonPhiNode();
-    if (firstNonPhiNode == nullptr)
-    {
-        return ReadOnlyRange();
-    }
-
-    return ReadOnlyRange(firstNonPhiNode, m_lastNode);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -92,15 +92,14 @@ public:
     //     // View the block as a range
     //     LIR::Range& blockRange = LIR::AsRange(block);
     //
-    //     // Create a range from the first non-phi node in the block to the
-    //     // last node in the block
-    //     LIR::ReadOnlyRange nonPhis = blockRange.NonPhiNodes();
+    //     // Create a read only range from from it.
+    //     LIR::ReadOnlyRange readRange = blockRange;
     //
     //     // Remove the last node from the block
     //     blockRange.Remove(blockRange.LastNode());
     //
     // After the removal of the last node in the block, the last node of
-    // nonPhis is no longer linked to any of the other nodes in nonPhis. Due
+    // readRange is no longer linked to any of the other nodes in readRange. Due
     // to issues such as the above, some care must be taken in order to
     // ensure that ranges are not used once they have been invalidated.
     //
@@ -256,12 +255,7 @@ public:
         Range();
         Range(Range&& other);
 
-        GenTree* LastPhiNode() const;
-        GenTree* FirstNonPhiNode() const;
-        GenTree* FirstNonPhiOrCatchArgNode() const;
-
-        ReadOnlyRange PhiNodes() const;
-        ReadOnlyRange NonPhiNodes() const;
+        GenTree* FirstNonCatchArgNode() const;
 
         void InsertBefore(GenTree* insertionPoint, GenTree* node);
         void InsertAfter(GenTree* insertionPoint, GenTree* node);

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -501,7 +501,7 @@ void Compiler::fgPerBlockLocalVarLiveness()
         compCurBB = block;
         if (block->IsLIR())
         {
-            for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
+            for (GenTree* node : LIR::AsRange(block))
             {
                 fgPerNodeLocalVarLiveness(node);
             }
@@ -1873,14 +1873,13 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
 
     noway_assert(VarSetOps::IsSubset(this, keepAliveVars, life));
 
-    LIR::Range& blockRange      = LIR::AsRange(block);
-    GenTree*    firstNonPhiNode = blockRange.FirstNonPhiNode();
-    if (firstNonPhiNode == nullptr)
+    LIR::Range& blockRange = LIR::AsRange(block);
+    GenTree*    firstNode  = blockRange.FirstNode();
+    if (firstNode == nullptr)
     {
         return;
     }
-    for (GenTree *node = blockRange.LastNode(), *next = nullptr, *end = firstNonPhiNode->gtPrev; node != end;
-         node = next)
+    for (GenTree *node = blockRange.LastNode(), *next = nullptr, *end = firstNode->gtPrev; node != end; node = next)
     {
         next = node->gtPrev;
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4037,7 +4037,7 @@ void Lowering::InsertPInvokeMethodProlog()
     store->AsOp()->gtOp1 = call;
     store->gtFlags |= GTF_VAR_DEF;
 
-    GenTree* const insertionPoint = firstBlockRange.FirstNonPhiOrCatchArgNode();
+    GenTree* const insertionPoint = firstBlockRange.FirstNonCatchArgNode();
 
     comp->fgMorphTree(store);
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, store));

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6046,6 +6046,11 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
             break;
         }
 
+        case GT_PHI:
+        case GT_PHI_ARG:
+            assert(!"Should not see phi nodes after rationalize");
+            break;
+
         default:
             break;
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2042,9 +2042,6 @@ void Lowering::RehomeArgForFastTailCall(unsigned int lclNum,
             continue;
         }
 
-        // This should not be a GT_PHI_ARG.
-        assert(treeNode->OperGet() != GT_PHI_ARG);
-
         GenTreeLclVarCommon* lcl = treeNode->AsLclVarCommon();
 
         if (lcl->GetLclNum() != lclNum)
@@ -3118,7 +3115,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
         }
         CheckMultiRegLclVar(lclStore->AsLclVar(), retTypeDesc);
     }
-    if ((lclStore->TypeGet() == TYP_STRUCT) && !srcIsMultiReg && (src->OperGet() != GT_PHI))
+    if ((lclStore->TypeGet() == TYP_STRUCT) && !srcIsMultiReg)
     {
         bool convertToStoreObj;
         if (src->OperGet() == GT_CALL)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7803,7 +7803,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
                 // so if we have only EH vars, we'll do that instead of splitting the edge.
                 if ((compiler->compHndBBtabCount > 0) && VarSetOps::IsSubset(compiler, edgeResolutionSet, exceptVars))
                 {
-                    GenTree*        insertionPoint = LIR::AsRange(succBlock).FirstNonPhiNode();
+                    GenTree*        insertionPoint = LIR::AsRange(succBlock).FirstNode();
                     VarSetOps::Iter edgeSetIter(compiler, edgeResolutionSet);
                     unsigned        edgeVarIndex = 0;
                     while (edgeSetIter.NextElem(&edgeVarIndex))
@@ -8178,7 +8178,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     GenTree* insertionPoint = nullptr;
     if (resolveType == ResolveSplit || resolveType == ResolveCritical)
     {
-        insertionPoint = LIR::AsRange(block).FirstNonPhiNode();
+        insertionPoint = LIR::AsRange(block).FirstNode();
     }
 
     // If this is an edge between EH regions, we may have "extra" live-out EH vars.
@@ -9436,7 +9436,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                    splitEdgeInfo.toBBNum);
         }
 
-        for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
+        for (GenTree* node : LIR::AsRange(block))
         {
             GenTree* tree = node;
 
@@ -10358,7 +10358,7 @@ void LinearScan::verifyFinalAllocation()
                     bool foundNonResolutionNode = false;
 
                     LIR::Range& currentBlockRange = LIR::AsRange(currentBlock);
-                    for (GenTree* node : currentBlockRange.NonPhiNodes())
+                    for (GenTree* node : currentBlockRange)
                     {
                         if (IsResolutionNode(currentBlockRange, node))
                         {
@@ -10666,7 +10666,7 @@ void LinearScan::verifyFinalAllocation()
 
             // Verify the moves in this block
             LIR::Range& currentBlockRange = LIR::AsRange(currentBlock);
-            for (GenTree* node : currentBlockRange.NonPhiNodes())
+            for (GenTree* node : currentBlockRange)
             {
                 assert(IsResolutionNode(currentBlockRange, node));
                 if (IsResolutionMove(node))

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2334,7 +2334,7 @@ void LinearScan::buildIntervals()
         }
 
         LIR::Range& blockRange = LIR::AsRange(block);
-        for (GenTree* node : blockRange.NonPhiNodes())
+        for (GenTree* node : blockRange)
         {
             // We increment the location of each tree node by 2 so that the node definition, if any,
             // is at a new location and doesn't interfere with the uses.

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -426,7 +426,6 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
     {
         case GT_LCL_VAR:
         case GT_LCL_FLD:
-        case GT_PHI_ARG:
             RewriteAssignmentIntoStoreLclCore(assignment, location, value, locationOp);
             BlockRange().Remove(location);
             break;
@@ -949,20 +948,23 @@ PhaseStatus Rationalizer::DoPhase()
             assert(statement->GetRootNode() != nullptr);
             assert(statement->GetRootNode()->gtNext == nullptr);
 
-            BlockRange().InsertAtEnd(LIR::Range(statement->GetTreeList(), statement->GetRootNode()));
-
-            // If this statement has correct offset information, change it into an IL offset
-            // node and insert it into the LIR.
-            if (statement->GetILOffsetX() != BAD_IL_OFFSET)
+            if (!statement->IsPhiDefnStmt()) // Note that we get rid of PHI nodes here.
             {
-                assert(!statement->IsPhiDefnStmt());
-                GenTreeILOffset* ilOffset = new (comp, GT_IL_OFFSET)
-                    GenTreeILOffset(statement->GetILOffsetX() DEBUGARG(statement->GetLastILOffset()));
-                BlockRange().InsertBefore(statement->GetTreeList(), ilOffset);
-            }
+                BlockRange().InsertAtEnd(LIR::Range(statement->GetTreeList(), statement->GetRootNode()));
 
-            m_block = block;
-            visitor.WalkTree(statement->GetRootNodePointer(), nullptr);
+                // If this statement has correct offset information, change it into an IL offset
+                // node and insert it into the LIR.
+                if (statement->GetILOffsetX() != BAD_IL_OFFSET)
+                {
+                    assert(!statement->IsPhiDefnStmt());
+                    GenTreeILOffset* ilOffset = new (comp, GT_IL_OFFSET)
+                        GenTreeILOffset(statement->GetILOffsetX() DEBUGARG(statement->GetLastILOffset()));
+                    BlockRange().InsertBefore(statement->GetTreeList(), ilOffset);
+                }
+
+                m_block = block;
+                visitor.WalkTree(statement->GetRootNodePointer(), nullptr);
+            }
         }
 
         block->bbStmtList = nullptr;


### PR DESCRIPTION
Get rid of PHI/PHI_ARG nodes during rationalize phase, these nodes are not used after optimization phases.

This change allows us to 
1. save some compilation time (trying to measure now, problems with PIN tool)
2. simplify the code;
3. solve my issue with LONG phi store on x86/arm that are not decomposed;

I did not expect any diffs but I have one on x86 windows libraries tests (out of all spmi collections that we have)
```
Top method improvements (bytes):
         -21 (-2.31% of base) : 282396.dasm - System.DirectoryServices.Tests.DirectoryServicesTests:TestInvalidUserAndPassword():this
```

it looks like LSRA noise but I am analyzing it now.