### PR TITLE
Show PID when using debug attach flag with corerun

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -74,7 +74,8 @@ static void wait_for_debugger()
     }
     else if (state == pal::debugger_state_t::not_attached)
     {
-        pal::fprintf(stdout, W("Waiting for the debugger to attach. Press any key to continue ...\n"));
+        uint32_t pid = pal::get_process_id();
+        pal::fprintf(stdout, W("Waiting for the debugger to attach (PID: %u). Press any key to continue ...\n"), pid);
         (void)getchar();
         state = pal::is_debugger_attached();
     }

--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -106,6 +106,11 @@ namespace pal
         return { buffer.get() };
     }
 
+    uint32_t get_process_id()
+    {
+        return (uint32_t)::GetCurrentProcessId();
+    }
+
     debugger_state_t is_debugger_attached()
     {
         return (::IsDebuggerPresent() == TRUE) ? debugger_state_t::attached : debugger_state_t::not_attached;
@@ -365,6 +370,11 @@ namespace pal
         }
 
         return abs_path;
+    }
+
+    uint32_t get_process_id()
+    {
+        return (uint32_t)getpid();
     }
 
     debugger_state_t is_debugger_attached()


### PR DESCRIPTION
The `corerun` application has a flag for waiting for debugger to attach. Showing the process ID helps with having to figure out which `corerun` to attach to.

/cc @elinor-fung 