### PR TITLE
46239 v2 (no runtime layout changes)

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -147,7 +147,8 @@ jobs:
     jobParameters:
       testGroup: outerloop
       readyToRun: true
-      displayNameArgs: R2R
+      crossgen2: true
+      displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
 
 #

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -840,7 +840,7 @@ namespace Internal.TypeSystem
                 result.Alignment = fieldType.Context.Target.LayoutPointerSize;
             }
 
-            if (fieldType.Context.Target.Architecture != TargetArchitecture.ARM)
+            if (!hasLayout || fieldType.Context.Target.Architecture != TargetArchitecture.ARM)
             {
                 result.Alignment = LayoutInt.Min(result.Alignment, new LayoutInt(packingSize));
             }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -358,8 +358,6 @@ namespace Internal.TypeSystem
                     );
                 if (needsToBeAligned)
                 {
-                    // ByRefLike types aren't guaranteed to have pointer alignment by themselves
-                    largestAlignmentRequired = LayoutInt.Max(largestAlignmentRequired, type.Context.Target.LayoutPointerSize);
                     int offsetModulo = computedOffset.AsInt % type.Context.Target.PointerSize;
                     if (offsetModulo != 0)
                     {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -305,7 +305,7 @@ namespace Internal.TypeSystem
         {
         }
 
-        protected virtual bool IsBlittableOrManagedSequential(TypeDesc type) => false;
+        protected virtual bool IsBlittableOrManagedSequential(TypeDesc type) => throw new NotImplementedException();
 
         protected ComputedInstanceFieldLayout ComputeExplicitFieldLayout(MetadataType type, int numInstanceFields)
         {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -313,15 +313,6 @@ namespace Internal.TypeSystem
             // It is calculated as the field whose offset and size add to the greatest value.
             LayoutInt offsetBias = !type.IsValueType ? new LayoutInt(type.Context.Target.PointerSize) : LayoutInt.Zero;
             LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type, requiresAlign8: false, requiresAlignedBase: false) - offsetBias;
-            if (!type.IsValueType)
-            {
-                // CoreCLR runtime has a bug in field offset calculation in the presence of class inheritance
-                // and explicit layout: in classlayoutinfo.cpp, the calculated layout adds base class size to
-                // field offsets (so that they are instance-relative) but HandleExplicitLayout in methodtablebuilder
-                // treats them as relative to the 'instance slice' which is offset by the base class size once more,
-                // effectively doubling the base class offset.
-                cumulativeInstanceFieldPos = cumulativeInstanceFieldPos + cumulativeInstanceFieldPos;
-            }
             LayoutInt instanceSize = cumulativeInstanceFieldPos + offsetBias;
 
             var layoutMetadata = type.GetClassLayout();

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -305,7 +305,7 @@ namespace Internal.TypeSystem
         {
         }
 
-        protected virtual bool IsBlittableOrManagedSequential(TypeDesc type) => throw new NotImplementedException();
+        protected virtual bool AlignUpInstanceByteSizeForExplicitFieldLayoutCompatQuirk(TypeDesc type) => true;
 
         protected ComputedInstanceFieldLayout ComputeExplicitFieldLayout(MetadataType type, int numInstanceFields)
         {
@@ -373,7 +373,7 @@ namespace Internal.TypeSystem
                 instanceSize,
                 largestAlignmentRequired,
                 layoutMetadata.Size,
-                alignUpInstanceByteSize: IsBlittableOrManagedSequential(type),
+                alignUpInstanceByteSize: AlignUpInstanceByteSizeForExplicitFieldLayoutCompatQuirk(type),
                 out instanceByteSizeAndAlignment);
 
             ComputedInstanceFieldLayout computedLayout = new ComputedInstanceFieldLayout();

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -325,8 +325,6 @@ namespace Internal.TypeSystem
             LayoutInt instanceSize = cumulativeInstanceFieldPos + offsetBias;
 
             var layoutMetadata = type.GetClassLayout();
-            LayoutInt instanceSize = cumulativeInstanceFieldPos + new LayoutInt(layoutMetadata.Size) + offsetBias;
-
             int packingSize = ComputePackingSize(type, layoutMetadata);
             LayoutInt largestAlignmentRequired = LayoutInt.One;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -317,7 +317,7 @@ namespace Internal.TypeSystem
             cumulativeInstanceFieldPos -= offsetBias;
 
             var layoutMetadata = type.GetClassLayout();
-            LayoutInt instanceSize = cumulativeInstanceFieldPos + new LayoutInt(layoutMetadata.Size);
+            LayoutInt instanceSize = cumulativeInstanceFieldPos + new LayoutInt(layoutMetadata.Size) + offsetBias;
 
             int packingSize = ComputePackingSize(type, layoutMetadata);
             LayoutInt largestAlignmentRequired = LayoutInt.One;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -840,13 +840,13 @@ namespace Internal.TypeSystem
                 result.Alignment = fieldType.Context.Target.LayoutPointerSize;
             }
 
-            if (!hasLayout || fieldType.Context.Target.Architecture != TargetArchitecture.ARM)
+            if (hasLayout)
             {
                 result.Alignment = LayoutInt.Min(result.Alignment, new LayoutInt(packingSize));
             }
-            else if (packingSize < 8)
+            else
             {
-                result.Alignment = LayoutInt.Min(result.Alignment, fieldType.Context.Target.LayoutPointerSize);
+                result.Alignment = LayoutInt.Min(result.Alignment, fieldType.Context.Target.GetObjectAlignment(result.Alignment));
             }
 
             return result;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -840,9 +840,13 @@ namespace Internal.TypeSystem
                 result.Alignment = fieldType.Context.Target.LayoutPointerSize;
             }
 
-            if (hasLayout)
+            if (fieldType.Context.Target.Architecture != TargetArchitecture.ARM)
             {
                 result.Alignment = LayoutInt.Min(result.Alignment, new LayoutInt(packingSize));
+            }
+            else if (packingSize < 8)
+            {
+                result.Alignment = LayoutInt.Min(result.Alignment, fieldType.Context.Target.LayoutPointerSize);
             }
 
             return result;
@@ -850,8 +854,7 @@ namespace Internal.TypeSystem
 
         private static int ComputePackingSize(MetadataType type, ClassLayoutMetadata layoutMetadata)
         {
-            // If a type contains pointers then the metadata specified packing size is ignored (On .NET Framework this is disqualification from ManagedSequential)
-            if (layoutMetadata.PackingSize == 0 || type.ContainsGCPointers)
+            if (layoutMetadata.PackingSize == 0)
                 return type.Context.Target.DefaultPackingSize;
             else
                 return layoutMetadata.PackingSize;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -813,8 +813,6 @@ namespace ILCompiler
             }
         }
 
-        protected override bool IsBlittableOrManagedSequential(TypeDesc type) => MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type);
-
         /// <summary>
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -813,6 +813,8 @@ namespace ILCompiler
             }
         }
 
+        protected override bool IsBlittableOrManagedSequential(TypeDesc type) => MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type);
+
         /// <summary>
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -827,6 +827,11 @@ namespace ILCompiler
             }
         }
 
+        protected override bool IsBlittableOrManagedSequential(TypeDesc type)
+        {
+            return MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type);
+        }
+
         public static bool IsManagedSequentialType(TypeDesc type)
         {
             if (type.IsPointer)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -827,7 +827,7 @@ namespace ILCompiler
             }
         }
 
-        protected override bool IsBlittableOrManagedSequential(TypeDesc type)
+        protected override bool AlignUpInstanceByteSizeForExplicitFieldLayoutCompatQuirk(TypeDesc type)
         {
             return MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type);
         }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/InstanceFieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/InstanceFieldLayoutTests.cs
@@ -86,7 +86,7 @@ namespace TypeSystemTests
 
             // Class1 has size 24 which Class2 inherits from.  Class2 adds a byte at offset 20, so + 21
             // = 45, rounding up to the next pointer size = 48
-            Assert.Equal(56, class2Type.InstanceByteCount.AsInt);
+            Assert.Equal(48, class2Type.InstanceByteCount.AsInt);
 
             foreach (var f in class2Type.GetFields())
             {
@@ -97,12 +97,12 @@ namespace TypeSystemTests
                 {
                     // First field after base class, with offset 0 so it should lie on the byte count of 
                     // the base class = 24
-                    Assert.Equal(32, f.Offset.AsInt);
+                    Assert.Equal(20, f.Offset.AsInt);
                 }
                 else if (f.Name == "Omg")
                 {
                     // Offset 20 from base class byte count = 44
-                    Assert.Equal(52, f.Offset.AsInt);
+                    Assert.Equal(40, f.Offset.AsInt);
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/InstanceFieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/InstanceFieldLayoutTests.cs
@@ -86,7 +86,7 @@ namespace TypeSystemTests
 
             // Class1 has size 24 which Class2 inherits from.  Class2 adds a byte at offset 20, so + 21
             // = 45, rounding up to the next pointer size = 48
-            Assert.Equal(48, class2Type.InstanceByteCount.AsInt);
+            Assert.Equal(56, class2Type.InstanceByteCount.AsInt);
 
             foreach (var f in class2Type.GetFields())
             {
@@ -97,12 +97,12 @@ namespace TypeSystemTests
                 {
                     // First field after base class, with offset 0 so it should lie on the byte count of 
                     // the base class = 24
-                    Assert.Equal(24, f.Offset.AsInt);
+                    Assert.Equal(32, f.Offset.AsInt);
                 }
                 else if (f.Name == "Omg")
                 {
                     // Offset 20 from base class byte count = 44
-                    Assert.Equal(44, f.Offset.AsInt);
+                    Assert.Equal(52, f.Offset.AsInt);
                 }
                 else
                 {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -349,6 +349,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/*">
             <Issue>https://github.com/dotnet/runtime/issues/8034 The test causes OutOfMemory exception in crossgen mode.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/explicitlayout/Regressions/ASURT/ASURT150271/test3/*">
+            <Issue>https://github.com/dotnet/runtime/issues/53559</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/regressions/asurt150271/test3/*">
+            <Issue>https://github.com/dotnet/runtime/issues/53559</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>
@@ -566,11 +572,20 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b91248/b91248/*">
             <Issue>https://github.com/dotnet/runtime/issues/12979</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170/*">
+            <Issue>https://github.com/dotnet/runtime/issues/53560</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/PREFIX/unaligned/4/arglist_Target_ARM/*">
             <Issue>https://github.com/dotnet/runtime/issues/12979</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i10/*">
             <Issue>https://github.com/dotnet/runtime/issues/12979</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Ldfld_ro/*">
+            <Issue>https://github.com/dotnet/runtime/issues/53561</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Ldfld_r/*">
+            <Issue>https://github.com/dotnet/runtime/issues/53561</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
This is a simplified version of my original fix for 46239 as the full fix including runtime layout cleanup,

https://github.com/dotnet/runtime/pull/51416

has an enormous bug tail and seems too risky to take relatively late in the release cycle.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 