### PR TITLE
Add SimplePerfScore output, not scaled by block weights

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2517,6 +2517,7 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars,
     {
         emitCurIG->igWeight    = getCurrentBlockWeight();
         emitCurIG->igPerfScore = 0.0;
+        emitCurIG->igPerfScoreSimple = 0.0;
     }
 #endif
 
@@ -3607,7 +3608,7 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
 
         if (emitComp->compCodeGenDone)
         {
-            printf("%sbbWeight=%s PerfScore %.2f", separator, refCntWtd2str(ig->igWeight), ig->igPerfScore);
+            printf("%sbbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", separator, refCntWtd2str(ig->igWeight), ig->igPerfScore, ig->igPerfScoreSimple);
             separator = ", ";
         }
 
@@ -3751,8 +3752,10 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
     float insExeCost = insEvaluateExecutionCost(id);
     // All compPerfScore calculations must be performed using doubles
     double insPerfScore = (double)(ig->igWeight / (double)BB_UNITY_WEIGHT) * insExeCost;
+    double insPerfScoreSimple = (double)insExeCost;
     emitComp->info.compPerfScore += insPerfScore;
     ig->igPerfScore += insPerfScore;
+    ig->igPerfScoreSimple += insPerfScoreSimple;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 // printf("[S=%02u]\n", emitCurStackLvl);
@@ -5971,7 +5974,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #ifdef DEBUG
         if (emitComp->opts.disAsm || emitComp->verbose)
         {
-            printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f", refCntWtd2str(ig->igWeight), ig->igPerfScore);
+            printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", refCntWtd2str(ig->igWeight), ig->igPerfScore, ig->igPerfScoreSimple);
         }
         *instrCount += ig->igInsCnt;
 #endif // DEBUG
@@ -7935,6 +7938,7 @@ insGroup* emitter::emitAllocIG()
 #if defined(DEBUG) || defined(LATE_DISASM)
     ig->igWeight    = getCurrentBlockWeight();
     ig->igPerfScore = 0.0;
+    ig->igPerfScoreSimple = 0.0;
 #endif
 
 #if EMITTER_STATS

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2515,8 +2515,8 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars,
 #if defined(DEBUG) || defined(LATE_DISASM)
     else
     {
-        emitCurIG->igWeight    = getCurrentBlockWeight();
-        emitCurIG->igPerfScore = 0.0;
+        emitCurIG->igWeight          = getCurrentBlockWeight();
+        emitCurIG->igPerfScore       = 0.0;
         emitCurIG->igPerfScoreSimple = 0.0;
     }
 #endif
@@ -3608,7 +3608,8 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
 
         if (emitComp->compCodeGenDone)
         {
-            printf("%sbbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", separator, refCntWtd2str(ig->igWeight), ig->igPerfScore, ig->igPerfScoreSimple);
+            printf("%sbbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", separator, refCntWtd2str(ig->igWeight),
+                   ig->igPerfScore, ig->igPerfScoreSimple);
             separator = ", ";
         }
 
@@ -3751,7 +3752,7 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
 #if defined(DEBUG) || defined(LATE_DISASM)
     float insExeCost = insEvaluateExecutionCost(id);
     // All compPerfScore calculations must be performed using doubles
-    double insPerfScore = (double)(ig->igWeight / (double)BB_UNITY_WEIGHT) * insExeCost;
+    double insPerfScore       = (double)(ig->igWeight / (double)BB_UNITY_WEIGHT) * insExeCost;
     double insPerfScoreSimple = (double)insExeCost;
     emitComp->info.compPerfScore += insPerfScore;
     ig->igPerfScore += insPerfScore;
@@ -5974,7 +5975,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #ifdef DEBUG
         if (emitComp->opts.disAsm || emitComp->verbose)
         {
-            printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", refCntWtd2str(ig->igWeight), ig->igPerfScore, ig->igPerfScoreSimple);
+            printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f PerfScoreSimple %.2f", refCntWtd2str(ig->igWeight),
+                   ig->igPerfScore, ig->igPerfScoreSimple);
         }
         *instrCount += ig->igInsCnt;
 #endif // DEBUG
@@ -7936,8 +7938,8 @@ insGroup* emitter::emitAllocIG()
 #endif
 
 #if defined(DEBUG) || defined(LATE_DISASM)
-    ig->igWeight    = getCurrentBlockWeight();
-    ig->igPerfScore = 0.0;
+    ig->igWeight          = getCurrentBlockWeight();
+    ig->igPerfScore       = 0.0;
     ig->igPerfScoreSimple = 0.0;
 #endif
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -243,8 +243,8 @@ struct insGroup
     insGroup* igSelf; // for consistency checking
 #endif
 #if defined(DEBUG) || defined(LATE_DISASM)
-    BasicBlock::weight_t igWeight;    // the block weight used for this insGroup
-    double               igPerfScore; // The PerfScore for this insGroup
+    BasicBlock::weight_t igWeight;          // the block weight used for this insGroup
+    double               igPerfScore;       // The PerfScore for this insGroup
     double               igPerfScoreSimple; // The PerfScore for this insGroup, not weighted by block weight
 #endif
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -245,6 +245,7 @@ struct insGroup
 #if defined(DEBUG) || defined(LATE_DISASM)
     BasicBlock::weight_t igWeight;    // the block weight used for this insGroup
     double               igPerfScore; // The PerfScore for this insGroup
+    double               igPerfScoreSimple; // The PerfScore for this insGroup, not weighted by block weight
 #endif
 
     UNATIVE_OFFSET igNum;     // for ordering (and display) purposes


### PR DESCRIPTION
Example output:
```
;; bbWeight=0.63 PerfScore 13.02 PerfScoreSimple 20.75
```

This is useful when working on things that change the block weights, which then affect the perf scores greatly. If you want to just see how the unweighted perf scores change, you can look at PerfScoreSimple.