### PR TITLE
Mark logging source generator file as generated

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Logging.Generators
                 var e = new Emitter();
                 string result = e.Emit(logClasses, context.CancellationToken);
     
-                context.AddSource("LoggerMessage", SourceText.From(result, Encoding.UTF8));
+                context.AddSource("LoggerMessage.g.cs", SourceText.From(result, Encoding.UTF8));
             }
         }
 


### PR DESCRIPTION
Give the output file for the M.E.Logging logging classes a `.g` suffix so that it is treated as a generated file to prevent it being flagged by source analyzers for violations the application developer cannot fix for themselves.

This is essentially the same kind of issue as I found with the Razor generator in dotnet/sdk#16777 with .NET 6 preview 3.

The use case for finding this was that I was playing around with using the Logging source generator announced in the [.NET 6 preview 4 blog post](https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-4/#microsoft-extensions-logging-compile-time-source-generator) and initially had the `Log` class I was using defined as `public`.

The project I was trying it out with has `TreatWarningsAsErrors` set to `true` and as it is a library requires public documentation on its members. I temporarily suppressed this with a `#pragma warning disable CS1591` in the `Log` class, but the compilation still failed with the following error:

```
1>C:\Code\MyLib\src\MyLib\Microsoft.Extensions.Logging.Generators\Microsoft.Extensions.Logging.Generators.LoggerMessageGenerator\LoggerMessageGenerator.cs(13,36,13,51): error CS1591: Missing XML comment for publicly visible type or member 'Log.LogSomething(ILogger, string)'
```

In my case it's easily fixed by making the `Log` class be `internal` instead, but it highlights the issue that source analyzers may still cause user applications using the feature to fail to compile if the generated source does not conform to a rule required by the non-generated code.
