### PR TITLE
Fix CQ regression & correctness bug in morphing of long muls

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5810,6 +5810,12 @@ private:
     GenTree* fgRecognizeAndMorphBitwiseRotation(GenTree* tree);
     bool fgOperIsBitwiseRotationRoot(genTreeOps oper);
 
+#if !defined(TARGET_64BIT)
+    //                  Recognize and morph a long multiplication with 32 bit operands.
+    GenTreeOp* fgRecognizeAndMorphLongMul(GenTreeOp* mul);
+    GenTreeOp* fgMorphLongMul(GenTreeOp* mul);
+#endif
+
     //-------- Determine the order in which the trees will be evaluated -------
 
     unsigned fgTreeSeqNum;

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -600,12 +600,12 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
             {
                 //
                 // This int->long cast is used by a GT_MUL that will be transformed by DecomposeMul into a
-                // GT_LONG_MUL and as a result the high operand produced by the cast will become dead.
+                // GT_MUL_LONG and as a result the high operand produced by the cast will become dead.
                 // Skip cast decomposition so DecomposeMul doesn't need to bother with dead code removal,
                 // especially in the case of sign extending casts that also introduce new lclvars.
                 //
 
-                assert((use.User()->gtFlags & GTF_MUL_64RSLT) != 0);
+                assert(use.User()->Is64RsltMul());
 
                 skipDecomposition = true;
             }
@@ -1533,19 +1533,29 @@ GenTree* DecomposeLongs::DecomposeMul(LIR::Use& use)
 {
     assert(use.IsInitialized());
 
-    GenTree*   tree = use.Def();
-    genTreeOps oper = tree->OperGet();
+    GenTree* tree = use.Def();
 
-    assert(oper == GT_MUL);
-    assert((tree->gtFlags & GTF_MUL_64RSLT) != 0);
+    assert(tree->OperIs(GT_MUL));
+    assert(tree->Is64RsltMul());
 
     GenTree* op1 = tree->gtGetOp1();
     GenTree* op2 = tree->gtGetOp2();
 
-    // We expect both operands to be int->long casts. DecomposeCast specifically
-    // ignores such casts when they are used by GT_MULs.
-    assert((op1->OperGet() == GT_CAST) && (op1->TypeGet() == TYP_LONG));
-    assert((op2->OperGet() == GT_CAST) && (op2->TypeGet() == TYP_LONG));
+    assert(op1->TypeIs(TYP_LONG) && op2->TypeIs(TYP_LONG));
+
+    // We expect the first operand to be an int->long cast.
+    // DecomposeCast specifically ignores such casts when they are used by GT_MULs.
+    assert(op1->OperIs(GT_CAST));
+
+    // The second operand can be a cast or a constant.
+    if (!op2->OperIs(GT_CAST))
+    {
+        assert(op2->OperIs(GT_LONG));
+        assert(op2->gtGetOp1()->IsIntegralConst());
+        assert(op2->gtGetOp2()->IsIntegralConst());
+
+        Range().Remove(op2->gtGetOp2());
+    }
 
     Range().Remove(op1);
     Range().Remove(op2);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2117,6 +2117,63 @@ public:
         return ((gtFlags & GTF_UNSIGNED) != 0);
     }
 
+    void SetUnsigned()
+    {
+        assert(OperIs(GT_ADD, GT_SUB, GT_MUL, GT_CAST));
+        gtFlags |= GTF_UNSIGNED;
+    }
+
+    void ClearUnsigned()
+    {
+        assert(OperIs(GT_ADD, GT_SUB, GT_MUL, GT_CAST));
+        gtFlags &= ~GTF_UNSIGNED;
+    }
+
+    void SetOverflow()
+    {
+        assert(OperMayOverflow());
+        gtFlags |= GTF_OVERFLOW;
+    }
+
+    void ClearOverflow()
+    {
+        assert(OperMayOverflow());
+        gtFlags &= ~GTF_OVERFLOW;
+    }
+
+    bool Is64RsltMul() const
+    {
+        return (gtFlags & GTF_MUL_64RSLT) != 0;
+    }
+
+    void Set64RsltMul()
+    {
+        gtFlags |= GTF_MUL_64RSLT;
+    }
+
+    void Clear64RsltMul()
+    {
+        gtFlags &= ~GTF_MUL_64RSLT;
+    }
+
+    void SetAllEffectsFlags(GenTree* source)
+    {
+        SetAllEffectsFlags(source->gtFlags & GTF_ALL_EFFECT);
+    }
+
+    void SetAllEffectsFlags(GenTree* source, GenTree* otherSource)
+    {
+        SetAllEffectsFlags((source->gtFlags | otherSource->gtFlags) & GTF_ALL_EFFECT);
+    }
+
+    void SetAllEffectsFlags(GenTreeFlags sourceFlags)
+    {
+        assert((sourceFlags & ~GTF_ALL_EFFECT) == 0);
+
+        gtFlags &= ~GTF_ALL_EFFECT;
+        gtFlags |= sourceFlags;
+    }
+
     inline bool IsCnsIntOrI() const;
 
     inline bool IsIntegralConst() const;

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -230,6 +230,12 @@ inline bool varTypeIsIntOrI(T vt)
 }
 
 template <class T>
+inline bool genActualTypeIsInt(T vt)
+{
+    return ((TypeGet(vt) >= TYP_BOOL) && (TypeGet(vt) <= TYP_UINT));
+}
+
+template <class T>
 inline bool genActualTypeIsIntOrI(T vt)
 {
     return ((TypeGet(vt) >= TYP_BOOL) && (TypeGet(vt) <= TYP_U_IMPL));

--- a/src/tests/JIT/Methodical/int64/misc/longmul.il
+++ b/src/tests/JIT/Methodical/int64/misc/longmul.il
@@ -1,0 +1,5869 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime { auto }
+.assembly LongMulOn32BitTest { }
+
+.class auto LongMulOn32BitTest extends [System.Runtime]System.Object
+{
+  .method private hidebysig static void PrintErrorWithResult(string message, int64 result) cil managed
+  {
+    call class [System.Runtime]System.IO.TextWriter [System.Console]System.Console::get_Error()
+    ldarg message
+    ldarg result
+    box [System.Runtime]System.Int64
+    callvirt instance void [System.Runtime]System.IO.TextWriter::WriteLine(string, object)
+    ret
+  }
+
+  .method private hidebysig static void PrintError(string message) cil managed
+  {
+    call class [System.Runtime]System.IO.TextWriter [System.Console]System.Console::get_Error()
+    ldarg message
+    callvirt instance void [System.Runtime]System.IO.TextWriter::WriteLine(string)
+    ret
+  }
+
+  .method private hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .locals ( int64 result )
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_1(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT1
+    ldstr "'LongMulOn32BitTest::LongMul_1' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT1:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_1(int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT2
+    ldstr "'LongMulOn32BitTest::LongMul_1' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT2:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_1(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT3
+    ldstr "'LongMulOn32BitTest::LongMul_1' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT3:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_1(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT4
+    ldstr "'LongMulOn32BitTest::LongMul_1' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT4:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_2(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT5
+    ldstr "'LongMulOn32BitTest::LongMul_2' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT5:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_2(int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT6
+    ldstr "'LongMulOn32BitTest::LongMul_2' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT6:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_2(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT7
+    ldstr "'LongMulOn32BitTest::LongMul_2' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT7:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_2(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT8
+    ldstr "'LongMulOn32BitTest::LongMul_2' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT8:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_3(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_3' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT9
+    }
+  NEXT9:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_3(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_3' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT10
+    }
+  NEXT10:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_3(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT11
+    ldstr "'LongMulOn32BitTest::LongMul_3' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT11:
+
+    .try
+    {
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_3(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_3' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT12
+    }
+  NEXT12:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_4(int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT13
+    ldstr "'LongMulOn32BitTest::LongMul_4' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT13:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_4(int32)
+    stloc result
+    ldloc result
+    ldc.i8 1
+    ceq
+    brtrue NEXT14
+    ldstr "'LongMulOn32BitTest::LongMul_4' returned: '{0}'. Expected: '1'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT14:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_4(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT15
+    ldstr "'LongMulOn32BitTest::LongMul_4' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT15:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_4(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT16
+    ldstr "'LongMulOn32BitTest::LongMul_4' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT16:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_5(int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT17
+    ldstr "'LongMulOn32BitTest::LongMul_5' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT17:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_5(int32)
+    stloc result
+    ldloc result
+    ldc.i8 1
+    ceq
+    brtrue NEXT18
+    ldstr "'LongMulOn32BitTest::LongMul_5' returned: '{0}'. Expected: '1'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT18:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_5(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT19
+    ldstr "'LongMulOn32BitTest::LongMul_5' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT19:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_5(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT20
+    ldstr "'LongMulOn32BitTest::LongMul_5' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT20:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_6(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_6' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT21
+    }
+  NEXT21:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_6(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_6' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT22
+    }
+  NEXT22:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_6(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT23
+    ldstr "'LongMulOn32BitTest::LongMul_6' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT23:
+
+    .try
+    {
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_6(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_6' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT24
+    }
+  NEXT24:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_7(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT25
+    ldstr "'LongMulOn32BitTest::LongMul_7' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT25:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_7(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT26
+    ldstr "'LongMulOn32BitTest::LongMul_7' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT26:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_7(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT27
+    ldstr "'LongMulOn32BitTest::LongMul_7' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT27:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_7(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT28
+    ldstr "'LongMulOn32BitTest::LongMul_7' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT28:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_8(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT29
+    ldstr "'LongMulOn32BitTest::LongMul_8' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT29:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_8(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT30
+    ldstr "'LongMulOn32BitTest::LongMul_8' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT30:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_8(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT31
+    ldstr "'LongMulOn32BitTest::LongMul_8' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT31:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_8(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT32
+    ldstr "'LongMulOn32BitTest::LongMul_8' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT32:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_9(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT33
+    ldstr "'LongMulOn32BitTest::LongMul_9' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT33:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_9(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT34
+    ldstr "'LongMulOn32BitTest::LongMul_9' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT34:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_9(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT35
+    ldstr "'LongMulOn32BitTest::LongMul_9' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT35:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_9(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT36
+    ldstr "'LongMulOn32BitTest::LongMul_9' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT36:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_10(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT37
+    ldstr "'LongMulOn32BitTest::LongMul_10' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT37:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_10(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT38
+    ldstr "'LongMulOn32BitTest::LongMul_10' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT38:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_10(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT39
+    ldstr "'LongMulOn32BitTest::LongMul_10' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT39:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_10(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT40
+    ldstr "'LongMulOn32BitTest::LongMul_10' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT40:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_11(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT41
+    ldstr "'LongMulOn32BitTest::LongMul_11' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT41:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_11(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT42
+    ldstr "'LongMulOn32BitTest::LongMul_11' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT42:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_11(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT43
+    ldstr "'LongMulOn32BitTest::LongMul_11' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT43:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_11(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT44
+    ldstr "'LongMulOn32BitTest::LongMul_11' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT44:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_12(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_12' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT45
+    }
+  NEXT45:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_12(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_12' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT46
+    }
+  NEXT46:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_12(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT47
+    ldstr "'LongMulOn32BitTest::LongMul_12' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT47:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_12(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT48
+    ldstr "'LongMulOn32BitTest::LongMul_12' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT48:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT49
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT49:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT50
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT50:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT51
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT51:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT52
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT52:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT53
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT53:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 1
+    ceq
+    brtrue NEXT54
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '1'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT54:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT55
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT55:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT56
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT56:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT57
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT57:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT58
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT58:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT59
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT59:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT60
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT60:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT61
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT61:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT62
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT62:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT63
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT63:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_13(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT64
+    ldstr "'LongMulOn32BitTest::LongMul_13' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT64:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT65
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT65:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT66
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT66:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT67
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT67:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT68
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT68:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 2147483648
+    ceq
+    brtrue NEXT69
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT69:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 1
+    ceq
+    brtrue NEXT70
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '1'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT70:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT71
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT71:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT72
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT72:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT73
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT73:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT74
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT74:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT75
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT75:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT76
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT76:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT77
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT77:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT78
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT78:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT79
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT79:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_14(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT80
+    ldstr "'LongMulOn32BitTest::LongMul_14' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT80:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT81
+    }
+  NEXT81:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT82
+    }
+  NEXT82:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT83
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT83:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT84
+    }
+  NEXT84:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT85
+    }
+  NEXT85:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT86
+    }
+  NEXT86:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT87
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT87:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT88
+    }
+  NEXT88:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT89
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT89:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT90
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT90:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT91
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT91:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT92
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT92:
+
+    .try
+    {
+      ldc.i4 2147483647
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT93
+    }
+  NEXT93:
+
+    .try
+    {
+      ldc.i4 2147483647
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_15' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT94
+    }
+  NEXT94:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT95
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT95:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_15(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT96
+    ldstr "'LongMulOn32BitTest::LongMul_15' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT96:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_16(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT97
+    ldstr "'LongMulOn32BitTest::LongMul_16' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT97:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_16(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT98
+    ldstr "'LongMulOn32BitTest::LongMul_16' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT98:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_16(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT99
+    ldstr "'LongMulOn32BitTest::LongMul_16' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT99:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_16(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT100
+    ldstr "'LongMulOn32BitTest::LongMul_16' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT100:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_17(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT101
+    ldstr "'LongMulOn32BitTest::LongMul_17' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT101:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_17(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT102
+    ldstr "'LongMulOn32BitTest::LongMul_17' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT102:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_17(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT103
+    ldstr "'LongMulOn32BitTest::LongMul_17' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT103:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_17(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT104
+    ldstr "'LongMulOn32BitTest::LongMul_17' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT104:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_18(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_18' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT105
+    }
+  NEXT105:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_18(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_18' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT106
+    }
+  NEXT106:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_18(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT107
+    ldstr "'LongMulOn32BitTest::LongMul_18' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT107:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_18(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT108
+    ldstr "'LongMulOn32BitTest::LongMul_18' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT108:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_19(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT109
+    ldstr "'LongMulOn32BitTest::LongMul_19' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT109:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_19(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT110
+    ldstr "'LongMulOn32BitTest::LongMul_19' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT110:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_19(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT111
+    ldstr "'LongMulOn32BitTest::LongMul_19' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT111:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_19(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT112
+    ldstr "'LongMulOn32BitTest::LongMul_19' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT112:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_20(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT113
+    ldstr "'LongMulOn32BitTest::LongMul_20' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT113:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_20(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT114
+    ldstr "'LongMulOn32BitTest::LongMul_20' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT114:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_20(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT115
+    ldstr "'LongMulOn32BitTest::LongMul_20' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT115:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_20(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT116
+    ldstr "'LongMulOn32BitTest::LongMul_20' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT116:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_21(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_21' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT117
+    }
+  NEXT117:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_21(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_21' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT118
+    }
+  NEXT118:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_21(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT119
+    ldstr "'LongMulOn32BitTest::LongMul_21' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT119:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_21(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT120
+    ldstr "'LongMulOn32BitTest::LongMul_21' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT120:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_22(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT121
+    ldstr "'LongMulOn32BitTest::LongMul_22' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT121:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_22(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT122
+    ldstr "'LongMulOn32BitTest::LongMul_22' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT122:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_22(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT123
+    ldstr "'LongMulOn32BitTest::LongMul_22' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT123:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_22(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT124
+    ldstr "'LongMulOn32BitTest::LongMul_22' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT124:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_23(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT125
+    ldstr "'LongMulOn32BitTest::LongMul_23' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT125:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_23(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT126
+    ldstr "'LongMulOn32BitTest::LongMul_23' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT126:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_23(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT127
+    ldstr "'LongMulOn32BitTest::LongMul_23' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT127:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_23(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT128
+    ldstr "'LongMulOn32BitTest::LongMul_23' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT128:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_24(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT129
+    ldstr "'LongMulOn32BitTest::LongMul_24' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT129:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_24(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT130
+    ldstr "'LongMulOn32BitTest::LongMul_24' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT130:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_24(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT131
+    ldstr "'LongMulOn32BitTest::LongMul_24' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT131:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_24(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT132
+    ldstr "'LongMulOn32BitTest::LongMul_24' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT132:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_25(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT133
+    ldstr "'LongMulOn32BitTest::LongMul_25' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT133:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_25(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT134
+    ldstr "'LongMulOn32BitTest::LongMul_25' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT134:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_25(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT135
+    ldstr "'LongMulOn32BitTest::LongMul_25' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT135:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_25(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT136
+    ldstr "'LongMulOn32BitTest::LongMul_25' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT136:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_26(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT137
+    ldstr "'LongMulOn32BitTest::LongMul_26' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT137:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_26(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT138
+    ldstr "'LongMulOn32BitTest::LongMul_26' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT138:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_26(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT139
+    ldstr "'LongMulOn32BitTest::LongMul_26' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT139:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_26(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT140
+    ldstr "'LongMulOn32BitTest::LongMul_26' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT140:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_27(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_27' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT141
+    }
+  NEXT141:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_27(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_27' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT142
+    }
+  NEXT142:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_27(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT143
+    ldstr "'LongMulOn32BitTest::LongMul_27' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT143:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_27(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT144
+    ldstr "'LongMulOn32BitTest::LongMul_27' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT144:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT145
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT145:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT146
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT146:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT147
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT147:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT148
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT148:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT149
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT149:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT150
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT150:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT151
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT151:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT152
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT152:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT153
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT153:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT154
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT154:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT155
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT155:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT156
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT156:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT157
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT157:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT158
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT158:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT159
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT159:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_28(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT160
+    ldstr "'LongMulOn32BitTest::LongMul_28' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT160:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT161
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT161:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT162
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT162:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT163
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT163:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT164
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT164:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT165
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT165:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT166
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT166:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT167
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT167:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT168
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT168:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT169
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT169:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT170
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT170:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT171
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT171:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT172
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT172:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT173
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT173:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT174
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT174:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT175
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT175:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_29(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT176
+    ldstr "'LongMulOn32BitTest::LongMul_29' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT176:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT177
+    }
+  NEXT177:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT178
+    }
+  NEXT178:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT179
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT179:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT180
+    }
+  NEXT180:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT181
+    }
+  NEXT181:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT182
+    }
+  NEXT182:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT183
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT183:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_30' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT184
+    }
+  NEXT184:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT185
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT185:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT186
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT186:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT187
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT187:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT188
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT188:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT189
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT189:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT190
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT190:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT191
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT191:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_30(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT192
+    ldstr "'LongMulOn32BitTest::LongMul_30' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT192:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_31(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT193
+    ldstr "'LongMulOn32BitTest::LongMul_31' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT193:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_31(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT194
+    ldstr "'LongMulOn32BitTest::LongMul_31' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT194:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_31(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT195
+    ldstr "'LongMulOn32BitTest::LongMul_31' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT195:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_31(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT196
+    ldstr "'LongMulOn32BitTest::LongMul_31' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT196:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_32(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT197
+    ldstr "'LongMulOn32BitTest::LongMul_32' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT197:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_32(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT198
+    ldstr "'LongMulOn32BitTest::LongMul_32' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT198:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_32(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT199
+    ldstr "'LongMulOn32BitTest::LongMul_32' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT199:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_32(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT200
+    ldstr "'LongMulOn32BitTest::LongMul_32' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT200:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_33(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_33' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT201
+    }
+  NEXT201:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_33(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_33' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT202
+    }
+  NEXT202:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_33(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT203
+    ldstr "'LongMulOn32BitTest::LongMul_33' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT203:
+
+    .try
+    {
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_33(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_33' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT204
+    }
+  NEXT204:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_34(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT205
+    ldstr "'LongMulOn32BitTest::LongMul_34' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT205:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_34(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT206
+    ldstr "'LongMulOn32BitTest::LongMul_34' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT206:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_34(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT207
+    ldstr "'LongMulOn32BitTest::LongMul_34' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT207:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_34(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT208
+    ldstr "'LongMulOn32BitTest::LongMul_34' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT208:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_35(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT209
+    ldstr "'LongMulOn32BitTest::LongMul_35' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT209:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_35(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT210
+    ldstr "'LongMulOn32BitTest::LongMul_35' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT210:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_35(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT211
+    ldstr "'LongMulOn32BitTest::LongMul_35' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT211:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_35(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT212
+    ldstr "'LongMulOn32BitTest::LongMul_35' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT212:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_36(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_36' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT213
+    }
+  NEXT213:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_36(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_36' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT214
+    }
+  NEXT214:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_36(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT215
+    ldstr "'LongMulOn32BitTest::LongMul_36' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT215:
+
+    .try
+    {
+      ldc.i4 2147483647
+      call int64 LongMulOn32BitTest::LongMul_36(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_36' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT216
+    }
+  NEXT216:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_37(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT217
+    ldstr "'LongMulOn32BitTest::LongMul_37' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT217:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_37(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT218
+    ldstr "'LongMulOn32BitTest::LongMul_37' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT218:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_37(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT219
+    ldstr "'LongMulOn32BitTest::LongMul_37' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT219:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_37(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT220
+    ldstr "'LongMulOn32BitTest::LongMul_37' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT220:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_38(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT221
+    ldstr "'LongMulOn32BitTest::LongMul_38' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT221:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_38(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT222
+    ldstr "'LongMulOn32BitTest::LongMul_38' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT222:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_38(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT223
+    ldstr "'LongMulOn32BitTest::LongMul_38' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT223:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_38(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT224
+    ldstr "'LongMulOn32BitTest::LongMul_38' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT224:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_39(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT225
+    ldstr "'LongMulOn32BitTest::LongMul_39' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT225:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_39(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT226
+    ldstr "'LongMulOn32BitTest::LongMul_39' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT226:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_39(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT227
+    ldstr "'LongMulOn32BitTest::LongMul_39' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT227:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_39(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT228
+    ldstr "'LongMulOn32BitTest::LongMul_39' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT228:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_40(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT229
+    ldstr "'LongMulOn32BitTest::LongMul_40' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT229:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_40(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT230
+    ldstr "'LongMulOn32BitTest::LongMul_40' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT230:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_40(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT231
+    ldstr "'LongMulOn32BitTest::LongMul_40' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT231:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_40(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT232
+    ldstr "'LongMulOn32BitTest::LongMul_40' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT232:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_41(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT233
+    ldstr "'LongMulOn32BitTest::LongMul_41' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT233:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_41(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT234
+    ldstr "'LongMulOn32BitTest::LongMul_41' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT234:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_41(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT235
+    ldstr "'LongMulOn32BitTest::LongMul_41' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT235:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_41(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT236
+    ldstr "'LongMulOn32BitTest::LongMul_41' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT236:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_42(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT237
+    ldstr "'LongMulOn32BitTest::LongMul_42' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT237:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_42(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT238
+    ldstr "'LongMulOn32BitTest::LongMul_42' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT238:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_42(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT239
+    ldstr "'LongMulOn32BitTest::LongMul_42' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT239:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_42(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT240
+    ldstr "'LongMulOn32BitTest::LongMul_42' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT240:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT241
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT241:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT242
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT242:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT243
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT243:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT244
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT244:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT245
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT245:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT246
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT246:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT247
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT247:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT248
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT248:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT249
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT249:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT250
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT250:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT251
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT251:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT252
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT252:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT253
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT253:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT254
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT254:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT255
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT255:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_43(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT256
+    ldstr "'LongMulOn32BitTest::LongMul_43' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT256:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686018427387904
+    ceq
+    brtrue NEXT257
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT257:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483648
+    ceq
+    brtrue NEXT258
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-2147483648'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT258:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT259
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT259:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT260
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT260:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -9223372034707292160
+    ceq
+    brtrue NEXT261
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT261:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4294967295
+    ceq
+    brtrue NEXT262
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-4294967295'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT262:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT263
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT263:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT264
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT264:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT265
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT265:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT266
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT266:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT267
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT267:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT268
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT268:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -4611686016279904256
+    ceq
+    brtrue NEXT269
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT269:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -2147483647
+    ceq
+    brtrue NEXT270
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '-2147483647'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT270:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT271
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT271:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_44(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT272
+    ldstr "'LongMulOn32BitTest::LongMul_44' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT272:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT273
+    }
+  NEXT273:
+
+    .try
+    {
+      ldc.i4 -2147483648
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT274
+    }
+  NEXT274:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT275
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT275:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT276
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT276:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT277
+    }
+  NEXT277:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT278
+    }
+  NEXT278:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT279
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT279:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT280
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT280:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT281
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT281:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT282
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT282:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT283
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT283:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT284
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT284:
+
+    .try
+    {
+      ldc.i4 2147483647
+      ldc.i4 -2147483648
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT285
+    }
+  NEXT285:
+
+    .try
+    {
+      ldc.i4 2147483647
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_45' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT286
+    }
+  NEXT286:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT287
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT287:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_45(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT288
+    ldstr "'LongMulOn32BitTest::LongMul_45' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT288:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_46(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT289
+    ldstr "'LongMulOn32BitTest::LongMul_46' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT289:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_46(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT290
+    ldstr "'LongMulOn32BitTest::LongMul_46' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT290:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_46(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT291
+    ldstr "'LongMulOn32BitTest::LongMul_46' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT291:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_46(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT292
+    ldstr "'LongMulOn32BitTest::LongMul_46' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT292:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_47(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT293
+    ldstr "'LongMulOn32BitTest::LongMul_47' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT293:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_47(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT294
+    ldstr "'LongMulOn32BitTest::LongMul_47' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT294:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_47(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT295
+    ldstr "'LongMulOn32BitTest::LongMul_47' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT295:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_47(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT296
+    ldstr "'LongMulOn32BitTest::LongMul_47' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT296:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_48(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT297
+    ldstr "'LongMulOn32BitTest::LongMul_48' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT297:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_48(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT298
+    ldstr "'LongMulOn32BitTest::LongMul_48' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT298:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_48(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT299
+    ldstr "'LongMulOn32BitTest::LongMul_48' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT299:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_48(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT300
+    ldstr "'LongMulOn32BitTest::LongMul_48' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT300:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_49(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT301
+    ldstr "'LongMulOn32BitTest::LongMul_49' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT301:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_49(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -8589934591
+    ceq
+    brtrue NEXT302
+    ldstr "'LongMulOn32BitTest::LongMul_49' returned: '{0}'. Expected: '-8589934591'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT302:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_49(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT303
+    ldstr "'LongMulOn32BitTest::LongMul_49' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT303:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_49(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT304
+    ldstr "'LongMulOn32BitTest::LongMul_49' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT304:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_50(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT305
+    ldstr "'LongMulOn32BitTest::LongMul_50' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT305:
+
+    .try
+    {
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_50(int32)
+      ldstr "'LongMulOn32BitTest::LongMul_50' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT306
+    }
+  NEXT306:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_50(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT307
+    ldstr "'LongMulOn32BitTest::LongMul_50' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT307:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_50(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT308
+    ldstr "'LongMulOn32BitTest::LongMul_50' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT308:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_51(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT309
+    ldstr "'LongMulOn32BitTest::LongMul_51' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT309:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_51(int32)
+    stloc result
+    ldloc result
+    ldc.i8 -8589934591
+    ceq
+    brtrue NEXT310
+    ldstr "'LongMulOn32BitTest::LongMul_51' returned: '{0}'. Expected: '-8589934591'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT310:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_51(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT311
+    ldstr "'LongMulOn32BitTest::LongMul_51' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT311:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_51(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT312
+    ldstr "'LongMulOn32BitTest::LongMul_51' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT312:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_52(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT313
+    ldstr "'LongMulOn32BitTest::LongMul_52' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT313:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_52(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT314
+    ldstr "'LongMulOn32BitTest::LongMul_52' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT314:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_52(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT315
+    ldstr "'LongMulOn32BitTest::LongMul_52' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT315:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_52(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT316
+    ldstr "'LongMulOn32BitTest::LongMul_52' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT316:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_53(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT317
+    ldstr "'LongMulOn32BitTest::LongMul_53' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT317:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_53(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT318
+    ldstr "'LongMulOn32BitTest::LongMul_53' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT318:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_53(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT319
+    ldstr "'LongMulOn32BitTest::LongMul_53' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT319:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_53(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT320
+    ldstr "'LongMulOn32BitTest::LongMul_53' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT320:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_54(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT321
+    ldstr "'LongMulOn32BitTest::LongMul_54' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT321:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_54(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT322
+    ldstr "'LongMulOn32BitTest::LongMul_54' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT322:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_54(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT323
+    ldstr "'LongMulOn32BitTest::LongMul_54' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT323:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_54(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT324
+    ldstr "'LongMulOn32BitTest::LongMul_54' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT324:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_55(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT325
+    ldstr "'LongMulOn32BitTest::LongMul_55' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT325:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_55(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT326
+    ldstr "'LongMulOn32BitTest::LongMul_55' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT326:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_55(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT327
+    ldstr "'LongMulOn32BitTest::LongMul_55' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT327:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_55(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT328
+    ldstr "'LongMulOn32BitTest::LongMul_55' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT328:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_56(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT329
+    ldstr "'LongMulOn32BitTest::LongMul_56' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT329:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_56(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT330
+    ldstr "'LongMulOn32BitTest::LongMul_56' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT330:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_56(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT331
+    ldstr "'LongMulOn32BitTest::LongMul_56' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT331:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_56(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT332
+    ldstr "'LongMulOn32BitTest::LongMul_56' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT332:
+
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_57(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT333
+    ldstr "'LongMulOn32BitTest::LongMul_57' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT333:
+
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_57(int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT334
+    ldstr "'LongMulOn32BitTest::LongMul_57' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT334:
+
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_57(int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT335
+    ldstr "'LongMulOn32BitTest::LongMul_57' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT335:
+
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_57(int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT336
+    ldstr "'LongMulOn32BitTest::LongMul_57' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT336:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT337
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT337:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT338
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT338:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT339
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT339:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT340
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT340:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT341
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT341:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -8589934591
+    ceq
+    brtrue NEXT342
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '-8589934591'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT342:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT343
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT343:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT344
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT344:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT345
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT345:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT346
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT346:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT347
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT347:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT348
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT348:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT349
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT349:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT350
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT350:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT351
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT351:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_58(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT352
+    ldstr "'LongMulOn32BitTest::LongMul_58' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT352:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT353
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT353:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT354
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT354:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT355
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT355:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT356
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT356:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT357
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT357:
+
+    .try
+    {
+      ldc.i4 -1
+      ldc.i4 -1
+      call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+      ldstr "'LongMulOn32BitTest::LongMul_59' failed to throw OverflowException"
+      call void LongMulOn32BitTest::PrintError(string)
+      leave FAIL
+    }
+    catch [System.Runtime]System.OverflowException
+    {
+      leave NEXT358
+    }
+  NEXT358:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT359
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT359:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT360
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT360:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT361
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT361:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT362
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT362:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT363
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT363:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT364
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT364:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT365
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT365:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT366
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT366:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT367
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT367:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_59(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT368
+    ldstr "'LongMulOn32BitTest::LongMul_59' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT368:
+
+    ldc.i4 -2147483648
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686018427387904
+    ceq
+    brtrue NEXT369
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '4611686018427387904'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT369:
+
+    ldc.i4 -2147483648
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT370
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT370:
+
+    ldc.i4 -2147483648
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT371
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT371:
+
+    ldc.i4 -2147483648
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT372
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT372:
+
+    ldc.i4 -1
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372034707292160
+    ceq
+    brtrue NEXT373
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '9223372034707292160'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT373:
+
+    ldc.i4 -1
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 -8589934591
+    ceq
+    brtrue NEXT374
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '-8589934591'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT374:
+
+    ldc.i4 -1
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT375
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT375:
+
+    ldc.i4 -1
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT376
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT376:
+
+    ldc.i4 0
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT377
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT377:
+
+    ldc.i4 0
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT378
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT378:
+
+    ldc.i4 0
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT379
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT379:
+
+    ldc.i4 0
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT380
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT380:
+
+    ldc.i4 2147483647
+    ldc.i4 -2147483648
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686016279904256
+    ceq
+    brtrue NEXT381
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '4611686016279904256'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT381:
+
+    ldc.i4 2147483647
+    ldc.i4 -1
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 9223372030412324865
+    ceq
+    brtrue NEXT382
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '9223372030412324865'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT382:
+
+    ldc.i4 2147483647
+    ldc.i4 0
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 0
+    ceq
+    brtrue NEXT383
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '0'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT383:
+
+    ldc.i4 2147483647
+    ldc.i4 2147483647
+    call int64 LongMulOn32BitTest::LongMul_60(int32, int32)
+    stloc result
+    ldloc result
+    ldc.i8 4611686014132420609
+    ceq
+    brtrue NEXT384
+    ldstr "'LongMulOn32BitTest::LongMul_60' returned: '{0}'. Expected: '4611686014132420609'"
+    ldloc result
+    call void LongMulOn32BitTest::PrintErrorWithResult(string, int64)
+    br FAIL
+  NEXT384:
+
+    ldstr "SUCCESS"
+    call void [System.Console]System.Console::WriteLine(string)
+    ldc.i4 100
+    ret
+FAIL:
+    ldstr "FAILED"
+    call void LongMulOn32BitTest::PrintError(string)
+    ldc.i4 1
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_1(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_2(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_3(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_4(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_5(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_6(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_7(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_8(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_9(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_10(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_11(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_12(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_13(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_14(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_15(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_16(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_17(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_18(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -2147483648
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_19(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_20(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_21(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 -1
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_22(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_23(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_24(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 0
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_25(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_26(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_27(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldc.i4 2147483647
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_28(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_29(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_30(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.i8
+    ldarg right
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_31(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_32(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_33(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_34(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_35(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_36(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_37(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_38(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_39(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_40(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_41(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_42(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_43(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.i8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_44(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.i8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_45(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.i8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_46(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_47(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_48(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -2147483648
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_49(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_50(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_51(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 -1
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_52(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_53(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_54(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 0
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_55(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_56(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_57(int32 left) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldc.i4 2147483647
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_58(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.u8
+    mul
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_59(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.u8
+    mul.ovf
+    ret
+  }
+
+  .method private hidebysig static int64 LongMul_60(int32 left, int32 right) cil managed noinlining
+  {
+    ldarg left
+    conv.u8
+    ldarg right
+    conv.u8
+    mul.ovf.un
+    ret
+  }
+}

--- a/src/tests/JIT/Methodical/int64/misc/longmul.ilproj
+++ b/src/tests/JIT/Methodical/int64/misc/longmul.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="longmul.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Methodical/int64/misc/longmul_gen.csx
+++ b/src/tests/JIT/Methodical/int64/misc/longmul_gen.csx
@@ -1,0 +1,324 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file contains the code that generates "longmul.il", on stdout.
+// It can be executed via the global "dotnet-script" tool (dotnet tool install -g dotnet-script).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using static TestsGen;
+
+var testName = "LongMulOn32BitTest";
+
+OutLicenseHeader();
+Out(".assembly extern System.Console { auto }");
+Out(".assembly extern System.Runtime { auto }");
+Out($".assembly {testName} {{ }}");
+Out();
+
+OpenScope($".class auto {testName} extends [System.Runtime]System.Object");
+
+var inputConsts = new int[]
+{
+    int.MinValue,
+    -1,
+    0,
+    int.MaxValue
+};
+
+var inputValues = new List<string>();
+foreach (var inputConst in inputConsts)
+{
+    inputValues.Add($"ldc.i4 {inputConst}");
+}
+inputValues.Add("ldarg");
+
+var casts = new[] { "conv.i8", "conv.u8" };
+var inputs = new List<InputKind>();
+foreach (var cast in casts)
+{
+    foreach (var value in inputValues)
+    {
+        inputs.Add(new InputKind { Cast = cast, Value = value });
+    }
+}
+
+var muls = new HashSet<LongMul>();
+foreach (var left in inputs)
+{
+    foreach (var right in inputs)
+    {
+        // Don't include folded cases to keep the size of the test down.
+        if (left.IsConst && right.IsConst)
+        {
+            break;
+        }
+
+        var leftInput = left;
+        var rightInput = right;
+        if (left.IsArg)
+        {
+            leftInput = new InputKind { Cast = left.Cast, Value = "ldarg left" };
+        }
+        if (right.IsArg)
+        {
+            rightInput = new InputKind { Cast = right.Cast, Value = "ldarg right" };
+        }
+
+        var index = muls.Count;
+        var mul = new LongMul { Left = leftInput, Right = rightInput };
+
+        muls.Add(new LongMul { Left = mul.Left, Right = mul.Right, MethodName = $"LongMul_{++index}" });
+        muls.Add(new LongMul { Left = mul.Left, Right = mul.Right, MethodName = $"LongMul_{++index}", IsOverflow = true });
+        muls.Add(new LongMul { Left = mul.Left, Right = mul.Right, MethodName = $"LongMul_{++index}", IsOverflow = true, IsUnsigned = true });
+    }
+}
+
+OpenScope(".method private hidebysig static void PrintErrorWithResult(string message, int64 result) cil managed");
+Out("call class [System.Runtime]System.IO.TextWriter [System.Console]System.Console::get_Error()");
+Out("ldarg message");
+Out("ldarg result");
+Out("box [System.Runtime]System.Int64");
+Out("callvirt instance void [System.Runtime]System.IO.TextWriter::WriteLine(string, object)");
+Out("ret");
+CloseScope();
+
+Out();
+OpenScope(".method private hidebysig static void PrintError(string message) cil managed");
+Out($"call class [System.Runtime]System.IO.TextWriter [System.Console]System.Console::get_Error()");
+Out($"ldarg message");
+Out($"callvirt instance void [System.Runtime]System.IO.TextWriter::WriteLine(string)");
+Out("ret");
+CloseScope();
+
+void Print(string msg)
+{
+    Out($@"ldstr ""{msg}""");
+    Out($"call void [System.Console]System.Console::WriteLine(string)");
+}
+
+void PrintError(string msg)
+{
+    Out($@"ldstr ""{msg}""");
+    Out($"call void {testName}::PrintError(string)");
+}
+
+void PrintErrorWithResult(string fmt)
+{
+    Out($@"ldstr ""{fmt}""");
+    Out("ldloc result");
+    Out($"call void {testName}::PrintErrorWithResult(string, int64)");
+}
+
+Out();
+OpenScope(".method private hidebysig static int32 Main() cil managed");
+Out(".entrypoint");
+Out(".locals ( int64 result )");
+
+var nextBranchIndex = 0;
+foreach (var mul in muls)
+{
+    var leftValues = mul.Left.IsConst ? new[] { mul.Left.Const } : inputConsts;
+    var rightValues = mul.Right.IsConst ? new[] { mul.Right.Const } : inputConsts;
+    var scenarios = new List<(bool EmitLeft, bool EmitRight, int LeftValue, int RightValue, long? Expected)>();
+
+    foreach (var leftValue in leftValues)
+    {
+        foreach (var rightValue in rightValues)
+        {
+            var longLeftValue = mul.Left.SignExtends ? SignExtend(leftValue) : ZeroExtend(leftValue);
+            var longRightValue = mul.Right.SignExtends ? SignExtend(rightValue) : ZeroExtend(rightValue);
+
+            long? expected = longLeftValue * longRightValue;
+            var emitLeft = mul.Left.IsArg;
+            var emitRight = mul.Right.IsArg;
+
+            if (mul.IsOverflow)
+            {
+                bool overflow = mul.IsUnsigned ?
+                    (ulong)expected != new BigInteger((ulong)longLeftValue) * new BigInteger((ulong)longRightValue) :
+                    expected != new BigInteger(longLeftValue) * new BigInteger(longRightValue);
+
+                if (overflow)
+                {
+                    expected = null;
+                }
+            }
+
+            scenarios.Add((emitLeft, emitRight, leftValue, rightValue, expected));
+        }
+    }
+
+    foreach (var (emitLeft, emitRight, leftValue, rightValue, expected) in scenarios)
+    {
+        Out();
+
+        var expectOverflow = expected is null;
+        if (expectOverflow)
+        {
+            OpenScope(".try");
+        }
+
+        if (emitLeft)
+        {
+            Out($"ldc.i4 {leftValue}");
+        }
+        if (emitRight)
+        {
+            Out($"ldc.i4 {rightValue}");
+        }
+        var fullMethodName = $"{testName}::{mul.MethodName}";
+        Out($"call int64 {fullMethodName}({string.Join(", ", Enumerable.Repeat("int32", mul.ArgCount))})");
+
+        if (expectOverflow)
+        {
+            PrintError($"'{fullMethodName}' failed to throw OverflowException");
+            Out("leave FAIL");
+            CloseScope();
+            OpenScope("catch [System.Runtime]System.OverflowException");
+            Out($"leave NEXT{++nextBranchIndex}");
+            CloseScope();
+        }
+        else
+        {
+            Out("stloc result");
+            Out("ldloc result");
+            Out($"ldc.i8 {expected}");
+            Out($"ceq");
+            Out($"brtrue NEXT{++nextBranchIndex}");
+            PrintErrorWithResult($"'{fullMethodName}' returned: '{{0}}'. Expected: '{expected}'");
+            Out("br FAIL");
+        }
+
+        Out($"NEXT{nextBranchIndex}:", $"{TestsGen.LastIndent}");
+    }
+}
+
+Out();
+Print("SUCCESS");
+Out("ldc.i4 100");
+Out("ret");
+
+Out("FAIL:", "");
+PrintError("FAILED");
+Out("ldc.i4 1");
+Out("ret");
+
+CloseScope();
+
+foreach (var mul in muls)
+{
+    var parameters = new List<string>();
+    if (mul.Left.IsArg)
+    {
+        parameters.Add("int32 left");
+    }
+    if (mul.Right.IsArg)
+    {
+        parameters.Add("int32 right");
+    }
+
+    Out();
+    OpenScope($".method private hidebysig static int64 {mul.MethodName}({string.Join(", ", parameters)}) cil managed noinlining");
+    Out(mul.Left.Value);
+    Out(mul.Left.Cast);
+    Out(mul.Right.Value);
+    Out(mul.Right.Cast);
+    Out(mul.Instruction());
+    Out("ret");
+    CloseScope();
+}
+
+CloseScope();
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+static long SignExtend(int value) => value;
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+static long ZeroExtend(int value) => (uint)value;
+
+public sealed class LongMul
+{
+    public InputKind Left { get; set; }
+    public InputKind Right { get; set; }
+    public bool IsOverflow { get; set; }
+    public bool IsUnsigned { get; set; }
+
+    public string MethodName { get; set; }
+
+    public int ArgCount => (Left.IsArg, Right.IsArg) switch
+    {
+        (true, true) => 2,
+        (false, false) => 0,
+        _ => 1
+    };
+
+    public string Instruction() => $"mul{(IsOverflow ? ".ovf" : "")}{(IsUnsigned ? ".un" : "")}";
+
+    public override int GetHashCode() => HashCode.Combine(Left, Right, IsOverflow, IsUnsigned);
+
+    public bool Equals(LongMul other) =>
+        other != null &&
+        Left.Equals(other.Left) &&
+        Right.Equals(other.Right) &&
+        IsOverflow == other.IsOverflow &&
+        IsUnsigned == other.IsUnsigned;
+}
+
+public sealed class InputKind : IEquatable<InputKind>
+{
+    public string Value { get; set; }
+    public string Cast { get; set; }
+
+    public bool SignExtends => Cast.Contains("i8");
+    public bool IsArg => Value.Contains("ldarg");
+    public bool IsConst => Value.Contains("ldc");
+
+    public int Const => int.Parse(Value.Split()[1]);
+
+    public override bool Equals(object obj) => Equals(obj as InputKind);
+    public bool Equals(InputKind other) => other != null && Value == other.Value && Cast == other.Cast;
+    public override int GetHashCode() => HashCode.Combine(Value, Cast);
+}
+
+public static class TestsGen
+{
+    public static string IndentBase { get; set; } = "  ";
+    public static string Indent { get; private set; }
+    public static string LastIndent => Indent.Substring(0, Indent.Length - IndentBase.Length);
+
+    public static void OpenScope(string header)
+    {
+        Out(header);
+        Out("{");
+        Indent += IndentBase;
+    }
+
+    public static void CloseScope()
+    {
+        Indent = Indent.Substring(0, Indent.Length - IndentBase.Length);
+        Out("}");
+    }
+
+    public static void Out(string line = "", string indent = null)
+    {
+        if (indent is null)
+        {
+            indent = Indent;
+        }
+
+        line = string.IsNullOrWhiteSpace(line) ? "" : indent + line;
+
+        Console.WriteLine(line);
+    }
+
+    public static void OutLicenseHeader()
+    {
+        Out("// Licensed to the .NET Foundation under one or more agreements.");
+        Out("// The .NET Foundation licenses this file to you under the MIT license.");
+        Out();
+    }
+}

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1031,6 +1031,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/value_numbering_checked_casts_of_constants/*">
             <Issue>https://github.com/dotnet/runtime/issues/51323</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/int64/misc/longmul/*">
+            <Issue>https://github.com/dotnet/runtime/issues/51323</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
             <Issue>Mono does not define out of range fp to int conversions</Issue>
         </ExcludeList>


### PR DESCRIPTION
Previously, morph was looking for the exact pattern of `MUL(CAST(long <- int), CAST(long <- int))` when assessing
candidacy of `GT_MUL` for being marked with `GTF_MUL_64RSLT` and emitted as "long mul".

This worked fine, until the importer [was changed](https://github.com/dotnet/runtime/pull/47133) to fold all casts with constant operands. This broke the pattern matching and thus all `MUL`s in the form of `(long)value * 10` started being emitted as helper calls.

This change updates morph to understand the new folded casts and in general updates the "format" of long mul from `CAST * CAST` to `CAST * (CAST | CONST)`.

In the process, new helper functions have been introduced, to avoid bloating `fgMorphSmpOp` with the new sizeable logic.

Recognition of overflowing cases has been upgraded, and a correctness bug, where `checked((long)uint.MaxValue * (long)uint.MaxValue)` was wrongly treated as non-overflowing, fixed.

Additionally, the logic to emit intermediate `NOP`s has been changed to instead always skip morphing the casts themselves,
even when remorphing.

A new test has been added, generated via a [script](https://gist.github.com/SingleAccretion/79a6994c53ea9576e33fd090f97254af). The test is meant to be an outerloop one, but I am temporarily marking it Pri0 for it to run in CI.

Also, a few helpers for working with `gtFlags` have been added.

Diffs for this change:

<details>
<summary>Windows x86</summary>

```
Running asm diffs of benchmarks.run.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 222768
Total bytes of diff: 220093
Total bytes of delta: -2675 (-1.20% of base)
    diff is an improvement.


Top file improvements (bytes):
        -298 : 13447.dasm (-3.03% of base)
        -265 : 19727.dasm (-2.85% of base)
        -250 : 14674.dasm (-0.79% of base)
        -243 : 21662.dasm (-1.17% of base)
        -197 : 15230.dasm (-0.57% of base)
        -176 : 13430.dasm (-0.69% of base)
        -172 : 22974.dasm (-1.85% of base)
        -169 : 15250.dasm (-1.72% of base)
         -70 : 13795.dasm (-10.39% of base)
         -62 : 22688.dasm (-2.95% of base)
         -56 : 14057.dasm (-4.83% of base)
         -55 : 6211.dasm (-3.92% of base)
         -40 : 19713.dasm (-0.39% of base)
         -37 : 23755.dasm (-2.74% of base)
         -37 : 2650.dasm (-0.99% of base)
         -33 : 1986.dasm (-10.89% of base)
         -28 : 14675.dasm (-0.70% of base)
         -28 : 10969.dasm (-0.54% of base)
         -25 : 10376.dasm (-1.61% of base)
         -21 : 20640.dasm (-0.49% of base)

57 total files with Code Size differences (57 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -298 (-3.03% of base) - Jil.Deserialize.Methods:_ReadISO8601DateWithOffsetThunkReader(byref,System.Char[]):System.DateTimeOffset
        -265 (-2.85% of base) - Jil.Deserialize.Methods:_ReadISO8601DateThunkReader(byref,System.Char[]):System.DateTime
        -250 (-0.79% of base) - DynamicClass:_DynamicMethod0(byref,MicroBenchmarks.Serializers.MyEventsListerItem,int)
        -243 (-1.17% of base) - DynamicClass:_DynamicMethod0(System.IO.TextWriter,MicroBenchmarks.Serializers.IndexViewModel,int)
        -197 (-0.57% of base) - DynamicClass:_DynamicMethod0(System.IO.TextWriter,MicroBenchmarks.Serializers.MyEventsListerItem,int)
        -176 (-0.69% of base) - DynamicClass:_DynamicMethod0(byref,MicroBenchmarks.Serializers.IndexViewModel,int)
        -172 (-1.85% of base) - Jil.Deserialize.Methods:_ReadISO8601Date(System.IO.TextReader,System.Char[]):System.DateTime
        -169 (-1.72% of base) - Jil.Deserialize.Methods:_ReadISO8601DateWithOffset(System.IO.TextReader,System.Char[]):System.DateTimeOffset
         -70 (-10.39% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -62 (-2.95% of base) - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTime
         -56 (-4.83% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
         -55 (-3.92% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -40 (-0.39% of base) - DynamicClass:_DynamicMethod0(byref,MicroBenchmarks.Serializers.CollectionsOfPrimitives,int)
         -37 (-2.74% of base) - System.Xml.XmlConverter:TryParseDateTime(System.Byte[],int,int,byref):bool
         -37 (-0.99% of base) - Utf8Json.Formatters.ISO8601DateTimeOffsetFormatter:Deserialize(byref,Utf8Json.IJsonFormatterResolver):System.DateTimeOffset:this
         -33 (-10.89% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -28 (-0.70% of base) - Jil.Serialize.Methods:_CustomISO8601WithOffsetToString_ThunkWriter(byref,System.DateTime,int,int,System.Char[])
         -28 (-0.54% of base) - DynamicClass:_DynamicMethod0(System.IO.TextWriter,MicroBenchmarks.Serializers.CollectionsOfPrimitives,int)
         -25 (-1.61% of base) - System.TimeZoneInfo:CreateAdjustmentRuleFromTimeZoneInformation(byref,System.DateTime,System.DateTime,int):AdjustmentRule
         -21 (-0.49% of base) - Utf8Json.Formatters.ISO8601DateTimeFormatter:Deserialize(byref,Utf8Json.IJsonFormatterResolver):System.DateTime:this

Top method improvements (percentages):
         -33 (-10.89% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -70 (-10.39% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
          -9 (-8.91% of base) - System.Globalization.HebrewCalendar:IsLeapYear(int,int):bool:this
          -9 (-7.96% of base) - System.DateTimeOffset:get_Offset():System.TimeSpan:this
         -12 (-7.89% of base) - System.Net.Http.HttpConnection:ThrowIfExceededAllowedReadLineBytes():this
         -16 (-5.76% of base) - System.Tests.Perf_DateTime:.ctor():this
          -9 (-5.73% of base) - System.DateTimeOffset:ToString():System.String:this
         -18 (-5.70% of base) - System.DateTimeOffset:System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(System.Object):this
          -9 (-5.59% of base) - System.DateTimeOffset:ToString(System.String):System.String:this
          -9 (-5.11% of base) - System.DateTimeOffset:TryFormat(System.Span`1[Char],byref,System.ReadOnlySpan`1[Char],System.IFormatProvider):bool:this
         -56 (-4.83% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
          -9 (-4.64% of base) - System.Text.OSEncoding:GetMaxByteCount(int):int:this
          -9 (-4.35% of base) - System.DateTimeOffset:AddTicks(long):System.DateTimeOffset:this
          -9 (-4.21% of base) - System.DateTimeOffset:get_ClockDateTime():System.DateTime:this
          -9 (-4.15% of base) - System.DateTimeOffset:op_Addition(System.DateTimeOffset,System.TimeSpan):System.DateTimeOffset
          -9 (-4.11% of base) - System.DateTimeOffset:AddHours(double):System.DateTimeOffset:this
         -55 (-3.92% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -16 (-3.90% of base) - System.Tests.Perf_DateTimeOffset:.ctor():this
         -18 (-3.81% of base) - System.Runtime.Serialization.DateTimeOffsetAdapter:GetDateTimeOffset(System.Runtime.Serialization.DateTimeOffsetAdapter):System.DateTimeOffset
         -14 (-3.46% of base) - System.Text.Json.JsonHelpers:TryCreateDateTimeOffset(System.DateTime,byref,byref):bool

57 total methods with Code Size differences (57 improved, 0 regressed), 0 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 6480
Total bytes of diff: 6410
Total bytes of delta: -70 (-1.08% of base)
    diff is an improvement.


Top method regressions (bytes):
          27 ( 4.16% of base) - JitTest.Test:Main():int
          27 ( 4.16% of base) - JitTest.Test:Main():int
          18 ( 4.03% of base) - JitTest.Test:Main():int

Top method improvements (bytes):
         -28 (-2.87% of base) - Test:TestAllocInNoGCRegion(int,int,bool):bool
         -16 (-3.12% of base) - FinalizerTest:allocateInFinalizerTest():bool:this
         -11 (-11.70% of base) - SP2a:Foo(int,S):long
         -11 (-11.70% of base) - SP2b:Foo(int,S):long
         -10 (-1.19% of base) - ExchangeAdd.InterlockedAddInt:Main(System.String[]):int
         -10 (-12.50% of base) - AA:Static2(System.String[]):TestEnum[]
          -9 (-7.26% of base) - SP2c:Foo(int,long,S):long
          -9 (-4.64% of base) - System.Text.OSEncoding:GetMaxByteCount(int):int:this
          -9 (-22.50% of base) - LargeObject:get_Size():long:this
          -9 (-18.37% of base) - SP2:Foo(S):long
          -8 (-1.14% of base) - Repro:Main():int
          -5 (-1.30% of base) - JitTest.Test:Main():int
          -5 (-1.30% of base) - JitTest.Test:Main():int
          -2 (-1.74% of base) - CC:Static3(short):float

Top method regressions (percentages):
          27 ( 4.16% of base) - JitTest.Test:Main():int
          27 ( 4.16% of base) - JitTest.Test:Main():int
          18 ( 4.03% of base) - JitTest.Test:Main():int

Top method improvements (percentages):
          -9 (-22.50% of base) - LargeObject:get_Size():long:this
          -9 (-18.37% of base) - SP2:Foo(S):long
         -10 (-12.50% of base) - AA:Static2(System.String[]):TestEnum[]
         -11 (-11.70% of base) - SP2a:Foo(int,S):long
         -11 (-11.70% of base) - SP2b:Foo(int,S):long
          -9 (-7.26% of base) - SP2c:Foo(int,long,S):long
          -9 (-4.64% of base) - System.Text.OSEncoding:GetMaxByteCount(int):int:this
         -16 (-3.12% of base) - FinalizerTest:allocateInFinalizerTest():bool:this
         -28 (-2.87% of base) - Test:TestAllocInNoGCRegion(int,int,bool):bool
          -2 (-1.74% of base) - CC:Static3(short):float
          -5 (-1.30% of base) - JitTest.Test:Main():int
          -5 (-1.30% of base) - JitTest.Test:Main():int
         -10 (-1.19% of base) - ExchangeAdd.InterlockedAddInt:Main(System.String[]):int
          -8 (-1.14% of base) - Repro:Main():int

17 total methods with Code Size differences (14 improved, 3 regressed), 1 unchanged.

Running asm diffs of libraries.crossgen.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 38967
Total bytes of diff: 37400
Total bytes of delta: -1567 (-4.02% of base)
    diff is an improvement.


Top method regressions (bytes):
           3 ( 0.25% of base) - <ReadHeadersAsync>d__43:MoveNext():this

Top method improvements (bytes):
         -64 (-5.58% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
         -48 (-12.40% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,byref):bool
         -36 (-11.92% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -32 (-14.68% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -31 (-6.75% of base) - System.DateTimeParse:ParseTimeZoneOffset(byref,int,byref):bool
         -30 (-6.56% of base) - StringParser:ParseTime(byref,byref):bool:this
         -29 (-14.87% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -28 (-1.80% of base) - System.TimeZoneInfo:CreateAdjustmentRuleFromTimeZoneInformation(byref,System.DateTime,System.DateTime,int):AdjustmentRule
         -28 (-25.23% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -26 (-8.05% of base) - System.Diagnostics.EventLogInternal:ModifyOverflowPolicy(int,int):this
         -25 (-15.62% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -25 (-12.63% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -22 (-3.06% of base) - System.DateTimeParse:ParseTimeZone(byref,byref):bool
         -21 (-1.31% of base) - System.DateTimeParse:ParseFormatO(System.ReadOnlySpan`1[Char],byref):bool
         -21 (-12.65% of base) - System.TimeSpan:.ctor(int,int,int):this
         -21 (-5.16% of base) - System.Buffers.Text.Utf8Parser:TryCreateDateTimeOffset(System.DateTime,bool,int,int,byref):bool
         -20 (-3.85% of base) - Internal.Cryptography.TripleDesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -20 (-6.27% of base) - System.DateTimeOffset:System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(System.Object):this
         -20 (-2.16% of base) - DecCalc:VarDecFromR4(float,byref)
         -20 (-3.28% of base) - Internal.Cryptography.DesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this

Top method regressions (percentages):
           3 ( 0.25% of base) - <ReadHeadersAsync>d__43:MoveNext():this

Top method improvements (percentages):
         -14 (-33.33% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -19 (-32.76% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -28 (-25.23% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -15 (-17.65% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -25 (-15.62% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -29 (-14.87% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -32 (-14.68% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -13 (-13.00% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -13 (-12.87% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -13 (-12.87% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -21 (-12.65% of base) - System.TimeSpan:.ctor(int,int,int):this
         -25 (-12.63% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -17 (-12.59% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -48 (-12.40% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,byref):bool
         -36 (-11.92% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
          -9 (-11.54% of base) - System.DateTime:TimeToTicks(int,int,int):long
         -13 (-11.30% of base) - System.Data.SqlTypes.SqlMoney:op_Explicit(System.Data.SqlTypes.SqlBoolean):System.Data.SqlTypes.SqlMoney

103 total methods with Code Size differences (102 improved, 1 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 50308
Total bytes of diff: 48838
Total bytes of delta: -1470 (-2.92% of base)
    diff is an improvement.


Top method regressions (bytes):
          68 ( 5.84% of base) - <ReadHeadersAsync>d__43:MoveNext():this
          14 ( 1.68% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (bytes):
         -60 (-5.33% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
         -48 (-12.40% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,byref):bool
         -36 (-12.04% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -32 (-14.61% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -31 (-6.75% of base) - System.DateTimeParse:ParseTimeZoneOffset(byref,int,byref):bool
         -30 (-6.56% of base) - StringParser:ParseTime(byref,byref):bool:this
         -28 (-25.23% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -28 (-1.80% of base) - System.TimeZoneInfo:CreateAdjustmentRuleFromTimeZoneInformation(byref,System.DateTime,System.DateTime,int):System.TimeZoneInfo+AdjustmentRule
         -26 (-8.25% of base) - System.Diagnostics.EventLogInternal:ModifyOverflowPolicy(int,int):this
         -25 (-12.82% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -25 (-15.62% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -22 (-3.05% of base) - System.DateTimeParse:ParseTimeZone(byref,byref):bool
         -21 (-5.15% of base) - System.Buffers.Text.Utf8Parser:TryCreateDateTimeOffset(System.DateTime,bool,int,int,byref):bool
         -21 (-12.65% of base) - System.TimeSpan:.ctor(int,int,int):this
         -21 (-1.32% of base) - System.DateTimeParse:ParseFormatO(System.ReadOnlySpan`1[System.Char],byref):bool
         -20 (-3.45% of base) - Internal.Cryptography.DesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -20 (-6.25% of base) - System.DateTimeOffset:System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(System.Object):this
         -20 (-4.26% of base) - System.DateTimeOffset:EqualsExact(System.DateTimeOffset):bool:this
         -20 (-3.24% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.DateTimeOffset,System.Span`1[System.Byte],byref,System.Buffers.StandardFormat):bool
         -20 (-2.36% of base) - DecCalc:VarDecFromR4(float,byref)

Top method regressions (percentages):
          68 ( 5.84% of base) - <ReadHeadersAsync>d__43:MoveNext():this
          14 ( 1.68% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (percentages):
         -14 (-33.33% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -19 (-32.76% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -28 (-25.23% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -15 (-17.44% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -25 (-15.62% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -13 (-14.77% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -32 (-14.61% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -13 (-13.00% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -13 (-12.87% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -13 (-12.87% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -25 (-12.82% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -21 (-12.65% of base) - System.TimeSpan:.ctor(int,int,int):this
         -17 (-12.50% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -48 (-12.40% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,byref):bool
         -36 (-12.04% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
          -9 (-11.54% of base) - System.DateTime:TimeToTicks(int,int,int):long
         -13 (-11.30% of base) - System.Data.SqlTypes.SqlMoney:op_Explicit(System.Data.SqlTypes.SqlBoolean):System.Data.SqlTypes.SqlMoney
         -17 (-10.69% of base) - System.Speech.Internal.Synthesis.AudioDeviceOut:get_Duration():System.TimeSpan:this

104 total methods with Code Size differences (102 improved, 2 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 74388
Total bytes of diff: 72792
Total bytes of delta: -1596 (-2.15% of base)
    diff is an improvement.


Top method regressions (bytes):
          20 ( 1.28% of base) - <ReadHeadersAsync>d__43:MoveNext():this
           4 ( 0.46% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (bytes):
         -70 (-4.20% of base) - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTimeOffset
         -70 (-10.14% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -70 (-10.25% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(System.String,byref):bool
         -62 (-2.92% of base) - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTime
         -58 (-4.06% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -58 (-4.19% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeIso(System.String,int,byref):bool
         -53 (-1.43% of base) - System.Formats.Asn1.AsnDecoder:ParseGeneralizedTime(int,System.ReadOnlySpan`1[Byte]):System.DateTimeOffset
         -40 (-6.43% of base) - System.Xml.Schema.XsdDateTime:ToZulu():System.DateTime:this
         -39 (-0.81% of base) - System.Data.FunctionNode:EvalFunction(int,System.Object[],System.Data.DataRow,int):System.Object:this
         -37 (-2.74% of base) - System.Xml.XmlConverter:TryParseDateTime(System.Byte[],int,int,byref):bool
         -29 (-8.10% of base) - System.Net.Mime.SmtpDateTime:TryParseTimeZoneString(System.String,byref):bool:this
         -28 (-14.43% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -27 (-4.55% of base) - System.ServiceModel.Syndication.Atom10FeedFormatter:AsString(System.DateTimeOffset):System.String:this
         -27 (-3.98% of base) - System.ServiceModel.Syndication.Rss20FeedFormatter:AsString(System.DateTimeOffset):System.String:this
         -27 (-1.32% of base) - System.ComponentModel.DateTimeOffsetConverter:ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type):System.Object:this
         -26 (-23.85% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -25 (-7.60% of base) - System.Diagnostics.EventLogInternal:ModifyOverflowPolicy(int,int):this
         -23 (-10.31% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -23 (-10.31% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -20 (-4.20% of base) - System.Runtime.Serialization.DateTimeOffsetAdapter:GetDateTimeOffset(System.Runtime.Serialization.DateTimeOffsetAdapter):System.DateTimeOffset

Top method regressions (percentages):
          20 ( 1.28% of base) - <ReadHeadersAsync>d__43:MoveNext():this
           4 ( 0.46% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (percentages):
         -13 (-31.71% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -18 (-31.58% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -26 (-23.85% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -14 (-22.95% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -14 (-22.95% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -14 (-22.95% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -14 (-16.67% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -28 (-14.43% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -16 (-12.12% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -14 (-11.02% of base) - Microsoft.VisualBasic.DateAndTime:TimeSerial(int,int,int):System.DateTime
         -12 (-10.71% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -12 (-10.62% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -12 (-10.62% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -23 (-10.31% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -23 (-10.31% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -12 (-10.26% of base) - System.Speech.Internal.Synthesis.AudioDeviceOut:get_Duration():System.TimeSpan:this
         -12 (-10.26% of base) - System.Speech.Internal.Synthesis.AudioFileOut:get_Duration():System.TimeSpan:this
         -70 (-10.25% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(System.String,byref):bool
         -70 (-10.14% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -12 (-9.45% of base) - System.Data.SqlTypes.SqlMoney:op_Explicit(System.Data.SqlTypes.SqlBoolean):System.Data.SqlTypes.SqlMoney

92 total methods with Code Size differences (90 improved, 2 regressed), 1 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 372209
Total bytes of diff: 366677
Total bytes of delta: -5532 (-1.49% of base)
    diff is an improvement.


Top method regressions (bytes):
           2 ( 0.86% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime4()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime1()
           2 ( 0.80% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime10()
           2 ( 0.86% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime7()
           2 ( 0.84% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime8()
           2 ( 0.81% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime5()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime10()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime4()

Top method improvements (bytes):
        -225 (-3.08% of base) - System.Xml.Tests.ToTypeTests:ToType57():int:this
        -190 (-1.17% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_Amsterdam()
        -171 (-5.72% of base) - <GetYear_TestData>d__0:MoveNext():bool:this
        -171 (-6.17% of base) - <GetEra_TestData>d__0:MoveNext():bool:this
        -171 (-6.17% of base) - <GetMonth_TestData>d__0:MoveNext():bool:this
        -159 (-1.08% of base) - System.Tests.TimeZoneInfoTests:IsInvalidTime()
        -154 (-1.04% of base) - System.Tests.TimeZoneInfoTests:IsDaylightSavingTime()
        -120 (-1.91% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_MiscUtc()
        -111 (-2.75% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_PerthRules()
        -110 (-2.64% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_LocalAmbiguousOffsets()
        -106 (-1.55% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToUtc()
         -99 (-2.24% of base) - System.Tests.TimeZoneInfoTests:ConverTime_DateTime_VariousSystemTimeZonesTest()
         -98 (-3.61% of base) - System.Tests.DateTimeOffsetTests:ParseExact_ToStringThenParseExactRoundtrip_Success(System.String)
         -85 (-2.23% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_UtcToLocal()
         -82 (-5.35% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_Nairobi_Invalid()
         -81 (-2.66% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_Invalid()
         -77 (-1.39% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToLocal()
         -69 (-0.78% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToSystem()
         -58 (-1.26% of base) - <ConvertToTestData>d__3:MoveNext():bool:this
         -58 (-3.77% of base) - <AddMonths_TestData>d__2:MoveNext():bool:this

Top method regressions (percentages):
           2 ( 0.86% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime4()
           2 ( 0.86% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime7()
           2 ( 0.84% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime8()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeElementContentTests:ReadElementContentAsDateTime10()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime1()
           2 ( 0.83% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime4()
           2 ( 0.81% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime5()
           2 ( 0.80% of base) - System.Xml.Tests.DateTimeTests:ReadContentAsDateTime10()

Top method improvements (percentages):
         -20 (-36.36% of base) - System.Data.SqlClient.TdsParserStateObject:SetTimeoutSeconds(int):this
         -20 (-36.36% of base) - System.Data.SqlClient.TdsParserStateObject:SetTimeoutSeconds(int):this
         -13 (-31.71% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -15 (-20.00% of base) - ExtendedArray`1[Byte][System.Byte]:get_Count():long:this
         -15 (-20.00% of base) - ExtendedArray`1[__Canon][System.__Canon]:get_Count():long:this
         -24 (-16.55% of base) - NuGet.Packaging.Signing.Accuracy:GetTotalMicroseconds():System.Nullable`1[Int64]:this
         -28 (-14.43% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -29 (-12.18% of base) - genTimeZone@885-2:Invoke(int):FsCheck.Gen`1[TimeSpan]:this
         -16 (-11.85% of base) - System.Data.SqlClient.SqlBulkCopy:WriteMetaData(System.Data.SqlClient.BulkCopySimpleResultSet):this
         -16 (-11.85% of base) - System.Data.SqlClient.SqlBulkCopy:WriteMetaData(System.Data.SqlClient.BulkCopySimpleResultSet):this
         -16 (-9.70% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -16 (-9.70% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -12 (-8.51% of base) - System.Data.SqlClient.SqlSequentialStream:.ctor(System.Data.SqlClient.SqlDataReader,int):this
         -12 (-8.51% of base) - System.Data.SqlClient.SqlSequentialStream:.ctor(System.Data.SqlClient.SqlDataReader,int):this
         -14 (-8.48% of base) - <>c__DisplayClass20_0:<Ctor_InvalidMinute_ThrowsArgumentOutOfRangeException>b__0():System.Object:this
         -14 (-8.43% of base) - <>c__DisplayClass19_0:<Ctor_InvalidHour_ThrowsArgumentOutOfRangeException>b__0():System.Object:this
         -13 (-8.18% of base) - <>c__DisplayClass18_0:<Ctor_InvalidDay_ThrowsArgumentOutOfRangeException>b__2():System.Object:this
         -29 (-7.86% of base) - System.Net.Mime.SmtpDateTime:TryParseTimeZoneString(System.String,byref):bool:this
          -5 (-7.69% of base) - Microsoft.Diagnostics.Runtime.Utilities.MINIDUMP_MODULE:get_Timestamp():System.DateTime:this
         -12 (-7.36% of base) - <>c__DisplayClass21_0:<Ctor_InvalidSecond_ThrowsArgumentOutOfRangeException>b__0():System.Object:this

236 total methods with Code Size differences (228 improved, 8 regressed), 0 unchanged.
```
</details>

<details>
<summary>Linux ARM</summary>

```
Running asm diffs of coreclr_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 8500
Total bytes of diff: 8368
Total bytes of delta: -132 (-1.55% of base)
    diff is an improvement.


Top method regressions (bytes):
          16 ( 4.08% of base) - JitTest.Test:Main():int
          16 ( 2.19% of base) - JitTest.Test:Main():int
          16 ( 2.19% of base) - JitTest.Test:Main():int

Top method improvements (bytes):
         -24 (-1.84% of base) - Test:TestAllocInNoGCRegion(int,int,bool):bool
         -22 (-3.59% of base) - FinalizerTest:allocateInFinalizerTest():bool:this
         -16 (-17.39% of base) - CC:Static3(short):float
         -12 (-1.39% of base) - Repro:Main():int
         -12 (-1.12% of base) - VectorTest:Main():int
         -10 (-11.11% of base) - SP2b:Foo(int,S):long
         -10 (-1.77% of base) - JitTest.Test:Main():int
         -10 (-10.64% of base) - AA:Static2(System.String[]):TestEnum[]
         -10 (-1.77% of base) - JitTest.Test:Main():int
         -10 (-11.11% of base) - SP2a:Foo(int,S):long
         -10 (-27.78% of base) - LargeObject:get_Size():long:this
         -10 (-16.67% of base) - SP2:Foo(S):long
         -10 (-1.05% of base) - ExchangeAdd.InterlockedAddInt:Main(System.String[]):int
          -8 (-6.67% of base) - SP2c:Foo(int,long,S):long
          -6 (-4.84% of base) - AA:Static1(ushort,int,System.Boolean[,],System.SByte[][,][,,,][][,],byref,byref):System.Char[,,][,,,,]

Top method regressions (percentages):
          16 ( 4.08% of base) - JitTest.Test:Main():int
          16 ( 2.19% of base) - JitTest.Test:Main():int
          16 ( 2.19% of base) - JitTest.Test:Main():int

Top method improvements (percentages):
         -10 (-27.78% of base) - LargeObject:get_Size():long:this
         -16 (-17.39% of base) - CC:Static3(short):float
         -10 (-16.67% of base) - SP2:Foo(S):long
         -10 (-11.11% of base) - SP2b:Foo(int,S):long
         -10 (-11.11% of base) - SP2a:Foo(int,S):long
         -10 (-10.64% of base) - AA:Static2(System.String[]):TestEnum[]
          -8 (-6.67% of base) - SP2c:Foo(int,long,S):long
          -6 (-4.84% of base) - AA:Static1(ushort,int,System.Boolean[,],System.SByte[][,][,,,][][,],byref,byref):System.Char[,,][,,,,]
         -22 (-3.59% of base) - FinalizerTest:allocateInFinalizerTest():bool:this
         -24 (-1.84% of base) - Test:TestAllocInNoGCRegion(int,int,bool):bool
         -10 (-1.77% of base) - JitTest.Test:Main():int
         -10 (-1.77% of base) - JitTest.Test:Main():int
         -12 (-1.39% of base) - Repro:Main():int
         -12 (-1.12% of base) - VectorTest:Main():int
         -10 (-1.05% of base) - ExchangeAdd.InterlockedAddInt:Main(System.String[]):int

18 total methods with Code Size differences (15 improved, 3 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 49340
Total bytes of diff: 46970
Total bytes of delta: -2370 (-4.80% of base)
    diff is an improvement.


Top file improvements (bytes):
         -90 : 74659.dasm (-7.92% of base)
         -72 : 79523.dasm (-12.77% of base)
         -58 : 76410.dasm (-15.85% of base)
         -58 : 76605.dasm (-6.13% of base)
         -48 : 79154.dasm (-11.48% of base)
         -48 : 71327.dasm (-4.94% of base)
         -42 : 76579.dasm (-2.53% of base)
         -40 : 76601.dasm (-12.74% of base)
         -40 : 73835.dasm (-4.94% of base)
         -38 : 76408.dasm (-19.00% of base)
         -34 : 73589.dasm (-8.06% of base)
         -34 : 79476.dasm (-6.67% of base)
         -34 : 152799.dasm (-17.00% of base)
         -34 : 73885.dasm (-6.64% of base)
         -34 : 79213.dasm (-7.11% of base)
         -32 : 76444.dasm (-17.02% of base)
         -32 : 131539.dasm (-5.37% of base)
         -32 : 79429.dasm (-4.72% of base)
         -32 : 73584.dasm (-6.43% of base)
         -32 : 131548.dasm (-4.04% of base)

107 total files with Code Size differences (107 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -90 (-7.92% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
         -72 (-12.77% of base) - System.Buffers.Text.Utf8Parser:TryCreateTimeSpan(bool,int,int,int,int,int,byref):bool
         -58 (-15.85% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -58 (-6.13% of base) - System.TimeZoneInfo:ParseTimeOfDay(System.ReadOnlySpan`1[Char]):System.DateTime
         -48 (-11.48% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,TimeSpanToken,byref):bool
         -48 (-4.94% of base) - DecCalc:VarDecFromR4(float,byref)
         -42 (-2.53% of base) - System.TimeZoneInfo:.ctor(System.Byte[],System.String,bool):this
         -40 (-12.74% of base) - System.TimeZoneInfo:TZif_CalculateTransitionOffsetFromBase(System.TimeSpan,System.TimeSpan):System.TimeSpan
         -40 (-4.94% of base) - System.DateTimeParse:ParseTimeZone(byref,byref):bool
         -38 (-19.00% of base) - System.TimeSpan:.ctor(int,int,int):this
         -34 (-8.06% of base) - System.DateTimeOffset:System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(System.Object):this
         -34 (-6.67% of base) - System.Buffers.Text.Utf8Parser:TryCreateDateTimeOffset(System.DateTime,bool,int,int,byref):bool
         -34 (-17.00% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -34 (-6.64% of base) - System.DateTimeParse:ParseTimeZoneOffset(byref,int,byref):bool
         -34 (-7.11% of base) - StringParser:ParseTime(byref,byref):bool:this
         -32 (-17.02% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -32 (-5.37% of base) - Internal.Cryptography.AesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -32 (-4.72% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.DateTimeOffset,System.Span`1[Byte],byref,System.Buffers.StandardFormat):bool
         -32 (-6.43% of base) - System.DateTimeOffset:EqualsExact(System.DateTimeOffset):bool:this
         -32 (-4.04% of base) - Internal.Cryptography.DesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this

Top method improvements (percentages):
         -16 (-36.36% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -20 (-35.71% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -32 (-30.19% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -16 (-20.00% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -38 (-19.00% of base) - System.TimeSpan:.ctor(int,int,int):this
         -32 (-17.02% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -34 (-17.00% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -16 (-16.67% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -16 (-16.33% of base) - System.DateTime:TimeToTicks(int,int,int):long
         -16 (-16.00% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -16 (-16.00% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -58 (-15.85% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -18 (-14.75% of base) - System.Globalization.HebrewCalendar:IsLeapYear(int,int):bool:this
         -32 (-13.22% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -16 (-12.90% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -72 (-12.77% of base) - System.Buffers.Text.Utf8Parser:TryCreateTimeSpan(bool,int,int,int,int,int,byref):bool
         -40 (-12.74% of base) - System.TimeZoneInfo:TZif_CalculateTransitionOffsetFromBase(System.TimeSpan,System.TimeSpan):System.TimeSpan
         -16 (-12.70% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -16 (-12.70% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -18 (-12.68% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this

107 total methods with Code Size differences (107 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 66384
Total bytes of diff: 64020
Total bytes of delta: -2364 (-3.56% of base)
    diff is an improvement.


Top method regressions (bytes):
          12 ( 1.00% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this
           2 ( 1.20% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[System.Char],byref):bool

Top method improvements (bytes):
         -90 (-7.59% of base) - System.Number:TryNumberToDecimal(byref,byref):bool
         -72 (-12.77% of base) - System.Buffers.Text.Utf8Parser:TryCreateTimeSpan(bool,int,int,int,int,int,byref):bool
         -58 (-15.34% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -58 (-6.07% of base) - System.TimeZoneInfo:ParseTimeOfDay(System.ReadOnlySpan`1[System.Char]):System.DateTime
         -48 (-11.48% of base) - System.Globalization.TimeSpanParse:TryTimeToTicks(bool,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,System.Globalization.TimeSpanParse+TimeSpanToken,byref):bool
         -48 (-4.89% of base) - DecCalc:VarDecFromR4(float,byref)
         -42 (-2.52% of base) - System.TimeZoneInfo:.ctor(System.Byte[],System.String,bool):this
         -40 (-4.88% of base) - System.DateTimeParse:ParseTimeZone(byref,byref):bool
         -40 (-12.74% of base) - System.TimeZoneInfo:TZif_CalculateTransitionOffsetFromBase(System.TimeSpan,System.TimeSpan):System.TimeSpan
         -38 (-19.00% of base) - System.TimeSpan:.ctor(int,int,int):this
         -34 (-16.19% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -34 (-7.11% of base) - StringParser:ParseTime(byref,byref):bool:this
         -34 (-6.67% of base) - System.Buffers.Text.Utf8Parser:TryCreateDateTimeOffset(System.DateTime,bool,int,int,byref):bool
         -34 (-7.87% of base) - System.DateTimeOffset:System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(System.Object):this
         -34 (-6.64% of base) - System.DateTimeParse:ParseTimeZoneOffset(byref,int,byref):bool
         -32 (-4.41% of base) - Internal.Cryptography.TripleDesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -32 (-17.02% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -32 (-4.48% of base) - Internal.Cryptography.RC2Implementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -32 (-4.91% of base) - Internal.Cryptography.AesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -32 (-3.62% of base) - Internal.Cryptography.DesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this

Top method regressions (percentages):
           2 ( 1.20% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[System.Char],byref):bool
          12 ( 1.00% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (percentages):
         -16 (-36.36% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -20 (-35.71% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -32 (-30.19% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -38 (-19.00% of base) - System.TimeSpan:.ctor(int,int,int):this
         -16 (-17.78% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -32 (-17.02% of base) - System.TimeSpan:TimeToTicks(int,int,int):long
         -16 (-16.67% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -16 (-16.33% of base) - System.DateTime:TimeToTicks(int,int,int):long
         -34 (-16.19% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -16 (-16.00% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -16 (-16.00% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -58 (-15.34% of base) - System.TimeSpan:.ctor(int,int,int,int,int):this
         -18 (-14.75% of base) - System.Globalization.HebrewCalendar:IsLeapYear(int,int):bool:this
         -16 (-12.90% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -72 (-12.77% of base) - System.Buffers.Text.Utf8Parser:TryCreateTimeSpan(bool,int,int,int,int,int,byref):bool
         -40 (-12.74% of base) - System.TimeZoneInfo:TZif_CalculateTransitionOffsetFromBase(System.TimeSpan,System.TimeSpan):System.TimeSpan
         -16 (-12.70% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -16 (-12.70% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -32 (-12.60% of base) - System.Globalization.InternalGlobalizationHelper:TimeToTicks(int,int,int):long
         -18 (-11.84% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this

110 total methods with Code Size differences (108 improved, 2 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 76032
Total bytes of diff: 74632
Total bytes of delta: -1400 (-1.84% of base)
    diff is an improvement.


Top method regressions (bytes):
          14 ( 1.35% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (bytes):
         -58 (-1.53% of base) - System.Formats.Asn1.AsnDecoder:ParseGeneralizedTime(int,System.ReadOnlySpan`1[Byte]):System.DateTimeOffset
         -56 (-4.66% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -56 (-4.70% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeIso(System.String,int,byref):bool
         -50 (-3.06% of base) - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTimeOffset
         -50 (-8.45% of base) - System.Xml.Schema.XsdDateTime:ToZulu():System.DateTime:this
         -46 (-6.85% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -46 (-0.78% of base) - System.Data.FunctionNode:EvalFunction(int,System.Object[],System.Data.DataRow,int):System.Object:this
         -46 (-6.97% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(System.String,byref):bool
         -44 (-2.15% of base) - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTime
         -30 (-4.07% of base) - System.ServiceModel.Syndication.Rss20FeedFormatter:AsString(System.DateTimeOffset):System.String:this
         -30 (-1.29% of base) - System.ComponentModel.DateTimeOffsetConverter:ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type):System.Object:this
         -30 (-4.63% of base) - System.ServiceModel.Syndication.Atom10FeedFormatter:AsString(System.DateTimeOffset):System.String:this
         -26 (-1.67% of base) - System.Xml.XmlConverter:TryParseDateTime(System.Byte[],int,int,byref):bool
         -24 (-10.08% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -22 (-5.82% of base) - System.Net.Mime.SmtpDateTime:TryParseTimeZoneString(System.String,byref):bool:this
         -22 (-4.20% of base) - Internal.Cryptography.AesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -22 (-2.79% of base) - Internal.Cryptography.DesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -20 (-3.77% of base) - System.Runtime.Serialization.DateTimeOffsetAdapter:GetDateTimeOffset(System.Runtime.Serialization.DateTimeOffsetAdapter):System.DateTimeOffset
         -20 (-3.79% of base) - Internal.Cryptography.RC2Implementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this
         -20 (-3.37% of base) - Internal.Cryptography.TripleDesImplementation:CreateTransform(System.Byte[],System.Byte[],bool):System.Security.Cryptography.ICryptoTransform:this

Top method regressions (percentages):
          14 ( 1.35% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol:get_FixedSize():int:this

Top method improvements (percentages):
         -10 (-26.32% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -10 (-21.74% of base) - System.Data.SqlTypes.SqlMoney:.ctor(int):this
         -20 (-21.28% of base) - System.Security.Cryptography.Pkcs.Asn1.Rfc3161Accuracy:get_TotalMicros():long:this
         -10 (-20.83% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingWaitTimeout():System.TimeSpan:this
         -10 (-19.23% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_PingKeepAliveTimeout():System.TimeSpan:this
         -10 (-19.23% of base) - System.DirectoryServices.Protocols.LdapSessionOptions:get_SendTimeout():System.TimeSpan:this
         -10 (-12.50% of base) - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(System.Byte[],int):long
         -24 (-10.08% of base) - System.Data.ProviderBase.DbBuffer:ReadTime(int):System.TimeSpan:this
         -12 (-8.96% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -50 (-8.45% of base) - System.Xml.Schema.XsdDateTime:ToZulu():System.DateTime:this
         -10 (-7.81% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlMoney
         -10 (-7.69% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlByte):System.Data.SqlTypes.SqlMoney
         -10 (-7.69% of base) - System.Data.SqlTypes.SqlMoney:op_Implicit(System.Data.SqlTypes.SqlInt16):System.Data.SqlTypes.SqlMoney
         -12 (-7.32% of base) - Microsoft.VisualBasic.DateAndTime:TimeSerial(int,int,int):System.DateTime
         -46 (-6.97% of base) - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(System.String,byref):bool
         -46 (-6.85% of base) - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetIso(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -10 (-6.41% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -12 (-6.19% of base) - PEFile.PEHeader:TimeDateStampToDate(int):System.DateTime
         -12 (-5.83% of base) - System.Numerics.BigInteger:GetBitLength():long:this
         -22 (-5.82% of base) - System.Net.Mime.SmtpDateTime:TryParseTimeZoneString(System.String,byref):bool:this

83 total methods with Code Size differences (82 improved, 1 regressed), 1 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 575780
Total bytes of diff: 567378
Total bytes of delta: -8402 (-1.46% of base)
    diff is an improvement.


Top method regressions (bytes):
           2 ( 0.37% of base) - Microsoft.Diagnostics.Runtime.GCDesc:WalkObject(long,long,System.Func`2[UInt64,UInt64],System.Action`2[UInt64,Int32]):this

Top method improvements (bytes):
        -320 (-4.58% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_PerthRules()
        -300 (-4.60% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_Invalid()
        -292 (-3.92% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_LocalAmbiguousOffsets()
        -260 (-3.97% of base) - System.Tests.TimeZoneInfoTests:ConverTime_DateTime_VariousSystemTimeZonesTest()
        -250 (-3.38% of base) - System.Xml.Tests.ToTypeTests:ToType57():int:this
        -220 (-2.05% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToSystem()
        -210 (-2.87% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_MiscUtc()
        -150 (-2.95% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_Tonga()
        -140 (-2.10% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToUtc()
        -136 (-4.81% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_VariousDateTimeKinds()
        -130 (-2.21% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_LocalToLocal()
        -120 (-3.05% of base) - System.Tests.TimeZoneInfoTests:ConvertTime_DateTime_UtcToLocal()
        -104 (-3.08% of base) - System.Text.Json.Serialization.Tests.TestClassWithStringToPrimitiveDictionary:Initialize():this
        -102 (-4.01% of base) - System.Tests.DateTimeOffsetTests:ParseExact_ToStringThenParseExactRoundtrip_Success(System.String)
        -100 (-0.66% of base) - System.Tests.TimeZoneInfoTests:IsDaylightSavingTime()
        -100 (-2.21% of base) - System.Tests.TimeZoneInfoTests:IsDaylightSavingTime_CatamarcaMultiYearDaylightSavings()
        -100 (-4.63% of base) - System.Tests.TimeZoneInfoTests:GetAmbiguousTimeOffsets_Nairobi_Invalid()
         -96 (-3.18% of base) - <GetEra_TestData>d__0:MoveNext():bool:this
         -96 (-3.18% of base) - <GetMonth_TestData>d__0:MoveNext():bool:this
         -94 (-2.92% of base) - <GetYear_TestData>d__0:MoveNext():bool:this

Top method regressions (percentages):
           2 ( 0.37% of base) - Microsoft.Diagnostics.Runtime.GCDesc:WalkObject(long,long,System.Func`2[UInt64,UInt64],System.Action`2[UInt64,Int32]):this

Top method improvements (percentages):
         -10 (-26.32% of base) - System.Data.Common.ADP:TimerFromSeconds(int):long
         -12 (-26.09% of base) - System.Data.SqlClient.TdsParserStateObject:SetTimeoutSeconds(int):this
         -12 (-26.09% of base) - System.Data.SqlClient.TdsParserStateObject:SetTimeoutSeconds(int):this
         -14 (-21.21% of base) - ExtendedArray`1[__Canon][System.__Canon]:get_Count():long:this
         -14 (-21.21% of base) - ExtendedArray`1[Byte][System.Byte]:get_Count():long:this
         -16 (-11.59% of base) - System.Data.SqlClient.SqlBulkCopy:WriteMetaData(System.Data.SqlClient.BulkCopySimpleResultSet):this
         -16 (-11.59% of base) - System.Data.SqlClient.SqlBulkCopy:WriteMetaData(System.Data.SqlClient.BulkCopySimpleResultSet):this
         -24 (-8.82% of base) - genTimeZone@885-2:Invoke(int):FsCheck.Gen`1[TimeSpan]:this
          -6 (-8.57% of base) - Microsoft.Diagnostics.Runtime.Utilities.MINIDUMP_MODULE:get_Timestamp():System.DateTime:this
         -10 (-7.14% of base) - System.Data.SqlClient.SqlSequentialStream:.ctor(System.Data.SqlClient.SqlDataReader,int):this
         -10 (-7.14% of base) - System.Data.SqlClient.SqlSequentialStream:.ctor(System.Data.SqlClient.SqlDataReader,int):this
         -12 (-6.90% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
         -12 (-6.90% of base) - System.Data.ProviderBase.TimeoutTimer:SetTimeoutSeconds(int):this
          -8 (-6.56% of base) - NuGet.Packaging.Signing.Accuracy:GetTotalMicroseconds():System.Nullable`1[Int64]:this
         -10 (-6.41% of base) - System.Net.Http.Headers.AltSvcHeaderParser:TryReadQuotedInt32Value(System.ReadOnlySpan`1[Char],byref):bool
         -22 (-5.70% of base) - System.Net.Mime.SmtpDateTime:TryParseTimeZoneString(System.String,byref):bool:this
         -10 (-5.21% of base) - System.Data.SqlClient.TdsParserStaticMethods:GetRemainingTimeout(int,long):int
         -10 (-5.21% of base) - System.Data.SqlClient.TdsParserStaticMethods:GetRemainingTimeout(int,long):int
         -10 (-5.00% of base) - <>c:<Ctor_Int_Int_Int_Invalid>b__6_0():System.Object:this
         -10 (-5.00% of base) - <>c:<Ctor_Int_Int_Int_Invalid>b__6_1():System.Object:this

319 total methods with Code Size differences (318 improved, 1 regressed), 0 unchanged.
```
</details>

Most regressions are caused by the fact that the new code doesn't try to look for `CAST(CONST)`, and that is impactful for cases when we emit debuggable code - it now goes through the helper. Because there are so few regressions, and they are for debuggable code only, I decided not to complicate the code by fixing it. The `<ReadHeadersAsync>d__43:MoveNext()` regression is caused by different register allocation, even as the helper call was turned into `imul`. One of the regressions on `ARM` is caused by a lack of CSE.