### PR TITLE
Delete invalid assert in GetFileMuiPath

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -809,7 +809,6 @@ namespace System
                         return new string(fileMuiPath);
                     }
 
-                    Debug.Fail("Shouldn't get here, as there's always at least one language installed.");
                     return string.Empty;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53267

@mattjohnsonpint, @tarekgh, I'd converted the comment saying the location should never be reached into an assert, but it's failing, so the comment was wrong.  I'm deleting the assert.  Since you'd added the comment, please confirm it's expected we can actually reach this point and that things will behave correctly when it does.