### PR TITLE
Ensure that extracted bundle does not use preexisting files.

### DIFF
--- a/src/native/corehost/bundle/extractor.cpp
+++ b/src/native/corehost/bundle/extractor.cpp
@@ -35,7 +35,7 @@ pal::string_t& extractor_t::extraction_dir()
             {
                 trace::error(_X("Failure processing application bundle."));
                 trace::error(_X("Failed to determine location for extracting embedded files."));
-                trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write temp-directory couldn't be created."));
+                trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write cache directory couldn't be created."));
                 throw StatusCode::BundleExtractionFailure;
             }
         }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -301,9 +301,7 @@ namespace pal
     bool get_default_breadcrumb_store(string_t* recv);
     bool is_path_rooted(const string_t& path);
 
-    bool get_temp_directory(string_t& tmp_dir);
-
-    // Returns a platform-specific, user-private directory within get_temp_directory()
+    // Returns a platform-specific, user-private directory
     // that can be used for extracting out components of a single-file app.
     bool get_default_bundle_extraction_base_dir(string_t& extraction_dir);
 

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -569,7 +569,7 @@ bool pal::get_module_path(dll_t mod, string_t* recv)
     return GetModuleFileNameWrapper(mod, recv);
 }
 
-bool pal::get_temp_directory(pal::string_t& tmp_dir)
+bool get_extraction_base_parent_directory(pal::string_t& directory)
 {
     const size_t max_len = MAX_PATH + 1;
     pal::char_t temp_path[max_len];
@@ -581,14 +581,14 @@ bool pal::get_temp_directory(pal::string_t& tmp_dir)
     }
 
     assert(len < max_len);
-    tmp_dir.assign(temp_path);
+    directory.assign(temp_path);
 
-    return realpath(&tmp_dir);
+    return pal::realpath(&directory);
 }
 
 bool pal::get_default_bundle_extraction_base_dir(pal::string_t& extraction_dir)
 {
-    if (!get_temp_directory(extraction_dir))
+    if (!get_extraction_base_parent_directory(extraction_dir))
     {
         return false;
     }


### PR DESCRIPTION
port of a 5.0 fix.

---

Changed location of the extraction root directory on Unix:
-  from ` $TMPDIR\.net\ `     typical path is   ` \var\tmp\.net\userName\AppName\App.ID\stuff `
-  to  ` $HOME\.net\ `          typical path is   ` \home\userName\.net\AppName\App.ID\stuff `

