### PR TITLE
Use literals instead of static readonly for HostFactoryResolver.cs

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Extensions.Hosting
     {
         private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
-        public static readonly string BuildWebHost = nameof(BuildWebHost);
-        public static readonly string CreateWebHostBuilder = nameof(CreateWebHostBuilder);
-        public static readonly string CreateHostBuilder = nameof(CreateHostBuilder);
+        public const string BuildWebHost = nameof(BuildWebHost);
+        public const string CreateWebHostBuilder = nameof(CreateWebHostBuilder);
+        public const string CreateHostBuilder = nameof(CreateHostBuilder);
 
         public static Func<string[], TWebHost>? ResolveWebHostFactory<TWebHost>(Assembly assembly)
         {


### PR DESCRIPTION
The type is internal + part of a source-only package, so there shouldn't be any harm in this change. Also lets us remove [a workaround](https://github.com/dotnet/aspnetcore/blob/main/.editorconfig#L100-L102) in the AspNetCore repo.