### PR TITLE
Convert some uses of ArrayList to List<T>

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -28,9 +27,9 @@ namespace Microsoft.XmlSerializer.Generator
         private int Run(string[] args)
         {
             string assembly = null;
-            List<string> types = new List<string>();
+            var types = new List<string>();
             string codePath = null;
-            var errs = new ArrayList();
+            var errs = new List<string>();
             bool force = false;
             bool proxyOnly = false;
             bool disableRun = true;
@@ -247,8 +246,8 @@ namespace Microsoft.XmlSerializer.Generator
                 }
             }
 
-            var mappings = new ArrayList();
-            var importedTypes = new ArrayList();
+            var mappings = new List<XmlMapping>();
+            var importedTypes = new List<Type>();
             var importer = new XmlReflectionImporter();
 
             for (int i = 0; i < types.Length; i++)
@@ -296,8 +295,8 @@ namespace Microsoft.XmlSerializer.Generator
 
             if (importedTypes.Count > 0)
             {
-                var serializableTypes = (Type[])importedTypes.ToArray(typeof(Type));
-                var allMappings = (XmlMapping[])mappings.ToArray(typeof(XmlMapping));
+                var serializableTypes = importedTypes.ToArray();
+                var allMappings = mappings.ToArray();
 
                 bool gac = assembly.GlobalAssemblyCache;
                 outputDirectory = outputDirectory == null ? (gac ? Environment.CurrentDirectory : Path.GetDirectoryName(assembly.Location)) : outputDirectory;
@@ -406,7 +405,7 @@ namespace Microsoft.XmlSerializer.Generator
             return arg.Equals(shortName, StringComparison.InvariantCultureIgnoreCase);
         }
 
-        private void ImportType(Type type, ArrayList mappings, ArrayList importedTypes, bool verbose, XmlReflectionImporter importer, bool parsableerrors)
+        private void ImportType(Type type, List<XmlMapping> mappings, List<Type> importedTypes, bool verbose, XmlReflectionImporter importer, bool parsableerrors)
         {
             XmlTypeMapping xmlTypeMapping = null;
             var localImporter = new XmlReflectionImporter();

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -215,7 +215,8 @@ namespace System.ComponentModel.Design
                             propList.AddRange(child.Properties);
                         }
 
-                        PropertyDescriptor[] propArray = (PropertyDescriptor[])propList.ToArray(typeof(PropertyDescriptor));
+                        var propArray = new PropertyDescriptor[propList.Count];
+                        propList.CopyTo(propArray);
                         _properties = new PropertyDescriptorCollection(propArray, true);
                     }
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1052,7 +1052,9 @@ namespace System.ComponentModel
                 ArrayList filteredEvents = FilterMembers(events, attributes);
                 if (filteredEvents != null)
                 {
-                    events = new EventDescriptorCollection((EventDescriptor[])filteredEvents.ToArray(typeof(EventDescriptor)), true);
+                    var descriptors = new EventDescriptor[filteredEvents.Count];
+                    filteredEvents.CopyTo(descriptors);
+                    events = new EventDescriptorCollection(descriptors, true);
                 }
             }
 
@@ -1281,7 +1283,9 @@ namespace System.ComponentModel
                 ArrayList filteredProperties = FilterMembers(properties, attributes);
                 if (filteredProperties != null)
                 {
-                    properties = new PropertyDescriptorCollection((PropertyDescriptor[])filteredProperties.ToArray(typeof(PropertyDescriptor)), true);
+                    var descriptors = new PropertyDescriptor[filteredProperties.Count];
+                    filteredProperties.CopyTo(descriptors);
+                    properties = new PropertyDescriptorCollection(descriptors, true);
                 }
             }
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
@@ -771,7 +771,7 @@ namespace System.Configuration
         /// </summary>
         private PropertyInfo[] SettingsFilter(PropertyInfo[] allProps)
         {
-            ArrayList settingProps = new ArrayList();
+            var settingProps = new List<PropertyInfo>();
             object[] attributes;
             Attribute attr;
 
@@ -789,7 +789,7 @@ namespace System.Configuration
                 }
             }
 
-            return (PropertyInfo[])settingProps.ToArray(typeof(PropertyInfo));
+            return settingProps.ToArray();
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.Design;
@@ -1179,7 +1180,7 @@ namespace System.Diagnostics
             EventLogInternal[] interestedComponents;
             lock (InternalSyncObject)
             {
-                interestedComponents = (EventLogInternal[])info.listeningComponents.ToArray(typeof(EventLogInternal));
+                interestedComponents = info.listeningComponents.ToArray();
             }
 
             for (int i = 0; i < interestedComponents.Length; i++)
@@ -1413,7 +1414,7 @@ namespace System.Diagnostics
             public EventLogInternal handleOwner;
             public RegisteredWaitHandle registeredWaitHandle;
             public WaitHandle waitHandle;
-            public ArrayList listeningComponents = new ArrayList();
+            public List<EventLogInternal> listeningComponents = new();
         }
     }
 }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServerCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServerCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.DirectoryServices.ActiveDirectory
@@ -14,7 +15,7 @@ namespace System.DirectoryServices.ActiveDirectory
         internal readonly DirectoryContext context;
         internal bool initialized;
         internal readonly Hashtable? changeList;
-        private readonly ArrayList _copyList = new ArrayList();
+        private readonly List<object> _copyList = new();
         private readonly DirectoryEntry? _crossRefEntry;
         private readonly bool _isADAM;
         private readonly bool _isForNC;
@@ -263,7 +264,7 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 for (int i = 0; i < _copyList.Count; i++)
                 {
-                    OnRemoveComplete(i, _copyList[i]!);
+                    OnRemoveComplete(i, _copyList[i]);
                 }
             }
         }
@@ -397,7 +398,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal string[] GetMultiValuedProperty()
         {
-            ArrayList values = new ArrayList();
+            var values = new List<string>();
             for (int i = 0; i < InnerList.Count; i++)
             {
                 DirectoryServer ds = (DirectoryServer)InnerList[i]!;
@@ -405,7 +406,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 string ntdsaName = (ds is DomainController) ? ((DomainController)ds).NtdsaObjectName : ((AdamInstance)ds).NtdsaObjectName;
                 values.Add(ntdsaName);
             }
-            return (string[])values.ToArray(typeof(string));
+            return values.ToArray();
         }
     }
 }

--- a/src/libraries/System.IO.Ports/tests/SerialPort/DiscardNull.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/DiscardNull.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
@@ -380,8 +380,8 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_byte_int_int(SerialPort com)
         {
-            ArrayList receivedBytes = new ArrayList();
-            byte[] buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
+            var receivedBytes = new List<byte>();
+            var buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
             int totalBytesRead = 0;
             int numBytes;
 
@@ -403,14 +403,14 @@ namespace System.IO.Ports.Tests
             if (totalBytesRead < receivedBytes.Count)
                 receivedBytes.RemoveRange(totalBytesRead, receivedBytes.Count - totalBytesRead);
 
-            return com.Encoding.GetChars((byte[])receivedBytes.ToArray(typeof(byte)));
+            return com.Encoding.GetChars(receivedBytes.ToArray());
         }
 
 
         private char[] Read_char_int_int(SerialPort com)
         {
-            ArrayList receivedChars = new ArrayList();
-            char[] buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
+            var receivedChars = new List<char>();
+            var buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
             int totalCharsRead = 0;
             int numChars;
 
@@ -432,13 +432,13 @@ namespace System.IO.Ports.Tests
             if (totalCharsRead < receivedChars.Count)
                 receivedChars.RemoveRange(totalCharsRead, receivedChars.Count - totalCharsRead);
 
-            return (char[])receivedChars.ToArray(typeof(char));
+            return receivedChars.ToArray();
         }
 
 
         private char[] ReadByte(SerialPort com)
         {
-            ArrayList receivedBytes = new ArrayList();
+            var receivedBytes = new List<byte>();
             int rcvByte;
 
             while (true)
@@ -455,13 +455,13 @@ namespace System.IO.Ports.Tests
                 receivedBytes.Add((byte)rcvByte);
             }
 
-            return com.Encoding.GetChars((byte[])receivedBytes.ToArray(typeof(byte)));
+            return com.Encoding.GetChars(receivedBytes.ToArray());
         }
 
 
         private char[] ReadChar(SerialPort com)
         {
-            ArrayList receivedChars = new ArrayList();
+            var receivedChars = new List<char>();
             int rcvChar;
 
             while (true)
@@ -477,13 +477,13 @@ namespace System.IO.Ports.Tests
                 receivedChars.Add((char)rcvChar);
             }
 
-            return (char[])receivedChars.ToArray(typeof(char));
+            return receivedChars.ToArray();
         }
 
 
         private char[] ReadLine(SerialPort com)
         {
-            StringBuilder rcvStringBuilder = new StringBuilder();
+            var rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)
@@ -506,7 +506,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadTo(SerialPort com)
         {
-            StringBuilder rcvStringBuilder = new StringBuilder();
+            var rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)

--- a/src/libraries/System.IO.Ports/tests/SerialPort/ParityReplace.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/ParityReplace.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
@@ -297,8 +297,8 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_byte_int_int(SerialPort com)
         {
-            ArrayList receivedBytes = new ArrayList();
-            byte[] buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
+            var receivedBytes = new List<byte>();
+            var buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
             int totalBytesRead = 0;
 
             while (true)
@@ -320,14 +320,14 @@ namespace System.IO.Ports.Tests
             if (totalBytesRead < receivedBytes.Count)
                 receivedBytes.RemoveRange(totalBytesRead, receivedBytes.Count - totalBytesRead);
 
-            return com.Encoding.GetChars((byte[])receivedBytes.ToArray(typeof(byte)));
+            return com.Encoding.GetChars(receivedBytes.ToArray());
         }
 
 
         private char[] Read_char_int_int(SerialPort com)
         {
-            ArrayList receivedChars = new ArrayList();
-            char[] buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
+            var receivedChars = new List<char>();
+            var buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
             int totalCharsRead = 0;
             int numChars;
 
@@ -349,13 +349,13 @@ namespace System.IO.Ports.Tests
             if (totalCharsRead < receivedChars.Count)
                 receivedChars.RemoveRange(totalCharsRead, receivedChars.Count - totalCharsRead);
 
-            return (char[])receivedChars.ToArray(typeof(char));
+            return receivedChars.ToArray();
         }
 
 
         private char[] ReadByte(SerialPort com)
         {
-            ArrayList receivedBytes = new ArrayList();
+            var receivedBytes = new List<byte>();
             int rcvByte;
 
             while (true)
@@ -372,13 +372,13 @@ namespace System.IO.Ports.Tests
                 receivedBytes.Add((byte)rcvByte);
             }
 
-            return com.Encoding.GetChars((byte[])receivedBytes.ToArray(typeof(byte)));
+            return com.Encoding.GetChars(receivedBytes.ToArray());
         }
 
 
         private char[] ReadChar(SerialPort com)
         {
-            ArrayList receivedChars = new ArrayList();
+            var receivedChars = new List<char>();
             int rcvChar;
 
             while (true)
@@ -395,13 +395,13 @@ namespace System.IO.Ports.Tests
                 receivedChars.Add((char)rcvChar);
             }
 
-            return (char[])receivedChars.ToArray(typeof(char));
+            return receivedChars.ToArray();
         }
 
 
         private char[] ReadLine(SerialPort com)
         {
-            StringBuilder rcvStringBuilder = new StringBuilder();
+            var rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)
@@ -424,7 +424,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadTo(SerialPort com)
         {
-            StringBuilder rcvStringBuilder = new StringBuilder();
+            var rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -317,8 +317,8 @@ namespace System.Net.Mail
 
             System.Diagnostics.Debug.Assert(_readState == ReadState.Status0);
 
-            StringBuilder builder = new StringBuilder();
-            ArrayList lines = new ArrayList();
+            var builder = new StringBuilder();
+            var lines = new List<LineInfo>();
             int statusRead = 0;
 
             for (int start = 0, read = 0; ;)
@@ -354,7 +354,7 @@ namespace System.Net.Mail
                     if (oneLine)
                     {
                         _bufferedStream.Push(_byteBuffer, start, read - start);
-                        return (LineInfo[])lines.ToArray(typeof(LineInfo));
+                        return lines.ToArray();
                     }
                     builder = new StringBuilder();
                 }
@@ -362,7 +362,7 @@ namespace System.Net.Mail
                 {
                     lines.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // return everything except CRLF
                     _bufferedStream.Push(_byteBuffer, start, read - start);
-                    return (LineInfo[])lines.ToArray(typeof(LineInfo));
+                    return lines.ToArray();
                 }
             }
         }
@@ -370,7 +370,7 @@ namespace System.Net.Mail
         private sealed class ReadLinesAsyncResult : LazyAsyncResult
         {
             private StringBuilder? _builder;
-            private ArrayList? _lines;
+            private List<LineInfo>? _lines;
             private readonly SmtpReplyReaderFactory _parent;
             private static readonly AsyncCallback s_readCallback = new AsyncCallback(ReadCallback);
             private int _read;
@@ -406,7 +406,7 @@ namespace System.Net.Mail
                 System.Diagnostics.Debug.Assert(_parent._readState == ReadState.Status0);
 
                 _builder = new StringBuilder();
-                _lines = new ArrayList();
+                _lines = new List<LineInfo>();
 
                 Read();
             }
@@ -415,7 +415,7 @@ namespace System.Net.Mail
             {
                 ReadLinesAsyncResult thisPtr = (ReadLinesAsyncResult)result;
                 thisPtr.InternalWaitForCompletion();
-                return (LineInfo[])thisPtr._lines!.ToArray(typeof(LineInfo));
+                return thisPtr._lines!.ToArray();
             }
 
             private void Read()

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -434,16 +434,16 @@ namespace System.Net
                     if (domain_count > min_count)
                     {
                         // This case requires sorting all domain collections by timestamp.
-                        Array cookies;
-                        Array stamps;
+                        CookieCollection[] cookies;
+                        DateTime[] stamps;
                         lock (pathList.SyncRoot)
                         {
-                            cookies = Array.CreateInstance(typeof(CookieCollection), pathList.Count);
-                            stamps = Array.CreateInstance(typeof(DateTime), pathList.Count);
+                            cookies = new CookieCollection[pathList.Count];
+                            stamps = new DateTime[pathList.Count];
                             foreach (CookieCollection? cc in pathList.Values)
                             {
-                                stamps.SetValue(cc!.TimeStamp(CookieCollection.Stamp.Check), itemp);
-                                cookies.SetValue(cc, itemp);
+                                stamps[itemp] = cc!.TimeStamp(CookieCollection.Stamp.Check);
+                                cookies[itemp] = cc;
                                 ++itemp;
                             }
                         }
@@ -452,7 +452,7 @@ namespace System.Net
                         itemp = 0;
                         for (int i = 0; i < cookies.Length; ++i)
                         {
-                            CookieCollection cc = (CookieCollection)cookies.GetValue(i)!;
+                            CookieCollection cc = cookies[i];
 
                             lock (cc)
                             {

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -457,7 +457,8 @@ namespace System.Net
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             _responseUri = request.RequestUri;
-            ArrayList commandList = new ArrayList();
+
+            var commandList = new List<PipelineEntry>();
 
             if (request.EnableSsl && !UsingSecureStream)
             {
@@ -627,7 +628,7 @@ namespace System.Net
 
             commandList.Add(new PipelineEntry(FormatFtpCommand("QUIT", null)));
 
-            return (PipelineEntry[])commandList.ToArray(typeof(PipelineEntry));
+            return commandList.ToArray();
         }
 
         private PipelineInstruction QueueOrCreateDataConection(PipelineEntry entry, ResponseDescription response, bool timeout, ref Stream? stream, out bool isSocketReady)

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -66,7 +66,15 @@ namespace System.Net
         [AllowNull]
         public string[] BypassList
         {
-            get => _bypassList != null ? (string[])_bypassList.ToArray(typeof(string)) : Array.Empty<string>();
+            get
+            {
+                if (_bypassList == null)
+                    return Array.Empty<string>();
+
+                var bypassList = new string[_bypassList.Count];
+                _bypassList.CopyTo(bypassList);
+                return bypassList;
+            }
             set
             {
                 _bypassList = value != null ? new ArrayList(value) : null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -640,7 +640,7 @@ namespace System.Xml.Schema
         private XmlSchemaSimpleType[] CompileBaseMemberTypes(XmlSchemaSimpleType simpleType)
         {
             XmlSchemaSimpleType? unionMember;
-            ArrayList memberTypeDefinitions = new ArrayList();
+            var memberTypeDefinitions = new List<XmlSchemaSimpleType>();
 
             XmlSchemaSimpleTypeUnion mainUnion = (XmlSchemaSimpleTypeUnion)simpleType.Content!;
 
@@ -693,11 +693,11 @@ namespace System.Xml.Schema
             }
 
             //set all types
-            mainUnion.SetBaseMemberTypes((memberTypeDefinitions.ToArray(typeof(XmlSchemaSimpleType)) as XmlSchemaSimpleType[])!);
+            mainUnion.SetBaseMemberTypes(memberTypeDefinitions.ToArray());
             return mainUnion.BaseMemberTypes!;
         }
 
-        private void CheckUnionType(XmlSchemaSimpleType unionMember, ArrayList memberTypeDefinitions, XmlSchemaSimpleType parentType)
+        private void CheckUnionType(XmlSchemaSimpleType unionMember, List<XmlSchemaSimpleType> memberTypeDefinitions, XmlSchemaSimpleType parentType)
         {
             XmlSchemaDatatype unionDatatype = unionMember.Datatype!;
             if (unionMember.DerivedBy == XmlSchemaDerivationMethod.Restriction && (unionDatatype.HasLexicalFacets || unionDatatype.HasValueFacets))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -746,7 +746,7 @@ namespace System.Xml.Schema
         private XmlSchemaSimpleType[]? CompileBaseMemberTypes(XmlSchemaSimpleType simpleType)
         {
             XmlSchemaSimpleType? unionMember;
-            ArrayList memberTypeDefinitions = new ArrayList();
+            var memberTypeDefinitions = new List<XmlSchemaSimpleType>();
 
             XmlSchemaSimpleTypeUnion mainUnion = (XmlSchemaSimpleTypeUnion)simpleType.Content!;
 
@@ -798,11 +798,11 @@ namespace System.Xml.Schema
                 }
             }
             //set all types
-            mainUnion.SetBaseMemberTypes((memberTypeDefinitions.ToArray(typeof(XmlSchemaSimpleType)) as XmlSchemaSimpleType[])!);
+            mainUnion.SetBaseMemberTypes(memberTypeDefinitions.ToArray());
             return mainUnion.BaseMemberTypes;
         }
 
-        private void CheckUnionType(XmlSchemaSimpleType unionMember, ArrayList memberTypeDefinitions, XmlSchemaSimpleType parentType)
+        private void CheckUnionType(XmlSchemaSimpleType unionMember, List<XmlSchemaSimpleType> memberTypeDefinitions, XmlSchemaSimpleType parentType)
         {
             XmlSchemaDatatype unionDatatype = unionMember.Datatype!;
             if (unionMember.DerivedBy == XmlSchemaDerivationMethod.Restriction && (unionDatatype.HasLexicalFacets || unionDatatype.HasValueFacets))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
@@ -141,10 +141,6 @@ namespace System.Xml.Schema
         //Error message constants
         private const char Quote = '\'';
 
-        //Empty arrays
-        private static readonly XmlSchemaParticle[] s_emptyParticleArray = Array.Empty<XmlSchemaParticle>();
-        private static readonly XmlSchemaAttribute[] s_emptyAttributeArray = Array.Empty<XmlSchemaAttribute>();
-
         internal static bool[,] ValidStates = new bool[12, 12] {
                                                /*ValidatorState.None*/      /*ValidatorState.Start  /*ValidatorState.TopLevelAttribute*/     /*ValidatorState.TopLevelTOrWS*/ /*ValidatorState.Element*/      /*ValidatorState.Attribute*/    /*ValidatorState.EndAttributes*/    /*ValidatorState.Text/      /*ValidatorState.WS/*       /*ValidatorState.EndElement*/   /*ValidatorState.SkipToEndElement*/         /*ValidatorState.Finish*/
         /*ValidatorState.None*/             {  true,                        true,                     false,                                 false,                           false,                          false,                          false,                              false,                      false,                      false,                          false,                                      false},
@@ -1003,7 +999,7 @@ namespace System.Xml.Schema
                         return new XmlSchemaParticle[1] { element };
                     }
 
-                    return s_emptyParticleArray;
+                    return Array.Empty<XmlSchemaParticle>();
                 }
                 else
                 {
@@ -1028,7 +1024,7 @@ namespace System.Xml.Schema
                 }
             }
 
-            return s_emptyParticleArray;
+            return Array.Empty<XmlSchemaParticle>();
         }
 
         public XmlSchemaAttribute[] GetExpectedAttributes()
@@ -1065,7 +1061,7 @@ namespace System.Xml.Schema
                     }
                 }
             }
-            return s_emptyAttributeArray;
+            return Array.Empty<XmlSchemaAttribute>();
         }
 
         internal void GetUnspecifiedDefaultAttributes(ArrayList defaultAttributes, bool createNodeData)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
-using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml;
 using System.Xml.Serialization;
-using System.Collections.Generic;
 
 namespace System.Xml.Schema
 {
@@ -679,7 +678,7 @@ namespace System.Xml.Schema
         private XmlSchemaRedefine? _redefine;
 
         private readonly ValidationEventHandler? _validationEventHandler;
-        private readonly ArrayList _unhandledAttributes = new ArrayList();
+        private readonly List<XmlAttribute> _unhandledAttributes = new List<XmlAttribute>();
         private Dictionary<string, string>? _namespaces;
 
         internal XsdBuilder(
@@ -799,7 +798,7 @@ namespace System.Xml.Schema
                 }
                 if (_unhandledAttributes.Count != 0)
                 {
-                    _xso.SetUnhandledAttributes((XmlAttribute[])_unhandledAttributes.ToArray(typeof(System.Xml.XmlAttribute)));
+                    _xso.SetUnhandledAttributes(_unhandledAttributes.ToArray());
                     _unhandledAttributes.Clear();
                 }
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
@@ -5,6 +5,8 @@ namespace System.Xml.Serialization
 {
     using System.Reflection;
     using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Xml.Schema;
     using System;
     using System.Text;
@@ -765,14 +767,14 @@ namespace System.Xml.Serialization
             Array.Sort(elements, new AccessorComparer());
         }
 
-        internal sealed class AccessorComparer : IComparer
+        internal sealed class AccessorComparer : IComparer<ElementAccessor>
         {
-            public int Compare(object? o1, object? o2)
+            public int Compare(ElementAccessor? a1, ElementAccessor? a2)
             {
-                if (o1 == o2)
+                if (a1 == a2)
                     return 0;
-                Accessor a1 = (Accessor)o1!;
-                Accessor a2 = (Accessor)o2!;
+                Debug.Assert(a1 != null);
+                Debug.Assert(a2 != null);
                 int w1 = a1.Mapping!.TypeDesc!.Weight;
                 int w2 = a2.Mapping!.TypeDesc!.Weight;
                 if (w1 == w2)
@@ -880,13 +882,12 @@ namespace System.Xml.Serialization
         }
     }
 
-    internal sealed class MemberMappingComparer : IComparer
+    internal sealed class MemberMappingComparer : IComparer<MemberMapping>
     {
-        public int Compare(object? o1, object? o2)
+        public int Compare(MemberMapping? m1, MemberMapping? m2)
         {
-            MemberMapping m1 = (MemberMapping)o1!;
-            MemberMapping m2 = (MemberMapping)o2!;
-
+            Debug.Assert(m1 != null);
+            Debug.Assert(m2 != null);
             bool m1Text = m1.IsText;
             if (m1Text)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SoapReflectionImporter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SoapReflectionImporter.cs
@@ -7,7 +7,7 @@ namespace System.Xml.Serialization
     using System;
     using System.Globalization;
     using System.Xml.Schema;
-    using System.Collections;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Threading;
     using System.Xml;
@@ -382,7 +382,7 @@ namespace System.Xml.Serialization
                     return false;
                 }
             }
-            ArrayList members = new ArrayList();
+            var members = new List<MemberMapping>();
             foreach (MemberInfo memberInfo in model.GetMemberInfos())
             {
                 if (!(memberInfo is FieldInfo) && !(memberInfo is PropertyInfo))
@@ -407,7 +407,7 @@ namespace System.Xml.Serialization
                 }
                 members.Add(member);
             }
-            mapping.Members = (MemberMapping[])members.ToArray(typeof(MemberMapping));
+            mapping.Members = members.ToArray();
             if (mapping.BaseMapping == null) mapping.BaseMapping = GetRootMapping();
             IncludeTypes(model.Type, limiter);
 
@@ -572,7 +572,7 @@ namespace System.Xml.Serialization
                 mapping.IsFlags = model.Type.IsDefined(typeof(FlagsAttribute), false);
                 _typeScope.AddTypeMapping(mapping);
                 _types.Add(typeName, typeNs, mapping);
-                ArrayList constants = new ArrayList();
+                var constants = new List<ConstantMapping>();
                 for (int i = 0; i < model.Constants.Length; i++)
                 {
                     ConstantMapping? constant = ImportConstantMapping(model.Constants[i]);
@@ -582,7 +582,7 @@ namespace System.Xml.Serialization
                 {
                     throw new InvalidOperationException(SR.Format(SR.XmlNoSerializableMembers, model.TypeDesc.FullName));
                 }
-                mapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));
+                mapping.Constants = constants.ToArray();
             }
             return mapping;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -1066,12 +1066,12 @@ namespace System.Xml.Serialization
         {
             if (mapping.BaseMapping == null)
                 return mapping.Members!;
-            ArrayList list = new ArrayList();
+            var list = new List<MemberMapping>();
             GetAllMembers(mapping, list);
-            return (MemberMapping[])list.ToArray(typeof(MemberMapping));
+            return list.ToArray();
         }
 
-        internal static void GetAllMembers(StructMapping mapping, ArrayList list)
+        internal static void GetAllMembers(StructMapping mapping, List<MemberMapping> list)
         {
             if (mapping.BaseMapping != null)
             {
@@ -1092,12 +1092,12 @@ namespace System.Xml.Serialization
 
         internal static MemberMapping[] GetSettableMembers(StructMapping structMapping)
         {
-            ArrayList list = new ArrayList();
+            var list = new List<MemberMapping>();
             GetSettableMembers(structMapping, list);
-            return (MemberMapping[])list.ToArray(typeof(MemberMapping));
+            return list.ToArray();
         }
 
-        private static void GetSettableMembers(StructMapping mapping, ArrayList list)
+        private static void GetSettableMembers(StructMapping mapping, List<MemberMapping> list)
         {
             if (mapping.BaseMapping != null)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -7,11 +7,11 @@ namespace System.Xml.Serialization
     using System;
     using System.Xml.Schema;
     using System.Collections;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Globalization;
     using System.Threading;
     using System.Diagnostics;
-    using System.Collections.Generic;
     using System.Xml.Extensions;
     using System.Xml;
     using System.Xml.Serialization;
@@ -840,7 +840,7 @@ namespace System.Xml.Serialization
                     return false;
                 }
             }
-            ArrayList members = new ArrayList();
+            var members = new List<MemberMapping>();
             TextAccessor? textAccessor = null;
             bool hasElements = false;
             bool isSequence = false;
@@ -902,7 +902,7 @@ namespace System.Xml.Serialization
                 Hashtable ids = new Hashtable();
                 for (int i = 0; i < members.Count; i++)
                 {
-                    MemberMapping member = (MemberMapping)members[i]!;
+                    MemberMapping member = members[i]!;
                     if (!member.IsParticle)
                         continue;
                     if (member.IsSequence)
@@ -920,7 +920,7 @@ namespace System.Xml.Serialization
                 }
                 members.Sort(new MemberMappingComparer());
             }
-            mapping.Members = (MemberMapping[])members.ToArray(typeof(MemberMapping));
+            mapping.Members = members.ToArray();
 
             if (mapping.BaseMapping == null) mapping.BaseMapping = GetRootMapping();
 
@@ -1211,7 +1211,7 @@ namespace System.Xml.Serialization
                     _types.Add(typeName, typeNs, mapping);
                 else
                     _anonymous[model.Type] = mapping;
-                ArrayList constants = new ArrayList();
+                var constants = new List<ConstantMapping>();
                 for (int i = 0; i < model.Constants.Length; i++)
                 {
                     ConstantMapping? constant = ImportConstantMapping(model.Constants[i]);
@@ -1221,7 +1221,7 @@ namespace System.Xml.Serialization
                 {
                     throw new InvalidOperationException(SR.Format(SR.XmlNoSerializableMembers, model.TypeDesc.FullName));
                 }
-                mapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));
+                mapping.Constants = constants.ToArray();
                 _typeScope.AddTypeMapping(mapping);
             }
             return mapping;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -5,6 +5,7 @@ namespace System.Xml.Serialization
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
@@ -1872,7 +1873,7 @@ namespace System.Xml.Serialization
 
         private object ReadXmlNodes(bool elementCanBeType)
         {
-            ArrayList xmlNodeList = new ArrayList();
+            var xmlNodeList = new List<XmlNode>();
             string elemLocalName = Reader.LocalName;
             string elemNs = Reader.NamespaceURI;
             string elemName = Reader.Name;
@@ -1956,7 +1957,7 @@ namespace System.Xml.Serialization
             if (xmlNodeList.Count <= skippableNodeCount)
                 return new object();
 
-            XmlNode[] childNodes = (XmlNode[])xmlNodeList.ToArray(typeof(XmlNode));
+            XmlNode[] childNodes = xmlNodeList.ToArray();
 
             UnknownNode(unknownNode, null, null);
             return childNodes;
@@ -2512,9 +2513,9 @@ namespace System.Xml.Serialization
             Member? anyElement = null;
             Member? anyAttribute = null;
 
-            ArrayList membersList = new ArrayList();
-            ArrayList textOrArrayMembersList = new ArrayList();
-            ArrayList attributeMembersList = new ArrayList();
+            var membersList = new List<Member>();
+            var textOrArrayMembersList = new List<Member>();
+            var attributeMembersList = new List<Member>();
 
             for (int i = 0; i < mappings.Length; i++)
             {
@@ -2579,8 +2580,8 @@ namespace System.Xml.Serialization
                     membersList.Add(member);
                 }
             }
-            Member[] members = (Member[])membersList.ToArray(typeof(Member));
-            Member[] textOrArrayMembers = (Member[])textOrArrayMembersList.ToArray(typeof(Member));
+            Member[] members = membersList.ToArray();
+            Member[] textOrArrayMembers = textOrArrayMembersList.ToArray();
 
             if (members.Length > 0 && members[0].Mapping.IsReturnValue) Writer.WriteLine("IsReturnValue = true;");
 
@@ -2588,7 +2589,7 @@ namespace System.Xml.Serialization
 
             if (attributeMembersList.Count > 0)
             {
-                Member[] attributeMembers = (Member[])attributeMembersList.ToArray(typeof(Member));
+                Member[] attributeMembers = attributeMembersList.ToArray();
                 WriteMemberBegin(attributeMembers);
                 WriteAttributes(attributeMembers, anyAttribute, "UnknownNode", "(object)p");
                 WriteMemberEnd(attributeMembers);
@@ -3324,9 +3325,9 @@ namespace System.Xml.Serialization
                 Member? anyAttribute = null;
                 bool isSequence = structMapping.HasExplicitSequence();
 
-                ArrayList arraysToDeclareList = new ArrayList(mappings.Length);
-                ArrayList arraysToSetList = new ArrayList(mappings.Length);
-                ArrayList allMembersList = new ArrayList(mappings.Length);
+                var arraysToDeclareList = new List<Member>(mappings.Length);
+                var arraysToSetList = new List<Member>(mappings.Length);
+                var allMembersList = new List<Member>(mappings.Length);
 
                 for (int i = 0; i < mappings.Length; i++)
                 {
@@ -3392,9 +3393,9 @@ namespace System.Xml.Serialization
                 if (anyElement != null) arraysToSetList.Add(anyElement);
                 if (anyText != null && anyText != anyElement) arraysToSetList.Add(anyText);
 
-                Member[] arraysToDeclare = (Member[])arraysToDeclareList.ToArray(typeof(Member));
-                Member[] arraysToSet = (Member[])arraysToSetList.ToArray(typeof(Member));
-                Member[] allMembers = (Member[])allMembersList.ToArray(typeof(Member));
+                Member[] arraysToDeclare = arraysToDeclareList.ToArray();
+                Member[] arraysToSet = arraysToSetList.ToArray();
+                Member[] allMembers = allMembersList.ToArray();
 
                 WriteMemberBegin(arraysToDeclare);
                 WriteParamsRead(mappings.Length);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerNamespaces.cs
@@ -73,9 +73,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlQualifiedName[] ToArray()
         {
-            if (NamespaceList == null)
+            ArrayList? namespaceList = NamespaceList;
+            if (namespaceList == null)
                 return Array.Empty<XmlQualifiedName>();
-            return (XmlQualifiedName[])NamespaceList.ToArray(typeof(XmlQualifiedName));
+            var array = new XmlQualifiedName[namespaceList.Count];
+            namespaceList.CopyTo(array);
+            return array;
         }
 
         /// <devdoc>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/DbgCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/DbgCompiler.cs
@@ -4,7 +4,7 @@
 namespace System.Xml.Xsl.XsltOld
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Xml.XPath;
     using System.Xml.Xsl.XsltOld.Debugger;
@@ -50,8 +50,8 @@ namespace System.Xml.Xsl.XsltOld
         //          Duplicated globals from different stilesheets are replaced (by import presidence)
         // Locals:  Visible only in scope and after it was defined.
         //          No duplicates posible.
-        private readonly ArrayList _globalVars = new ArrayList();
-        private readonly ArrayList _localVars = new ArrayList();
+        private readonly List<VariableAction> _globalVars = new List<VariableAction>();
+        private readonly List<VariableAction> _localVars = new List<VariableAction>();
         private VariableAction[]? _globalVarsCache, _localVarsCache;
 
         public VariableAction[] GlobalVariables
@@ -61,7 +61,7 @@ namespace System.Xml.Xsl.XsltOld
                 Debug.Assert(this.Debugger != null);
                 if (_globalVarsCache == null)
                 {
-                    _globalVarsCache = (VariableAction[])_globalVars.ToArray(typeof(VariableAction));
+                    _globalVarsCache = _globalVars.ToArray();
                 }
                 return _globalVarsCache;
             }
@@ -73,7 +73,7 @@ namespace System.Xml.Xsl.XsltOld
                 Debug.Assert(this.Debugger != null);
                 if (_localVarsCache == null)
                 {
-                    _localVarsCache = (VariableAction[])_localVars.ToArray(typeof(VariableAction));
+                    _localVarsCache = _localVars.ToArray();
                 }
                 return _localVarsCache;
             }


### PR DESCRIPTION
ArrayList.ToArray(Type) has to lookup the array type in the type loader structures. It makes it slow and potentially AOT unfriendly since the code required to support the array type may not exist.
Convert most uses of ArrayList.ToArray in libraries to use List<T> if possible, or ArrayList.CopyTo if the conversion to List<T> was not straightforward.

Simplified a few other places that created arrays while I was on it.