### PR TITLE
Relax a threading related assert

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -5396,7 +5396,7 @@ void ThreadStore::TransferStartedThread(Thread *thread)
     //    is that the lock is held and not by this thread.
     _ASSERTE(!lockHeld
         || (lockHeld
-            && s_pThreadStore->m_HoldingThread != NULL
+            && !s_pThreadStore->m_holderthreadid.IsUnknown()
             && !ThreadStore::HoldingThreadStore()));
 
     LOG((LF_SYNC, INFO3, "TransferStartedThread obtain lock\n"));

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -5372,7 +5372,6 @@ BOOL ThreadStore::RemoveThread(Thread *target)
     return found;
 }
 
-
 // When a thread is created as unstarted.  Later it may get started, in which case
 // someone calls Thread::HasStarted() on that physical thread.  This completes
 // the Setup and calls here.
@@ -5397,6 +5396,7 @@ void ThreadStore::TransferStartedThread(Thread *thread)
     _ASSERTE(!lockHeld
         || (lockHeld
             && !s_pThreadStore->m_holderthreadid.IsUnknown()
+            && ((s_pThreadStore->m_HoldingThread != NULL) || IsGCSpecialThread())
             && !ThreadStore::HoldingThreadStore()));
 
     LOG((LF_SYNC, INFO3, "TransferStartedThread obtain lock\n"));


### PR DESCRIPTION
This assert assumes when a thread is holding the ThreadStoreLock, `s_pThreadStore->m_HoldingThread` should not be `NULL`. This can be false.

Note that when a thread attempts to take the ThreadStoreLock, it is supposed to call `ThreadSuspend::LockThreadStore`, which saves the holding thread as follow:

https://github.com/dotnet/runtime/blob/d43e88620fe574045f026a4ebce50f7a8541347a/src/coreclr/vm/threadsuspend.cpp#L1881

The thread object instance itself is obtained a few lines earlier. Note that we allow `NULL` there.

https://github.com/dotnet/runtime/blob/d43e88620fe574045f026a4ebce50f7a8541347a/src/coreclr/vm/threadsuspend.cpp#L1851

Therefore it is possible, at least theoretically, that the ThreadStoreLock is held when `s_pThreadStore->m_HoldingThread` is `NULL`.

It remains to understand what is the case when `s_pThreadStore->m_HoldingThread` is `NULL` while the ThreadStoreLock is held. The situation happens when the GC is creating a background GC thread.

In Server GC, we create the server GC threads through `CreateNonSuspendableThread`. 

https://github.com/dotnet/runtime/blob/5f15498d937653986821d636c04cd03c58d4bb4c/src/coreclr/vm/gcenv.ee.cpp#L1445

The code eventually calls `Thread::CreateUtilityThread`, that code will not set up the thread as usual. Judging from the code, it appears to be intentional.

Next, the server GC thread suspends the runtime, and when it does, `ThreadSuspend::LockThreadStore` would get a `NULL` thread from `GetThreadNULLOk` and saved that `NULL` into  `s_pThreadStore->m_HoldingThread`.

Lastly, when the server GC creates a background GC thread, that thread would startup and hit the assert because now we have a case where the `ThreadStoreLock` is held but `s_pThreadStore->m_HoldingThread` is `NULL`.

To confirm this is a correct fix, I have two particular questions:

1. @Maoni0, do we expect the thread static thread object to be `NULL` for the server GC thread (not the background GC threads)
2. Why didn't I hit that all the time? It appears that the code works sometimes. That is still a mystery.

In any case, this fix saved me from hitting the assert and doesn't change the intent of the code. I think we should merge it to avoid the assertion (except if things are broken if that assertion is not true)