### PR TITLE
Remove WSL checks and platform detection

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -306,7 +306,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         public async Task Proxy_SslProxyUnsupported_Throws()
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1815,7 +1815,7 @@ namespace System.Net.Http.Functional.Tests
         }
 #endregion
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux), nameof(PlatformDetection.IsNotBrowserDomSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowserDomSupported))]
         public async Task GetAsync_InvalidUrl_ExpectedExceptionThrown()
         {
             string invalidUri = $"http://nosuchhost.invalid";

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -103,30 +103,6 @@ namespace System
             }
         }
 
-        public static bool IsWindowsSubsystemForLinux => m_isWindowsSubsystemForLinux.Value;
-        public static bool IsNotWindowsSubsystemForLinux => !IsWindowsSubsystemForLinux;
-
-        private static Lazy<bool> m_isWindowsSubsystemForLinux = new Lazy<bool>(GetIsWindowsSubsystemForLinux);
-        private static bool GetIsWindowsSubsystemForLinux()
-        {
-            // https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
-            if (IsLinux)
-            {
-                const string versionFile = "/proc/version";
-                if (File.Exists(versionFile))
-                {
-                    string s = File.ReadAllText(versionFile);
-
-                    if (s.Contains("Microsoft") || s.Contains("WSL"))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
         private static string GetWindowsInstallationType()
         {
             string key = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion";

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -453,21 +453,12 @@ namespace System.Diagnostics.Tests
 
             ProcessPriorityClass originalPriority = _process.PriorityClass;
             Assert.Equal(ProcessPriorityClass.Normal, originalPriority);
-
-            // https://github.com/dotnet/runtime/issues/24426 -- returns "-19" and not "19"
-            if (!PlatformDetection.IsWindowsSubsystemForLinux)
-            {
-                SetAndCheckBasePriority(ProcessPriorityClass.Idle, 19);
-            }
+            SetAndCheckBasePriority(ProcessPriorityClass.Idle, 19);
 
             try
             {
                 SetAndCheckBasePriority(ProcessPriorityClass.Normal, 0);
-                // https://github.com/dotnet/runtime/issues/24426 -- returns "11" and not "-11"
-                if (!PlatformDetection.IsWindowsSubsystemForLinux)
-                {
-                    SetAndCheckBasePriority(ProcessPriorityClass.High, -11);
-                }
+                SetAndCheckBasePriority(ProcessPriorityClass.High, -11);
                 _process.PriorityClass = originalPriority;
             }
             catch (Win32Exception ex)

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -59,7 +59,7 @@ namespace System.IO.FileSystem.DriveInfoTests
             Assert.Equal(invalidDriveName, invalidDrive.VolumeLabel);   // VolumeLabel is equivalent to Name on Unix
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/18487
+        [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Android)]
         public void PropertiesOfValidDrive()
         {

--- a/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -454,7 +454,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/21022", platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
@@ -494,7 +494,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/21022", platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -25,7 +25,7 @@ namespace System.Net.NetworkInformation.Tests
             _log = output;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IPGlobalProperties_AccessAllMethods_NoErrors()
         {
@@ -50,7 +50,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotNull(gp.GetUdpIPv6Statistics());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Theory]
         [MemberData(nameof(Loopbacks))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
@@ -76,7 +76,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [MemberData(nameof(Loopbacks))]
@@ -108,7 +108,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         public void IPGlobalProperties_TcpActiveConnections_NotListening()
         {
             TcpConnectionInformation[] tcpCconnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
@@ -118,7 +118,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public async Task GetUnicastAddresses_NotEmpty()
         {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -222,7 +222,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]  // Some APIs are not supported on Linux
         public void BasicTest_GetIPInterfaceStatistics_Success_Linux()
         {
@@ -271,7 +271,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void BasicTest_GetIsNetworkAvailable_Success()

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
@@ -44,7 +44,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]  // Some APIs are not supported on Windows and OSX
         public void BasicTest_GetIPv4InterfaceStatistics_Success_Linux()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -86,7 +86,7 @@ namespace System.Xml.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void InitializationWithUriOnNonAsyncReaderThrows()
         {
             Assert.Throws<System.Net.Http.HttpRequestException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));

--- a/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -208,7 +208,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a Unicode character array with UTF8 encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         public void EncoderUTF8ConvertUnicodeCharArrayPartial()
         {
             char[] chars = "\uD83D\uDE01Test".ToCharArray();
@@ -228,7 +228,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a ASCII+Unicode character array with ASCII encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         public void EncoderASCIIConvertMixedASCIIUnicodeCharArrayPartial()
         {
             char[] chars = "T\uD83D\uDE01est".ToCharArray();
@@ -250,7 +250,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a ASCII+Unicode character array with UTF8 encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        [Fact]
         public void EncoderUTF8ConvertMixedASCIIUnicodeCharArrayPartial()
         {
             char[] chars = "T\uD83D\uDE01est".ToCharArray();


### PR DESCRIPTION
WSL1 isn't a supported build or execution environment for dotnet/runtime.
Because of that removing the checks and platform detection for it as
that code path isn't necessary for WSL2 anymore as it contains a fully
featured kernel which behaves just a like a usual Linux distro.

Fixes https://github.com/dotnet/runtime/issues/18258

cc @ManickaP 