### PR TITLE
Reduce lock holds during EP session disable

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -309,9 +309,6 @@ ep_session_execute_rundown (EventPipeSession *session)
 {
 	EP_ASSERT (session != NULL);
 
-	// Lock must be held by ep_disable.
-	ep_requires_lock_held ();
-
 	ep_return_void_if_nok (session->file != NULL);
 
 	ep_rt_execute_rundown ();


### PR DESCRIPTION
> I'm putting this up in draft mode while I iterate it on it to get feedback early 😄 

Fixes #1892

This patch reduces the holding of the global EventPipe lock during the disable code path. Executing rundown takes additional global locks, e.g., the code table manager lock. Layering two global locks with a blocking call to `FlushAllBuffersToFile` can result in bad behavior in the presence of a malformed client.

Part of #45518 

CC @noahfalk @davmason @lateralusX @tommcdon 