### PR TITLE
Added some logic to include rcwrefcache references required by feature_comwrappers

### DIFF
--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -568,6 +568,9 @@ if(FEATURE_COMWRAPPERS OR FEATURE_OBJCMARSHAL)
             interoplibinterface.cpp
             rcwrefcache.cpp
         )
+        list(APPEND VM_HEADERS_WKS
+            rcwrefcache.h
+        )
     endif (FEATURE_COMWRAPPERS)
 
     if (FEATURE_OBJCMARSHAL)
@@ -660,12 +663,6 @@ if(CLR_CMAKE_TARGET_WIN32)
     )
 
 endif(CLR_CMAKE_TARGET_WIN32)
-
-if(CLR_CMAKE_HOST_UNIX)          
-    list(APPEND VM_HEADERS_WKS
-        rcwrefcache.h
-        )
-endif(CLR_CMAKE_HOST_UNIX)
 
 if(CLR_CMAKE_TARGET_WIN32)
 

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -630,7 +630,6 @@ if(CLR_CMAKE_TARGET_WIN32)
         mngstdinterfaces.cpp
         notifyexternals.cpp
         olecontexthelpers.cpp
-        rcwrefcache.cpp
         runtimecallablewrapper.cpp
         stdinterfaces.cpp
         stdinterfaces_wrapper.cpp
@@ -648,7 +647,6 @@ if(CLR_CMAKE_TARGET_WIN32)
         mngstdinterfaces.h
         notifyexternals.h
         olecontexthelpers.h
-        rcwrefcache.h
         runtimecallablewrapper.h
         stdinterfaces.h
         stdinterfaces_internal.h

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -660,6 +660,19 @@ if(CLR_CMAKE_TARGET_WIN32)
 
 endif(CLR_CMAKE_TARGET_WIN32)
 
+if(CLR_CMAKE_HOST_UNIX)
+    # COM wrappers scenarios
+    if (FEATURE_COMWRAPPERS)
+        list(APPEND VM_SOURCES_WKS
+            rcwrefcache.cpp
+            )
+    endif (FEATURE_COMWRAPPERS)      
+          
+    list(APPEND VM_HEADERS_WKS
+        rcwrefcache.h
+        )
+endif(CLR_CMAKE_HOST_UNIX)
+
 if(CLR_CMAKE_TARGET_WIN32)
 
 if(CLR_CMAKE_TARGET_ARCH_AMD64)

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -566,6 +566,7 @@ if(FEATURE_COMWRAPPERS OR FEATURE_OBJCMARSHAL)
     if (FEATURE_COMWRAPPERS)
         list(APPEND VM_SOURCES_WKS
             interoplibinterface.cpp
+            rcwrefcache.cpp
         )
     endif (FEATURE_COMWRAPPERS)
 
@@ -660,14 +661,7 @@ if(CLR_CMAKE_TARGET_WIN32)
 
 endif(CLR_CMAKE_TARGET_WIN32)
 
-if(CLR_CMAKE_HOST_UNIX)
-    # COM wrappers scenarios
-    if (FEATURE_COMWRAPPERS)
-        list(APPEND VM_SOURCES_WKS
-            rcwrefcache.cpp
-            )
-    endif (FEATURE_COMWRAPPERS)      
-          
+if(CLR_CMAKE_HOST_UNIX)          
     list(APPEND VM_HEADERS_WKS
         rcwrefcache.h
         )

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -47,7 +47,6 @@
 #include "runtimecallablewrapper.h"
 #include "mngstdinterfaces.h"
 #include "olevariant.h"
-#include "rcwrefcache.h"
 #include "olecontexthelpers.h"
 #endif // FEATURE_COMINTEROP
 
@@ -2118,9 +2117,9 @@ AppDomain::AppDomain()
 #ifdef FEATURE_COMINTEROP
     m_pRCWCache = NULL;
 #endif //FEATURE_COMINTEROP
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)  
+#ifdef FEATURE_COMWRAPPERS
     m_pRCWRefCache = NULL;
-#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#endif // FEATURE_COMWRAPPERS
 
     m_handleStore = NULL;
 
@@ -4424,7 +4423,7 @@ void AppDomain::NotifyDebuggerUnload()
 
 #ifndef CROSSGEN_COMPILE
 
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMWRAPPERS
 
 RCWRefCache *AppDomain::GetRCWRefCache()
 {
@@ -4446,7 +4445,7 @@ RCWRefCache *AppDomain::GetRCWRefCache()
     }
     RETURN m_pRCWRefCache;
 }
-#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#endif // FEATURE_COMWRAPPERS
 
 #ifdef FEATURE_COMINTEROP
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2115,10 +2115,10 @@ AppDomain::AppDomain()
     m_pRootAssembly = NULL;
 
     m_dwFlags = 0;
-#if  defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 #ifdef FEATURE_COMINTEROP
     m_pRCWCache = NULL;
-#endif    
+#endif //FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)  
     m_pRCWRefCache = NULL;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -51,9 +51,9 @@
 #include "olecontexthelpers.h"
 #endif // FEATURE_COMINTEROP
 
-#if defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+#if defined(FEATURE_COMWRAPPERS)
 #include "rcwrefcache.h"
-#endif // defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+#endif // FEATURE_COMWRAPPERS
 
 #include "typeequivalencehash.hpp"
 
@@ -2116,7 +2116,9 @@ AppDomain::AppDomain()
 
     m_dwFlags = 0;
 #if  defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMINTEROP
     m_pRCWCache = NULL;
+#endif    
     m_pRCWRefCache = NULL;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -51,6 +51,10 @@
 #include "olecontexthelpers.h"
 #endif // FEATURE_COMINTEROP
 
+#if defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+#include "rcwrefcache.h"
+#endif // defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+
 #include "typeequivalencehash.hpp"
 
 #include "appdomain.inl"
@@ -2111,10 +2115,10 @@ AppDomain::AppDomain()
     m_pRootAssembly = NULL;
 
     m_dwFlags = 0;
-#ifdef FEATURE_COMINTEROP
+#if  defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
     m_pRCWCache = NULL;
     m_pRCWRefCache = NULL;
-#endif // FEATURE_COMINTEROP
+#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
     m_handleStore = NULL;
 
@@ -4418,7 +4422,7 @@ void AppDomain::NotifyDebuggerUnload()
 
 #ifndef CROSSGEN_COMPILE
 
-#ifdef FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
 RCWRefCache *AppDomain::GetRCWRefCache()
 {
@@ -4440,6 +4444,9 @@ RCWRefCache *AppDomain::GetRCWRefCache()
     }
     RETURN m_pRCWRefCache;
 }
+#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+
+#ifdef FEATURE_COMINTEROP
 
 RCWCache *AppDomain::CreateRCWCache()
 {

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -49,9 +49,9 @@ class TypeEquivalenceHashTable;
 #ifdef FEATURE_COMINTEROP
 class RCWCache;
 #endif //FEATURE_COMINTEROP
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMWRAPPERS
 class RCWRefCache;
-#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#endif // FEATURE_COMWRAPPERS
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1974,13 +1974,12 @@ public:
         return m_pRCWCache;
     }
 
-    RCWRefCache *GetRCWRefCache();
 #endif // FEATURE_COMINTEROP
 
-#if defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+#ifdef FEATURE_COMWRAPPERS
 public:
     RCWRefCache *GetRCWRefCache();
-#endif // defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+#endif // FEATURE_COMWRAPPERS
 
     TPIndex GetTPIndex()
     {
@@ -2248,10 +2247,10 @@ private:
     // this cache stores the RCWs in this domain
     RCWCache *m_pRCWCache;
 #endif //FEATURE_COMINTEROP
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMWRAPPERS
     // this cache stores the RCW -> CCW references in this domain
     RCWRefCache *m_pRCWRefCache;
-#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#endif // FEATURE_COMWRAPPERS
 
     // The thread-pool index of this app domain among existing app domains (starting from 1)
     TPIndex m_tpIndex;

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -47,7 +47,9 @@ class LoadLevelLimiter;
 class TypeEquivalenceHashTable;
 
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMINTEROP
 class RCWCache;
+#endif
 class RCWRefCache;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
@@ -2243,9 +2245,10 @@ private:
     MapSHash<LPCUTF8, PTR_NativeImage, NativeImageIndexTraits> m_nativeImageMap;
 
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
+#ifdef FEATURE_COMINTEROP
     // this cache stores the RCWs in this domain
     RCWCache *m_pRCWCache;
-
+#endif
     // this cache stores the RCW -> CCW references in this domain
     RCWRefCache *m_pRCWRefCache;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -46,10 +46,10 @@ class DomainAssembly;
 class LoadLevelLimiter;
 class TypeEquivalenceHashTable;
 
-#ifdef FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 class RCWCache;
 class RCWRefCache;
-#endif // FEATURE_COMINTEROP
+#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1975,6 +1975,11 @@ public:
     RCWRefCache *GetRCWRefCache();
 #endif // FEATURE_COMINTEROP
 
+#if defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+public:
+    RCWRefCache *GetRCWRefCache();
+#endif // defined(FEATURE_COMWRAPPERS) && !defined(FEATURE_COMINTEROP)
+
     TPIndex GetTPIndex()
     {
         LIMITED_METHOD_CONTRACT;
@@ -2237,13 +2242,13 @@ private:
     CrstExplicitInit m_nativeImageLoadCrst;
     MapSHash<LPCUTF8, PTR_NativeImage, NativeImageIndexTraits> m_nativeImageMap;
 
-#ifdef FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
     // this cache stores the RCWs in this domain
     RCWCache *m_pRCWCache;
 
     // this cache stores the RCW -> CCW references in this domain
     RCWRefCache *m_pRCWRefCache;
-#endif // FEATURE_COMINTEROP
+#endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
     // The thread-pool index of this app domain among existing app domains (starting from 1)
     TPIndex m_tpIndex;

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -46,10 +46,10 @@ class DomainAssembly;
 class LoadLevelLimiter;
 class TypeEquivalenceHashTable;
 
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 #ifdef FEATURE_COMINTEROP
 class RCWCache;
-#endif
+#endif //FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 class RCWRefCache;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
@@ -2244,11 +2244,11 @@ private:
     CrstExplicitInit m_nativeImageLoadCrst;
     MapSHash<LPCUTF8, PTR_NativeImage, NativeImageIndexTraits> m_nativeImageMap;
 
-#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 #ifdef FEATURE_COMINTEROP
     // this cache stores the RCWs in this domain
     RCWCache *m_pRCWCache;
-#endif
+#endif //FEATURE_COMINTEROP
+#if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
     // this cache stores the RCW -> CCW references in this domain
     RCWRefCache *m_pRCWRefCache;
 #endif // defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)


### PR DESCRIPTION
In order to build clr subset on unix with feature_comwrappers enabled, we made some changes to fix error found in interoplibinterface.cpp due to the lack of GetRCWRefCache()