### PR TITLE
add AcceptAsync cancellation overloads

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -78,7 +78,7 @@ namespace System.IO.Pipes
                 WaitForConnectionAsyncCore();
 
             async Task WaitForConnectionAsyncCore() =>
-               HandleAcceptedSocket(await _instance!.ListeningSocket.AcceptAsync().ConfigureAwait(false));
+               HandleAcceptedSocket(await _instance!.ListeningSocket.AcceptAsync(cancellationToken).ConfigureAwait(false));
         }
 
         private void HandleAcceptedSocket(Socket acceptedSocket)

--- a/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
@@ -201,14 +201,10 @@ namespace System.IO.Pipes.Tests
 
             var ctx = new CancellationTokenSource();
 
-            if (OperatingSystem.IsWindows()) // cancellation token after the operation has been initiated
-            {
-                Task serverWaitTimeout = server.WaitForConnectionAsync(ctx.Token);
-                ctx.Cancel();
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverWaitTimeout);
-            }
-
+            Task serverWaitTimeout = server.WaitForConnectionAsync(ctx.Token);
             ctx.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverWaitTimeout);
+
             Assert.True(server.WaitForConnectionAsync(ctx.Token).IsCanceled);
         }
 

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -693,8 +693,10 @@ namespace System.Net.Sockets
         public System.Net.Sockets.Socket Server { get { throw null; } }
         public System.Net.Sockets.Socket AcceptSocket() { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.Socket> AcceptSocketAsync() { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Sockets.Socket> AcceptSocketAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Net.Sockets.TcpClient AcceptTcpClient() { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.TcpClient> AcceptTcpClientAsync() { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Sockets.TcpClient> AcceptTcpClientAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void AllowNatTraversal(bool allowed) { }
         public System.IAsyncResult BeginAcceptSocket(System.AsyncCallback? callback, object? state) { throw null; }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -297,7 +297,9 @@ namespace System.Net.Sockets
         public bool UseOnlyOverlappedIO { get { throw null; } set { } }
         public System.Net.Sockets.Socket Accept() { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.Socket> AcceptAsync() { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Sockets.Socket> AcceptAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.Socket> AcceptAsync(System.Net.Sockets.Socket? acceptSocket) { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Sockets.Socket> AcceptAsync(System.Net.Sockets.Socket? acceptSocket, System.Threading.CancellationToken cancellationToken) { throw null; }
         public bool AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public System.IAsyncResult BeginAccept(System.AsyncCallback? callback, object? state) { throw null; }
         public System.IAsyncResult BeginAccept(int receiveSize, System.AsyncCallback? callback, object? state) { throw null; }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2656,7 +2656,9 @@ namespace System.Net.Sockets
         // Async methods
         //
 
-        public bool AcceptAsync(SocketAsyncEventArgs e)
+        public bool AcceptAsync(SocketAsyncEventArgs e) => AcceptAsync(e, CancellationToken.None);
+
+        private bool AcceptAsync(SocketAsyncEventArgs e, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -2689,7 +2691,7 @@ namespace System.Net.Sockets
             SocketError socketError;
             try
             {
-                socketError = e.DoOperationAccept(this, _handle, acceptHandle);
+                socketError = e.DoOperationAccept(this, _handle, acceptHandle, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1433,7 +1433,7 @@ namespace System.Net.Sockets
             return operation.ErrorCode;
         }
 
-        public SocketError AcceptAsync(byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd, Action<IntPtr, byte[], int, SocketError> callback)
+        public SocketError AcceptAsync(byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd, Action<IntPtr, byte[], int, SocketError> callback, CancellationToken cancellationToken)
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
             Debug.Assert(socketAddressLen > 0, $"Unexpected socketAddressLen: {socketAddressLen}");
@@ -1456,7 +1456,7 @@ namespace System.Net.Sockets
             operation.SocketAddress = socketAddress;
             operation.SocketAddressLen = socketAddressLen;
 
-            if (!_receiveQueue.StartAsyncOperation(this, operation, observedSequenceNumber))
+            if (!_receiveQueue.StartAsyncOperation(this, operation, observedSequenceNumber, cancellationToken))
             {
                 socketAddressLen = operation.SocketAddressLen;
                 acceptedFd = operation.AcceptedFileDescriptor;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -51,7 +51,7 @@ namespace System.Net.Sockets
             _acceptAddressBufferCount = socketAddressSize;
         }
 
-        internal unsafe SocketError DoOperationAccept(Socket socket, SafeSocketHandle handle, SafeSocketHandle? acceptHandle)
+        internal unsafe SocketError DoOperationAccept(Socket socket, SafeSocketHandle handle, SafeSocketHandle? acceptHandle, CancellationToken cancellationToken)
         {
             if (!_buffer.Equals(default))
             {
@@ -64,7 +64,7 @@ namespace System.Net.Sockets
 
             IntPtr acceptedFd;
             int socketAddressLen = _acceptAddressBufferCount / 2;
-            SocketError socketError = handle.AsyncContext.AcceptAsync(_acceptBuffer!, ref socketAddressLen, out acceptedFd, AcceptCompletionCallback);
+            SocketError socketError = handle.AsyncContext.AcceptAsync(_acceptBuffer!, ref socketAddressLen, out acceptedFd, AcceptCompletionCallback, cancellationToken);
 
             if (socketError != SocketError.IOPending)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.Versioning;
 using System.Diagnostics;
@@ -220,24 +221,27 @@ namespace System.Net.Sockets
         public TcpClient EndAcceptTcpClient(IAsyncResult asyncResult) =>
             EndAcceptCore<TcpClient>(asyncResult);
 
-        public Task<Socket> AcceptSocketAsync()
+        public Task<Socket> AcceptSocketAsync() => AcceptSocketAsync(CancellationToken.None).AsTask();
+
+        public ValueTask<Socket> AcceptSocketAsync(CancellationToken cancellationToken)
         {
             if (!_active)
             {
                 throw new InvalidOperationException(SR.net_stopped);
             }
 
-            return _serverSocket!.AcceptAsync();
+            return _serverSocket!.AcceptAsync(cancellationToken);
         }
 
-        public Task<TcpClient> AcceptTcpClientAsync()
-        {
-            return WaitAndWrap(AcceptSocketAsync());
+        public Task<TcpClient> AcceptTcpClientAsync() => AcceptTcpClientAsync(CancellationToken.None).AsTask();
 
-            static async Task<TcpClient> WaitAndWrap(Task<Socket> task) =>
+        public ValueTask<TcpClient> AcceptTcpClientAsync(CancellationToken cancellationToken)
+        {
+            return WaitAndWrap(AcceptSocketAsync(cancellationToken));
+
+            static async ValueTask<TcpClient> WaitAndWrap(ValueTask<Socket> task) =>
                 new TcpClient(await task.ConfigureAwait(false));
         }
-
 
         // This creates a TcpListener that listens on both IPv4 and IPv6 on the given port.
         public static TcpListener Create(int port)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -421,9 +421,14 @@ namespace System.Net.Sockets.Tests
     public sealed class SendFile_Task : SendFile<SocketHelperTask>
     {
         public SendFile_Task(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class SendFile_CancellableTask : SendFile<SocketHelperCancellableTask>
+    {
+        public SendFile_CancellableTask(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public async Task Precanceled_Throws()
+        public async Task SendFileAsync_Precanceled_Throws()
         {
             using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -445,7 +450,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task SendAsync_CanceledDuringOperation_Throws(bool ipv6)
+        public async Task SendFileAsync_CanceledDuringOperation_Throws(bool ipv6)
         {
             const int CancelAfter = 200; // ms
             const int NumOfSends = 100;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -263,11 +263,11 @@ namespace System.Net.Sockets.Tests
         public override bool ValidatesArrayArguments => false;
 
         public override Task<Socket> AcceptAsync(Socket s) =>
-            s.AcceptAsync();
+            s.AcceptAsync(_cts.Token).AsTask();
         public override Task<(Socket socket, byte[] buffer)> AcceptAsync(Socket s, int receiveSize)
             => throw new NotSupportedException();
         public override Task<Socket> AcceptAsync(Socket s, Socket acceptSocket) =>
-            s.AcceptAsync(acceptSocket);
+            s.AcceptAsync(acceptSocket, _cts.Token).AsTask();
         public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
             s.ConnectAsync(endPoint, _cts.Token).AsTask();
         public override Task MultiConnectAsync(Socket s, IPAddress[] addresses, int port) =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -127,7 +127,8 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(0)] // Sync
         [InlineData(1)] // Async
-        [InlineData(2)] // APM
+        [InlineData(2)] // Async with Cancellation
+        [InlineData(3)] // APM
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51392", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task Accept_AcceptsPendingSocketOrClient(int mode)
         {
@@ -141,6 +142,7 @@ namespace System.Net.Sockets.Tests
                 {
                     0 => listener.AcceptSocket(),
                     1 => await listener.AcceptSocketAsync(),
+                    2 => await listener.AcceptSocketAsync(CancellationToken.None),
                     _ => await Task.Factory.FromAsync(listener.BeginAcceptSocket, listener.EndAcceptSocket, null),
                 })
                 {
@@ -156,6 +158,7 @@ namespace System.Net.Sockets.Tests
                 {
                     0 => listener.AcceptTcpClient(),
                     1 => await listener.AcceptTcpClientAsync(),
+                    2 => await listener.AcceptTcpClientAsync(CancellationToken.None),
                     _ => await Task.Factory.FromAsync(listener.BeginAcceptTcpClient, listener.EndAcceptTcpClient, null),
                 })
                 {


### PR DESCRIPTION
Contributes to #33418 
Fixes #40289

Add overloads to Socket.AcceptAsync that take a CancellationToken, and wire up support for cancellation.

AcceptAsync now uses the ValueTask-based mapping to SocketAsyncEventArgs (it previously used the Task-based mapping).

Optimize AcceptAsync for synchronous completion by deferring pinning of the accept buffer.

Minor SendFileAsync test cleanup from recent SendFileAsync PR.

Add similar overloads for TcpListener.

Fix the Unix implementation of named pipe servers to wire up cancellation via this new overload.
