### PR TITLE
Fix Culture Native and Display Names

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Locale.cs
+++ b/src/libraries/Common/src/Interop/Interop.Locale.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool GetLocaleInfoString(string localeName, uint localeStringData, char* value, int valueLength);
+        internal static extern unsafe bool GetLocaleInfoString(string localeName, uint localeStringData, char* value, int valueLength, string? uiLocaleName = null);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
@@ -94,6 +94,7 @@ typedef void* UCalendar;
 
 typedef enum UErrorCode {
     U_STRING_NOT_TERMINATED_WARNING = -124,
+    U_USING_DEFAULT_WARNING = -127,
     U_ZERO_ERROR =  0,
     U_ILLEGAL_ARGUMENT_ERROR = 1,
     U_INTERNAL_PROGRAM_ERROR = 5,
@@ -441,7 +442,7 @@ UChar * u_strcpy(UChar * dst, const UChar * src);
 UChar * u_strncpy(UChar * dst, const UChar * src, int32_t n);
 UChar32 u_tolower(UChar32 c);
 UChar32 u_toupper(UChar32 c);
-UChar* u_uastrcpy(UChar * dst, const char * src);	
+UChar* u_uastrcpy(UChar * dst, const char * src);
 void ucal_add(UCalendar * cal, UCalendarDateFields field, int32_t amount, UErrorCode * status);
 void ucal_close(UCalendar * cal);
 int32_t ucal_get(const UCalendar * cal, UCalendarDateFields field, UErrorCode * status);
@@ -455,7 +456,7 @@ int32_t ucal_getWindowsTimeZoneID(const UChar *	id, int32_t	len, UChar * winid, 
 UCalendar * ucal_open(const UChar * zoneID, int32_t len, const char * locale, UCalendarType type, UErrorCode * status);
 UEnumeration * ucal_openTimeZoneIDEnumeration(USystemTimeZoneType zoneType, const char * region, const int32_t * rawOffset, UErrorCode * ec);
 void ucal_set(UCalendar * cal, UCalendarDateFields field, int32_t value);
-void ucal_setMillis(UCalendar * cal, UDate dateTime, UErrorCode * status);	
+void ucal_setMillis(UCalendar * cal, UDate dateTime, UErrorCode * status);
 void ucol_close(UCollator * coll);
 void ucol_closeElements(UCollationElements * elems);
 int32_t ucol_getOffset(const UCollationElements *elems);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.h
@@ -46,7 +46,8 @@ typedef enum
 PALEXPORT int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
                                                           LocaleStringData localeStringData,
                                                           UChar* value,
-                                                          int32_t valueLength);
+                                                          int32_t valueLength,
+                                                          const UChar* uiLocaleName);
 
 PALEXPORT int32_t GlobalizationNative_GetLocaleTimeFormat(const UChar* localeName,
                                                           int shortFormat, UChar* value,

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
@@ -10,7 +10,9 @@ namespace System.Globalization.Tests
 {
     public class CultureInfoNames
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        private static bool SupportFullIcuResources => PlatformDetection.IsNotMobile && PlatformDetection.IsIcuGlobalization;
+
+        [ConditionalTheory(nameof(SupportFullIcuResources))]
         [InlineData("en", "en", "English", "English")]
         [InlineData("en", "fr", "English", "anglais")]
         [InlineData("aa", "aa", "Afar", "Afar")]
@@ -31,7 +33,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        [ConditionalFact(nameof(SupportFullIcuResources))]
         public void TestDisplayNameWithSettingUICultureMultipleTime()
         {
             using (new ThreadCultureChange(null, CultureInfo.GetCultureInfo("en-US")))

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
@@ -33,5 +33,22 @@ namespace System.Globalization.Tests
                 Assert.Equal(display, ci.DisplayName);
             }, cultureName, uiCultureName, nativeName, displayName).Dispose();
         }
+
+        [ConditionalFact(nameof(IsIcuAndRemoteExecutionSupported))]
+        public void TestDisplayNameWithSettingUICultureMultipleTime()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                CultureInfo ci = CultureInfo.GetCultureInfo("en-US");
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+                Assert.Equal("English (United States)", ci.DisplayName);
+
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+                Assert.Equal("anglais (États-Unis)", ci.DisplayName);
+
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+                Assert.Equal("Englisch (Vereinigte Staaten)", ci.DisplayName);
+            }).Dispose();
+        }
     }
 }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Tests;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -22,42 +23,25 @@ namespace System.Globalization.Tests
         [InlineData("", "", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
         public void TestDisplayName(string cultureName, string uiCultureName, string nativeName, string displayName)
         {
-            CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
-
-            try
+            using (new ThreadCultureChange(null, CultureInfo.GetCultureInfo(uiCultureName)))
             {
                 CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
-                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(uiCultureName);
-
                 Assert.Equal(nativeName, ci.NativeName);
                 Assert.Equal(displayName, ci.DisplayName);
-            }
-            finally
-            {
-                CultureInfo.CurrentUICulture = originalUiCulture;
             }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         public void TestDisplayNameWithSettingUICultureMultipleTime()
         {
-            CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
-
-            try
+            using (new ThreadCultureChange(null, CultureInfo.GetCultureInfo("en-US")))
             {
-                CultureInfo ci = CultureInfo.GetCultureInfo("en-US");
-                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+                CultureInfo ci = new CultureInfo("en-US");
                 Assert.Equal("English (United States)", ci.DisplayName);
-
                 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
                 Assert.Equal("anglais (États-Unis)", ci.DisplayName);
-
                 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
                 Assert.Equal("Englisch (Vereinigte Staaten)", ci.DisplayName);
-            }
-            finally
-            {
-                CultureInfo.CurrentUICulture = originalUiCulture;
             }
         }
     }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNames.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Globalization.Tests
+{
+    public class CultureInfoNames
+    {
+        private static bool IsIcuAndRemoteExecutionSupported => RemoteExecutor.IsSupported && PlatformDetection.IsIcuGlobalization;
+        [ConditionalTheory(nameof(IsIcuAndRemoteExecutionSupported))]
+        [InlineData("en", "en", "English", "English")]
+        [InlineData("en", "fr", "English", "anglais")]
+        [InlineData("aa", "aa", "Afar", "Afar")]
+        [InlineData("en-US", "en-US", "English (United States)", "English (United States)")]
+        [InlineData("en-US", "fr-FR", "English (United States)", "anglais (États-Unis)")]
+        [InlineData("en-US", "de-DE", "English (United States)", "Englisch (Vereinigte Staaten)")]
+        [InlineData("aa-ER", "aa-ER", "Afar (Eritrea)", "Afar (Eritrea)")]
+        [InlineData("", "en-US", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
+        [InlineData("", "fr-FR", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
+        [InlineData("", "", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
+        public void TestDisplayName(string cultureName, string uiCultureName, string nativeName, string displayName)
+        {
+            RemoteExecutor.Invoke((locale, uiLocale, native, display) =>
+            {
+                CultureInfo ci = CultureInfo.GetCultureInfo(locale);
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(uiLocale);
+
+                Assert.Equal(native, ci.NativeName);
+                Assert.Equal(display, ci.DisplayName);
+            }, cultureName, uiCultureName, nativeName, displayName).Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="CultureInfo\CultureInfoGetFormat.cs" />
     <Compile Include="CultureInfo\CultureInfoGetHashCode.cs" />
     <Compile Include="CultureInfo\CultureInfoIsNeutralCulture.cs" />
+    <Compile Include="CultureInfo\CultureInfoNames.cs" />
     <Compile Include="CultureInfo\CultureInfoNativeName.cs" />
     <Compile Include="CultureInfo\CultureInfoNumberFormat.cs" />
     <Compile Include="CultureInfo\CultureInfoParent.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -103,17 +103,17 @@ namespace System.Globalization
             return true;
         }
 
-        private string IcuGetLocaleInfo(LocaleStringData type)
+        private string IcuGetLocaleInfo(LocaleStringData type, string? uiCultureName = null)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(_sWindowsName != null, "[CultureData.IcuGetLocaleInfo] Expected _sWindowsName to be populated already");
-            return IcuGetLocaleInfo(_sWindowsName, type);
+            return IcuGetLocaleInfo(_sWindowsName, type, uiCultureName);
         }
 
         // For LOCALE_SPARENT we need the option of using the "real" name (forcing neutral names) instead of the
         // "windows" name, which can be specific for downlevel (< windows 7) os's.
-        private unsafe string IcuGetLocaleInfo(string localeName, LocaleStringData type)
+        private unsafe string IcuGetLocaleInfo(string localeName, LocaleStringData type, string? uiCultureName = null)
         {
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(localeName != null, "[CultureData.IcuGetLocaleInfo] Expected localeName to be not be null");
@@ -127,7 +127,7 @@ namespace System.Globalization
             }
 
             char* buffer = stackalloc char[ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY];
-            bool result = Interop.Globalization.GetLocaleInfoString(localeName, (uint)type, buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
+            bool result = Interop.Globalization.GetLocaleInfoString(localeName, (uint)type, buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY, uiCultureName);
             if (!result)
             {
                 // Failed, just use empty string
@@ -204,22 +204,13 @@ namespace System.Globalization
             return ConvertIcuTimeFormatString(span.Slice(0, span.IndexOf('\0')));
         }
 
-        private static CultureData? IcuGetCultureDataFromRegionName(string? regionName)
-        {
-            // no support to lookup by region name, other than the hard-coded list in CultureData
-            return null;
-        }
+        // no support to lookup by region name, other than the hard-coded list in CultureData
+        private static CultureData? IcuGetCultureDataFromRegionName(string? regionName) => null;
 
-        private static string IcuGetLanguageDisplayName(string cultureName)
-        {
-            return new CultureInfo(cultureName)._cultureData.IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName);
-        }
+        private string IcuGetLanguageDisplayName(string cultureName) => IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName, CultureInfo.CurrentUICulture.Name);
 
-        private static string? IcuGetRegionDisplayName()
-        {
-            // use the fallback which is to return NativeName
-            return null;
-        }
+        // use the fallback which is to return NativeName
+        private static string? IcuGetRegionDisplayName() => null;
 
         internal static bool IcuIsEnsurePredefinedLocaleName(string name)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -49,7 +49,6 @@ namespace System.Globalization
         // Identity
         private string? _sName; // locale name (ie: en-us, NO sort info, but could be neutral)
         private string? _sParent; // Parent name (which may be a custom locale/culture)
-        private string? _sLocalizedDisplayName; // Localized pretty name for this locale
         private string? _sEnglishDisplayName; // English pretty name for this locale
         private string? _sNativeDisplayName; // Native pretty name for this locale
         private string? _sSpecificCulture; // The culture name to be used in CultureInfo.CreateSpecificCulture(), en-US form if neutral, sort name if sort
@@ -57,7 +56,6 @@ namespace System.Globalization
         // Language
         private string? _sISO639Language; // ISO 639 Language Name
         private string? _sISO639Language2; // ISO 639 Language Name
-        private string? _sLocalizedLanguage; // Localized name for this language
         private string? _sEnglishLanguage; // English name for this language
         private string? _sNativeLanguage; // Native name of this language
         private string? _sAbbrevLang; // abbreviated language name (Windows Language Name) ex: ENU
@@ -563,7 +561,6 @@ namespace System.Globalization
             // Language
             invariant._sISO639Language = "iv";                   // ISO 639 Language Name
             invariant._sISO639Language2 = "ivl";                  // 3 char ISO 639 lang name 2
-            invariant._sLocalizedLanguage = "Invariant Language";   // Display name for this Language
             invariant._sEnglishLanguage = "Invariant Language";   // English name for this language
             invariant._sNativeLanguage = "Invariant Language";   // Native name of this language
             invariant._sAbbrevLang = "IVL";                  // abbreviated language name (Windows Language Name)
@@ -647,7 +644,6 @@ namespace System.Globalization
 
             if (GlobalizationMode.Invariant)
             {
-                invariant._sLocalizedDisplayName = invariant._sNativeDisplayName;
                 invariant._sLocalizedCountry = invariant._sNativeCountry;
             }
 
@@ -931,74 +927,37 @@ namespace System.Globalization
         {
             get
             {
-                string? localizedDisplayName = _sLocalizedDisplayName;
-                if (localizedDisplayName == null && !GlobalizationMode.Invariant)
+                string? localizedDisplayName = NativeName;
+                if (!GlobalizationMode.Invariant && Name.Length > 0)
                 {
-                    if (IsSupplementalCustomCulture)
+                    try
                     {
-                        if (IsNeutralCulture)
+                        const string ZH_CHT = "zh-CHT";
+                        const string ZH_CHS = "zh-CHS";
+
+                        if (Name.Equals(ZH_CHT, StringComparison.OrdinalIgnoreCase))
                         {
-                            localizedDisplayName = NativeLanguageName;
+                            localizedDisplayName = GetLanguageDisplayNameCore("zh-Hant");
+                        }
+                        else if (Name.Equals(ZH_CHS, StringComparison.OrdinalIgnoreCase))
+                        {
+                            localizedDisplayName = GetLanguageDisplayNameCore("zh-Hans");
                         }
                         else
                         {
-                            localizedDisplayName = NativeName;
+                            localizedDisplayName = GetLanguageDisplayNameCore(Name);
                         }
                     }
-                    else
+                    catch
                     {
-                        try
-                        {
-                            const string ZH_CHT = "zh-CHT";
-                            const string ZH_CHS = "zh-CHS";
-
-                            if (Name.Equals(ZH_CHT, StringComparison.OrdinalIgnoreCase))
-                            {
-                                localizedDisplayName = GetLanguageDisplayNameCore("zh-Hant");
-                            }
-                            else if (Name.Equals(ZH_CHS, StringComparison.OrdinalIgnoreCase))
-                            {
-                                localizedDisplayName = GetLanguageDisplayNameCore("zh-Hans");
-                            }
-                            else
-                            {
-                                localizedDisplayName = GetLanguageDisplayNameCore(Name);
-                            }
-                        }
-                        catch
-                        {
-                            // do nothing
-                        }
+                        // do nothing
                     }
 
                     // If it hasn't been found (Windows 8 and up), fallback to the system
-                    if (string.IsNullOrEmpty(localizedDisplayName))
+                    if (string.IsNullOrEmpty(localizedDisplayName) && IsNeutralCulture)
                     {
-                        // If its neutral use the language name
-                        if (IsNeutralCulture)
-                        {
-                            localizedDisplayName = LocalizedLanguageName;
-                        }
-                        else
-                        {
-                            // Usually the UI culture shouldn't be different than what we got from WinRT except
-                            // if DefaultThreadCurrentUICulture was set
-                            CultureInfo ci;
-
-                            if (CultureInfo.DefaultThreadCurrentUICulture != null &&
-                                ((ci = CultureInfo.GetUserDefaultCulture()) != null) &&
-                                !CultureInfo.DefaultThreadCurrentUICulture.Name.Equals(ci.Name))
-                            {
-                                localizedDisplayName = NativeName;
-                            }
-                            else
-                            {
-                                localizedDisplayName = GetLocaleInfoCore(LocaleStringData.LocalizedDisplayName);
-                            }
-                        }
+                        localizedDisplayName = LocalizedLanguageName;
                     }
-
-                    _sLocalizedDisplayName = localizedDisplayName;
                 }
 
                 return localizedDisplayName!;
@@ -1148,7 +1107,8 @@ namespace System.Globalization
         {
             get
             {
-                if (_sLocalizedLanguage == null && !GlobalizationMode.Invariant)
+                string sLocalizedLanguage = NativeLanguageName;
+                if (!GlobalizationMode.Invariant && Name.Length > 0)
                 {
                     // Usually the UI culture shouldn't be different than what we got from WinRT except
                     // if DefaultThreadCurrentUICulture was set
@@ -1158,15 +1118,15 @@ namespace System.Globalization
                         ((ci = CultureInfo.GetUserDefaultCulture()) != null) &&
                         !CultureInfo.DefaultThreadCurrentUICulture!.Name.Equals(ci.Name))
                     {
-                        _sLocalizedLanguage = NativeLanguageName;
+                        sLocalizedLanguage = NativeLanguageName;
                     }
                     else
                     {
-                        _sLocalizedLanguage = GetLocaleInfoCore(LocaleStringData.LocalizedLanguageName);
+                        sLocalizedLanguage = GetLocaleInfoCore(LocaleStringData.LocalizedLanguageName, CultureInfo.CurrentUICulture.Name);
                     }
                 }
 
-                return _sLocalizedLanguage!;
+                return sLocalizedLanguage;
             }
         }
 
@@ -2292,22 +2252,22 @@ namespace System.Globalization
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
         }
 
-        private string GetLocaleInfoCore(LocaleStringData type)
+        private string GetLocaleInfoCore(LocaleStringData type, string? uiCultureName = null)
         {
             // This is never reached but helps illinker statically remove dependencies
             if (GlobalizationMode.Invariant)
                 return null!;
 
-            return GlobalizationMode.UseNls ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
+            return GlobalizationMode.UseNls ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type, uiCultureName);
         }
 
-        private string GetLocaleInfoCore(string localeName, LocaleStringData type)
+        private string GetLocaleInfoCore(string localeName, LocaleStringData type, string? uiCultureName = null)
         {
             // This is never reached but helps illinker statically remove dependencies
             if (GlobalizationMode.Invariant)
                 return null!;
 
-            return GlobalizationMode.UseNls ? NlsGetLocaleInfo(localeName, type) : IcuGetLocaleInfo(localeName, type);
+            return GlobalizationMode.UseNls ? NlsGetLocaleInfo(localeName, type) : IcuGetLocaleInfo(localeName, type, uiCultureName);
         }
 
         private int[] GetLocaleInfoCoreUserOverride(LocaleGroupingData type)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -932,21 +932,10 @@ namespace System.Globalization
                 {
                     try
                     {
-                        const string ZH_CHT = "zh-CHT";
-                        const string ZH_CHS = "zh-CHS";
-
-                        if (Name.Equals(ZH_CHT, StringComparison.OrdinalIgnoreCase))
-                        {
-                            localizedDisplayName = GetLanguageDisplayNameCore("zh-Hant");
-                        }
-                        else if (Name.Equals(ZH_CHS, StringComparison.OrdinalIgnoreCase))
-                        {
-                            localizedDisplayName = GetLanguageDisplayNameCore("zh-Hans");
-                        }
-                        else
-                        {
-                            localizedDisplayName = GetLanguageDisplayNameCore(Name);
-                        }
+                        localizedDisplayName = GetLanguageDisplayNameCore(
+                            Name.Equals("zh-CHT", StringComparison.OrdinalIgnoreCase) ? "zh-Hant" :
+                            Name.Equals("zh-CHS", StringComparison.OrdinalIgnoreCase) ? "zh-Hans" :
+                            Name);
                     }
                     catch
                     {
@@ -1106,17 +1095,17 @@ namespace System.Globalization
         {
             get
             {
-                string sLocalizedLanguage = NativeLanguageName;
+                string localizedLanguage = NativeLanguageName;
                 if (!GlobalizationMode.Invariant && Name.Length > 0)
                 {
                     // If ICU is enabled we call it anyway. If NLS, we call it only if the Windows UI language match the Current UI language
                     if (!GlobalizationMode.UseNls || CultureInfo.UserDefaultUICulture?.Name == CultureInfo.CurrentUICulture.Name)
                     {
-                        sLocalizedLanguage = GetLocaleInfoCore(LocaleStringData.LocalizedLanguageName, CultureInfo.CurrentUICulture.Name);
+                        localizedLanguage = GetLocaleInfoCore(LocaleStringData.LocalizedLanguageName, CultureInfo.CurrentUICulture.Name);
                     }
                 }
 
-                return sLocalizedLanguage;
+                return localizedLanguage;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -1100,8 +1100,7 @@ namespace System.Globalization
                                                                             IcuGetThreeLetterWindowsLanguageName(_sRealName!);
 
         /// <summary>
-        /// Localized name for this language (Windows Only) ie: Inglis
-        /// This is only valid for Windows 8 and higher neutrals:
+        /// Localized name for this language
         /// </summary>
         private string LocalizedLanguageName
         {
@@ -1110,17 +1109,8 @@ namespace System.Globalization
                 string sLocalizedLanguage = NativeLanguageName;
                 if (!GlobalizationMode.Invariant && Name.Length > 0)
                 {
-                    // Usually the UI culture shouldn't be different than what we got from WinRT except
-                    // if DefaultThreadCurrentUICulture was set
-                    CultureInfo ci;
-
-                    if (CultureInfo.DefaultThreadCurrentUICulture != null &&
-                        ((ci = CultureInfo.GetUserDefaultCulture()) != null) &&
-                        !CultureInfo.DefaultThreadCurrentUICulture!.Name.Equals(ci.Name))
-                    {
-                        sLocalizedLanguage = NativeLanguageName;
-                    }
-                    else
+                    // If ICU is enabled we call it anyway. If NLS, we call it only if the Windows UI language match the Current UI language
+                    if (!GlobalizationMode.UseNls || CultureInfo.UserDefaultUICulture?.Name == CultureInfo.CurrentUICulture.Name)
                     {
                         sLocalizedLanguage = GetLocaleInfoCore(LocaleStringData.LocalizedLanguageName, CultureInfo.CurrentUICulture.Name);
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53362

This change is fixing the wrong behavior of the Culture Native and Display names. We had the following behavior:
- Display names were cached which is wrong. The display names should be treated as the localized resources and should be retrieved every time using the CurrentUICulture.
- There is some old special case for supplemental culture which is not applying anymore because Windows already using supplemental culture LCID values for some of its built-in cultures. 
- When requesting the native or display names using ICU, if ICU couldn't find a suitable resource for the request, it just return the culture name e.g. `en-US instead of English (United States) ` which is not suitable to use in the UI apps.

The fix here is doing the following:

- For display names now, we use CurrentUICulture to retrieve the name.
- Removed the supplemental culture special case. 
- When requesting the display and native names from ICU, we fallback to English names if couldn't find resources for the requested culture. 
- Added some test