### PR TITLE
Remove forced serialization of async-over-sync in Stream base methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -120,6 +120,12 @@ namespace System.IO.Strategies
                 vt.AsTask().GetAwaiter().GetResult();
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+            TaskToApm.Begin(ReadAsync(buffer, offset, count), callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) =>
+            TaskToApm.End<int>(asyncResult);
+
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
 
@@ -206,6 +212,12 @@ namespace System.IO.Strategies
 
         public override void Write(byte[] buffer, int offset, int count)
             => WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+            TaskToApm.Begin(WriteAsync(buffer, offset, count), callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
@@ -163,7 +163,7 @@ namespace System.IO.Strategies
                 // Read is invoked asynchronously.  But we can do so using the base Stream's internal helper
                 // that bypasses delegating to BeginRead, since we already know this is FileStream rather
                 // than something derived from it and what our BeginRead implementation is going to do.
-                return (Task<int>)base.BeginReadInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+                return BeginReadInternal(buffer, offset, count, null, null);
             }
 
             return ReadAsyncTask(buffer, offset, count, cancellationToken);
@@ -178,7 +178,7 @@ namespace System.IO.Strategies
                 // internal helper that bypasses delegating to BeginRead, since we already know this is FileStream
                 // rather than something derived from it and what our BeginRead implementation is going to do.
                 return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
-                    new ValueTask<int>((Task<int>)base.BeginReadInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                    new ValueTask<int>(BeginReadInternal(segment.Array!, segment.Offset, segment.Count, null, null)) :
                     base.ReadAsync(buffer, cancellationToken);
             }
 
@@ -245,7 +245,7 @@ namespace System.IO.Strategies
                 // Write is invoked asynchronously.  But we can do so using the base Stream's internal helper
                 // that bypasses delegating to BeginWrite, since we already know this is FileStream rather
                 // than something derived from it and what our BeginWrite implementation is going to do.
-                return (Task)base.BeginWriteInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+                return BeginWriteInternal(buffer, offset, count, null, null);
             }
 
             return WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
@@ -260,7 +260,7 @@ namespace System.IO.Strategies
                 // internal helper that bypasses delegating to BeginWrite, since we already know this is FileStream
                 // rather than something derived from it and what our BeginWrite implementation is going to do.
                 return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
-                    new ValueTask((Task)base.BeginWriteInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                    new ValueTask(BeginWriteInternal(segment.Array!, segment.Offset, segment.Count, null, null)) :
                     base.WriteAsync(buffer, cancellationToken);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/SyncWindowsFileStreamStrategy.cs
@@ -46,7 +46,7 @@ namespace System.IO.Strategies
             // Read is invoked asynchronously.  But we can do so using the base Stream's internal helper
             // that bypasses delegating to BeginRead, since we already know this is FileStream rather
             // than something derived from it and what our BeginRead implementation is going to do.
-            return (Task<int>)BeginReadInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+            return BeginReadInternal(buffer, offset, count, null, null);
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -56,7 +56,7 @@ namespace System.IO.Strategies
             // internal helper that bypasses delegating to BeginRead, since we already know this is FileStream
             // rather than something derived from it and what our BeginRead implementation is going to do.
             return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
-                new ValueTask<int>((Task<int>)BeginReadInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                new ValueTask<int>(BeginReadInternal(segment.Array!, segment.Offset, segment.Count, null, null)) :
                 base.ReadAsync(buffer, cancellationToken);
         }
 
@@ -79,7 +79,7 @@ namespace System.IO.Strategies
             // Write is invoked asynchronously.  But we can do so using the base Stream's internal helper
             // that bypasses delegating to BeginWrite, since we already know this is FileStream rather
             // than something derived from it and what our BeginWrite implementation is going to do.
-            return (Task)BeginWriteInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+            return BeginWriteInternal(buffer, offset, count, null, null);
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -89,7 +89,7 @@ namespace System.IO.Strategies
             // internal helper that bypasses delegating to BeginWrite, since we already know this is FileStream
             // rather than something derived from it and what our BeginWrite implementation is going to do.
             return MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment) ?
-                new ValueTask((Task)BeginWriteInternal(segment.Array!, segment.Offset, segment.Count, null, null, serializeAsynchronously: true, apm: false)) :
+                new ValueTask(BeginWriteInternal(segment.Array!, segment.Offset, segment.Count, null, null)) :
                 base.WriteAsync(buffer, cancellationToken);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/45089

The base implementation of Stream.BeginRead/Write queue a work items that invoke the abstract Read/Write methods.  When Stream.BeginRead/Write were introduced long ago, for reasons I’m not privy to, someone decided it would be a good idea to add protection to these methods, such that if you try to call either BeginRead or BeginWrite while a previous BeginRead or BeginWrite operation was still in flight, the synchronous call to BeginXx would synchronously block.  Yuck.  Back in .NET Framework 4.5 when we added Stream.Read/WriteAsync, we had to add the base implementations as wrappers for the BeginRead/Write methods, since Read/WriteAsync should pick up the overrides of those methods if they existed.  The idea of propagating that synchronous blocking behavior to Read/WriteAsync was unstomachable, but for compatibility we made it so that Read/WriteAsync would still serialize, just asynchronously (later we added a fast path optimization that would skip BeginRead/Write entirely if they weren’t overridden by the derived type).  That serialization, however, even though it was asynchronous, was also misguided.  In addition to adding overhead, both in terms of needing a semaphore and somewhere to store it and in terms of using that semaphore for every operation, it prevents the concurrent use of read and write.  In general, streams aren’t meant to be used concurrently at all, but some streams are duplex and support up to a single reader and single writer at a time.  This serialization ends up blocking such duplex streams from being used (if they don’t override Read/WriteAsync), but worse, it ends up hiding misuse of streams that shouldn’t be used concurrently by masking the misuse and turning it into behavior that might appear to work but is unlikely to actually be the desired behavior.

This PR deletes that serialization and then cleans up all the cruft that was built up around it.  This is a breaking change, as it’s possible code could have been relying on this (undocumented) protection; the fix for such an app is to stop doing that erroneous concurrent access, which could include applying its own serialization if necessary.

BufferedStream was explicitly using the same serialization mechanism; I left that intact, though we might want to revisit that.  BufferedFileStreamStrategy was also using it, as FileStream kinda sorta somewhat tries to enable concurrent (not parallel) usage when useAsync == true on Windows.

cc: @jkotas, @geoffkizer, @adamsitnik, @marklio 