### PR TITLE
Fix arm build fail with clang11

### DIFF
--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -294,7 +294,7 @@ inline void emitJump(LPBYTE pBuffer, LPVOID target)
 
     // ldr pc, [pc, #0]
     pCode[0] = 0xf000f8df;
-    pCode[1] = (DWORD)target;
+    pCode[1] = (DWORD)(size_t)target;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
fix ```error: cast to smaller integer type 'unsigned int' from 'void *'```