### PR TITLE
Add GCHandle in native default ALC at creation

### DIFF
--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -28,6 +28,7 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHa
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, void *user_data, mono_bool append);
 
+// This can point at NULL before the default ALC is initialized
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssemblyLoadContextGCHandle
 mono_alc_get_default_gchandle (void);
 

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -630,6 +630,9 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	if (mono_runtime_get_no_exec ())
 		return NULL;
 
+	if (!mono_gchandle_get_target_internal (alc->gchandle))
+		return NULL;
+
 	HANDLE_FUNCTION_ENTER ();
 
 	MonoStringHandle scope_handle;
@@ -691,6 +694,9 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 		return NULL;
 
 	if (mono_runtime_get_no_exec ())
+		return NULL;
+
+	if (!mono_gchandle_get_target_internal (alc->gchandle))
 		return NULL;
 
 	HANDLE_FUNCTION_ENTER ();


### PR DESCRIPTION
This lets embedders have a handle to fetch and pass before the runtime is properly started up and the managed default ALC is not yet created. Once the managed counterpart is initialized, the handle's target is changed, but the handle stays the same.

Fixes https://github.com/dotnet/runtime/issues/48610

cc: @grendello 