### PR TITLE
[wasm][xharness] install development SSL certificate on Helix agent before xharness run via SDK or powershell

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -105,15 +105,6 @@
     <HelixPreCommand Include="set XHARNESS_DISABLE_COLORED_OUTPUT=true" />
     <HelixPreCommand Include="set XHARNESS_LOG_WITH_TIMESTAMPS=true" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
-    <!-- 
-      We are hosting the payloads for the WASM/browser on kestrel in the xharness process.
-      We also run some network tests to this server and so, we are running it on both HTTP and HTTPS.
-      For the HTTPS endpoint we need development SSL certificate.
-      Below is alternative to `dotnet dev-certs https` but we don't have full SDK installed on helix, so the tool is not available.
-    -->
-    <HelixPreCommand Include="powershell -command &quot;New-SelfSignedCertificate -FriendlyName &#39;ASP.NET Core HTTPS development certificate&#39; -DnsName @(&#39;localhost&#39;) -Subject &#39;CN = localhost&#39; -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm sha256 -CertStoreLocation &#39;Cert:\CurrentUser\My&#39; -TextExtension @(&#39;2.5.29.37={text}1.3.6.1.5.5.7.3.1&#39;,&#39;1.3.6.1.4.1.311.84.1.1={hex}02&#39;,&#39;2.5.29.19={text}&#39;) -KeyUsage DigitalSignature,KeyEncipherment&quot;" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'BuildWasmApps'">
     <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/chromedriver_linux64:$PATH" />
@@ -157,21 +148,36 @@
     <HelixPreCommand Include="printenv | grep COMPlus" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
-    <IncludeHelixCorrelationPayload Condition="'$(HelixCorrelationPayload)' != '' and '$(TargetOS)' != 'Browser'">true</IncludeHelixCorrelationPayload>
-  </PropertyGroup>
+    <!-- 
+      We are hosting the payloads for the WASM/browser on kestrel in the xharness process.
+      We also run some network tests to this server and so, we are running it on both HTTP and HTTPS.
+      For the HTTPS endpoint we need development SSL certificate.
+    -->
+  <PropertyGroup Condition="''$(TestPackages)' != 'true' and $(TargetsWindows)' != 'true' and '$(BrowserHost)' != 'windows'">
+    <!-- install SDK so that, we could use `dotnet dev-certs https`. -->
+    <IncludeDotNetCli>true</IncludeDotNetCli>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
+    <HelixPreCommand Include="export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
+    <HelixCommand>dotnet dev-certs https &amp;&amp; </HelixCommand>
 
-  <PropertyGroup Condition="'$(HelixCommand)' == ''">
+    <HelixCommand>$(HelixCommand) ./RunTests.sh</HelixCommand>
+    <HelixCommand Condition="'$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path "$HELIX_CORRELATION_PAYLOAD"</HelixCommand>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TestPackages)' != 'true' and ('$(TargetsWindows)' == 'true' or '$(BrowserHost)' == 'windows')">
+    <!-- install SSL cert via powershell on windows -->
+    <HelixCommand>powershell -command &quot;New-SelfSignedCertificate -FriendlyName &#39;ASP.NET Core HTTPS development certificate&#39; -DnsName @(&#39;localhost&#39;) -Subject &#39;CN = localhost&#39; -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm sha256 -CertStoreLocation &#39;Cert:\CurrentUser\My&#39; -TextExtension @(&#39;2.5.29.37={text}1.3.6.1.5.5.7.3.1&#39;,&#39;1.3.6.1.4.1.311.84.1.1={hex}02&#39;,&#39;2.5.29.19={text}&#39;) -KeyUsage DigitalSignature,KeyEncipherment&quot; &amp;&amp; </HelixCommand>
     <!--
       For Windows we need to use "call", since the command is going to be called from a batch script created by Helix.
       We "exit /b" at the end of RunTests.cmd. Helix runs some other commands after ours within the batch script,
       so if we don't use "call", then we cause the parent script to exit, and anything after will not be executed.
     -->
-    <HelixCommand Condition="'$(TargetsWindows)' == 'true' or '$(BrowserHost)' == 'windows'">call RunTests.cmd</HelixCommand>
-    <HelixCommand Condition="('$(TargetsWindows)' == 'true' or '$(BrowserHost)' == 'windows') and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
-    <HelixCommand Condition="'$(TargetsWindows)' != 'true' and '$(BrowserHost)' != 'windows'">./RunTests.sh</HelixCommand>
-    <HelixCommand Condition="'$(TargetsWindows)' != 'true' and '$(BrowserHost)' != 'windows' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path "$HELIX_CORRELATION_PAYLOAD"</HelixCommand>
+    <HelixCommand>$(HelixCommand) call RunTests.cmd</HelixCommand>
+    <HelixCommand Condition="'$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
+    <IncludeHelixCorrelationPayload Condition="'$(HelixCorrelationPayload)' != '' and '$(TargetOS)' != 'Browser'">true</IncludeHelixCorrelationPayload>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -72,11 +72,12 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser' or '$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst'">
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <IncludeDotNetCli>true</IncludeDotNetCli>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestPackages)' == 'true'">
     <HelixPreCommand Include="set DOTNET_CLI_TELEMETRY_OPTOUT=1" />
-    <HelixPreCommand Include="set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
+    <HelixPreCommand Include="set DOTNET_NOLOGO=1" />
     <HelixPreCommand Include="set DOTNET_MULTILEVEL_LOOKUP=0" />
   </ItemGroup>
 
@@ -98,7 +99,7 @@
     <HelixPreCommand Condition="'$(Scenario)' == 'WasmTestOnBrowser'" Include="export XHARNESS_COMMAND=test-browser" />
     <HelixPreCommand Include="export XHARNESS_DISABLE_COLORED_OUTPUT=true" />
     <HelixPreCommand Include="export XHARNESS_LOG_WITH_TIMESTAMPS=true" />
-    <HelixPreCommand Include="export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
+    <HelixPreCommand Include="export DOTNET_NOLOGO=1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows'">
     <HelixPreCommand Condition="'$(Scenario)' != 'WasmTestOnBrowser'" Include="set XHARNESS_COMMAND=test" />
@@ -156,7 +157,6 @@
     -->
   <PropertyGroup Condition="''$(TestPackages)' != 'true' and $(TargetsWindows)' != 'true' and '$(BrowserHost)' != 'windows'">
     <!-- install SDK so that, we could use `dotnet dev-certs https`. -->
-    <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
     <HelixCommand>dotnet dev-certs https &amp;&amp; </HelixCommand>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -98,6 +98,7 @@
     <HelixPreCommand Condition="'$(Scenario)' == 'WasmTestOnBrowser'" Include="export XHARNESS_COMMAND=test-browser" />
     <HelixPreCommand Include="export XHARNESS_DISABLE_COLORED_OUTPUT=true" />
     <HelixPreCommand Include="export XHARNESS_LOG_WITH_TIMESTAMPS=true" />
+    <HelixPreCommand Include="export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows'">
     <HelixPreCommand Condition="'$(Scenario)' != 'WasmTestOnBrowser'" Include="set XHARNESS_COMMAND=test" />
@@ -149,15 +150,14 @@
   </ItemGroup>
 
     <!-- 
-      We are hosting the payloads for the WASM/browser on kestrel in the xharness process.
-      We also run some network tests to this server and so, we are running it on both HTTP and HTTPS.
-      For the HTTPS endpoint we need development SSL certificate.
+      We are hosting the payloads for the WASM/browser on Kestrel in the xharness process.
+      We also run some network (HTTP and HTTPS) tests that connect to this server.
+      In order to set up an HTTPS endpoint we need to install a development SSL certificate.
     -->
   <PropertyGroup Condition="''$(TestPackages)' != 'true' and $(TargetsWindows)' != 'true' and '$(BrowserHost)' != 'windows'">
     <!-- install SDK so that, we could use `dotnet dev-certs https`. -->
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
-    <HelixPreCommand Include="export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
     <HelixCommand>dotnet dev-certs https &amp;&amp; </HelixCommand>
 
     <HelixCommand>$(HelixCommand) ./RunTests.sh</HelixCommand>


### PR DESCRIPTION
Caused by https://github.com/dotnet/runtime/pull/53180, https://github.com/dotnet/runtime/pull/53225
The original approach to install certificates didn't work because we don't have dotnet SDK, just runtime on some helix agents.
Fixes https://github.com/dotnet/runtime/issues/53207
