### PR TITLE
Update clrjit.natvis to cover GT_SIMD and GT_HWINTRINSIC

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -41,6 +41,8 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Type Name="GenTreeOp">
     <DisplayString Condition="this->gtOper==GT_ASG">[{this-&gt;gtOp1,na}={this-&gt;gtOp2,na}]</DisplayString>
     <DisplayString Condition="this->gtOper==GT_CAST">[{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}]</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_SIMD">[{((GenTreeSIMD*)this)-&gt;gtSIMDIntrinsicID,en}, {gtType,en}]</DisplayString>
+    <DisplayString Condition="this->gtOper==GT_HWINTRINSIC">[{((GenTreeHWIntrinsic*)this)-&gt;gtHWIntrinsicId,en}, {gtType,en}]</DisplayString>
     <DisplayString>[{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>
 


### PR DESCRIPTION
Small improvement so we can get the actual intrinsic operation listed.

Ideally we'd also print the simd type and base type (e.g. `TYP_SIMD32<TYP_FLOAT>`) but natvis doesn't allow function evaluation (it just shows `???<???>` until you explicitly refresh) and the backing fields aren't the "right type" (both `unsigned char` to save on size)