### PR TITLE
[mono] Separate LLVM optimization and compilation into two separate functions

### DIFF
--- a/src/mono/mono/mini/llvm-jit.h
+++ b/src/mono/mono/mini/llvm-jit.h
@@ -42,6 +42,9 @@ mono_llvm_create_ee (LLVMExecutionEngineRef *ee);
 void
 mono_llvm_dispose_ee (MonoEERef *mono_ee);
 
+void
+mono_llvm_optimize_method (LLVMValueRef method);
+
 gpointer
 mono_llvm_compile_method (MonoEERef mono_ee, MonoCompile *cfg, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame);
 

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -13581,10 +13581,7 @@ llvm_jit_finalize_method (EmitContext *ctx)
 	while (g_hash_table_iter_next (&iter, NULL, (void**)&var))
 		callee_vars [i ++] = var;
 
-	mono_codeman_enable_write ();
-	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, cfg, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
-	mono_llvm_remove_gc_safepoint_poll (ctx->lmodule);
-	mono_codeman_disable_write ();
+	mono_llvm_optimize_method (ctx->lmethod);
 	if (cfg->verbose_level > 1) {
 		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
 		if (cfg->compile_aot) {
@@ -13594,6 +13591,11 @@ llvm_jit_finalize_method (EmitContext *ctx)
 		}
 		g_print ("***\n\n");
 	}
+
+	mono_codeman_enable_write ();
+	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, cfg, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
+	mono_llvm_remove_gc_safepoint_poll (ctx->lmodule);
+	mono_codeman_disable_write ();
 
 	decode_llvm_eh_info (ctx, eh_frame);
 


### PR DESCRIPTION
Dump optimized IR before attempting compilation to machine code. Makes
more information available when debugging.

Split from https://github.com/dotnet/runtime/pull/53132.