### PR TITLE
Remove some unneeded code from division morphing

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12604,24 +12604,24 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             noway_assert(op2);
             if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD))
             {
-                if (op2->gtOper == GT_CNS_NATIVELONG && op2->AsIntConCommon()->LngValue() >= 2 &&
+                if (op2->OperIs(GT_CNS_NATIVELONG) && op2->AsIntConCommon()->LngValue() >= 2 &&
                     op2->AsIntConCommon()->LngValue() <= 0x3fffffff)
                 {
                     tree->AsOp()->gtOp1 = op1 = fgMorphTree(op1);
-                    noway_assert(op1->TypeGet() == TYP_LONG);
+                    noway_assert(op1->TypeIs(TYP_LONG));
 
-                    // Update flags for op1 morph
+                    // Update flags for op1 morph.
                     tree->gtFlags &= ~GTF_ALL_EFFECT;
 
-                    tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT); // Only update with op1 as op2 is a constant
+                    // Only update with op1 as op2 is a constant.
+                    tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT);
 
-                    // If op1 is a constant, then do constant folding of the division operator
-                    if (op1->gtOper == GT_CNS_NATIVELONG)
+                    // If op1 is a constant, then do constant folding of the division operator.
+                    if (op1->OperIs(GT_CNS_NATIVELONG))
                     {
                         tree = gtFoldExpr(tree);
                     }
 
-                    // We may fail to fold
                     if (!tree->OperIsConst())
                     {
                         tree->AsOp()->CheckDivideByConstOptimized(this);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12603,15 +12603,11 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 // Note for TARGET_ARMARCH we don't have  a remainder instruction, so we don't do this optimization
 //
 #else  // TARGET_XARCH
-            /* If this is an unsigned long mod with op2 which is a cast to long from a
-               constant int, then don't morph to a call to the helper.  This can be done
-               faster inline using idiv.
-            */
+            // If this is an unsigned long mod with a constant divisor,
+            // then don't morph to a helper call - it can be done faster inline using idiv.
 
             noway_assert(op2);
-            if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD) &&
-                ((tree->gtFlags & GTF_UNSIGNED) == (op1->gtFlags & GTF_UNSIGNED)) &&
-                ((tree->gtFlags & GTF_UNSIGNED) == (op2->gtFlags & GTF_UNSIGNED)))
+            if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD))
             {
                 if (op2->gtOper == GT_CAST && op2->AsCast()->CastOp()->gtOper == GT_CNS_INT &&
                     op2->AsCast()->CastOp()->AsIntCon()->gtIconVal >= 2 &&

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12531,11 +12531,6 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             }
 #endif
 #endif // !TARGET_64BIT
-
-            if (op2->gtOper == GT_CAST && op2->AsOp()->gtOp1->IsCnsIntOrI())
-            {
-                op2 = gtFoldExprConst(op2);
-            }
             break;
 
         case GT_UDIV:
@@ -12609,15 +12604,6 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             noway_assert(op2);
             if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD))
             {
-                if (op2->gtOper == GT_CAST && op2->AsCast()->CastOp()->gtOper == GT_CNS_INT &&
-                    op2->AsCast()->CastOp()->AsIntCon()->gtIconVal >= 2 &&
-                    op2->AsCast()->CastOp()->AsIntCon()->gtIconVal <= 0x3fffffff &&
-                    (tree->gtFlags & GTF_UNSIGNED) == (op2->AsCast()->CastOp()->gtFlags & GTF_UNSIGNED))
-                {
-                    tree->AsOp()->gtOp2 = op2 = fgMorphCast(op2);
-                    noway_assert(op2->gtOper == GT_CNS_NATIVELONG);
-                }
-
                 if (op2->gtOper == GT_CNS_NATIVELONG && op2->AsIntConCommon()->LngValue() >= 2 &&
                     op2->AsIntConCommon()->LngValue() <= 0x3fffffff)
                 {
@@ -12688,11 +12674,6 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             }
 #endif
 #endif // !TARGET_64BIT
-
-            if (op2->gtOper == GT_CAST && op2->AsOp()->gtOp1->IsCnsIntOrI())
-            {
-                op2 = gtFoldExprConst(op2);
-            }
 
 #ifdef TARGET_ARM64
             // For ARM64 we don't have a remainder instruction,


### PR DESCRIPTION
#### Remove GTF_UNSIGNED check from the condition

It is not necessary: GTF_UNSIGNED does not have anything
to do with the operands being unsigned.

Some positive diffs in runtime tests for win-x86 and
one regression in System.Net.WebSockets.ManagedWebSocket.ApplyMask.
The regression is because we generate two "div"s for a long UMOD
on x86 with a constant divisor, always, even for powers of two.
Something to improve for sure (and I have a fix for it in the pipeline).

<details>
<summary>The diffs</summary>

```
Running asm diffs of coreclr_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 11904
Total bytes of diff: 11564
Total bytes of delta: -340 (-2.86% of base)
    diff is an improvement.


Top method regressions (bytes):
           6 ( 2.78% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
           6 ( 2.78% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
           1 ( 0.46% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int

Top method improvements (bytes):
        -104 (-5.68% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
        -104 (-7.28% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -77 (-5.95% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -22 (-1.45% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -22 (-1.45% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -12 (-0.66% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -12 (-0.66% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int

Top method regressions (percentages):
           6 ( 2.78% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
           6 ( 2.78% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
           1 ( 0.46% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int

Top method improvements (percentages):
        -104 (-7.28% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -77 (-5.95% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
        -104 (-5.68% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -22 (-1.45% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -22 (-1.45% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -12 (-0.66% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -12 (-0.66% of base) - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int

10 total methods with Code Size differences (7 improved, 3 regressed), 0 unchanged.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 417
Total bytes of diff: 468
Total bytes of delta: 51 (12.23% of base)
    diff is a regression.


Top method regressions (bytes):
          51 (12.23% of base) - System.Net.WebSockets.ManagedWebSocket:ApplyMask(System.Span`1[Byte],int,int):int

Top method regressions (percentages):
          51 (12.23% of base) - System.Net.WebSockets.ManagedWebSocket:ApplyMask(System.Span`1[Byte],int,int):int

1 total methods with Code Size differences (0 improved, 1 regressed), 0 unchanged.
```
</details>

Naturally, no diffs for win-x64, linux-x64 or linux-arm.

#### Don't fold casts from constants in UMOD morphing

It used to be that `ldc.i4.1 conv.i8` sequences survived
importation, and since division morphing is sensitive to
constant divisors, morph tried to fold them. This is
no longer the case, so stop doing that.

Of couse, morph can be called from anywhere at any
point, but if some code is creating casts from constants,
the proper place to fix is that code.

No diffs for win-x86 or win-x64 or linux-arm.

There is one more place in morph (`GTF_MUL_64RSLT` recognition) that needs fixing for the same reasons as above, but that one actually has CQ (I regressed it with #47133) _and_ correctness (it can lead to silent bad codegen) implications, so it will be a separate PR.

cc @sandreenko