### PR TITLE
Add HttpHeaders.NonValidated

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -4,6 +4,7 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
@@ -520,6 +521,26 @@ namespace System.Net.Http.Headers
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.EntityTagHeaderValue? parsedValue) { throw null; }
     }
+    public readonly partial struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IReadOnlyCollection<string>, System.Collections.IEnumerable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public int Count { get { throw null; } }
+        public System.Net.Http.Headers.HeaderStringValues.Enumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public override string ToString() { throw null; }
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<string>, System.Collections.IEnumerator, System.IDisposable
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public string Current { get { throw null; } }
+            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            void System.Collections.IEnumerator.Reset() { }
+        }
+    }
     public sealed partial class HttpContentHeaders : System.Net.Http.Headers.HttpHeaders
     {
         internal HttpContentHeaders() { }
@@ -538,6 +559,7 @@ namespace System.Net.Http.Headers
     public abstract partial class HttpHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>>, System.Collections.IEnumerable
     {
         protected HttpHeaders() { }
+        public System.Net.Http.Headers.HttpHeadersNonValidated NonValidated { get { throw null; } }
         public void Add(string name, System.Collections.Generic.IEnumerable<string?> values) { }
         public void Add(string name, string? value) { }
         public void Clear() { }
@@ -550,6 +572,32 @@ namespace System.Net.Http.Headers
         public bool TryAddWithoutValidation(string name, System.Collections.Generic.IEnumerable<string?> values) { throw null; }
         public bool TryAddWithoutValidation(string name, string? value) { throw null; }
         public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
+    }
+    public readonly partial struct HttpHeadersNonValidated : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.Generic.IReadOnlyDictionary<string, System.Net.Http.Headers.HeaderStringValues>, System.Collections.IEnumerable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public int Count { get { throw null; } }
+        public System.Net.Http.Headers.HeaderStringValues this[string headerName] { get { throw null; } }
+        System.Collections.Generic.IEnumerable<string> System.Collections.Generic.IReadOnlyDictionary<string, System.Net.Http.Headers.HeaderStringValues>.Keys { get { throw null; } }
+        System.Collections.Generic.IEnumerable<System.Net.Http.Headers.HeaderStringValues> System.Collections.Generic.IReadOnlyDictionary<string, System.Net.Http.Headers.HeaderStringValues>.Values { get { throw null; } }
+        public bool Contains(string headerName) { throw null; }
+        bool System.Collections.Generic.IReadOnlyDictionary<string, System.Net.Http.Headers.HeaderStringValues>.ContainsKey(string key) { throw null; }
+        public System.Net.Http.Headers.HttpHeadersNonValidated.Enumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValues(string headerName, out System.Net.Http.Headers.HeaderStringValues values) { throw null; }
+        bool System.Collections.Generic.IReadOnlyDictionary<string, System.Net.Http.Headers.HeaderStringValues>.TryGetValue(string key, out System.Net.Http.Headers.HeaderStringValues value) { throw null; }
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.IEnumerator, System.IDisposable
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues> Current { get { throw null; } }
+            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            void System.Collections.IEnumerator.Reset() { }
+        }
     }
     public sealed partial class HttpHeaderValueCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : class
     {

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -76,11 +76,13 @@
     <Compile Include="System\Net\Http\Headers\EntityTagHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\GenericHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\HeaderDescriptor.cs" />
+    <Compile Include="System\Net\Http\Headers\HeaderStringValues.cs" />
     <Compile Include="System\Net\Http\Headers\HeaderUtilities.cs" />
     <Compile Include="System\Net\Http\Headers\HttpContentHeaders.cs" />
     <Compile Include="System\Net\Http\Headers\HttpGeneralHeaders.cs" />
     <Compile Include="System\Net\Http\Headers\HttpHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\HttpHeaders.cs" />
+    <Compile Include="System\Net\Http\Headers\HttpHeadersNonValidated.cs" />
     <Compile Include="System\Net\Http\Headers\HttpHeaderValueCollection.cs" />
     <Compile Include="System\Net\Http\Headers\HttpRequestHeaders.cs" />
     <Compile Include="System\Net\Http\Headers\HttpResponseHeaders.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System.Net.Http.Headers
+{
+    /// <summary>Provides a collection of header string values.</summary>
+    public readonly struct HeaderStringValues : IReadOnlyCollection<string>
+    {
+        /// <summary>The associated header.  This is used only for producing a string from <see cref="_value"/> when it's an array.</summary>
+        private readonly HeaderDescriptor _header;
+        /// <summary>A string or string array (or null if the instance is default).</summary>
+        private readonly object _value;
+
+        /// <summary>Initializes the instance.</summary>
+        /// <param name="descriptor">The header descriptor associated with the header value.</param>
+        /// <param name="value">The header value.</param>
+        internal HeaderStringValues(HeaderDescriptor descriptor, string value)
+        {
+            _header = descriptor;
+            _value = value;
+        }
+
+        /// <summary>Initializes the instance.</summary>
+        /// <param name="descriptor">The header descriptor associated with the header values.</param>
+        /// <param name="values">The header values.</param>
+        internal HeaderStringValues(HeaderDescriptor descriptor, string[] values)
+        {
+            _header = descriptor;
+            _value = values;
+        }
+
+        /// <summary>Gets the number of header values in the collection.</summary>
+        public int Count => _value switch
+        {
+            string => 1,
+            string[] values => values.Length,
+            _ => 0
+        };
+
+        /// <summary>Gets a string containing all the headers in the collection.</summary>
+        /// <returns></returns>
+        public override string ToString() => _value switch
+        {
+            string value => value,
+            string[] values => string.Join(_header.Parser is HttpHeaderParser parser && parser.SupportsMultipleValues ? parser.Separator : HttpHeaderParser.DefaultSeparator, values),
+            _ => string.Empty,
+        };
+
+        /// <summary>Gets an enumerator for all of the strings in the collection.</summary>
+        /// <returns></returns>
+        public Enumerator GetEnumerator() => new Enumerator(_value);
+
+        /// <inheritdoc/>
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>Enumerates the elements of a <see cref="HeaderStringValues"/>.</summary>
+        public struct Enumerator : IEnumerator<string>
+        {
+            /// <summary>If this wraps a string[], that array. Otherwise, null.</summary>
+            private readonly string[]? _values;
+            /// <summary>The current string header value.  If this wraps a single string, that string.</summary>
+            private string? _current;
+            /// <summary>Current state of the iteration.</summary>
+            private int _index;
+
+            /// <summary>Initializes the enumerator with a string or string[].</summary>
+            /// <param name="value">The string or string[] value, or null if this collection is empty.</param>
+            internal Enumerator(object value)
+            {
+                if (value is string s)
+                {
+                    _values = null;
+                    _current = s;
+                }
+                else
+                {
+                    _values = value as string[];
+                    _current = null;
+                }
+
+                _index = 0;
+            }
+
+            /// <inheritdoc/>
+            public bool MoveNext()
+            {
+                int index = _index;
+                if (index < 0)
+                {
+                    return false;
+                }
+
+                string[]? values = _values;
+                if (values != null)
+                {
+                    if ((uint)index < (uint)values.Length)
+                    {
+                        _index = index + 1;
+                        _current = values[index];
+                        return true;
+                    }
+
+                    _index = -1;
+                    return false;
+                }
+
+                _index = -1;
+                return _current != null;
+            }
+
+            /// <inheritdoc/>
+            public string Current => _current!;
+
+            /// <inheritdoc/>
+            object IEnumerator.Current => Current;
+
+            /// <inheritdoc/>
+            public void Dispose() { }
+
+            /// <inheritdoc/>
+            void IEnumerator.Reset() => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -357,7 +357,7 @@ namespace System.Net.Http.Headers
             {
                 if (headers[i] is HttpHeaders hh)
                 {
-                    foreach (KeyValuePair<string, string[]> header in hh.EnumerateWithoutValidation())
+                    foreach (KeyValuePair<string, HeaderStringValues> header in hh.NonValidated)
                     {
                         foreach (string headerValue in header.Value)
                         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Net.Http.Headers
+{
+    /// <summary>Provides a view on top of a <see cref="HttpHeaders"/> collection that avoids forcing validation or parsing on its contents.</summary>
+    /// <remarks>
+    /// The view surfaces data as it's stored in the headers collection.  Any header values that have not yet been parsed / validated won't be
+    /// as part of any accesses from this view, e.g. a raw header value of "one, two" that hasn't yet been parsed due to other operations
+    /// on the <see cref="HttpHeaders"/> will be surfaced as a single header value rather than two.  For any header values that have already
+    /// been parsed and validated, that value will be converted to a string to be returned from operations on this view.
+    /// </remarks>
+    public readonly struct HttpHeadersNonValidated : IReadOnlyDictionary<string, HeaderStringValues>
+    {
+        /// <summary>The wrapped headers collection.</summary>
+        private readonly HttpHeaders? _headers;
+
+        /// <summary>Initializes the view.</summary>
+        /// <param name="headers">The wrapped headers collection.</param>
+        internal HttpHeadersNonValidated(HttpHeaders headers) => _headers = headers;
+
+        /// <summary>Gets the number of headers stored in the collection.</summary>
+        /// <remarks>Multiple header values associated with the same header name are considered to be one header as far as this count is concerned.</remarks>
+        public int Count => _headers?.HeaderStore?.Count ?? 0;
+
+        /// <summary>Gets whether the collection contains the specified header.</summary>
+        /// <param name="headerName">The name of the header.</param>
+        /// <returns>true if the collection contains the header; otherwise, false.</returns>
+        public bool Contains(string headerName) =>
+            _headers is HttpHeaders headers &&
+            HeaderDescriptor.TryGet(headerName, out HeaderDescriptor descriptor) &&
+            headers.TryGetHeaderValue(descriptor, out _);
+
+        /// <summary>Gets the values for the specified header name.</summary>
+        /// <param name="headerName">The name of the header.</param>
+        /// <returns>The values for the specified header.</returns>
+        /// <exception cref="KeyNotFoundException">The header was not contained in the collection.</exception>
+        public HeaderStringValues this[string headerName]
+        {
+            get
+            {
+                if (TryGetValues(headerName, out HeaderStringValues values))
+                {
+                    return values;
+                }
+
+                throw new KeyNotFoundException(SR.net_http_headers_not_found);
+            }
+        }
+
+        /// <inheritdoc/>
+        bool IReadOnlyDictionary<string, HeaderStringValues>.ContainsKey(string key) => Contains(key);
+
+        /// <summary>Attempts to retrieve the values associated with the specified header name.</summary>
+        /// <param name="headerName">The name of the header.</param>
+        /// <param name="values">The retrieved header values.</param>
+        /// <returns>true if the collection contains the specified header; otherwise, false.</returns>
+        public bool TryGetValues(string headerName, out HeaderStringValues values)
+        {
+            if (_headers is HttpHeaders headers &&
+                HeaderDescriptor.TryGet(headerName, out HeaderDescriptor descriptor) &&
+                headers.TryGetHeaderValue(descriptor, out object? info))
+            {
+                HttpHeaders.GetStoreValuesAsStringOrStringArray(descriptor, info, out string? singleValue, out string[]? multiValue);
+                Debug.Assert(singleValue is not null ^ multiValue is not null);
+                values = singleValue is not null ?
+                    new HeaderStringValues(descriptor, singleValue) :
+                    new HeaderStringValues(descriptor, multiValue!);
+                return true;
+            }
+
+            values = default;
+            return false;
+        }
+
+        /// <inheritdoc/>
+        bool IReadOnlyDictionary<string, HeaderStringValues>.TryGetValue(string key, out HeaderStringValues value) => TryGetValues(key, out value);
+
+        /// <summary>Gets an enumerator that iterates through the <see cref="HttpHeadersNonValidated"/>.</summary>
+        /// <returns>An enumerator that iterates through the <see cref="HttpHeadersNonValidated"/>.</returns>
+        public Enumerator GetEnumerator() =>
+            _headers is HttpHeaders headers && headers.HeaderStore is Dictionary<HeaderDescriptor, object> store ?
+                new Enumerator(store.GetEnumerator()) :
+                default;
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<string, HeaderStringValues>> IEnumerable<KeyValuePair<string, HeaderStringValues>>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerable<string> IReadOnlyDictionary<string, HeaderStringValues>.Keys
+        {
+            get
+            {
+                foreach (KeyValuePair<string, HeaderStringValues> header in this)
+                {
+                    yield return header.Key;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        IEnumerable<HeaderStringValues> IReadOnlyDictionary<string, HeaderStringValues>.Values
+        {
+            get
+            {
+                foreach (KeyValuePair<string, HeaderStringValues> header in this)
+                {
+                    yield return header.Value;
+                }
+            }
+        }
+
+        /// <summary>Enumerates the elements of a <see cref="HttpHeadersNonValidated"/>.</summary>
+        public struct Enumerator : IEnumerator<KeyValuePair<string, HeaderStringValues>>
+        {
+            /// <summary>The wrapped enumerator for the underlying headers dictionary.</summary>
+            private Dictionary<HeaderDescriptor, object>.Enumerator _headerStoreEnumerator;
+            /// <summary>The current value.</summary>
+            private KeyValuePair<string, HeaderStringValues> _current;
+            /// <summary>true if the enumerator was constructed via the ctor; otherwise, false./</summary>
+            private bool _valid;
+
+            /// <summary>Initializes the enumerator.</summary>
+            /// <param name="headerStoreEnumerator">The underlying dictionary enumerator.</param>
+            internal Enumerator(Dictionary<HeaderDescriptor, object>.Enumerator headerStoreEnumerator)
+            {
+                _headerStoreEnumerator = headerStoreEnumerator;
+                _current = default;
+                _valid = true;
+            }
+
+            /// <inheritdoc/>
+            public bool MoveNext()
+            {
+                if (_valid && _headerStoreEnumerator.MoveNext())
+                {
+                    KeyValuePair<HeaderDescriptor, object> current = _headerStoreEnumerator.Current;
+
+                    HttpHeaders.GetStoreValuesAsStringOrStringArray(current.Key, current.Value, out string? singleValue, out string[]? multiValue);
+                    Debug.Assert(singleValue is not null ^ multiValue is not null);
+
+                    _current = new KeyValuePair<string, HeaderStringValues>(
+                        current.Key.Name,
+                        singleValue is not null ? new HeaderStringValues(current.Key, singleValue) : new HeaderStringValues(current.Key, multiValue!));
+                    return true;
+                }
+
+                _current = default;
+                return false;
+            }
+
+            /// <inheritdoc/>
+            public KeyValuePair<string, HeaderStringValues> Current => _current;
+
+            /// <inheritdoc/>
+            object IEnumerator.Current => _current;
+
+            /// <inheritdoc/>
+            public void Dispose() { }
+
+            /// <inheritdoc/>
+            void IEnumerator.Reset() => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -4,7 +4,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
@@ -333,7 +332,7 @@ namespace System.Net.Http
             }
 
             // Add headers.
-            foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
+            foreach (KeyValuePair<string, HeaderStringValues> headerPair in content.Headers.NonValidated)
             {
                 Encoding headerValueEncoding = HeaderEncodingSelector?.Invoke(headerPair.Key, content) ?? HttpRuleParser.DefaultHttpEncoding;
 
@@ -388,7 +387,7 @@ namespace System.Net.Http
             foreach (HttpContent content in _nestedContent)
             {
                 // Headers.
-                foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
+                foreach (KeyValuePair<string, HeaderStringValues> headerPair in content.Headers.NonValidated)
                 {
                     currentLength += headerPair.Key.Length + ColonSpaceLength;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1136,7 +1136,7 @@ namespace System.Net.Http
             ref string[]? tmpHeaderValuesArray = ref t_headerValues;
             foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
-                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref tmpHeaderValuesArray);
+                int headerValuesCount = HttpHeaders.GetStoreValuesIntoStringArray(header.Key, header.Value, ref tmpHeaderValuesArray);
                 Debug.Assert(headerValuesCount > 0, "No values for header??");
                 ReadOnlySpan<string> headerValues = tmpHeaderValuesArray.AsSpan(0, headerValuesCount);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -587,7 +587,7 @@ namespace System.Net.Http
 
             foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
-                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
+                int headerValuesCount = HttpHeaders.GetStoreValuesIntoStringArray(header.Key, header.Value, ref _headerValues);
                 Debug.Assert(headerValuesCount > 0, "No values for header??");
                 ReadOnlySpan<string> headerValues = _headerValues.AsSpan(0, headerValuesCount);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -263,7 +263,7 @@ namespace System.Net.Http
                         await WriteTwoBytesAsync((byte)':', (byte)' ', async).ConfigureAwait(false);
                     }
 
-                    int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
+                    int headerValuesCount = HttpHeaders.GetStoreValuesIntoStringArray(header.Key, header.Value, ref _headerValues);
                     Debug.Assert(headerValuesCount > 0, "No values for header??");
                     if (headerValuesCount > 0)
                     {

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
-                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref headerValues);
+                int headerValuesCount = HttpHeaders.GetStoreValuesIntoStringArray(header.Key, header.Value, ref headerValues);
                 Assert.InRange(headerValuesCount, 0, int.MaxValue);
                 ReadOnlySpan<string> headerValuesSpan = headerValues.AsSpan(0, headerValuesCount);
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
@@ -151,10 +151,10 @@ namespace System.Net.Http.Tests
             headers.Add("Accept-Charset", "utf-8");
             headers.AcceptCharset.Add(new StringWithQualityHeaderValue("iso-8859-5", 0.5));
 
-            foreach (var header in headers.GetHeaderStrings())
+            foreach (var header in headers.NonValidated)
             {
                 Assert.Equal("Accept-Charset", header.Key);
-                Assert.Equal("utf-8, iso-8859-5; q=0.5, invalid value", header.Value);
+                Assert.Equal("utf-8, iso-8859-5; q=0.5, invalid value", header.Value.ToString());
             }
         }
 
@@ -656,10 +656,10 @@ namespace System.Net.Http.Tests
             headers.Add("User-Agent", "custom2/1.1");
             headers.UserAgent.Add(new ProductInfoHeaderValue("(comment)"));
 
-            foreach (var header in headers.GetHeaderStrings())
+            foreach (var header in headers.NonValidated)
             {
                 Assert.Equal("User-Agent", header.Key);
-                Assert.Equal("custom2/1.1 (comment) custom\u4F1A", header.Value);
+                Assert.Equal("custom2/1.1 (comment) custom\u4F1A", header.Value.ToString());
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -106,6 +106,8 @@
              Link="ProductionCode\System\Net\Http\Headers\GenericHeaderParser.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HeaderDescriptor.cs"
              Link="ProductionCode\System\Net\Http\Headers\HeaderDescriptor.cs" />
+    <Compile Include="..\..\src\System\Net\Http\Headers\HeaderStringValues.cs"
+             Link="ProductionCode\System\Net\Http\Headers\HeaderStringValues.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HeaderUtilities.cs"
              Link="ProductionCode\System\Net\Http\Headers\HeaderUtilities.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HttpContentHeaders.cs"
@@ -116,6 +118,8 @@
              Link="ProductionCode\System\Net\Http\Headers\HttpHeaderParser.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HttpHeaders.cs"
              Link="ProductionCode\System\Net\Http\Headers\HttpHeaders.cs" />
+    <Compile Include="..\..\src\System\Net\Http\Headers\HttpHeadersNonValidated.cs"
+             Link="ProductionCode\System\Net\Http\Headers\HttpHeadersNonValidated.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HttpHeaderType.cs"
              Link="ProductionCode\System\Net\Http\Headers\HttpHeaderType.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\HttpHeaderValueCollection.cs"


### PR DESCRIPTION
This adds an HttpHeaders.NonValidated property, which returns a type that provides a non-validating / non-parsing / non-allocating view of headers in the collection.  Querying the resulting collection does not force parsing or validation on the contents of the headers, handing back exactly the raw data that it contains; if a header doesn't contain a raw value but instead contains an already parsed value, a string representation of that header value(s) is returned.  When using the strongly-typed members, querying and enumeration is allocation-free, unless strings need to be created to represent already parsed values.

Fixes https://github.com/dotnet/runtime/issues/35126#issuecomment-852464215
cc: @geoffkizer, @scalablecory 