### PR TITLE
Remove a failing unnecessary test

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
@@ -27,30 +27,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(n, f());
         }
 
-        [ClassData(typeof(CompilationTypes))]
-        [OuterLoop("May fail with SO on Debug JIT")]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        public static void CompileDeepTree_NoStackOverflowFast(bool useInterpreter)
-        {
-            Expression e = Expression.Constant(0);
-
-            int n = 100;
-
-            for (int i = 0; i < n; i++)
-                e = Expression.Add(e, Expression.Constant(1));
-
-            Func<int> f = null;
-            // Request a stack size of 128KiB to get very small stack.
-            // This reduces the size of tree needed to risk a stack overflow.
-            // This though will only risk overflow once, so the outerloop test
-            // above is still needed.
-            Thread t = new Thread(() => f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter), 128 * 1024);
-            t.Start();
-            t.Join();
-
-            Assert.Equal(n, f());
-        }
-
 #if FEATURE_COMPILE
         [Fact]
         public static void EmitConstantsToIL_NonNullableValueTypes()


### PR DESCRIPTION
The manually assigned 128 KiB stack here is bordering on the amount of
stack space that release JIT needs to JIT functions with deep trees.
Since the JIT already has a limit on the depth of trees it creates

https://github.com/dotnet/runtime/blob/44f050acc0f7791d6cd7ac772945444912bcf299/src/coreclr/jit/importer.cpp#L11234-L11252

it seems unnecessary to pessimize the JIT further to allow this test to
pass. Also, the test was originally added as a
faster equivalent to the test above it that could run in inner loop
(https://github.com/dotnet/corefx/pull/14444), but it was subsequently
moved to outer loop (https://github.com/dotnet/corefx/pull/19563), so
now it does not seem like there's much point in retaining it.

Fix #53309