### PR TITLE
Do not assume about another half regrec

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5615,10 +5615,6 @@ void LinearScan::allocateRegisters()
 // Return Value:
 //    None
 //
-// Assumptions:
-//    For ARM32, when "regType" is TYP_DOUBLE, "reg" should be a even-numbered
-//    float register, i.e. lower half of double register.
-//
 // Note:
 //    For ARM32, two float registers consisting a double register are updated
 //    together when "regType" is TYP_DOUBLE.
@@ -5631,8 +5627,8 @@ void LinearScan::updateAssignedInterval(RegRecord* reg, Interval* interval, Regi
     regNumber doubleReg           = REG_NA;
     if (regType == TYP_DOUBLE)
     {
-        doubleReg                        = reg->regNum;
-        RegRecord* anotherHalfReg        = getSecondHalfRegRec(reg);
+        RegRecord* anotherHalfReg        = findAnotherHalfRegRec(reg);
+        doubleReg                        = genIsValidDoubleReg(reg->regNum) ? reg->regNum : anotherHalfReg->regNum;
         anotherHalfReg->assignedInterval = interval;
     }
     else if ((oldAssignedInterval != nullptr) && (oldAssignedInterval->registerType == TYP_DOUBLE))


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/45135, we started assuming at one place that `RegisterRecord` would always be the even-numbered. (See [my question ](https://github.com/dotnet/runtime/pull/45135/files#r534603519) in that PR). However, it seems that recent work of porting SIMDIntrinsicGetItem and SIMDIntrinsicSetItem to HWIntrinsics done in #52288 exposed the problem and prove that the assumption is wrong.

The fix is to revert back to pre #45135 change.

Fixes: #53322 