### PR TITLE
Avoid setting the brick of the next region during sweep in plan

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28536,7 +28536,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
         // We only need to make sure we fix the brick the last marked object's end is in.
         // Note this brick could have been fixed already.
         size_t last_marked_obj_start_b = brick_of (last_marked_obj_start);
-        size_t last_marked_obj_end_b = brick_of (last_marked_obj_end);
+        size_t last_marked_obj_end_b = brick_of (last_marked_obj_end - 1);
         dprintf (REGIONS_LOG, ("last live obj %Ix(%Ix)-%Ix, fixing its brick(s) %Ix-%Ix",
             last_marked_obj_start, method_table (last_marked_obj_start), last_marked_obj_end,
             last_marked_obj_start_b, last_marked_obj_end_b));
@@ -28546,7 +28546,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
             set_brick (last_marked_obj_start_b, 
                     (last_marked_obj_start - brick_address (last_marked_obj_start_b)));
         }
-        else if (last_marked_obj_end_b != brick_of(end)) 
+        else
         {
             set_brick (last_marked_obj_end_b, 
                     (last_marked_obj_start_b - last_marked_obj_end_b));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28546,7 +28546,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
             set_brick (last_marked_obj_start_b, 
                     (last_marked_obj_start - brick_address (last_marked_obj_start_b)));
         }
-        else
+        else if (last_marked_obj_end_b != brick_of(end)) 
         {
             set_brick (last_marked_obj_end_b, 
                     (last_marked_obj_start_b - last_marked_obj_end_b));


### PR DESCRIPTION
Note that the `last_marked_obj_end_b` is the exclusive end address of the last marked object including alignment, therefore in a special case when the region ends with a marked object, `last_marked_obj_end_b` is exactly the end of the region. 

In that case, if we set that brick, we could potentially overwrite the brick of another region (which could belong to another heap)

Let's say we had a plug tree root stored on the brick of the next region, but the entry got overwritten by -1 because of the above. The subsequent `relocate_address` would read a `-1` on that brick and miss the plug tree. The rest will go south.