### PR TITLE
Wasm.Build.Tests should not use local targeting runtime pack

### DIFF
--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -10,6 +10,8 @@
     <WasmGenerateAppBundle>false</WasmGenerateAppBundle>
     <EnableDefaultItems>true</EnableDefaultItems>
     <DefineConstants Condition="'$(ContinuousIntegrationBuild)' != 'true'">TEST_DEBUG_CONFIG_ALSO</DefineConstants>
+    <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->
+    <UseLocalTargetingRuntimePack>false</UseLocalTargetingRuntimePack>
 
     <!-- don't run any wasm build steps -->
     <WasmBuildAppAfterThisTarget />


### PR DESCRIPTION
fixes #53405 

For more context please refer to https://github.com/dotnet/runtime/pull/53290