### PR TITLE
Build support for s390x: Fix a few paltests

### DIFF
--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
@@ -45,7 +45,7 @@ DllTest1()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = (volatile int *)0x11; // Invalid pointer
+        volatile int* p = (volatile int *)0x11000; // Invalid pointer
 
         bTry = TRUE;                            // Indicate we hit the PAL_TRY block
         FailingFunction(p);  // Throw in function to fool C++ runtime into handling
@@ -60,10 +60,10 @@ DllTest1()
             Fail("ERROR: PAL_EXCEPT was hit without PAL_TRY being hit.\n");
         }
 
-        // Validate that the faulting address is correct; the contents of "p" (0x11).
-        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x11)
+        // Validate that the faulting address is correct; the contents of "p" (0x11000).
+        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x11000)
         {
-            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x11\n");
+            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x11000\n");
         }
 
         bExcept = TRUE;                         // Indicate we hit the PAL_EXCEPT block 

--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
@@ -45,7 +45,7 @@ DllTest2()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = (volatile int *)0x22; // Invalid pointer
+        volatile int* p = (volatile int *)0x22000; // Invalid pointer
 
         bTry = TRUE;                            // Indicate we hit the PAL_TRY block
         FailingFunction(p);  // Throw in function to fool C++ runtime into handling
@@ -60,10 +60,10 @@ DllTest2()
             Fail("ERROR: PAL_EXCEPT was hit without PAL_TRY being hit.\n");
         }
 
-        // Validate that the faulting address is correct; the contents of "p" (0x22).
-        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x22)
+        // Validate that the faulting address is correct; the contents of "p" (0x22000).
+        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x22000)
         {
-            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x22\n");
+            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x22000\n");
         }
 
         bExcept = TRUE;                         // Indicate we hit the PAL_EXCEPT block

--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -45,10 +45,10 @@ void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
         _exit(FAIL);
     }
 
-    // Validate that the faulting address is correct; the contents of "p" (0x22).
-    if (siginfo->si_addr != (void *)0x33)
+    // Validate that the faulting address is correct; the contents of "p" (0x33000).
+    if (siginfo->si_addr != (void *)0x33000)
     {
-        printf("ERROR: signal handler faulting address != 0x33\n");
+        printf("ERROR: signal handler faulting address != 0x33000\n");
         _exit(FAIL);
     }
 
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 
     bSignal = true;
 
-    volatile int* p = (volatile int *)0x33; // Invalid pointer
+    volatile int* p = (volatile int *)0x33000; // Invalid pointer
     *p = 3;                                 // Causes an access violation exception
 
     printf("ERROR: code was executed after the access violation.\n");


### PR DESCRIPTION
* Accommodate platforms (like s390x) where the SIGSEGV fault address
  is only provided on a page granularity by the HW/OS

* All paltests now pass on s390x

```
Finished running PAL tests.

PAL Test Results:
  Passed: 696
  Failed: 0

~/runtime/artifacts/bin/coreclr/Linux.s390x.Debug/paltests

```