### PR TITLE
Expose underlying unix file descriptor in SafeMemoryMappedFileHandle

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Win32.SafeHandles
 
         protected override bool ReleaseHandle()
         {
-            if (_fileStreamHandle != null) {
+            if (_fileStreamHandle != null)
+            {
                 SetHandle((IntPtr) (-1));
                 _fileStreamHandle.DangerousRelease();
                 _fileStreamHandle = null;

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Win32.SafeHandles
                 _fileStreamHandle = fileStream.SafeFileHandle;
                 handlePtr = _fileStreamHandle.DangerousGetHandle();
             }
-            else {
+            else
+            {
                 handlePtr = IntPtr.MaxValue;
             }
 

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -11,15 +11,13 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        /// <summary>Counter used to produce a unique handle value.</summary>
-        private static long s_counter;
-
         /// <summary>
         /// The underlying FileStream.  May be null.  We hold onto the stream rather than just
         /// onto the underlying handle to ensure that logic associated with disposing the stream
         /// (e.g. deleting the file for DeleteOnClose) happens at the appropriate time.
         /// </summary>
-        internal readonly FileStream? _fileStream;
+        private readonly FileStream? _fileStream;
+        internal SafeFileHandle? _fileStreamHandle;
 
         /// <summary>Whether this SafeHandle owns the _fileStream and should Dispose it when disposed.</summary>
         internal readonly bool _ownsFileStream;
@@ -59,9 +57,22 @@ namespace Microsoft.Win32.SafeHandles
             _options = options;
             _capacity = capacity;
 
-            // Fake a unique int handle value > 0.
-            int nextHandleValue = (int)((Interlocked.Increment(ref s_counter) % (int.MaxValue - 1)) + 1);
-            SetHandle(new IntPtr(nextHandleValue));
+            IntPtr handlePtr;
+
+            if (fileStream != null) {
+                _fileStreamHandle = fileStream.SafeFileHandle;
+
+                bool ignored = false;
+                _fileStreamHandle.DangerousAddRef(ref ignored);
+
+                handlePtr = _fileStreamHandle.DangerousGetHandle();
+            }
+            else {
+                _fileStreamHandle = null;
+                handlePtr = IntPtr.MaxValue;
+            }
+
+            SetHandle(handlePtr);
         }
 
         protected override void Dispose(bool disposing)
@@ -74,7 +85,17 @@ namespace Microsoft.Win32.SafeHandles
             base.Dispose(disposing);
         }
 
-        protected override bool ReleaseHandle() => true; // Nothing to clean up.  We unlinked immediately after creating the backing store.
+        protected override bool ReleaseHandle() {
+            Debug.Assert(!IsInvalid);
+
+            if (_fileStreamHandle != null) {
+                SetHandle((IntPtr) (-1));
+                _fileStreamHandle.DangerousRelease();
+                _fileStreamHandle = null;
+            }
+
+            return true;
+        }
 
         public override bool IsInvalid => (long)handle <= 0;
     }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Win32.SafeHandles
             base.Dispose(disposing);
         }
 
-        protected override bool ReleaseHandle() {
+        protected override bool ReleaseHandle()
+        {
             if (_fileStreamHandle != null) {
                 SetHandle((IntPtr) (-1));
                 _fileStreamHandle.DangerousRelease();

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -59,16 +59,15 @@ namespace Microsoft.Win32.SafeHandles
 
             IntPtr handlePtr;
 
-            if (fileStream != null) {
-                _fileStreamHandle = fileStream.SafeFileHandle;
-
+            if (fileStream != null)
+            {
                 bool ignored = false;
-                _fileStreamHandle.DangerousAddRef(ref ignored);
+                fileStream.SafeFileHandle.DangerousAddRef(ref ignored);
 
+                _fileStreamHandle = fileStream.SafeFileHandle;
                 handlePtr = _fileStreamHandle.DangerousGetHandle();
             }
             else {
-                _fileStreamHandle = null;
                 handlePtr = IntPtr.MaxValue;
             }
 
@@ -86,8 +85,6 @@ namespace Microsoft.Win32.SafeHandles
         }
 
         protected override bool ReleaseHandle() {
-            Debug.Assert(!IsInvalid);
-
             if (_fileStreamHandle != null) {
                 SetHandle((IntPtr) (-1));
                 _fileStreamHandle.DangerousRelease();

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Win32.SafeHandles
         /// (e.g. deleting the file for DeleteOnClose) happens at the appropriate time.
         /// </summary>
         private readonly FileStream? _fileStream;
+        /// <summary>The FileStream's handle, cached to avoid repeated accesses to FileStream.SafeFileHandle that could, in theory, change.</summary>
         internal SafeFileHandle? _fileStreamHandle;
 
         /// <summary>Whether this SafeHandle owns the _fileStream and should Dispose it when disposed.</summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Win32.SafeHandles
             if (fileStream != null)
             {
                 bool ignored = false;
-                fileStream.SafeFileHandle.DangerousAddRef(ref ignored);
-
-                _fileStreamHandle = fileStream.SafeFileHandle;
-                handlePtr = _fileStreamHandle.DangerousGetHandle();
+                SafeFileHandle handle = fileStream.SafeFileHandle;
+                handle.DangerousAddRef(ref ignored);
+                _fileStreamHandle = handle;
+                handlePtr = handle.DangerousGetHandle();
             }
             else
             {

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
@@ -56,10 +56,10 @@ namespace System.IO.MemoryMappedFiles
             // If we have a file handle, get the file descriptor from it.  If the handle is null,
             // we'll use an anonymous backing store for the map.
             SafeFileHandle fd;
-            if (memMappedFileHandle._fileStream != null)
+            if (memMappedFileHandle._fileStreamHandle != null)
             {
                 // Get the file descriptor from the SafeFileHandle
-                fd = memMappedFileHandle._fileStream.SafeFileHandle;
+                fd = memMappedFileHandle._fileStreamHandle;
                 Debug.Assert(!fd.IsInvalid);
             }
             else

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -963,8 +963,8 @@ namespace System.IO.MemoryMappedFiles.Tests
                     fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false
                 );
                 SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
-                Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
                 mmf.Dispose();
+                Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
             }
         }
     }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -959,7 +959,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         {
             using (FileStream fs = File.OpenWrite(GetTestFilePath()))
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false)
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
                 {
                     SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
                     Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -949,5 +949,21 @@ namespace System.IO.MemoryMappedFiles.Tests
             // ENODEV Operation not supported by device.
             catch (IOException ex) when (ex.HResult == 19) { };
         }
+
+        /// <summary>
+        /// Test to verify that the MemoryMappedFile has the same underlying handle as the FileStream it's created from
+        /// </summary>
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public void MapHandleMatchesFileStreamHandle()
+        {
+            using (FileStream fs = File.OpenWrite(GetTestFilePath())) {
+                MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(
+                    fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false
+                );
+                SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
+                Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -959,12 +959,11 @@ namespace System.IO.MemoryMappedFiles.Tests
         {
             using (FileStream fs = File.OpenWrite(GetTestFilePath()))
             {
-                MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(
-                    fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false
-                );
-                SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
-                mmf.Dispose();
-                Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
+                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false)
+                {
+                    SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
+                    Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
+                }
             }
         }
     }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -964,6 +964,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 );
                 SafeMemoryMappedFileHandle handle = mmf.SafeMemoryMappedFileHandle;
                 Assert.Equal(fs.SafeFileHandle.DangerousGetHandle(), handle.DangerousGetHandle());
+                mmf.Dispose();
             }
         }
     }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -957,7 +957,8 @@ namespace System.IO.MemoryMappedFiles.Tests
         [Fact]
         public void MapHandleMatchesFileStreamHandle()
         {
-            using (FileStream fs = File.OpenWrite(GetTestFilePath())) {
+            using (FileStream fs = File.OpenWrite(GetTestFilePath()))
+            {
                 MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(
                     fs, null, 4096, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false
                 );


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/52854

Done in a similar way to [SafePipeHandle](https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs#L106).