### PR TITLE
Improve cancellation in StreamPipeReader.ReadAtLeastAsync

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -664,6 +664,11 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowInvalidOperationException_NoReadingAllowed();
             }
 
+            if (token.IsCancellationRequested)
+            {
+                return new ValueTask<ReadResult>(Task.FromCanceled<ReadResult>(token));
+            }
+
             CompletionData completionData = default;
             ValueTask<ReadResult> result;
             lock (SyncObj)
@@ -713,6 +718,11 @@ namespace System.IO.Pipelines
             if (_readerCompletion.IsCompleted)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoReadingAllowed();
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                return new ValueTask<ReadResult>(Task.FromCanceled<ReadResult>(token));
             }
 
             ValueTask<ReadResult> result;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -194,7 +194,10 @@ namespace System.IO.Pipelines
             // TODO ReadyAsync needs to throw if there are overlapping reads.
             ThrowIfCompleted();
 
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<ReadResult>(Task.FromCanceled<ReadResult>(cancellationToken));
+            }
 
             // PERF: store InternalTokenSource locally to avoid querying it twice (which acquires a lock)
             CancellationTokenSource tokenSource = InternalTokenSource;
@@ -273,7 +276,10 @@ namespace System.IO.Pipelines
             // TODO ReadyAsync needs to throw if there are overlapping reads.
             ThrowIfCompleted();
 
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<ReadResult>(Task.FromCanceled<ReadResult>(cancellationToken));
+            }
 
             // PERF: store InternalTokenSource locally to avoid querying it twice (which acquires a lock)
             CancellationTokenSource tokenSource = InternalTokenSource;

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -178,7 +178,7 @@ namespace System.IO.Pipelines.Tests
             Pipe.Writer.WriteEmpty(10);
             await Pipe.Writer.FlushAsync();
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -178,7 +178,7 @@ namespace System.IO.Pipelines.Tests
             Pipe.Writer.WriteEmpty(10);
             await Pipe.Writer.FlushAsync();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => task);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
@@ -141,7 +141,8 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public Task ReadAtLeastAsyncThrowsIfPassedCanceledCancellationToken()
         {
-            return Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await PipeReader.ReadAtLeastAsync(0, new CancellationToken(true)));
+            ValueTask<ReadResult> task = PipeReader.ReadAtLeastAsync(0, new CancellationToken(true));
+            return Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
@@ -142,7 +142,7 @@ namespace System.IO.Pipelines.Tests
         public Task ReadAtLeastAsyncThrowsIfPassedCanceledCancellationToken()
         {
             ValueTask<ReadResult> task = PipeReader.ReadAtLeastAsync(0, new CancellationToken(canceled: true));
-            return Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+            return Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
@@ -141,7 +141,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public Task ReadAtLeastAsyncThrowsIfPassedCanceledCancellationToken()
         {
-            ValueTask<ReadResult> task = PipeReader.ReadAtLeastAsync(0, new CancellationToken(true));
+            ValueTask<ReadResult> task = PipeReader.ReadAtLeastAsync(0, new CancellationToken(canceled: true));
             return Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
         }
 

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderReadAtLeastAsyncTests.cs
@@ -141,7 +141,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public Task ReadAtLeastAsyncThrowsIfPassedCanceledCancellationToken()
         {
-            return Assert.ThrowsAsync<OperationCanceledException>(async () => await PipeReader.ReadAtLeastAsync(0, new CancellationToken(true)));
+            return Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await PipeReader.ReadAtLeastAsync(0, new CancellationToken(true)));
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -362,12 +362,10 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void ReadAsyncThrowsIfPassedCanceledCancellationToken()
+        public async Task ReadAsyncThrowsIfPassedCanceledCancellationToken()
         {
-            var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-
-            Assert.Throws<OperationCanceledException>(() => Pipe.Reader.ReadAsync(cancellationTokenSource.Token));
+            ValueTask<ReadResult> task = Pipe.Reader.ReadAsync(new CancellationToken(canceled: true));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -362,10 +362,10 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task ReadAsyncThrowsIfPassedCanceledCancellationToken()
+        public Task ReadAsyncThrowsIfPassedCanceledCancellationToken()
         {
             ValueTask<ReadResult> task = Pipe.Reader.ReadAsync(new CancellationToken(canceled: true));
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+            return Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
         }
 
         [Fact]


### PR DESCRIPTION
Adresses post-merge comment https://github.com/dotnet/runtime/pull/52246#discussion_r639373325

/cc @stephentoub 