### PR TITLE
Build support for s390x: clr.iltools and clr.paltests

### DIFF
--- a/src/coreclr/debug/daccess/s390x/primitives.cpp
+++ b/src/coreclr/debug/daccess/s390x/primitives.cpp
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+
+#include "stdafx.h"
+
+#include "../../shared/s390x/primitives.cpp"

--- a/src/coreclr/debug/ee/s390x/dbghelpers.S
+++ b/src/coreclr/debug/ee/s390x/dbghelpers.S
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "asmconstants.h"
+#include "unixasmmacros.inc"
+
+#error Unsupported platform
+

--- a/src/coreclr/debug/ee/s390x/primitives.cpp
+++ b/src/coreclr/debug/ee/s390x/primitives.cpp
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+
+#include "stdafx.h"
+#include "threads.h"
+#include "../../shared/s390x/primitives.cpp"
+

--- a/src/coreclr/debug/ee/wks/CMakeLists.txt
+++ b/src/coreclr/debug/ee/wks/CMakeLists.txt
@@ -32,11 +32,7 @@ if (CLR_CMAKE_TARGET_WIN32)
 
 else ()
 
-  if(CLR_CMAKE_HOST_ARCH_AMD64 OR CLR_CMAKE_HOST_ARCH_ARM OR CLR_CMAKE_HOST_ARCH_ARM64 OR CLR_CMAKE_HOST_ARCH_I386)
-    add_library_clr(cordbee_wks_obj OBJECT ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
-  else()
-    message(FATAL_ERROR "Unknown platform")
-  endif()
+  add_library_clr(cordbee_wks_obj OBJECT ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
 
 endif (CLR_CMAKE_TARGET_WIN32)
 

--- a/src/coreclr/debug/shared/s390x/primitives.cpp
+++ b/src/coreclr/debug/shared/s390x/primitives.cpp
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//*****************************************************************************
+// File: primitives.cpp
+//
+
+//
+// Platform-specific debugger primitives
+//
+//*****************************************************************************
+
+#include "primitives.h"
+
+#error Unsupported platform
+

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -31,6 +31,8 @@ function(create_standalone_jit)
     set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
   elseif(TARGETDETAILS_ARCH STREQUAL "arm64")
     set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
+  elseif(TARGETDETAILS_ARCH STREQUAL "s390x")
+    set(JIT_ARCH_SOURCES ${JIT_S390X_SOURCES})
   else()
     clr_unknown_arch()
   endif()
@@ -344,6 +346,10 @@ set( JIT_ARM64_SOURCES
   hwintrinsiccodegenarm64.cpp
 )
 
+set( JIT_S390X_SOURCES
+  # Not supported as JIT target
+)
+
 if(CLR_CMAKE_TARGET_ARCH_AMD64)
   set(JIT_ARCH_SOURCES ${JIT_AMD64_SOURCES})
 elseif(CLR_CMAKE_TARGET_ARCH_ARM)
@@ -352,6 +358,8 @@ elseif(CLR_CMAKE_TARGET_ARCH_I386)
   set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
 elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
   set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
+elseif(CLR_CMAKE_TARGET_ARCH_S390X)
+  set(JIT_ARCH_SOURCES ${JIT_S390X_SOURCES})
 else()
   clr_unknown_arch()
 endif()
@@ -508,7 +516,9 @@ create_standalone_jit(TARGET clrjit_win_arm_${ARCH_HOST_NAME} OS win ARCH arm DE
 create_standalone_jit(TARGET clrjit_win_x86_${ARCH_HOST_NAME} OS win ARCH x86 DESTINATIONS .)
 
 if (CLR_CMAKE_TARGET_UNIX)
-    install_clr(TARGETS clrjit_unix_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
+    if (NOT ARCH_TARGET_NAME STREQUAL s390x)
+      install_clr(TARGETS clrjit_unix_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
+    endif(NOT ARCH_TARGET_NAME STREQUAL s390x)
     if (ARCH_TARGET_NAME STREQUAL arm)
       target_compile_definitions(clrjit_unix_arm_${ARCH_HOST_NAME} PRIVATE ARM_SOFTFP CONFIGURABLE_ARM_ABI)
   endif (ARCH_TARGET_NAME STREQUAL arm)

--- a/src/coreclr/unwinder/s390x/unwinder_s390x.cpp
+++ b/src/coreclr/unwinder/s390x/unwinder_s390x.cpp
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+
+#include "stdafx.h"
+#include "utilcode.h"
+#include "crosscomp.h"
+
+#error Unsupported platform
+

--- a/src/coreclr/vm/crossgen/CMakeLists.txt
+++ b/src/coreclr/vm/crossgen/CMakeLists.txt
@@ -227,6 +227,10 @@ elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
   list(APPEND VM_CROSSGEN_SOURCES
     ../${ARCH_SOURCES_DIR}/stubs.cpp
   )
+elseif(CLR_CMAKE_TARGET_ARCH_S390X)
+  list(APPEND VM_CROSSGEN_SOURCES
+    # Not supported as VM target
+  )
 else()
   clr_unknown_arch()
 endif()

--- a/src/coreclr/vm/s390x/unixstubs.cpp
+++ b/src/coreclr/vm/s390x/unixstubs.cpp
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "common.h"
+
+extern "C"
+{
+    void RedirectForThrowControl()
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+};


### PR DESCRIPTION
* Add dummy support for s390x in vm, jit, debug, and unwinder

* This suffices to make clr.iltools and clr.paltests buildable

Note to reviewers:
- When building clr.iltools and/or clr.paltests, the vm/jit/debug/unwinder directories are never actually compiled.  However, the _cmake_ process is still executed, so there needs to be enough support for the s390x platform there to avoid cmake aborting (due to missing files or explicit aborts).  Let me know if you have any other suggestions on how to enable building just those clr subtargets.