### PR TITLE
Add hot reload test that adds custom attributes

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    [Obsolete]
+    public class ClassWithCustomAttributes {
+        [Obsolete]
+        public static string Method () {
+            return null;
+        }
+    }
+}
+
+
+    

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes.cs
@@ -5,6 +5,14 @@ using System;
 
 namespace System.Reflection.Metadata.ApplyUpdate.Test
 {
+    public static class ClassWithCustomAttributesHelper {
+        public static Type GetAttributedClass () {
+#pragma warning disable CS0612
+            return typeof(ClassWithCustomAttributes);
+#pragma warning restore CS0612
+        }
+    }
+
     [Obsolete]
     public class ClassWithCustomAttributes {
         [Obsolete]

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
@@ -8,7 +8,7 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
     public static class ClassWithCustomAttributesHelper {
         public static Type GetAttributedClass () {
 #pragma warning disable CS0612
-            return typeof(ClassWithCustomAttributes);
+            return typeof(ClassWithCustomAttributes2);
 #pragma warning restore CS0612
         }
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    [Obsolete]
+    public class ClassWithCustomAttributes {
+        [Obsolete]
+        public static string Method () {
+            return null;
+        }
+    }
+
+    [Obsolete]
+    public class ClassWithCustomAttributes2 {
+        [Obsolete]
+        public static string Method2 () {
+            return null;
+        }
+    }
+}
+
+
+    

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/ClassWithCustomAttributes_v1.cs
@@ -5,6 +5,14 @@ using System;
 
 namespace System.Reflection.Metadata.ApplyUpdate.Test
 {
+    public static class ClassWithCustomAttributesHelper {
+        public static Type GetAttributedClass () {
+#pragma warning disable CS0612
+            return typeof(ClassWithCustomAttributes);
+#pragma warning restore CS0612
+        }
+    }
+
     [Obsolete]
     public class ClassWithCustomAttributes {
         [Obsolete]

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassWithCustomAttributes.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "ClassWithCustomAttributes.cs", "update": "ClassWithCustomAttributes_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -45,41 +45,40 @@ namespace System.Reflection.Metadata
         {
             ApplyUpdateUtil.TestCase(static () =>
             {
-                // Get the custom attribtues from the newly-added type and method and check
-                // That they are the expected ones
-                var className = "System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes2";
-                var methodName = "Method2";
-#pragma warning disable CS0612
-                var assm = typeof(ApplyUpdate.Test.ClassWithCustomAttributes).Assembly;
-#pragma warning restore CS0612
+                // Get the custom attribtues from a newly-added type and method
+                // and check that they are the expected ones.
+                var assm = typeof(ApplyUpdate.Test.ClassWithCustomAttributesHelper).Assembly;
 
-                var ty = assm.GetType(className, throwOnError: false);
-
-                Assert.Null (ty);
+                // returns ClassWithCustomAttributes
+                var ty = ApplyUpdate.Test.ClassWithCustomAttributesHelper.GetAttributedClass();
+                Assert.NotNull (ty);
 
                 ApplyUpdateUtil.ApplyUpdate(assm);
 
-                ty = assm.GetType(className, throwOnError: false);
-
+                // returns ClassWithCustomAttributes2
+                ty = ApplyUpdate.Test.ClassWithCustomAttributesHelper.GetAttributedClass();
                 Assert.NotNull (ty);
 
-                var cattrs = Attribute.GetCustomAttributes(ty);
+                var attrType = typeof(ObsoleteAttribute);
+
+                var cattrs = Attribute.GetCustomAttributes(ty, attrType);
 
                 Assert.NotNull(cattrs);
                 Assert.Equal(1, cattrs.Length);
                 Assert.NotNull(cattrs[0]);
-                Assert.Equal(typeof(ObsoleteAttribute), cattrs[0].GetType());
+                Assert.Equal(attrType, cattrs[0].GetType());
 
+                var methodName = "Method2";
                 var mi = ty.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
 
                 Assert.NotNull (mi);
 
-                cattrs = Attribute.GetCustomAttributes(mi);
+                cattrs = Attribute.GetCustomAttributes(mi, attrType);
 
                 Assert.NotNull(cattrs);
                 Assert.Equal(1, cattrs.Length);
                 Assert.NotNull(cattrs[0]);
-                Assert.Equal(typeof(ObsoleteAttribute), cattrs[0].GetType());
+                Assert.Equal(attrType, cattrs[0].GetType());
             });
         }
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -40,7 +40,7 @@ namespace System.Reflection.Metadata
         }
 
         [Fact]
-        [ActiveIssue("xyz", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/52993", TestRuntimes.Mono)]
         void ClassWithCustomAttributes()
         {
             ApplyUpdateUtil.TestCase(static () =>
@@ -54,6 +54,7 @@ namespace System.Reflection.Metadata
                 Assert.NotNull (ty);
 
                 ApplyUpdateUtil.ApplyUpdate(assm);
+                ApplyUpdateUtil.ClearAllReflectionCaches();
 
                 // returns ClassWithCustomAttributes2
                 ty = ApplyUpdate.Test.ClassWithCustomAttributesHelper.GetAttributedClass();

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -38,5 +38,49 @@ namespace System.Reflection.Metadata
                 Assert.Equal ("NEWEST STRING", r);
             });
         }
+
+        [Fact]
+        [ActiveIssue("xyz", TestRuntimes.Mono)]
+        void ClassWithCustomAttributes()
+        {
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+                // Get the custom attribtues from the newly-added type and method and check
+                // That they are the expected ones
+                var className = "System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes2";
+                var methodName = "Method2";
+#pragma warning disable CS0612
+                var assm = typeof(ApplyUpdate.Test.ClassWithCustomAttributes).Assembly;
+#pragma warning restore CS0612
+
+                var ty = assm.GetType(className, throwOnError: false);
+
+                Assert.Null (ty);
+
+                ApplyUpdateUtil.ApplyUpdate(assm);
+
+                ty = assm.GetType(className, throwOnError: false);
+
+                Assert.NotNull (ty);
+
+                var cattrs = Attribute.GetCustomAttributes(ty);
+
+                Assert.NotNull(cattrs);
+                Assert.Equal(1, cattrs.Length);
+                Assert.NotNull(cattrs[0]);
+                Assert.Equal(typeof(ObsoleteAttribute), cattrs[0].GetType());
+
+                var mi = ty.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+
+                Assert.NotNull (mi);
+
+                cattrs = Attribute.GetCustomAttributes(mi);
+
+                Assert.NotNull(cattrs);
+                Assert.Equal(1, cattrs.Length);
+                Assert.NotNull(cattrs[0]);
+                Assert.Equal(typeof(ObsoleteAttribute), cattrs[0].GetType());
+            });
+        }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateUtil.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateUtil.cs
@@ -133,5 +133,26 @@ namespace System.Reflection.Metadata
                 testBody(arg1);
             }
         }
+
+
+        public static void ClearAllReflectionCaches()
+        {
+            // TODO: Implement for Mono, see https://github.com/dotnet/runtime/issues/50978
+            if (IsMonoRuntime)
+                return;
+            var clearCacheMethod = GetClearCacheMethod();
+            clearCacheMethod (null);
+        }
+
+        // CoreCLR only
+        private static Action<Type[]> GetClearCacheMethod()
+        {
+            // TODO: Unify with src/libraries/System.Runtime/tests/System/Reflection/ReflectionCacheTests.cs
+            Type updateHandler = typeof(Type).Assembly.GetType("System.Reflection.Metadata.RuntimeTypeMetadataUpdateHandler", throwOnError: true, ignoreCase: false);
+            MethodInfo clearCache = updateHandler.GetMethod("ClearCache", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) });
+            Assert.NotNull(clearCache);
+            return clearCache.CreateDelegate<Action<Type[]>>();
+        }
+        
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -39,6 +39,8 @@
     <ProjectReference Include="LoaderLinkTest.Shared\LoaderLinkTest.Shared.csproj" />
     <ProjectReference Include="LoaderLinkTest.Dynamic\LoaderLinkTest.Dynamic.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.csproj" />
+
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
@@ -53,6 +55,9 @@
       <!-- Don't modify EnC test assemblies -->
       <TrimmerRootAssembly
           Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.dll'))"
+          Include="%(ResolvedFileToPublish.FullPath)" />
+      <TrimmerRootAssembly
+          Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.dll'))"
           Include="%(ResolvedFileToPublish.FullPath)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This test adds new rows to the CustomAttribute table with both new a class and
a new method as parents.  That should result in an unsorted table, which
CoreCLR should be able to handle.