### PR TITLE
Disable flaky CodeDom tests

### DIFF
--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeCollectionTestBase.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeCollectionTestBase.cs
@@ -46,6 +46,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(AddRange_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/53042", framework: TargetFrameworkMonikers.Netcoreapp, runtimes: TestRuntimes.CoreCLR)]
         public void Ctor_Array_Works(TItem[] value)
         {
             var collection = CtorArray(value);
@@ -54,6 +55,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(AddRange_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/53042", framework: TargetFrameworkMonikers.Netcoreapp, runtimes: TestRuntimes.CoreCLR)]
         public void Ctor_CodeStatementCollection_Works(TItem[] value)
         {
             var collection = CtorCollection(CtorArray(value));
@@ -62,6 +64,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(AddRange_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/53042", framework: TargetFrameworkMonikers.Netcoreapp, runtimes: TestRuntimes.CoreCLR)]
         public void AddRange_CodeStatementArray_Works(TItem[] value)
         {
             var collection = Ctor();
@@ -71,6 +74,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(AddRange_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/53042", framework: TargetFrameworkMonikers.Netcoreapp, runtimes: TestRuntimes.CoreCLR)]
         public void AddRange_CodeStatementCollection_Works(TItem[] value)
         {
             var collection = Ctor();


### PR DESCRIPTION
Disable tests as https://github.com/dotnet/runtime/issues/53042 has reliability with CI health at 0% currently.