### PR TITLE
Force usage of VS2019 and revert VS 2022 support

### DIFF
--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -28,7 +28,7 @@ set "__VSCOMNTOOLS="
 
 if exist "%__VSWhere%" (
     for /f "tokens=*" %%p in (
-        '"%__VSWhere%" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath'
+        '"%__VSWhere%" -prerelease -version 16 -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath'
     ) do set __VSCOMNTOOLS=%%p\Common7\Tools
 )
 

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -50,14 +50,9 @@ if "%VisualStudioVersion%"=="16.0" (
     set __PlatformToolset=v142
     goto :SetVCEnvironment
 )
-if "%VisualStudioVersion%"=="17.0" (
-    set __VSVersion=vs2022
-    set __PlatformToolset=v142
-    goto :SetVCEnvironment
-)
 
 :VSMissing
-echo %__MsgPrefix%Error: Visual Studio 2019 or 2022 with C++ tools required. ^
+echo %__MsgPrefix%Error: Visual Studio 2019 with C++ tools required. ^
 Please see https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/windows-requirements.md for build requirements.
 exit /b 1
 


### PR DESCRIPTION
CMake doesn't yet support VS2022 and several team members have complained this change broke building the repo on their machine if VS2022 was installed SxS. 

cc: @tommcdon