### PR TITLE
Enable devirtualization in more scenarios on crossgen2

### DIFF
--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -6,6 +6,7 @@ Revisions:
 * 3.1 - [Tomas Rylek](https://github.com/trylek) - 2019
 * 4.1 - [Tomas Rylek](https://github.com/trylek) - 2020
 * 5.3 - [Tomas Rylek](https://github.com/trylek) - 2021
+* 5.4 - [David Wrighton](https://github.com/davidwrighton) - 2021
 
 # Introduction
 
@@ -251,6 +252,10 @@ fixup kind, the rest of the signature varies based on the fixup kind.
 | READYTORUN_FIXUP_IndirectPInvokeTarget   |  0x2E | Target (indirect) of an inlined PInvoke. Followed by method signature.
 | READYTORUN_FIXUP_PInvokeTarget           |  0x2F | Target of an inlined PInvoke. Followed by method signature.
 | READYTORUN_FIXUP_Check_InstructionSetSupport | 0x30 | Specify the instruction sets that must be supported/unsupported to use the R2R code associated with the fixup.
+| READYTORUN_FIXUP_Verify_FieldOffset      | 0x31 | Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike CheckFieldOffset, this will generate a runtime exception on failure instead of silently dropping the method
+| READYTORUN_FIXUP_Verify_TypeLayout       | 0x32 | Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike CheckFieldOffset, this will generate a runtime exception on failure instead of silently dropping the method
+| READYTORUN_FIXUP_Check_VirtualFunctionOverride | 0x33 | Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, code will not be used. See [Virtual override signatures](virtual-override-signatures) for details of the signature used.
+| READYTORUN_FIXUP_Verify_VirtualFunctionOverride | 0x33 | Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, generate runtime failure. See [Virtual override signatures](virtual-override-signatures) for details of the signature used.
 | READYTORUN_FIXUP_ModuleOverride          |  0x80 | When or-ed to the fixup ID, the fixup byte in the signature is followed by an encoded uint with assemblyref index, either within the MSIL metadata of the master context module for the signature or within the manifest metadata R2R header table (used in cases inlining brings in references to assemblies not seen in the input MSIL).
 
 #### Method Signatures
@@ -268,6 +273,7 @@ token, and additional data determined by the flags.
 | READYTORUN_METHOD_SIG_MemberRefToken      |  0x10 | If set, the token is memberref token. If not set, the token is methoddef token.
 | READYTORUN_METHOD_SIG_Constrained         |  0x20 | Constrained type for method resolution. Typespec appended as additional data.
 | READYTORUN_METHOD_SIG_OwnerType           |  0x40 | Method type. Typespec appended as additional data.
+| READYTORUN_METHOD_SIG_UpdateContext       |  0x80 | If set, update the module which is used to parse tokens before performing any token processing. A uint index into the modules table immediately follows the flags
 
 #### Field Signatures
 
@@ -280,6 +286,16 @@ additional data determined by the flags.
 | READYTORUN_FIELD_SIG_IndexInsteadOfToken |  0x08 | Used as an optimization for stable fields. Cannot be combined with `MemberRefToken`.
 | READYTORUN_FIELD_SIG_MemberRefToken      |  0x10 | If set, the token is memberref token. If not set, the token is fielddef token.
 | READYTORUN_FIELD_SIG_OwnerType           |  0x40 | Field type. Typespec appended as additional data.
+
+#### Virtual override signatures
+
+ECMA 335 does not have a natural encoding for describing an overriden method. These signatures are encoded as a ReadyToRunVirtualFunctionOverrideFlags byte, followed by a method signature representing the declaration method, a type signature representing the type which is being devirtualized, and (optionally) a method signature indicating the implementation method.
+
+| ReadyToRunVirtualFunctionOverrideFlags                | Value | Description
+|:------------------------------------------------------|------:|:-----------
+| READYTORUN_VIRTUAL_OVERRIDE_None                      |  0x00 | No flags are set
+| READYTORUN_VIRTUAL_OVERRIDE_VirtualFunctionOverriden  |  0x01 | If set, then the virtual function has an implementation, which is encoded in the optional method implementation signature.
+
 
 ### READYTORUN_IMPORT_SECTIONS::AuxiliaryData
 

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -16,9 +16,26 @@ jobs:
     buildConfig: checked
     platforms:
     - Linux_x64
+    - Linux_arm64
+    - OSX_arm64
     - OSX_x64
     - windows_x64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - OSX_arm64
+    - windows_x86
+    - windows_x64
     jobParameters:
       testGroup: outerloop
 
@@ -27,9 +44,14 @@ jobs:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
     buildConfig: Release
     platforms:
+    - Linux_arm
+    - Linux_arm64
     - Linux_x64
+    - OSX_arm64
     - OSX_x64
+    - windows_x86
     - windows_x64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false
@@ -45,6 +67,27 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
 
+# Test most platforms in composite mode as the expected mainline shipping mode
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Linux_arm64
+    - OSX_arm64
+    - OSX_x64
+    - windows_x64
+    - windows_arm64
+    jobParameters:
+      testGroup: outerloop
+      readyToRun: true
+      crossgen2: true
+      compositeBuildMode: true
+      displayNameArgs: Composite
+      liveLibrariesBuildConfig: Release
+
 # Limited outerloop testing in non-composite mode
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -53,11 +96,125 @@ jobs:
     buildConfig: checked
     platforms:
     - OSX_x64
-    - windows_x64
-    - Linux_x64
     jobParameters:
       testGroup: outerloop
       readyToRun: true
       crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
+
+# Build Crossgen2 baselines
+# These are the various crossgen2 targets that are supported, and cover all major
+# significantly different code generators
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - OSX_arm64
+    - windows_x86
+    - windows_x64
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+
+# test crossgen target Windows X86
+# This job verifies that 32-bit and 64 bit crossgen2 produces the same binaries,
+# and that cross-os targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_x64
+    - windows_x86
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: windows
+      targetarch: x86
+
+# test target Linux X64
+# verify that cross OS targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - windows_x64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: Linux
+      targetarch: x64
+
+# test target Windows X64
+# verify that cross OS targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_x64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: windows
+      targetarch: x64
+
+# test target Linux arm
+# verify that cross architecture targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_arm
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: Linux
+      targetarch: arm
+
+# test target Linux arm64
+# verify that cross architecture targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_arm64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: Linux
+      targetarch: arm64
+
+# test target osx-arm64
+# verify that cross architecture targetting works
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+    buildConfig: Release
+    platforms:
+    - OSX_arm64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      targetos: OSX
+      targetarch: arm64

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -16,26 +16,9 @@ jobs:
     buildConfig: checked
     platforms:
     - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
     - OSX_x64
     - windows_x64
-    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_x86
-    - windows_x64
     jobParameters:
       testGroup: outerloop
 
@@ -44,14 +27,9 @@ jobs:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
     buildConfig: Release
     platforms:
-    - Linux_arm
-    - Linux_arm64
     - Linux_x64
-    - OSX_arm64
     - OSX_x64
-    - windows_x86
     - windows_x64
-    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false
@@ -67,27 +45,6 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
 
-# Test most platforms in composite mode as the expected mainline shipping mode
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      crossgen2: true
-      compositeBuildMode: true
-      displayNameArgs: Composite
-      liveLibrariesBuildConfig: Release
-
 # Limited outerloop testing in non-composite mode
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -96,125 +53,11 @@ jobs:
     buildConfig: checked
     platforms:
     - OSX_x64
+    - windows_x64
+    - Linux_x64
     jobParameters:
       testGroup: outerloop
       readyToRun: true
       crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
-
-# Build Crossgen2 baselines
-# These are the various crossgen2 targets that are supported, and cover all major
-# significantly different code generators
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_x86
-    - windows_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-
-# test crossgen target Windows X86
-# This job verifies that 32-bit and 64 bit crossgen2 produces the same binaries,
-# and that cross-os targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    - windows_x86
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: windows
-      targetarch: x86
-
-# test target Linux X64
-# verify that cross OS targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: x64
-
-# test target Windows X64
-# verify that cross OS targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: windows
-      targetarch: x64
-
-# test target Linux arm
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: arm
-
-# test target Linux arm64
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: arm64
-
-# test target osx-arm64
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - OSX_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: OSX
-      targetarch: arm64

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/agnostic.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/agnostic.h
@@ -557,18 +557,22 @@ struct Agnostic_GetSystemVAmd64PassStructInRegisterDescriptor
 
 struct Agnostic_ResolveVirtualMethodKey
 {
-    DWORDLONG virtualMethod;
-    DWORDLONG objClass;
-    DWORDLONG context;
+    DWORDLONG                       virtualMethod;
+    DWORDLONG                       objClass;
+    DWORDLONG                       context;
+    DWORD                           pResolvedTokenVirtualMethodNonNull;
+    Agnostic_CORINFO_RESOLVED_TOKEN pResolvedTokenVirtualMethod;
 };
 
 struct Agnostic_ResolveVirtualMethodResult
 {
-    bool      returnValue;
-    DWORDLONG devirtualizedMethod;
-    bool      requiresInstMethodTableArg;
-    DWORDLONG exactContext;
-    DWORD     detail;
+    bool                            returnValue;
+    DWORDLONG                       devirtualizedMethod;
+    bool                            requiresInstMethodTableArg;
+    DWORDLONG                       exactContext;
+    DWORD                           detail;
+    Agnostic_CORINFO_RESOLVED_TOKEN resolvedTokenDevirtualizedMethod;
+    Agnostic_CORINFO_RESOLVED_TOKEN resolvedTokenDevirtualizedUnboxedMethod;
 };
 
 struct ResolveTokenValue

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
@@ -35,6 +35,10 @@ public:
     static Agnostic_CORINFO_RESOLVED_TOKEN RestoreAgnostic_CORINFO_RESOLVED_TOKEN(
         CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
 
+    template <typename key, typename value>
+    static CORINFO_RESOLVED_TOKEN Restore_CORINFO_RESOLVED_TOKEN(
+        Agnostic_CORINFO_RESOLVED_TOKEN* pResolvedTokenAgnostic, LightWeightMap<key, value>* buffers);
+
     // Restore the out values in the first argument from the second.
     // Can't just return whole CORINFO_RESOLVED_TOKEN because [in] values in it are important too.
     template <typename key, typename value>
@@ -197,6 +201,22 @@ inline Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::RestoreAgnostic_CORINF
     ZeroMemory(&token, sizeof(token));
     token.inValue  = CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
     token.outValue = RestoreAgnostic_CORINFO_RESOLVED_TOKENout(pResolvedToken, buffers);
+    return token;
+}
+
+template <typename key, typename value>
+inline CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::Restore_CORINFO_RESOLVED_TOKEN(
+    Agnostic_CORINFO_RESOLVED_TOKEN* pResolvedTokenAgnostic, LightWeightMap<key, value>* buffers)
+{
+    CORINFO_RESOLVED_TOKEN token;
+    ZeroMemory(&token, sizeof(token));
+
+    token.tokenContext = (CORINFO_CONTEXT_HANDLE)pResolvedTokenAgnostic->inValue.tokenContext;
+    token.tokenScope   = (CORINFO_MODULE_HANDLE)pResolvedTokenAgnostic->inValue.tokenScope;
+    token.token        = (mdToken)pResolvedTokenAgnostic->inValue.token;
+    token.tokenType    = (CorInfoTokenKind)pResolvedTokenAgnostic->inValue.tokenType;
+
+    Restore_CORINFO_RESOLVED_TOKENout(&token, pResolvedTokenAgnostic->outValue, buffers);
     return token;
 }
 

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -98,6 +98,7 @@
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
       <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) -m:$(MergedMibcPath) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
+      <CrossGenDllCmd>$(CrossGenDllCmd) --verify-type-and-field-layout</CrossGenDllCmd> <!-- TODO Make this conditional on checked/debug builds only before merge -->
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
     </PropertyGroup>
 

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -98,7 +98,7 @@
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
       <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) -m:$(MergedMibcPath) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
-      <CrossGenDllCmd>$(CrossGenDllCmd) --verify-type-and-field-layout</CrossGenDllCmd> <!-- TODO Make this conditional on checked/debug builds only before merge -->
+      <CrossGenDllCmd  Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">$(CrossGenDllCmd) --verify-type-and-field-layout</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
     </PropertyGroup>
 

--- a/src/coreclr/inc/corcompile.h
+++ b/src/coreclr/inc/corcompile.h
@@ -702,6 +702,9 @@ enum CORCOMPILE_FIXUP_BLOB_KIND
     ENCODE_VERIFY_FIELD_OFFSET,                     /* Used for the R2R compiler can generate a check against the real field offset used at runtime */
     ENCODE_VERIFY_TYPE_LAYOUT,                      /* Used for the R2R compiler can generate a check against the real type layout used at runtime */
 
+    ENCODE_CHECK_VIRTUAL_FUNCTION_OVERRIDE,         /* Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, code will not be used */
+    ENCODE_VERIFY_VIRTUAL_FUNCTION_OVERRIDE,        /* Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, generate runtime failure. */
+
     ENCODE_MODULE_HANDLE                = 0x50,     /* Module token */
     ENCODE_STATIC_FIELD_ADDRESS,                    /* For accessing a static field */
     ENCODE_MODULE_ID_FOR_STATICS,                   /* For accessing static fields */
@@ -724,6 +727,7 @@ enum EncodeMethodSigFlags
     ENCODE_METHOD_SIG_MemberRefToken            = 0x10,
     ENCODE_METHOD_SIG_Constrained               = 0x20,
     ENCODE_METHOD_SIG_OwnerType                 = 0x40,
+    ENCODE_METHOD_SIG_UpdateContext             = 0x80,
 };
 
 enum EncodeFieldSigFlags

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1604,18 +1604,24 @@ struct CORINFO_CALL_INFO
 
 enum CORINFO_DEVIRTUALIZATION_DETAIL
 {
-    CORINFO_DEVIRTUALIZATION_UNKNOWN,         // no details available
-    CORINFO_DEVIRTUALIZATION_SUCCESS,         // devirtualization was successful
-    CORINFO_DEVIRTUALIZATION_FAILED_CANON,    // object class was canonical
-    CORINFO_DEVIRTUALIZATION_FAILED_COM,      // object class was com
-    CORINFO_DEVIRTUALIZATION_FAILED_CAST,     // object class could not be cast to interface class
-    CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP,   // interface method could not be found
-    CORINFO_DEVIRTUALIZATION_FAILED_DIM,      // interface method was default interface method
-    CORINFO_DEVIRTUALIZATION_FAILED_SUBCLASS, // object not subclass of base class
-    CORINFO_DEVIRTUALIZATION_FAILED_SLOT,     // virtual method installed via explicit override
-    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE,   // devirtualization crossed version bubble
-    CORINFO_DEVIRTUALIZATION_MULTIPLE_IMPL,   // object has multiple implementations of interface class
-    CORINFO_DEVIRTUALIZATION_COUNT,           // sentinel for maximum value
+    CORINFO_DEVIRTUALIZATION_UNKNOWN,                              // no details available
+    CORINFO_DEVIRTUALIZATION_SUCCESS,                              // devirtualization was successful
+    CORINFO_DEVIRTUALIZATION_FAILED_CANON,                         // object class was canonical
+    CORINFO_DEVIRTUALIZATION_FAILED_COM,                           // object class was com
+    CORINFO_DEVIRTUALIZATION_FAILED_CAST,                          // object class could not be cast to interface class
+    CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP,                        // interface method could not be found
+    CORINFO_DEVIRTUALIZATION_FAILED_DIM,                           // interface method was default interface method
+    CORINFO_DEVIRTUALIZATION_FAILED_SUBCLASS,                      // object not subclass of base class
+    CORINFO_DEVIRTUALIZATION_FAILED_SLOT,                          // virtual method installed via explicit override
+    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE,                        // devirtualization crossed version bubble
+    CORINFO_DEVIRTUALIZATION_MULTIPLE_IMPL,                        // object has multiple implementations of interface class
+    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_CLASS_DECL,             // decl method is defined on class and decl method not in version bubble, and decl method not in closest to version bubble
+    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_INTERFACE_DECL,         // decl method is defined on interface and not in version bubble, and implementation type not entirely defined in bubble
+    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL,                   // object class not defined within version bubble
+    CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL_NOT_REFERENCEABLE, // object class cannot be referenced from R2R code due to missing tokens
+    CORINFO_DEVIRTUALIZATION_FAILED_DUPLICATE_INTERFACE,           // crossgen2 virtual method algorithm and runtime algorithm differ in the presence of duplicate interface implementations
+    CORINFO_DEVIRTUALIZATION_FAILED_DECL_NOT_REPRESENTABLE,        // Decl method cannot be represented in R2R image
+    CORINFO_DEVIRTUALIZATION_COUNT,                                // sentinel for maximum value
 };
 
 struct CORINFO_DEVIRTUALIZATION_INFO

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1626,6 +1626,7 @@ struct CORINFO_DEVIRTUALIZATION_INFO
     CORINFO_METHOD_HANDLE       virtualMethod;
     CORINFO_CLASS_HANDLE        objClass;
     CORINFO_CONTEXT_HANDLE      context;
+    CORINFO_RESOLVED_TOKEN     *pResolvedTokenVirtualMethod;
 
     //
     // [Out] results of resolveVirtualMethod.
@@ -1634,11 +1635,15 @@ struct CORINFO_DEVIRTUALIZATION_INFO
     // - requiresInstMethodTableArg is set to TRUE if the devirtualized method requires a type handle arg.
     // - exactContext is set to wrapped CORINFO_CLASS_HANDLE of devirt'ed method table.
     // - details on the computation done by the jit host
+    // - If pResolvedTokenDevirtualizedMethod is not set to NULL and targetting an R2R image
+    //   use it as the parameter to getCallInfo
     //
     CORINFO_METHOD_HANDLE           devirtualizedMethod;
     bool                            requiresInstMethodTableArg;
     CORINFO_CONTEXT_HANDLE          exactContext;
     CORINFO_DEVIRTUALIZATION_DETAIL detail;
+    CORINFO_RESOLVED_TOKEN          resolvedTokenDevirtualizedMethod;
+    CORINFO_RESOLVED_TOKEN          resolvedTokenDevirtualizedUnboxedMethod;
 };
 
 //----------------------------------------------------------------------------

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,11 +43,11 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 1052f490-cad7-4610-99bb-6f2bd91a1d19 */
-    0x1052f490,
-    0xcad7,
-    0x4610,
-    {0x99, 0xbb, 0x6f, 0x2b, 0xd9, 0x1a, 0x1d, 0x19}
+constexpr GUID JITEEVersionIdentifier = { /* de9a9a0e-c66a-4d97-a268-92a31f99d919 */
+    0xde9a9a0e,
+    0xc66a,
+    0x4d97,
+    {0xa2, 0x68, 0x92, 0xa3, 0x1f, 0x99, 0xd9, 0x19}
   };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -16,7 +16,7 @@
 
 // Keep these in sync with src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
 #define READYTORUN_MAJOR_VERSION 0x0005
-#define READYTORUN_MINOR_VERSION 0x0003
+#define READYTORUN_MINOR_VERSION 0x0004
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 0x003
 
@@ -134,6 +134,7 @@ enum ReadyToRunMethodSigFlags
     READYTORUN_METHOD_SIG_MemberRefToken        = 0x10,
     READYTORUN_METHOD_SIG_Constrained           = 0x20,
     READYTORUN_METHOD_SIG_OwnerType             = 0x40,
+    READYTORUN_METHOD_SIG_UpdateContext         = 0x80,
 };
 
 enum ReadyToRunFieldSigFlags
@@ -150,6 +151,12 @@ enum ReadyToRunTypeLayoutFlags
     READYTORUN_LAYOUT_Alignment_Native          = 0x04,
     READYTORUN_LAYOUT_GCLayout                  = 0x08,
     READYTORUN_LAYOUT_GCLayout_Empty            = 0x10,
+};
+
+enum ReadyToRunVirtualFunctionOverrideFlags
+{
+    READYTORUN_VIRTUAL_OVERRIDE_None = 0x00,
+    READYTORUN_VIRTUAL_OVERRIDE_VirtualFunctionOverriden = 0x01,
 };
 
 //
@@ -211,6 +218,9 @@ enum ReadyToRunFixupKind
 
     READYTORUN_FIXUP_Verify_FieldOffset         = 0x31, /* Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike Check_FieldOffset, this will generate a runtime failure instead of silently dropping the method */
     READYTORUN_FIXUP_Verify_TypeLayout          = 0x32, /* Generate a runtime check to ensure that the type layout (size, alignment, HFA, reference map) matches between compile and runtime. Unlike Check_TypeLayout, this will generate a runtime failure instead of silently dropping the method */
+
+    READYTORUN_FIXUP_Check_VirtualFunctionOverride = 0x33, /* Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, code will not be used */
+    READYTORUN_FIXUP_Verify_VirtualFunctionOverride = 0x34, /* Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, generate runtime failure. */
 };
 
 //

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9721,6 +9721,18 @@ const char* Compiler::devirtualizationDetailToString(CORINFO_DEVIRTUALIZATION_DE
             return "devirtualization crossed version bubble";
         case CORINFO_DEVIRTUALIZATION_MULTIPLE_IMPL:
             return "object class has multiple implementations of interface";
+        case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_CLASS_DECL:
+            return "decl method is defined on class and decl method not in version bubble, and decl method not in closest to version bubble";
+        case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_INTERFACE_DECL:
+            return "decl method is defined on interface and not in version bubble, and implementation type not entirely defined in bubble";
+        case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL:
+            return "object class not defined within version bubble";
+        case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL_NOT_REFERENCEABLE:
+            return "object class cannot be referenced from R2R code due to missing tokens";
+        case CORINFO_DEVIRTUALIZATION_FAILED_DUPLICATE_INTERFACE:
+            return "crossgen2 virtual method algorithm and runtime algorithm differ in the presence of duplicate interface implementations";
+        case CORINFO_DEVIRTUALIZATION_FAILED_DECL_NOT_REPRESENTABLE:
+            return "Decl method cannot be represented in R2R image";
         default:
             return "undefined";
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9722,15 +9722,18 @@ const char* Compiler::devirtualizationDetailToString(CORINFO_DEVIRTUALIZATION_DE
         case CORINFO_DEVIRTUALIZATION_MULTIPLE_IMPL:
             return "object class has multiple implementations of interface";
         case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_CLASS_DECL:
-            return "decl method is defined on class and decl method not in version bubble, and decl method not in closest to version bubble";
+            return "decl method is defined on class and decl method not in version bubble, and decl method not in "
+                   "type closest to version bubble";
         case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_INTERFACE_DECL:
-            return "decl method is defined on interface and not in version bubble, and implementation type not entirely defined in bubble";
+            return "decl method is defined on interface and not in version bubble, and implementation type not "
+                   "entirely defined in bubble";
         case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL:
             return "object class not defined within version bubble";
         case CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL_NOT_REFERENCEABLE:
             return "object class cannot be referenced from R2R code due to missing tokens";
         case CORINFO_DEVIRTUALIZATION_FAILED_DUPLICATE_INTERFACE:
-            return "crossgen2 virtual method algorithm and runtime algorithm differ in the presence of duplicate interface implementations";
+            return "crossgen2 virtual method algorithm and runtime algorithm differ in the presence of duplicate "
+                   "interface implementations";
         case CORINFO_DEVIRTUALIZATION_FAILED_DECL_NOT_REPRESENTABLE:
             return "Decl method cannot be represented in R2R image";
         default:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3947,6 +3947,7 @@ public:
     }
 
     void impDevirtualizeCall(GenTreeCall*            call,
+                             CORINFO_RESOLVED_TOKEN* pResolvedToken,
                              CORINFO_METHOD_HANDLE*  method,
                              unsigned*               methodFlags,
                              CORINFO_CONTEXT_HANDLE* contextHandle,

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -731,7 +731,7 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
             CORINFO_CONTEXT_HANDLE context                = nullptr;
             const bool             isLateDevirtualization = true;
             bool explicitTailCall = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
-            comp->impDevirtualizeCall(call, NULL, &method, &methodFlags, &context, nullptr, isLateDevirtualization,
+            comp->impDevirtualizeCall(call, nullptr, &method, &methodFlags, &context, nullptr, isLateDevirtualization,
                                       explicitTailCall);
         }
     }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -731,7 +731,7 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
             CORINFO_CONTEXT_HANDLE context                = nullptr;
             const bool             isLateDevirtualization = true;
             bool explicitTailCall = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
-            comp->impDevirtualizeCall(call, &method, &methodFlags, &context, nullptr, isLateDevirtualization,
+            comp->impDevirtualizeCall(call, NULL, &method, &methodFlags, &context, nullptr, isLateDevirtualization,
                                       explicitTailCall);
         }
     }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20644,6 +20644,7 @@ bool Compiler::IsMathIntrinsic(GenTree* tree)
 //
 // Arguments:
 //     call -- the call node to examine/modify
+//     pResolvedToken -- [IN] the resolved token used to create the call. Used for R2R.
 //     method   -- [IN/OUT] the method handle for call. Updated iff call devirtualized.
 //     methodFlags -- [IN/OUT] flags for the method to call. Updated iff call devirtualized.
 //     pContextHandle -- [IN/OUT] context handle for the call. Updated iff call devirtualized.
@@ -20682,7 +20683,6 @@ bool Compiler::IsMathIntrinsic(GenTree* tree)
 //     When guarded devirtualization is enabled, this method will mark
 //     calls as guarded devirtualization candidates, if the type of `this`
 //     is not exactly known, and there is a plausible guess for the type.
-//
 void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                                    CORINFO_RESOLVED_TOKEN* pResolvedToken,
                                    CORINFO_METHOD_HANDLE*  method,
@@ -21660,7 +21660,7 @@ void Compiler::considerGuardedDevirtualization(
     dvInfo.objClass                    = likelyClass;
     dvInfo.context                     = *pContextHandle;
     dvInfo.exactContext                = *pContextHandle;
-    dvInfo.pResolvedTokenVirtualMethod = NULL;
+    dvInfo.pResolvedTokenVirtualMethod = nullptr;
 
     const bool canResolve = info.compCompHnd->resolveVirtualMethod(&dvInfo);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21104,14 +21104,6 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         {
             JITDUMP("Have a direct explicit tail call to boxed entry point; can't optimize further\n");
         }
-        else if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT))
-        {
-            // Per https://github.com/dotnet/runtime/issues/52483, crossgen2 seemingly gets
-            // confused about whether the unboxed entry requires an extra arg.
-            // So defer further optimization for now.
-            //
-            JITDUMP("Have a direct boxed entry point, prejitting. Can't optimize further yet.\n");
-        }
         else
         {
             JITDUMP("Have a direct call to boxed entry point. Trying to optimize to call an unboxed entry point\n");

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8929,8 +8929,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
             const bool isExplicitTailCall     = (tailCallFlags & PREFIX_TAILCALL_EXPLICIT) != 0;
             const bool isLateDevirtualization = false;
-            impDevirtualizeCall(call->AsCall(), pResolvedToken, &callInfo->hMethod, &callInfo->methodFlags, &callInfo->contextHandle,
-                                &exactContextHnd, isLateDevirtualization, isExplicitTailCall, rawILOffset);
+            impDevirtualizeCall(call->AsCall(), pResolvedToken, &callInfo->hMethod, &callInfo->methodFlags,
+                                &callInfo->contextHandle, &exactContextHnd, isLateDevirtualization, isExplicitTailCall,
+                                rawILOffset);
         }
 
         if (impIsThis(obj))
@@ -20890,10 +20891,10 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
 
     info.compCompHnd->resolveVirtualMethod(&dvInfo);
 
-    CORINFO_METHOD_HANDLE   derivedMethod = dvInfo.devirtualizedMethod;
-    CORINFO_CONTEXT_HANDLE  exactContext  = dvInfo.exactContext;
-    CORINFO_CLASS_HANDLE    derivedClass  = NO_CLASS_HANDLE;
-    CORINFO_RESOLVED_TOKEN *pDerivedResolvedToken = &dvInfo.resolvedTokenDevirtualizedMethod;
+    CORINFO_METHOD_HANDLE   derivedMethod         = dvInfo.devirtualizedMethod;
+    CORINFO_CONTEXT_HANDLE  exactContext          = dvInfo.exactContext;
+    CORINFO_CLASS_HANDLE    derivedClass          = NO_CLASS_HANDLE;
+    CORINFO_RESOLVED_TOKEN* pDerivedResolvedToken = &dvInfo.resolvedTokenDevirtualizedMethod;
 
     if (derivedMethod != nullptr)
     {
@@ -21184,8 +21185,8 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                                     beforeArg->SetNext(gtNewCallArgs(methodTableArg));
                                 }
 
-                                call->gtCallMethHnd    = unboxedEntryMethod;
-                                derivedMethod          = unboxedEntryMethod;
+                                call->gtCallMethHnd   = unboxedEntryMethod;
+                                derivedMethod         = unboxedEntryMethod;
                                 pDerivedResolvedToken = &dvInfo.resolvedTokenDevirtualizedUnboxedMethod;
 
                                 // Method attributes will differ because unboxed entry point is shared
@@ -21218,7 +21219,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                             call->gtCallThisArg = gtNewCallArgs(localCopyThis);
                             call->gtCallMethHnd = unboxedEntryMethod;
                             call->gtCallMoreFlags |= GTF_CALL_M_UNBOXED;
-                            derivedMethod = unboxedEntryMethod;
+                            derivedMethod         = unboxedEntryMethod;
                             pDerivedResolvedToken = &dvInfo.resolvedTokenDevirtualizedUnboxedMethod;
 
                             optimizedTheBox = true;
@@ -21332,7 +21333,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                         call->gtCallThisArg = gtNewCallArgs(boxPayload);
                         call->gtCallMethHnd = unboxedEntryMethod;
                         call->gtCallMoreFlags |= GTF_CALL_M_UNBOXED;
-                        derivedMethod = unboxedEntryMethod;
+                        derivedMethod         = unboxedEntryMethod;
                         pDerivedResolvedToken = &dvInfo.resolvedTokenDevirtualizedUnboxedMethod;
                     }
                 }

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -754,7 +754,7 @@ private:
             CORINFO_CONTEXT_HANDLE context                = inlineInfo->exactContextHnd;
             const bool             isLateDevirtualization = true;
             const bool explicitTailCall = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
-            compiler->impDevirtualizeCall(call, &methodHnd, &methodFlags, &context, nullptr, isLateDevirtualization,
+            compiler->impDevirtualizeCall(call, nullptr, &methodHnd, &methodFlags, &context, nullptr, isLateDevirtualization,
                                           explicitTailCall);
 
             // We know this call can devirtualize or we would not have set up GDV here.

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -754,8 +754,8 @@ private:
             CORINFO_CONTEXT_HANDLE context                = inlineInfo->exactContextHnd;
             const bool             isLateDevirtualization = true;
             const bool explicitTailCall = (call->AsCall()->gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
-            compiler->impDevirtualizeCall(call, nullptr, &methodHnd, &methodFlags, &context, nullptr, isLateDevirtualization,
-                                          explicitTailCall);
+            compiler->impDevirtualizeCall(call, nullptr, &methodHnd, &methodFlags, &context, nullptr,
+                                          isLateDevirtualization, explicitTailCall);
 
             // We know this call can devirtualize or we would not have set up GDV here.
             // So impDevirtualizeCall should succeed in devirtualizing.

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 5;
-        public const ushort CurrentMinorVersion = 3;
+        public const ushort CurrentMinorVersion = 4;
     }
 
 #pragma warning disable 0169

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -4,6 +4,9 @@
 using System;
 using Internal.TypeSystem;
 
+// If any of these constants change, update src/coreclr/inc/readytorun.h and
+// src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs with the new R2R minor version
+
 namespace Internal.ReadyToRunConstants
 {
     [Flags]
@@ -31,6 +34,7 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_METHOD_SIG_MemberRefToken = 0x10,
         READYTORUN_METHOD_SIG_Constrained = 0x20,
         READYTORUN_METHOD_SIG_OwnerType = 0x40,
+        READYTORUN_METHOD_SIG_UpdateContext = 0x80,
     }
 
     [Flags]
@@ -49,6 +53,13 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_LAYOUT_Alignment_Native = 0x04,
         READYTORUN_LAYOUT_GCLayout = 0x08,
         READYTORUN_LAYOUT_GCLayout_Empty = 0x10,
+    }
+
+    [Flags]
+    public enum ReadyToRunVirtualFunctionOverrideFlags : uint
+    {
+        None = 0x00,
+        VirtualFunctionOverriden = 0x01,
     }
 
     public enum DictionaryEntryKind
@@ -120,6 +131,9 @@ namespace Internal.ReadyToRunConstants
 
         Verify_FieldOffset = 0x31,  // Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike CheckFieldOffset, this will generate a runtime exception on failure instead of silently dropping the method
         Verify_TypeLayout = 0x32,  // Generate a runtime check to ensure that the type layout (size, alignment, HFA, reference map) matches between compile and runtime. Unlike Check_TypeLayout, this will generate a runtime failure instead of silently dropping the method
+
+        Check_VirtualFunctionOverride = 0x33, // Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, code will not be used
+        Verify_VirtualFunctionOverride = 0x34, // Generate a runtime check to ensure that virtual function resolution has equivalent behavior at runtime as at compile time. If not equivalent, generate runtime failure.
 
         ModuleOverride = 0x80,
         // followed by sig-encoded UInt with assemblyref index into either the assemblyref

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1225,8 +1225,8 @@ namespace Internal.JitInterface
                 if (unboxingStub)
                 {
                     info->resolvedTokenDevirtualizedUnboxedMethod = info->resolvedTokenDevirtualizedMethod;
-                    info->resolvedTokenDevirtualizedMethod.tokenContext = contextFromMethod(nonUnboxingImpl);
-                    info->resolvedTokenDevirtualizedMethod.hMethod = ObjectToHandle(nonUnboxingImpl);
+                    info->resolvedTokenDevirtualizedUnboxedMethod.tokenContext = contextFromMethod(nonUnboxingImpl);
+                    info->resolvedTokenDevirtualizedUnboxedMethod.hMethod = ObjectToHandle(nonUnboxingImpl);
                 }
                 else
                 {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1167,6 +1167,11 @@ namespace Internal.JitInterface
                 return false;
             }
 
+            TypeDesc owningType = impl.OwningType;
+
+            // RyuJIT expects to get the canonical form back
+            impl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
             if (impl.OwningType.IsValueType)
             {
                 impl = getUnboxingThunk(impl);
@@ -1174,7 +1179,7 @@ namespace Internal.JitInterface
 
             info->devirtualizedMethod = ObjectToHandle(impl);
             info->requiresInstMethodTableArg = false;
-            info->exactContext = contextFromType(impl.OwningType);
+            info->exactContext = contextFromType(owningType);
 
             return true;
         }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1138,6 +1138,7 @@ namespace Internal.JitInterface
             info->devirtualizedMethod = null;
             info->requiresInstMethodTableArg = false;
             info->exactContext = null;
+            info->detail = CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN;
 
             TypeDesc objType = HandleToObject(info->objClass);
 
@@ -1161,7 +1162,7 @@ namespace Internal.JitInterface
                 }
             }
 
-            MethodDesc originalImpl = _compilation.ResolveVirtualMethod(decl, objType, ref info->detail);
+            MethodDesc originalImpl = _compilation.ResolveVirtualMethod(decl, objType, out info->detail);
 
             if (originalImpl == null)
             {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1199,6 +1199,10 @@ namespace Internal.JitInterface
                 {
                     return false;
                 }
+                if (!_compilation.CompilationModuleGroup.VersionsWithTypeReference(decl.OwningType))
+                {
+                    return false;
+                }
                 methodWithTokenDecl = new MethodWithToken(decl, declToken, null, false, null, devirtualizedMethodOwner: decl.OwningType);
             }
             MethodWithToken methodWithTokenImpl;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1181,7 +1181,7 @@ namespace Internal.JitInterface
             ModuleToken tokenDecl = resolver.GetModuleTokenForMethod(decl);
             ModuleToken tokenImpl = resolver.GetModuleTokenForMethod(impl);
             MethodWithToken methodWithTokenDecl = new MethodWithToken(decl, tokenDecl, null, false, null, devirtualizedMethodOwner: decl.OwningType);
-            MethodWithToken methodWithTokenImpl = new MethodWithToken(impl, tokenImpl, null, false, null, devirtualizedMethodOwner: impl.OwningType);
+            MethodWithToken methodWithTokenImpl = new MethodWithToken(impl, tokenImpl, null, unboxingStub, null, devirtualizedMethodOwner: impl.OwningType);
 
             ISymbolNode virtualResolutionNode = _compilation.SymbolNodeFactory.CheckVirtualFunctionOverride(methodWithTokenDecl, objType, methodWithTokenImpl);
             _methodCodeNode.Fixups.Add(virtualResolutionNode);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1286,7 +1286,10 @@ namespace Internal.JitInterface
                 result.tokenContext = jitInterface.contextFromMethod(method);
                 result.token = methodWithToken.Token.Token;
                 if (methodWithToken.Token.TokenType != CorTokenType.mdtMethodDef)
-                    throw new NotSupportedException();
+                {
+                    Debug.Assert(false); // This should never happen, but we protect against total failure with the throw below.
+                    throw new RequiresRuntimeJitException("Attempt to devirtualize and unable to create token for devirtualized method");
+                }
                 result.tokenType = CorInfoTokenKind.CORINFO_TOKENKIND_DevirtualizedMethod;
                 result.hClass = jitInterface.ObjectToHandle(methodWithToken.OwningType);
                 result.hMethod = jitInterface.ObjectToHandle(method);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1234,8 +1234,13 @@ namespace Internal.JitInterface
                 }
             }
 
-            ISymbolNode virtualResolutionNode = _compilation.SymbolNodeFactory.CheckVirtualFunctionOverride(methodWithTokenDecl, objType, methodWithTokenImpl);
-            _methodCodeNode.Fixups.Add(virtualResolutionNode);
+            // Testing has not shown that concerns about virtual matching are significant
+            // Only generate verification for builds with the stress mode enabled
+            if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+            {
+                ISymbolNode virtualResolutionNode = _compilation.SymbolNodeFactory.CheckVirtualFunctionOverride(methodWithTokenDecl, objType, methodWithTokenImpl);
+                _methodCodeNode.Fixups.Add(virtualResolutionNode);
+            }
 #else
             info->resolvedTokenDevirtualizedMethod = default(CORINFO_RESOLVED_TOKEN);
             info->resolvedTokenDevirtualizedUnboxedMethod = default(CORINFO_RESOLVED_TOKEN);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1165,6 +1165,12 @@ namespace Internal.JitInterface
 
             if (originalImpl == null)
             {
+                // If this assert fires, we failed to devirtualize, probably due to a failure to resolve the
+                // virtual to an exact target. This should never happen in practice if the input IL is valid,
+                // and the algorithm for virtual function resolution is correct; however, if it does, this is
+                // a safe condition, and we could delete this assert. This assert exists in order to help identify
+                // cases where the virtual function resolution algorithm either does not function, or is not used
+                // correctly.
                 Debug.Assert(info->detail != CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN);
                 return false;
             }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1160,17 +1160,17 @@ namespace Internal.JitInterface
                 }
             }
 
-            MethodDesc impl = _compilation.ResolveVirtualMethod(decl, objType);
+            MethodDesc originalImpl = _compilation.ResolveVirtualMethod(decl, objType);
 
-            if (impl == null)
+            if (originalImpl == null)
             {
                 return false;
             }
 
-            TypeDesc owningType = impl.OwningType;
+            TypeDesc owningType = originalImpl.OwningType;
 
             // RyuJIT expects to get the canonical form back
-            impl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            MethodDesc impl = originalImpl.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
             bool unboxingStub = impl.OwningType.IsValueType;
 
@@ -1207,7 +1207,7 @@ namespace Internal.JitInterface
             }
             MethodWithToken methodWithTokenImpl;
 
-            if (decl == impl)
+            if (decl == originalImpl)
             {
                 methodWithTokenImpl = methodWithTokenDecl;
                 if (info->pResolvedTokenVirtualMethod != null)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1194,7 +1194,7 @@ namespace Internal.JitInterface
             }
             else
             {
-                ModuleToken declToken = resolver.GetModuleTokenForMethod(impl.GetTypicalMethodDefinition(), throwIfNotFound: false);
+                ModuleToken declToken = resolver.GetModuleTokenForMethod(decl.GetTypicalMethodDefinition(), throwIfNotFound: false);
                 if (declToken.IsNull)
                 {
                     return false;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1171,7 +1171,13 @@ namespace Internal.JitInterface
                 // a safe condition, and we could delete this assert. This assert exists in order to help identify
                 // cases where the virtual function resolution algorithm either does not function, or is not used
                 // correctly.
-                Debug.Assert(info->detail != CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN);
+#if DEBUG
+                if (info->detail == CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN)
+                {
+                    Console.Error.WriteLine($"Failed devirtualization with unexpected unknown failure while compiling {MethodBeingCompiled} with decl {decl} targetting type {objType}");
+                    Debug.Assert(info->detail != CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN);
+                }
+#endif
                 return false;
             }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1072,17 +1072,24 @@ namespace Internal.JitInterface
 
     public enum CORINFO_DEVIRTUALIZATION_DETAIL
     {
-        CORINFO_DEVIRTUALIZATION_UNKNOWN,         // no details available
-        CORINFO_DEVIRTUALIZATION_SUCCESS,         // devirtualization was successful
-        CORINFO_DEVIRTUALIZATION_FAILED_CANON,    // object class was canonical
-        CORINFO_DEVIRTUALIZATION_FAILED_COM,      // object class was com
-        CORINFO_DEVIRTUALIZATION_FAILED_CAST,     // object class could not be cast to interface class
-        CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP,   // interface method could not be found
-        CORINFO_DEVIRTUALIZATION_FAILED_DIM,      // interface method was default interface method
-        CORINFO_DEVIRTUALIZATION_FAILED_SUBCLASS, // object not subclass of base class
-        CORINFO_DEVIRTUALIZATION_FAILED_SLOT,     // virtual method installed via explicit override
-        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE,   // devirtualization crossed version bubble
-        CORINFO_DEVIRTUALIZATION_COUNT,           // sentinel for maximum value
+        CORINFO_DEVIRTUALIZATION_UNKNOWN,                              // no details available
+        CORINFO_DEVIRTUALIZATION_SUCCESS,                              // devirtualization was successful
+        CORINFO_DEVIRTUALIZATION_FAILED_CANON,                         // object class was canonical
+        CORINFO_DEVIRTUALIZATION_FAILED_COM,                           // object class was com
+        CORINFO_DEVIRTUALIZATION_FAILED_CAST,                          // object class could not be cast to interface class
+        CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP,                        // interface method could not be found
+        CORINFO_DEVIRTUALIZATION_FAILED_DIM,                           // interface method was default interface method
+        CORINFO_DEVIRTUALIZATION_FAILED_SUBCLASS,                      // object not subclass of base class
+        CORINFO_DEVIRTUALIZATION_FAILED_SLOT,                          // virtual method installed via explicit override
+        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE,                        // devirtualization crossed version bubble
+        CORINFO_DEVIRTUALIZATION_MULTIPLE_IMPL,                        // object has multiple implementations of interface class
+        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_CLASS_DECL,             // decl method is defined on class and decl method not in version bubble, and decl method not in closest to version bubble
+        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_INTERFACE_DECL,         // decl method is defined on interface and not in version bubble, and implementation type not entirely defined in bubble
+        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL,                   // object class not defined within version bubble
+        CORINFO_DEVIRTUALIZATION_FAILED_BUBBLE_IMPL_NOT_REFERENCEABLE, // object class cannot be referenced from R2R code due to missing tokens
+        CORINFO_DEVIRTUALIZATION_FAILED_DUPLICATE_INTERFACE,           // crossgen2 virtual method algorithm and runtime algorithm differ in the presence of duplicate interface implementations
+        CORINFO_DEVIRTUALIZATION_FAILED_DECL_NOT_REPRESENTABLE,        // Decl method cannot be represented in R2R image
+        CORINFO_DEVIRTUALIZATION_COUNT,                                // sentinel for maximum value
     }
 
     public unsafe struct CORINFO_DEVIRTUALIZATION_INFO

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1093,6 +1093,7 @@ namespace Internal.JitInterface
         public CORINFO_METHOD_STRUCT_* virtualMethod;
         public CORINFO_CLASS_STRUCT_* objClass;
         public CORINFO_CONTEXT_STRUCT* context;
+        public CORINFO_RESOLVED_TOKEN* pResolvedTokenVirtualMethod;
 
         //
         // [Out] results of resolveVirtualMethod.
@@ -1107,6 +1108,8 @@ namespace Internal.JitInterface
         public bool requiresInstMethodTableArg { get { return _requiresInstMethodTableArg != 0; } set { _requiresInstMethodTableArg = value ? (byte)1 : (byte)0; } }
         public CORINFO_CONTEXT_STRUCT* exactContext;
         public CORINFO_DEVIRTUALIZATION_DETAIL detail;
+        public CORINFO_RESOLVED_TOKEN resolvedTokenDevirtualizedMethod;
+        public CORINFO_RESOLVED_TOKEN resolvedTokenDevirtualizedUnboxedMethod;
     }
 
     //----------------------------------------------------------------------------

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -459,6 +459,11 @@ namespace Internal.TypeSystem
 
             foreach (MethodDesc memberMethod in unificationGroup.Members)
             {
+                // If a method is both overriden via MethodImpl and name/sig, we don't remove it from the unification list
+                // as the local MethodImpl takes priority over the name/sig match, and prevents the slot disunificaiton
+                if (FindSlotDefiningMethodForVirtualMethod(memberMethod) == FindSlotDefiningMethodForVirtualMethod(originalDefiningMethod))
+                    continue;
+
                 MethodDesc nameSigMatchMemberMethod = FindMatchingVirtualMethodOnTypeByNameAndSigWithSlotCheck(memberMethod, currentType, reverseMethodSearch: true);
                 if (nameSigMatchMemberMethod != null && nameSigMatchMemberMethod != memberMethod)
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -670,7 +670,7 @@ namespace Internal.TypeSystem
 
             foreach (TypeDesc iface in currentType.RuntimeInterfaces)
             {
-                if (iface.CanCastTo(interfaceType))
+                if (iface.HasSameTypeDefinition(interfaceType) && iface.CanCastTo(interfaceType))
                 {
                     implMethod = iface.FindMethodOnTypeWithMatchingTypicalMethod(interfaceMethod);
                     Debug.Assert(implMethod != null);

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -382,6 +382,26 @@ namespace Internal.TypeSystem
             return result;
         }
 
+        /// <summary>
+        /// Scan the type and its base types for an implementation of an interface method. Returns null if no
+        /// implementation is found.
+        /// </summary>
+        public static MethodDesc ResolveInterfaceMethodTargetWithVariance(this TypeDesc thisType, MethodDesc interfaceMethodToResolve)
+        {
+            Debug.Assert(interfaceMethodToResolve.OwningType.IsInterface);
+
+            MethodDesc result = null;
+            TypeDesc currentType = thisType;
+            do
+            {
+                result = currentType.ResolveVariantInterfaceMethodToVirtualMethodOnType(interfaceMethodToResolve);
+                currentType = currentType.BaseType;
+            }
+            while (result == null && currentType != null);
+
+            return result;
+        }
+
         public static bool ContainsSignatureVariables(this TypeDesc thisType, bool treatGenericParameterLikeSignatureVariable = false)
         {
             switch (thisType.Category)

--- a/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/MethodIL.cs
@@ -53,13 +53,40 @@ namespace Internal.IL
     /// Represents a method body.
     /// </summary>
     [System.Diagnostics.DebuggerTypeProxy(typeof(MethodILDebugView))]
-    public abstract partial class MethodIL
+    public abstract partial class MethodILScope
     {
         /// <summary>
-        /// Gets the method whose body this <see cref="MethodIL"/> represents.
+        /// Gets the method whose body this <see cref=""/> represents.
         /// </summary>
         public abstract MethodDesc OwningMethod { get; }
 
+        /// <summary>
+        /// Gets the open (uninstantiated) version of the <see cref="MethodILScope"/>.
+        /// </summary>
+        public virtual MethodILScope GetMethodILScopeDefinition()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// Resolves a token from within the method body into a type system object
+        /// (typically a <see cref="MethodDesc"/>, <see cref="FieldDesc"/>, <see cref="TypeDesc"/>,
+        /// or <see cref="MethodSignature"/>).
+        /// </summary>
+        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw);
+
+        public override string ToString()
+        {
+            return OwningMethod.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Represents a method body.
+    /// </summary>
+    [System.Diagnostics.DebuggerTypeProxy(typeof(MethodILDebugView))]
+    public abstract partial class MethodIL : MethodILScope
+    {
         /// <summary>
         /// Gets the maximum possible stack depth this method declares.
         /// </summary>
@@ -82,16 +109,14 @@ namespace Internal.IL
         public abstract LocalVariableDefinition[] GetLocals();
 
         /// <summary>
-        /// Resolves a token from within the method body into a type system object
-        /// (typically a <see cref="MethodDesc"/>, <see cref="FieldDesc"/>, <see cref="TypeDesc"/>,
-        /// or <see cref="MethodSignature"/>).
-        /// </summary>
-        public abstract Object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw);
-
-        /// <summary>
         /// Gets a list of exception regions this method body defines.
         /// </summary>
         public abstract ILExceptionRegion[] GetExceptionRegions();
+
+        public override sealed MethodILScope GetMethodILScopeDefinition()
+        {
+            return GetMethodILDefinition();
+        }
 
         /// <summary>
         /// Gets the open (uninstantiated) version of the <see cref="MethodIL"/>.
@@ -99,11 +124,6 @@ namespace Internal.IL
         public virtual MethodIL GetMethodILDefinition()
         {
             return this;
-        }
-
-        public override string ToString()
-        {
-            return OwningMethod.ToString();
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -26,6 +26,14 @@ namespace ILCompiler
         public virtual bool VersionsWithType(TypeDesc typeDesc) => ContainsType(typeDesc);
 
         /// <summary>
+        /// Returns true when all of the tokens necessary to refer to a given type belong to the same version
+        /// bubble as the compilation module group. By default return the same outcome as VersionsWithType.
+        /// </summary>
+        /// <param name="typeDesc">Type to check</param>
+        /// <returns>True if the given type can safely be referred to within the current compilation module group</returns>
+        public virtual bool VersionsWithTypeReference(TypeDesc typeDesc) => VersionsWithType(typeDesc);
+
+        /// <summary>
         /// Returns true when a given method belongs to the same version bubble as the compilation module group.
         /// By default return the same outcome as ContainsMethodBody.
         /// </summary>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -25,8 +25,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return _compilationModuleGroup.VersionsWithMethodBody(method) && base.IsEffectivelySealed(method);
         }
 
-        protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType, ref CORINFO_DEVIRTUALIZATION_DETAIL devirtualizationDetail)
+        protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType, out CORINFO_DEVIRTUALIZATION_DETAIL devirtualizationDetail)
         {
+            devirtualizationDetail = CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_UNKNOWN;
+
             // Versioning resiliency rules here are complex
             // Decl method checking
             // 1. If the declMethod is a class method, then we do not need to check if it is within the version bubble with a VersionsWithCode check
@@ -157,7 +159,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
-            MethodDesc resolvedVirtualMethod = base.ResolveVirtualMethod(declMethod, implType, ref devirtualizationDetail);
+            MethodDesc resolvedVirtualMethod = base.ResolveVirtualMethod(declMethod, implType, out devirtualizationDetail);
 
             if (resolvedVirtualMethod != null)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -26,8 +26,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
-            if (_compilationModuleGroup.VersionsWithMethodBody(declMethod) &&
-                _compilationModuleGroup.VersionsWithType(implType))
+            if (_compilationModuleGroup.VersionsWithMethodBody(declMethod.GetTypicalMethodDefinition()) &&
+                _compilationModuleGroup.VersionsWithType(implType.GetTypeDefinition()))
             {
                 /**
                  * It is possible for us to hit a scenario where a type implements

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -161,14 +161,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (resolvedVirtualMethod != null)
             {
-                // Disable devirtualizing to a default interface method as the version resilience of that
-                // has not been analyzed, and is not expected to be particularly useful.
-                if (resolvedVirtualMethod.OwningType.IsInterface)
-                {
-                    devirtualizationDetail = CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_FAILED_DIM;
-                    return null;
-                }
-
                 // Validate that the inheritance chain for resolution is within version bubble
                 // The rule is somewhat tricky here.
                 // If the resolved method is the declMethod, then only types which derive from the

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             //    jit interface logic after the logic that executes here.
             //
             // ImplType checking
-            // 1. At all times the metadata definition of the implmenetation type must version with the application.
+            // 1. At all times the metadata definition of the implementation type must version with the application.
             // 2. Additionally, the exact implementation type must be representable within the R2R image (this is checked via VersionsWithTypeReference
             //
             // Result method checking

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -27,7 +27,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
             if (_compilationModuleGroup.VersionsWithMethodBody(declMethod.GetTypicalMethodDefinition()) &&
-                _compilationModuleGroup.VersionsWithType(implType.GetTypeDefinition()))
+                _compilationModuleGroup.VersionsWithType(implType.GetTypeDefinition()) &&
+                _compilationModuleGroup.VersionsWithTypeReference(implType))
             {
                 /**
                  * It is possible for us to hit a scenario where a type implements

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -59,32 +59,35 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 MethodDesc resolvedVirtualMethod = base.ResolveVirtualMethod(declMethod, implType);
 
-                // Validate that the inheritance chain for resolution is within version bubble
-                // The rule is somewhat tricky here.
-                // If the resolved method is the declMethod, then only types which derive from the
-                // OwningType of the decl method need to be within the version bubble.
-                //
-                // If not, then then all the types from the implType to the Owning type of the resolved
-                // virtual method must be within the version bubble.
-                bool encounteredOutsideOfVersionBubbleType = false;
-                TypeDesc resolvedVirtualMethodOwningType = resolvedVirtualMethod.OwningType;
-                for (TypeDesc typeExamine = implType; typeExamine != null; typeExamine = typeExamine.BaseType)
+                if (resolvedVirtualMethod != null)
                 {
-                    if (!_compilationModuleGroup.VersionsWithType(typeExamine.GetTypeDefinition()))
+                    // Validate that the inheritance chain for resolution is within version bubble
+                    // The rule is somewhat tricky here.
+                    // If the resolved method is the declMethod, then only types which derive from the
+                    // OwningType of the decl method need to be within the version bubble.
+                    //
+                    // If not, then then all the types from the implType to the Owning type of the resolved
+                    // virtual method must be within the version bubble.
+                    bool encounteredOutsideOfVersionBubbleType = false;
+                    TypeDesc resolvedVirtualMethodOwningType = resolvedVirtualMethod.OwningType;
+                    for (TypeDesc typeExamine = implType; typeExamine != null; typeExamine = typeExamine.BaseType)
                     {
+                        if (!_compilationModuleGroup.VersionsWithType(typeExamine.GetTypeDefinition()))
+                        {
+                            if (!declMethod.OwningType.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
+                                return null;
+
+                            encounteredOutsideOfVersionBubbleType = true;
+                        }
+                        if (typeExamine.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
+                            return resolvedVirtualMethod;
+
                         if (encounteredOutsideOfVersionBubbleType)
                         {
                             // Two levels of version bubble mismatch
                             return null;
                         }
-
-                        if (!declMethod.OwningType.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
-                            return null;
-
-                        encounteredOutsideOfVersionBubbleType = true;
                     }
-                    if (typeExamine.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
-                        return resolvedVirtualMethod;
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             //    but the metadata for it must be within the bubble, or the decl method is in the direct parent type
             //    of a type which is in the version bubble relative to the implType.
             // 2. If the declMethod is an interface method, we can allow it if interface type is defined within the version
-            //    bubble, or if the implementation type hierarchy is entirely within the version bubble (excluding System.Object).
+            //    bubble, or if the implementation type hierarchy is entirely within the version bubble (excluding System.Object and System.ValueType).
             // 3. At all times the declMethod must be representable as a token. That check is handled internally in the
             //    jit interface logic after the logic that executes here.
             //
@@ -69,7 +69,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 else
                 {
                     
-                    if (firstTypeInImplTypeHierarchyNotInVersionBubble == null || firstTypeInImplTypeHierarchyNotInVersionBubble.IsObject)
+                    if (firstTypeInImplTypeHierarchyNotInVersionBubble == null || implType.IsValueType || firstTypeInImplTypeHierarchyNotInVersionBubble.IsObject)
                         declMethodCheckFailed = false;
                     else
                         declMethodCheckFailed = true;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -26,74 +26,149 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
-            if (_compilationModuleGroup.VersionsWithMethodBody(declMethod.GetTypicalMethodDefinition()) &&
-                _compilationModuleGroup.VersionsWithType(implType.GetTypeDefinition()) &&
-                _compilationModuleGroup.VersionsWithTypeReference(implType))
+            // Versioning resiliency rules here are complex
+            // Decl method checking
+            // 1. If the declMethod is a class method, then we do not need to check if it is within the version bubble
+            //    but the metadata for it must be within the bubble, or the decl method is in the direct parent type
+            //    of a type which is in the version bubble relative to the implType.
+            // 2. If the declMethod is an interface method, we can allow it if interface type is defined within the version
+            //    bubble, or if the implementation type hierarchy is entirely within the version bubble (excluding System.Object).
+            // 3. At all times the declMethod must be representable as a token. That check is handled internally in the
+            //    jit interface logic after the logic that executes here.
+            //
+            // ImplType checking
+            // 1. At all times the metadata definition of the implmenetation type must version with the application.
+            // 2. Additionally, the exact implementation type must be representable within the R2R image (this is checked via VersionsWithTypeReference
+            //
+            // Result method checking
+            // 1. Ensure that the resolved result versions with the code, or is the decl method
+            // 2. Devirtualizing to a default interface method is not currently considered to be useful, and how to check for version
+            //    resilience has not yet been analyzed.
+            // 3. When checking that the resolved result versions with the code, validate that all of the types
+            //    From implType to the owning type of resolved result method also version with the code.
+
+            bool declMethodCheckFailed;
+            var firstTypeInImplTypeHierarchyNotInVersionBubble = FindVersionBubbleEdge(_compilationModuleGroup, implType, out TypeDesc lastTypeInHierarchyInVersionBubble);
+            if (!declMethod.OwningType.IsInterface)
             {
-                /**
-                 * It is possible for us to hit a scenario where a type implements
-                 * the same interface more than once due to generic instantiations.
-                 *
-                 * In some instances of those cases, the VirtualMethodAlgorithm
-                 * does not produce identical output as CoreCLR would, leading to
-                 * behavioral differences in compiled outputs.
-                 *
-                 * Instead of fixing the algorithm (in which the work to fix it is
-                 * tracked in https://github.com/dotnet/corert/issues/208), the
-                 * following duplication detection algorithm will detect the case and
-                 * refuse to devirtualize for those scenarios.
-                 */
-                if (declMethod.OwningType.IsInterface)
+                if (_compilationModuleGroup.VersionsWithType(declMethod.OwningType.GetTypeDefinition()))
                 {
-                    DefType[] implTypeRuntimeInterfaces = implType.RuntimeInterfaces;
-                    for (int i = 0; i < implTypeRuntimeInterfaces.Length; i++)
-                    {
-                        for (int j = i + 1; j < implTypeRuntimeInterfaces.Length; j++)
-                        {
-                            if (implTypeRuntimeInterfaces[i] == implTypeRuntimeInterfaces[j])
-                            {
-                                return null;
-                            }
-                        }
-                    }
+                    declMethodCheckFailed = false;
                 }
-
-                MethodDesc resolvedVirtualMethod = base.ResolveVirtualMethod(declMethod, implType);
-
-                if (resolvedVirtualMethod != null)
+                else
                 {
-                    // Validate that the inheritance chain for resolution is within version bubble
-                    // The rule is somewhat tricky here.
-                    // If the resolved method is the declMethod, then only types which derive from the
-                    // OwningType of the decl method need to be within the version bubble.
-                    //
-                    // If not, then then all the types from the implType to the Owning type of the resolved
-                    // virtual method must be within the version bubble.
-                    bool encounteredOutsideOfVersionBubbleType = false;
-                    TypeDesc resolvedVirtualMethodOwningType = resolvedVirtualMethod.OwningType;
-                    for (TypeDesc typeExamine = implType; typeExamine != null; typeExamine = typeExamine.BaseType)
+                    declMethodCheckFailed = firstTypeInImplTypeHierarchyNotInVersionBubble != declMethod.OwningType;
+                }
+            }
+            else
+            {
+                if (_compilationModuleGroup.VersionsWithType(declMethod.OwningType.GetTypeDefinition()))
+                {
+                    declMethodCheckFailed = false;
+                }
+                else
+                {
+                    
+                    if (firstTypeInImplTypeHierarchyNotInVersionBubble == null || firstTypeInImplTypeHierarchyNotInVersionBubble.IsObject)
+                        declMethodCheckFailed = false;
+                    else
+                        declMethodCheckFailed = true;
+                }
+            }
+
+            if (declMethodCheckFailed)
+                return null;
+
+            // Impl type check
+            if (!_compilationModuleGroup.VersionsWithType(implType.GetTypeDefinition()) ||
+                !_compilationModuleGroup.VersionsWithTypeReference(implType))
+            {
+                return null;
+            }
+
+            /**
+                * It is possible for us to hit a scenario where a type implements
+                * the same interface more than once due to generic instantiations.
+                *
+                * In some instances of those cases, the VirtualMethodAlgorithm
+                * does not produce identical output as CoreCLR would, leading to
+                * behavioral differences in compiled outputs.
+                *
+                * Instead of fixing the algorithm (in which the work to fix it is
+                * tracked in https://github.com/dotnet/corert/issues/208), the
+                * following duplication detection algorithm will detect the case and
+                * refuse to devirtualize for those scenarios.
+                */
+            if (declMethod.OwningType.IsInterface)
+            {
+                DefType[] implTypeRuntimeInterfaces = implType.RuntimeInterfaces;
+                for (int i = 0; i < implTypeRuntimeInterfaces.Length; i++)
+                {
+                    for (int j = i + 1; j < implTypeRuntimeInterfaces.Length; j++)
                     {
-                        if (!_compilationModuleGroup.VersionsWithType(typeExamine.GetTypeDefinition()))
+                        if (implTypeRuntimeInterfaces[i] == implTypeRuntimeInterfaces[j])
                         {
-                            if (!declMethod.OwningType.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
-                                return null;
-
-                            encounteredOutsideOfVersionBubbleType = true;
-                        }
-                        if (typeExamine.HasSameTypeDefinition(resolvedVirtualMethodOwningType))
-                            return resolvedVirtualMethod;
-
-                        if (encounteredOutsideOfVersionBubbleType)
-                        {
-                            // Two levels of version bubble mismatch
                             return null;
                         }
                     }
                 }
             }
 
-            // Cannot devirtualize across version bubble boundary
+            MethodDesc resolvedVirtualMethod = base.ResolveVirtualMethod(declMethod, implType);
+
+            if (resolvedVirtualMethod != null)
+            {
+                // Disable devirtualizing to a default interface method as the version resilience of that
+                // has not been analyzed, and is not expected to be particularly useful.
+                if (resolvedVirtualMethod.OwningType.IsInterface)
+                    return null;
+
+                // Validate that the inheritance chain for resolution is within version bubble
+                // The rule is somewhat tricky here.
+                // If the resolved method is the declMethod, then only types which derive from the
+                // OwningType of the decl method need to be within the version bubble.
+                //
+                // If not, then then all the types from the implType to the Owning type of the resolved
+                // virtual method must be within the version bubble.
+                if (firstTypeInImplTypeHierarchyNotInVersionBubble == null)
+                {
+                    // The entire type hierarchy of the implType is within the version bubble, and there is no more to check
+                    return resolvedVirtualMethod;
+                }
+
+                if (declMethod == resolvedVirtualMethod && firstTypeInImplTypeHierarchyNotInVersionBubble == declMethod.OwningType)
+                {
+                    // Exact match for use of decl method check
+                    return resolvedVirtualMethod;
+                }
+
+                // Ensure that declMethod is implemented on a type within the type hierarchy that is within the version bubble
+                for (TypeDesc typeExamine = resolvedVirtualMethod.OwningType; typeExamine != null; typeExamine = typeExamine.BaseType)
+                {
+                    if (typeExamine == lastTypeInHierarchyInVersionBubble)
+                    {
+                        return resolvedVirtualMethod;
+                    }
+                }
+            }
+
+            // Cannot devirtualize, as we can't resolve to a target.
             return null;
+
+            // This function returns the type where the metadata is not in the version bubble of the application, and has an out parameter
+            // which is the last type examined before that is found via a base type walk.
+            static TypeDesc FindVersionBubbleEdge(CompilationModuleGroup compilationModuleGroup, TypeDesc type, out TypeDesc lastTypeInVersionBubble)
+            {
+                lastTypeInVersionBubble = null;
+                while (compilationModuleGroup.VersionsWithType(type.GetTypeDefinition()))
+                {
+                    lastTypeInVersionBubble = type;
+                    type = type.BaseType;
+                    if (type == null)
+                        return null;
+                }
+                return type;
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstrumentationDataTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstrumentationDataTableNode.cs
@@ -93,7 +93,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     return computedInt;
                 }
-                if (type.AsType != null && _compilationGroup.VersionsWithType(type.AsType))
+                if (type.AsType != null && _compilationGroup.VersionsWithTypeReference(type.AsType))
                 {
                     Import typeHandleImport = (Import)_symbolFactory.CreateReadyToRunHelper(ReadyToRunHelperId.TypeHandle, type.AsType);
                     _imports.Add(typeHandleImport);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -417,7 +417,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType;
             }
 
-            EmitMethodSpecificationSignature(method, flags, enforceDefEncoding, context);
+            EmitMethodSpecificationSignature(method, flags, enforceDefEncoding, enforceOwningType, context);
 
             if (method.ConstrainedType != null)
             {
@@ -438,7 +438,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         }
 
         private void EmitMethodSpecificationSignature(MethodWithToken method, 
-            uint flags, bool enforceDefEncoding, SignatureContext context)
+            uint flags, bool enforceDefEncoding, bool enforceOwningType, SignatureContext context)
         {
             ModuleToken methodToken = method.Token;
 
@@ -470,8 +470,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     throw new NotImplementedException();
             }
 
-            if (method.Token.Module != context.LocalContext)
+            if ((method.Token.Module != context.LocalContext) && !enforceOwningType)
             {
+                // If enforeOwningType is set, this is an entry for the InstanceEntryPoint or InstrumentationDataTable nodes
+                // which are not used in quite the same way, and for which the MethodDef is always matched to the module
+                // which defines the type
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -441,6 +441,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             uint flags, bool enforceDefEncoding, SignatureContext context)
         {
             ModuleToken methodToken = method.Token;
+
             if (method.Method.HasInstantiation && !method.Method.IsGenericMethodDefinition)
             {
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation;
@@ -469,7 +470,20 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     throw new NotImplementedException();
             }
 
+            if (method.Token.Module != context.LocalContext)
+            {
+                flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext;
+            }
+
             EmitUInt(flags);
+
+            if ((flags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext) != 0)
+            {
+                uint moduleIndex = (uint)context.Resolver.GetModuleIndex(method.Token.Module);
+                EmitUInt(moduleIndex);
+                context = context.InnerContext(method.Token.Module);
+            }
+
             if ((flags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
             {
                 // The type here should be the type referred to by the memberref (if this is one, not the type where the method was eventually found!

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/VirtualResolutionFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/VirtualResolutionFixupSignature.cs
@@ -66,7 +66,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append(":");
             sb.Append(nameMangler.GetMangledTypeName(_implType));
             sb.Append(":");
-            _implMethod.AppendMangledName(nameMangler, sb);
+            if (_implMethod == null)
+                sb.Append("(null)");
+            else
+                _implMethod.AppendMangledName(nameMangler, sb);
         }
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
@@ -83,6 +86,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             result = _declMethod.CompareTo(otherNode._declMethod, comparer);
             if (result != 0)
                 return result;
+
+            // Handle null _implMethod scenario
+            if (_implMethod == otherNode._implMethod)
+                return 0;
 
             return _implMethod.CompareTo(otherNode._implMethod, comparer);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/VirtualResolutionFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/VirtualResolutionFixupSignature.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+using Internal.TypeSystem.Interop;
+using Internal.ReadyToRunConstants;
+using Internal.CorConstants;
+using Internal.JitInterface;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class VirtualResolutionFixupSignature : Signature, IEquatable<VirtualResolutionFixupSignature>
+    {
+        private readonly ReadyToRunFixupKind _fixupKind;
+
+        private readonly MethodWithToken _declMethod;
+        private readonly TypeDesc _implType;
+        private readonly MethodWithToken _implMethod;
+
+        public VirtualResolutionFixupSignature(ReadyToRunFixupKind fixupKind, MethodWithToken declMethod, TypeDesc implType, MethodWithToken implMethod)
+        {
+            _fixupKind = fixupKind;
+            _declMethod = declMethod;
+            _implType = implType;
+            _implMethod = implMethod;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            CompilerTypeSystemContext compilerContext = (CompilerTypeSystemContext)declMethod.Method.Context;
+            compilerContext.EnsureLoadableMethod(declMethod.Method);
+            compilerContext.EnsureLoadableType(implType);
+            if (implMethod != null)
+                compilerContext.EnsureLoadableMethod(implMethod.Method);
+        }
+
+        public override int ClassCode => 1092747257;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+
+            if (!relocsOnly)
+            {
+                dataBuilder.AddSymbol(this);
+
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, _declMethod.Token.Module, factory.SignatureContext);
+                dataBuilder.EmitUInt((uint)(_implMethod != null ? ReadyToRunVirtualFunctionOverrideFlags.VirtualFunctionOverriden : ReadyToRunVirtualFunctionOverrideFlags.None));
+                dataBuilder.EmitMethodSignature(_declMethod, enforceDefEncoding: false, enforceOwningType: false, innerContext, isInstantiatingStub: false);
+                dataBuilder.EmitTypeSignature(_implType, innerContext);
+                if (_implMethod != null)
+                    dataBuilder.EmitMethodSignature(_implMethod, enforceDefEncoding: false, enforceOwningType: false, innerContext, isInstantiatingStub: false);
+            }
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"VirtualResolutionFixupSignature({_fixupKind.ToString()}): ");
+            _declMethod.AppendMangledName(nameMangler, sb);
+            sb.Append(":");
+            sb.Append(nameMangler.GetMangledTypeName(_implType));
+            sb.Append(":");
+            _implMethod.AppendMangledName(nameMangler, sb);
+        }
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            VirtualResolutionFixupSignature otherNode = (VirtualResolutionFixupSignature)other;
+            int result = ((int)_fixupKind).CompareTo((int)otherNode._fixupKind);
+            if (result != 0)
+                return result;
+
+            result = comparer.Compare(_implType, otherNode._implType);
+            if (result != 0)
+                return result;
+
+            result = _declMethod.CompareTo(otherNode._declMethod, comparer);
+            if (result != 0)
+                return result;
+
+            return _implMethod.CompareTo(otherNode._implMethod, comparer);
+        }
+
+        public override string ToString()
+        {
+            return $"VirtualResolutionFixupSignature {_fixupKind} {_declMethod} {_implType} {_implMethod}";
+        }
+
+        public bool Equals(VirtualResolutionFixupSignature other) => object.ReferenceEquals(other, this);
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -166,6 +166,7 @@ namespace ILCompiler.DependencyAnalysis
             CopiedCorHeaderNode = corHeaderNode;
             DebugDirectoryNode = debugDirectoryNode;
             Resolver = new ModuleTokenResolver(compilationModuleGroup, TypeSystemContext);
+            ((ReadyToRunCompilationModuleGroupBase)compilationModuleGroup).AssociateTokenResolver(Resolver);
             Header = new GlobalHeaderNode(Target, flags);
             if (!win32Resources.IsEmpty)
                 Win32ResourcesNode = new Win32ResourcesNode(win32Resources);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -526,7 +526,8 @@ namespace ILCompiler.DependencyAnalysis
 
             public bool Equals(VirtualResolutionFixupSignatureFixupKey other)
             {
-                return FixupKind == other.FixupKind && DeclMethod.Equals(other.DeclMethod) && ImplType == other.ImplType && ImplMethod.Equals(other.ImplMethod);
+                return FixupKind == other.FixupKind && DeclMethod.Equals(other.DeclMethod) && ImplType == other.ImplType && 
+                    ((ImplMethod == null && other.ImplMethod == null) || (ImplMethod != null && ImplMethod.Equals(other.ImplMethod)));
             }
 
             public override bool Equals(object obj)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -53,7 +53,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public TargetDetails Target { get; }
 
-        public CompilationModuleGroup CompilationModuleGroup { get; }
+        public ReadyToRunCompilationModuleGroupBase CompilationModuleGroup { get; }
 
         public ProfileDataManager ProfileDataManager { get; }
 
@@ -149,7 +149,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public NodeFactory(
             CompilerTypeSystemContext context,
-            CompilationModuleGroup compilationModuleGroup,
+            ReadyToRunCompilationModuleGroupBase compilationModuleGroup,
             ProfileDataManager profileDataManager,
             NameMangler nameMangler,
             CopiedCorHeaderNode corHeaderNode,
@@ -165,8 +165,7 @@ namespace ILCompiler.DependencyAnalysis
             MetadataManager = new ReadyToRunTableManager(context);
             CopiedCorHeaderNode = corHeaderNode;
             DebugDirectoryNode = debugDirectoryNode;
-            Resolver = new ModuleTokenResolver(compilationModuleGroup, TypeSystemContext);
-            ((ReadyToRunCompilationModuleGroupBase)compilationModuleGroup).AssociateTokenResolver(Resolver);
+            Resolver = compilationModuleGroup.Resolver;
             Header = new GlobalHeaderNode(Target, flags);
             if (!win32Resources.IsEmpty)
                 Win32ResourcesNode = new Win32ResourcesNode(win32Resources);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -137,7 +137,7 @@ namespace ILCompiler.DependencyAnalysis
 
             _virtualFunctionOverrideCache = new NodeCache<VirtualResolutionFixupSignature, ISymbolNode>(key =>
             {
-                return new PrecodeHelperImport(_codegenNodeFactory,key);
+                return new PrecodeHelperImport(_codegenNodeFactory, key);
             });
 
             _genericLookupHelpers = new NodeCache<GenericLookupKey, ISymbolNode>(key =>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -135,6 +135,11 @@ namespace ILCompiler.DependencyAnalysis
                 );
             });
 
+            _virtualFunctionOverrideCache = new NodeCache<VirtualResolutionFixupSignature, ISymbolNode>(key =>
+            {
+                return new PrecodeHelperImport(_codegenNodeFactory,key);
+            });
+
             _genericLookupHelpers = new NodeCache<GenericLookupKey, ISymbolNode>(key =>
             {
                 return new DelayLoadHelperImport(
@@ -439,6 +444,15 @@ namespace ILCompiler.DependencyAnalysis
         public ISymbolNode CheckTypeLayout(TypeDesc type)
         {
             return _checkTypeLayoutCache.GetOrAdd(type);
+        }
+
+        private NodeCache<VirtualResolutionFixupSignature, ISymbolNode> _virtualFunctionOverrideCache;
+
+        public ISymbolNode CheckVirtualFunctionOverride(MethodWithToken declMethod, TypeDesc implType, MethodWithToken implMethod)
+        {
+            return _virtualFunctionOverrideCache.GetOrAdd(_codegenNodeFactory.VirtualResolutionFixupSignature(
+                _verifyTypeAndFieldLayout ? ReadyToRunFixupKind.Verify_VirtualFunctionOverride : ReadyToRunFixupKind.Check_VirtualFunctionOverride,
+                declMethod, implType, implMethod));
         }
 
         struct MethodAndCallSite : IEquatable<MethodAndCallSite>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/NoMethodsCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/NoMethodsCompilationModuleGroup.cs
@@ -16,7 +16,7 @@ namespace ILCompiler
     public class NoMethodsCompilationModuleGroup : ReadyToRunCompilationModuleGroupBase
     {
         public NoMethodsCompilationModuleGroup(
-            TypeSystemContext context,
+            CompilerTypeSystemContext context,
             bool isCompositeBuildMode,
             bool isInputBubble,
             IEnumerable<EcmaModule> compilationModuleSet,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -123,9 +123,9 @@ namespace ILCompiler
             return _devirtualizationManager.IsEffectivelySealed(method);
         }
 
-        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType, ref CORINFO_DEVIRTUALIZATION_DETAIL devirtualizationDetail)
+        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType, out CORINFO_DEVIRTUALIZATION_DETAIL devirtualizationDetail)
         {
-            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType, ref devirtualizationDetail);
+            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType, out devirtualizationDetail);
         }
 
         public bool IsModuleInstrumented(ModuleDesc module)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -123,9 +123,9 @@ namespace ILCompiler
             return _devirtualizationManager.IsEffectivelySealed(method);
         }
 
-        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType)
+        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType, ref CORINFO_DEVIRTUALIZATION_DETAIL devirtualizationDetail)
         {
-            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType);
+            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType, ref devirtualizationDetail);
         }
 
         public bool IsModuleInstrumented(ModuleDesc module)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -248,7 +248,7 @@ namespace ILCompiler
 
             NodeFactory factory = new NodeFactory(
                 _context,
-                _compilationGroup,
+                (ReadyToRunCompilationModuleGroupBase)_compilationGroup,
                 _profileData,
                 _nameMangler,
                 corHeaderNode,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -418,27 +418,8 @@ namespace ILCompiler
 
         private bool ComputeTypeReferenceVersionsWithCode(TypeDesc type)
         {
-            switch(type.Category)
-            {
-                case TypeFlags.Void:
-                case TypeFlags.Boolean:
-                case TypeFlags.Char:
-                case TypeFlags.SByte:
-                case TypeFlags.Byte:
-                case TypeFlags.Int16:
-                case TypeFlags.UInt16:
-                case TypeFlags.Int32:
-                case TypeFlags.UInt32:
-                case TypeFlags.Int64:
-                case TypeFlags.UInt64:
-                case TypeFlags.IntPtr:
-                case TypeFlags.UIntPtr:
-                case TypeFlags.Single:
-                case TypeFlags.Double:
-                    return true;
-            }
-
-            if (type.IsObject || type.IsString)
+            // Type represented by simple element type
+            if (type.IsPrimitive || type.IsVoid || type.IsObject || type.IsString)
                 return true;
 
             if (VersionsWithType(type))

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -407,7 +407,7 @@ namespace ILCompiler
 
                 if (!ComputeInstantiationTypeVersionsWithCode(this, instType))
                 {
-                    if (instType.IsPrimitive)
+                    if (instType.IsPrimitive || instType.IsObject || instType.IsString)
                     {
                         // Primitive type instantiations are only instantiated in the module of the generic defining type
                         // if the generic does not apply interface constraints to that type parameter, or if System.Private.CoreLib is part of the version bubble
@@ -423,8 +423,20 @@ namespace ILCompiler
                         }
 
                         GenericParameterDesc genericParam = (GenericParameterDesc)entityDefinitionInstantiation[iInstantiation];
-                        if (genericParam.HasReferenceTypeConstraint)
-                            return false;
+                        if (instType.IsPrimitive)
+                        {
+                            if (genericParam.HasReferenceTypeConstraint)
+                                return false;
+                        }
+                        else
+                        {
+                            Debug.Assert(instType.IsString || instType.IsObject);
+                            if (genericParam.HasNotNullableValueTypeConstraint)
+                                return false;
+
+                            if (instType.IsString && genericParam.HasDefaultConstructorConstraint)
+                                return false;
+                        }
 
                         // This checks to see if the type constraints list is empty
                         if (genericParam.TypeConstraints.GetEnumerator().MoveNext())

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -30,7 +30,7 @@ namespace ILCompiler
         private ModuleTokenResolver _tokenResolver = null;
 
         public ReadyToRunCompilationModuleGroupBase(
-            TypeSystemContext context,
+            CompilerTypeSystemContext context,
             bool isCompositeBuildMode,
             bool isInputBubble,
             IEnumerable<EcmaModule> compilationModuleSet,
@@ -47,7 +47,11 @@ namespace ILCompiler
             _versionBubbleModuleSet.UnionWith(_compilationModuleSet);
 
             _compileGenericDependenciesFromVersionBubbleModuleSet = compileGenericDependenciesFromVersionBubbleModuleSet;
+
+            _tokenResolver = new ModuleTokenResolver(this, context);
         }
+
+        public ModuleTokenResolver Resolver => _tokenResolver;
 
         public void AssociateTokenResolver(ModuleTokenResolver tokenResolver)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -17,7 +17,7 @@ namespace ILCompiler
         private bool _profileGuidedCompileRestrictionSet;
 
         public ReadyToRunSingleAssemblyCompilationModuleGroup(
-            TypeSystemContext context,
+            CompilerTypeSystemContext context,
             bool isCompositeBuildMode,
             bool isInputBubble,
             IEnumerable<EcmaModule> compilationModuleSet,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -17,7 +17,7 @@ namespace ILCompiler
         private MethodDesc _method;
 
         public SingleMethodCompilationModuleGroup(
-            TypeSystemContext context,
+            CompilerTypeSystemContext context,
             bool isCompositeBuildMode,
             bool isInputBubble,
             IEnumerable<EcmaModule> compilationModuleSet,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TransitionBlock.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\VirtualResolutionFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Win32ResourcesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunSymbolNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SortableDependencyNodeCompilerSpecific.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -221,6 +221,9 @@ namespace Internal.JitInterface
 
         public bool Equals(MethodWithToken methodWithToken)
         {
+            if (methodWithToken == null)
+                return false;
+
             bool equals = Method == methodWithToken.Method && Token.Equals(methodWithToken.Token)
                 && OwningType == methodWithToken.OwningType && ConstrainedType == methodWithToken.ConstrainedType
                 && Unboxing == methodWithToken.Unboxing;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -360,6 +360,7 @@ namespace Internal.JitInterface
         private NativeVarInfo[] _debugVarInfos;
         private ArrayBuilder<MethodDesc> _inlinedMethods;
         private UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
+        private Dictionary<MethodDesc, ValueTuple<ModuleToken, object>> _resolvedExternalMethodsToTokens = new Dictionary<MethodDesc, ValueTuple<ModuleToken, object>>();
 
         public CorInfoImpl(ReadyToRunCodegenCompilation compilation)
             : this()

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -23,7 +23,7 @@ using Internal.ReadyToRunConstants;
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
-
+using System.Text;
 
 namespace Internal.JitInterface
 {
@@ -245,6 +245,24 @@ namespace Internal.JitInterface
             sb.Append(Token.ToString());
             if (Unboxing)
                 sb.Append("; UNBOXING");
+        }
+
+        public override string ToString()
+        {
+            StringBuilder debuggingName = new StringBuilder();
+            debuggingName.Append(Method.ToString());
+            if (ConstrainedType != null)
+            {
+                debuggingName.Append(" @ ");
+                debuggingName.Append(ConstrainedType.ToString());
+            }
+
+            debuggingName.Append("; ");
+            debuggingName.Append(Token.ToString());
+            if (Unboxing)
+                debuggingName.Append("; UNBOXING");
+
+            return debuggingName.ToString();
         }
 
         public int CompareTo(MethodWithToken other, TypeSystemComparer comparer)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1387,9 +1387,9 @@ namespace ILCompiler.Reflection.ReadyToRun
                     }
 
                     if (fixupType == ReadyToRunFixupKind.Check_TypeLayout)
-                        builder.Append(" (Check_VirtualFunctionOverride)");
+                        builder.Append(" (CHECK_VIRTUAL_FUNCTION_OVERRIDE)");
                     else
-                        builder.Append(" (Verify_VirtualFunctionOverride)");
+                        builder.Append(" (VERIFY_VIRTUAL_FUNCTION_OVERRIDE)");
                     break;
 
                 case ReadyToRunFixupKind.Check_FieldOffset:

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14311,7 +14311,7 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                     pImplMethodRuntime = thImpl.GetMethodTable()->GetMethodDescForSlot(slot);
                 }
             }
-            
+
             if (pImplMethodRuntime != pImplMethodCompiler)
             {
                 if (kind == ENCODE_CHECK_VIRTUAL_FUNCTION_OVERRIDE)
@@ -14330,11 +14330,13 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
 
                     if (pImplMethodRuntime != NULL)
                     {
+                        methodNameImplRuntime.Clear();
                         pImplMethodRuntime->GetFullMethodInfo(methodNameImplRuntime);
                     }
 
                     if (pImplMethodCompiler != NULL)
                     {
+                        methodNameImplCompiler.Clear();
                         pImplMethodCompiler->GetFullMethodInfo(methodNameImplCompiler);
                     }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14265,7 +14265,7 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
 
             SigTypeContext typeContext;    // empty context is OK: encoding should not contain type variables.
             ZapSig::Context zapSigContext(pInfoModule, (void *)currentModule, ZapSig::NormalTokens);
-            MethodDesc *pDeclMethod = ZapSig::DecodeMethod(pInfoModule, updatedSignature, &typeContext, &zapSigContext, NULL, NULL, NULL, &updatedSignature);
+            MethodDesc *pDeclMethod = ZapSig::DecodeMethod(pInfoModule, updatedSignature, &typeContext, &zapSigContext, NULL, NULL, NULL, &updatedSignature, TRUE);
             TypeHandle thImpl = ZapSig::DecodeType(currentModule, pInfoModule, updatedSignature, CLASS_LOADED, &updatedSignature);
 
             MethodDesc *pImplMethodCompiler = NULL;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14278,6 +14278,21 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             MethodDesc *pImplMethodRuntime;
             if (pDeclMethod->IsInterface())
             {
+                if (!thImpl.CanCastTo(pDeclMethod->GetMethodTable()))
+                {
+                    MethodTable *pInterfaceTypeCanonical = pDeclMethod->GetMethodTable()->GetCanonicalMethodTable();
+
+                    // Its possible for the decl method to need to be found on the only canonically compatible interface on the owning type
+                    MethodTable::InterfaceMapIterator it = thImpl.GetMethodTable()->IterateInterfaceMap();
+                    while (it.Next())
+                    {
+                        if (pInterfaceTypeCanonical == it.GetInterface()->GetCanonicalMethodTable())
+                        {
+                            pDeclMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pDeclMethod, it.GetInterface(), FALSE, pDeclMethod->GetMethodInstantiation(), FALSE, TRUE);
+                            break;
+                        }
+                    }
+                }
                 DispatchSlot slot = thImpl.GetMethodTable()->FindDispatchSlotForInterfaceMD(pDeclMethod, /*throwOnConflict*/ FALSE);
                 pImplMethodRuntime = slot.GetMethodDesc();
             }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14256,6 +14256,113 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
         }
         break;
 
+    case ENCODE_VERIFY_VIRTUAL_FUNCTION_OVERRIDE:
+    case ENCODE_CHECK_VIRTUAL_FUNCTION_OVERRIDE:
+        {
+            PCCOR_SIGNATURE updatedSignature = pBlob;
+
+            ReadyToRunVirtualFunctionOverrideFlags flags = (ReadyToRunVirtualFunctionOverrideFlags)CorSigUncompressData(updatedSignature);
+
+            SigTypeContext typeContext;    // empty context is OK: encoding should not contain type variables.
+            ZapSig::Context zapSigContext(pInfoModule, (void *)currentModule, ZapSig::NormalTokens);
+            MethodDesc *pDeclMethod = ZapSig::DecodeMethod(pInfoModule, updatedSignature, &typeContext, &zapSigContext, NULL, NULL, NULL, &updatedSignature);
+            TypeHandle thImpl = ZapSig::DecodeType(currentModule, pInfoModule, updatedSignature, CLASS_LOADED, &updatedSignature);
+
+            MethodDesc *pImplMethodCompiler = NULL;
+            
+            if ((flags & READYTORUN_VIRTUAL_OVERRIDE_VirtualFunctionOverriden) != 0)
+            {
+                pImplMethodCompiler = ZapSig::DecodeMethod(currentModule, pInfoModule, updatedSignature);
+            }
+
+            MethodDesc *pImplMethodRuntime;
+            if (pDeclMethod->IsInterface())
+            {
+                DispatchSlot slot = thImpl.GetMethodTable()->FindDispatchSlotForInterfaceMD(pDeclMethod, /*throwOnConflict*/ FALSE);
+                pImplMethodRuntime = slot.GetMethodDesc();
+            }
+            else
+            {
+                MethodTable *pCheckMT = thImpl.GetMethodTable();
+                MethodTable *pBaseMT = pDeclMethod->GetMethodTable();
+                WORD slot = pDeclMethod->GetSlot();
+
+                while (pCheckMT != nullptr)
+                {
+                    if (pCheckMT->HasSameTypeDefAs(pBaseMT))
+                    {
+                        break;
+                    }
+
+                    pCheckMT = pCheckMT->GetParentMethodTable();
+                }
+
+                if (pCheckMT == nullptr)
+                {
+                    pImplMethodRuntime = NULL;
+                }
+                else if (IsMdFinal(pDeclMethod->GetAttrs()))
+                {
+                    pImplMethodRuntime = pDeclMethod;
+                }
+                else
+                {
+                    _ASSERTE(slot < pBaseMT->GetNumVirtuals());
+                    pImplMethodRuntime = thImpl.GetMethodTable()->GetMethodDescForSlot(slot);
+                }
+            }
+            
+            if (pImplMethodRuntime != pImplMethodCompiler)
+            {
+                if (kind == ENCODE_CHECK_VIRTUAL_FUNCTION_OVERRIDE)
+                {
+                    return FALSE;
+                }
+                else
+                {
+                    // Verification failures are failfast events
+                    DefineFullyQualifiedNameForClassW();
+                    SString methodNameDecl;
+                    SString methodNameImplRuntime(W("(NULL)"));
+                    SString methodNameImplCompiler(W("(NULL)"));
+
+                    pDeclMethod->GetFullMethodInfo(methodNameDecl);
+
+                    if (pImplMethodRuntime != NULL)
+                    {
+                        pImplMethodRuntime->GetFullMethodInfo(methodNameImplRuntime);
+                    }
+
+                    if (pImplMethodCompiler != NULL)
+                    {
+                        pImplMethodCompiler->GetFullMethodInfo(methodNameImplCompiler);
+                    }
+
+                    SString fatalErrorString;
+                    fatalErrorString.Printf(W("Verify_VirtualFunctionOverride Decl Method '%s' on type '%s' is '%s'(actual) instead of expected '%s'(from compiler)"),
+                        methodNameDecl.GetUnicode(),
+                        GetFullyQualifiedNameForClassW(thImpl.GetMethodTable()),
+                        methodNameImplRuntime.GetUnicode(),
+                        methodNameImplCompiler.GetUnicode());
+
+#ifdef _DEBUG
+                    {
+                        StackScratchBuffer buf;
+                        _ASSERTE_MSG(false, fatalErrorString.GetUTF8(buf));
+                    }
+#endif
+                    _ASSERTE(!IsDebuggerPresent() && "Stop on assert here instead of fatal error for ease of live debugging");
+
+                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(-1, fatalErrorString.GetUnicode());
+                    return FALSE;
+
+                }
+            }
+
+            result = 1;
+        }
+        break;
+
 
     case ENCODE_CHECK_INSTRUCTION_SET_SUPPORT:
         {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8904,6 +8904,8 @@ bool CEEInfo::resolveVirtualMethodHelper(CORINFO_DEVIRTUALIZATION_INFO * info)
     info->devirtualizedMethod = NULL;
     info->requiresInstMethodTableArg = false;
     info->exactContext = NULL;
+    memset(&info->resolvedTokenDevirtualizedMethod, 0, sizeof(info->resolvedTokenDevirtualizedMethod));
+    memset(&info->resolvedTokenDevirtualizedUnboxedMethod, 0, sizeof(info->resolvedTokenDevirtualizedUnboxedMethod));
 
     MethodDesc* pBaseMD = GetMethod(info->virtualMethod);
     MethodTable* pBaseMT = pBaseMD->GetMethodTable();

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -795,7 +795,8 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
                                  TypeHandle *ppTH, /*=NULL*/
                                  PCCOR_SIGNATURE *ppOwnerTypeSpecWithVars, /*=NULL*/
                                  PCCOR_SIGNATURE *ppMethodSpecWithVars, /*=NULL*/
-                                 PCCOR_SIGNATURE *ppAfterSig /*=NULL*/)
+                                 PCCOR_SIGNATURE *ppAfterSig /*=NULL*/,
+                                 BOOL actualOwnerRequired /*=FALSE*/)
 {
     STANDARD_VM_CONTRACT;
 
@@ -867,7 +868,7 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
                 MethodDesc * pMD = NULL;
                 FieldDesc * pFD = NULL;
 
-                MemberLoader::GetDescFromMemberRef(pInfoModule, TokenFromRid(rid, mdtMemberRef), &pMD, &pFD, NULL, FALSE, &th);
+                MemberLoader::GetDescFromMemberRef(pInfoModule, TokenFromRid(rid, mdtMemberRef), &pMD, &pFD, NULL, actualOwnerRequired, &th);
                 _ASSERTE(pMD != NULL);
 
                 thOwner = th;
@@ -955,7 +956,8 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
     pMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pMethod, thOwner.GetMethodTable(),
                                                             isUnboxingStub,
                                                             inst,
-                                                            !(isInstantiatingStub || isUnboxingStub));
+                                                            !(isInstantiatingStub || isUnboxingStub) && !actualOwnerRequired,
+                                                            actualOwnerRequired);
 
     g_IBCLogger.LogMethodDescAccess(pMethod);
 

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -741,7 +741,8 @@ Module *ZapSig::DecodeModuleFromIndexIfLoaded(Module *fromModule,
 TypeHandle ZapSig::DecodeType(Module *pEncodeModuleContext,
                               Module *pInfoModule,
                               PCCOR_SIGNATURE pBuffer,
-                              ClassLoadLevel level)
+                              ClassLoadLevel level,
+                              PCCOR_SIGNATURE *ppAfterSig /*=NULL*/)
 {
     CONTRACTL
     {
@@ -766,6 +767,12 @@ TypeHandle ZapSig::DecodeType(Module *pEncodeModuleContext,
                                             NULL,
                                             pZapSigContext);
 
+    if (ppAfterSig != NULL)
+    {
+        IfFailThrow(p.SkipExactlyOne());
+        *ppAfterSig = p.GetPtr();
+    }
+
     return th;
 }
 
@@ -778,7 +785,7 @@ MethodDesc *ZapSig::DecodeMethod(Module *pReferencingModule,
 
     SigTypeContext typeContext;    // empty context is OK: encoding should not contain type variables.
     ZapSig::Context zapSigContext(pInfoModule, (void *)pReferencingModule, ZapSig::NormalTokens);
-    return DecodeMethod(pInfoModule, pBuffer, &typeContext, &zapSigContext, ppTH);
+    return DecodeMethod(pInfoModule, pBuffer, &typeContext, &zapSigContext, ppTH, NULL, NULL);
 }
 
 MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
@@ -787,7 +794,8 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
                                  ZapSig::Context *pZapSigContext,
                                  TypeHandle *ppTH, /*=NULL*/
                                  PCCOR_SIGNATURE *ppOwnerTypeSpecWithVars, /*=NULL*/
-                                 PCCOR_SIGNATURE *ppMethodSpecWithVars /*=NULL*/)
+                                 PCCOR_SIGNATURE *ppMethodSpecWithVars, /*=NULL*/
+                                 PCCOR_SIGNATURE *ppAfterSig /*=NULL*/)
 {
     STANDARD_VM_CONTRACT;
 
@@ -800,6 +808,22 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
     IfFailThrow(sig.GetData(&methodFlags));
 
     TypeHandle thOwner = NULL;
+
+    if ( methodFlags & ENCODE_METHOD_SIG_UpdateContext)
+    {
+        uint32_t updatedModuleIndex;
+        IfFailThrow(sig.GetData(&updatedModuleIndex));
+#ifdef FEATURE_MULTICOREJIT
+        if (pZapSigContext->externalTokens == ZapSig::MulticoreJitTokens)
+        {
+            pInfoModule = MulticoreJitManager::DecodeModuleFromIndex(pZapSigContext->pModuleContext, updatedModuleIndex);
+        }
+        else
+#endif
+        {
+            pInfoModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndex(updatedModuleIndex);
+        }
+    }
 
     if ( methodFlags & ENCODE_METHOD_SIG_OwnerType )
     {
@@ -863,7 +887,12 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
     if (thOwner.IsNull())
     {
         if (pZapSigContext->externalTokens == ZapSig::MulticoreJitTokens)
+        {
+            if (ppAfterSig != NULL)
+                *ppAfterSig = sig.GetPtr();
+
             return NULL;
+        }
 
         thOwner = pMethod->GetMethodTable();
     }
@@ -940,6 +969,9 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
                                                 NULL,
                                                 pZapSigContext);
 
+        if (ppAfterSig != NULL)
+            IfFailThrow(sig.SkipExactlyOne());
+
         MethodDesc * directMethod = constrainedType.GetMethodTable()->TryResolveConstraintMethodApprox(thOwner.GetMethodTable(), pMethod);
         if (directMethod == NULL)
         {
@@ -959,6 +991,9 @@ MethodDesc *ZapSig::DecodeMethod(Module *pInfoModule,
             pMethod = directMethod;
         }
     }
+
+    if (ppAfterSig != NULL)
+        *ppAfterSig = sig.GetPtr();
 
     return pMethod;
 }

--- a/src/coreclr/vm/zapsig.h
+++ b/src/coreclr/vm/zapsig.h
@@ -180,7 +180,8 @@ public:
         TypeHandle          *ppTH = NULL,
         PCCOR_SIGNATURE     *ppOwnerTypeSpecWithVars = NULL,
         PCCOR_SIGNATURE     *ppMethodSpecWithVars = NULL,
-        PCCOR_SIGNATURE     *ppAfterSig = NULL);
+        PCCOR_SIGNATURE     *ppAfterSig = NULL,
+        BOOL                actualOwnerRequired = FALSE);
 
     static FieldDesc *DecodeField(
         Module              *referencingModule,

--- a/src/coreclr/vm/zapsig.h
+++ b/src/coreclr/vm/zapsig.h
@@ -163,7 +163,8 @@ public:
         Module              *referencingModule,
         Module              *fromModule,
         PCCOR_SIGNATURE     pBuffer,
-        ClassLoadLevel      level = CLASS_LOADED);
+        ClassLoadLevel      level = CLASS_LOADED,
+        PCCOR_SIGNATURE     *ppAfterSig = NULL);
 
     static MethodDesc *DecodeMethod(
         Module              *referencingModule,
@@ -178,7 +179,8 @@ public:
         ZapSig::Context     *pZapSigContext,
         TypeHandle          *ppTH = NULL,
         PCCOR_SIGNATURE     *ppOwnerTypeSpecWithVars = NULL,
-        PCCOR_SIGNATURE     *ppMethodSpecWithVars = NULL);
+        PCCOR_SIGNATURE     *ppMethodSpecWithVars = NULL,
+        PCCOR_SIGNATURE     *ppAfterSig = NULL);
 
     static FieldDesc *DecodeField(
         Module              *referencingModule,

--- a/src/coreclr/zap/zapreadytorun.cpp
+++ b/src/coreclr/zap/zapreadytorun.cpp
@@ -787,6 +787,7 @@ static_assert_no_msg((int)READYTORUN_METHOD_SIG_SlotInsteadOfToken   == (int)ENC
 static_assert_no_msg((int)READYTORUN_METHOD_SIG_MemberRefToken       == (int)ENCODE_METHOD_SIG_MemberRefToken);
 static_assert_no_msg((int)READYTORUN_METHOD_SIG_Constrained          == (int)ENCODE_METHOD_SIG_Constrained);
 static_assert_no_msg((int)READYTORUN_METHOD_SIG_OwnerType            == (int)ENCODE_METHOD_SIG_OwnerType);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_UpdateContext        == (int)ENCODE_METHOD_SIG_UpdateContext);
 
 //
 // READYTORUN_FIELD_SIG
@@ -852,6 +853,9 @@ static_assert_no_msg((int)READYTORUN_FIXUP_Check_InstructionSetSupport== (int)EN
 
 static_assert_no_msg((int)READYTORUN_FIXUP_Verify_FieldOffset         == (int)ENCODE_VERIFY_FIELD_OFFSET);
 static_assert_no_msg((int)READYTORUN_FIXUP_Verify_TypeLayout          == (int)ENCODE_VERIFY_TYPE_LAYOUT);
+
+static_assert_no_msg((int)READYTORUN_FIXUP_Check_VirtualFunctionOverride  == (int)ENCODE_CHECK_VIRTUAL_FUNCTION_OVERRIDE);
+static_assert_no_msg((int)READYTORUN_FIXUP_Verify_VirtualFunctionOverride == (int)ENCODE_VERIFY_VIRTUAL_FUNCTION_OVERRIDE);
 
 //
 // READYTORUN_EXCEPTION

--- a/src/tests/JIT/opt/Devirtualization/GitHub_51918.cs
+++ b/src/tests/JIT/opt/Devirtualization/GitHub_51918.cs
@@ -49,6 +49,9 @@ public class GitHub_51918
     public static int Main()
     {
         IGeneric<int> genInterface = new GenericClass<int, string>().GetInnerClass();
+        // Validate that two levels of inlining we don't behave incorrectly due to generic
+        // canonicalization. (Devirtualize the interface call, and then devirtualize/inline
+        // the call to ClassMethod)
         Console.WriteLine(genInterface.InterfaceMethod());
         if (genInterface.InterfaceMethod() == 0)
             return 100;

--- a/src/tests/JIT/opt/Devirtualization/GitHub_51918.cs
+++ b/src/tests/JIT/opt/Devirtualization/GitHub_51918.cs
@@ -1,0 +1,58 @@
+using System;
+
+public interface IGeneric<T>
+{
+    int InterfaceMethod();
+}
+
+public interface IMakeClassMethodSealedVirtual
+{
+    int ClassMethod();
+}
+
+public class GenericClass<A,B> : IMakeClassMethodSealedVirtual
+{
+    public static int _sv1;
+    public static int _sv2;
+
+    public int _v1;
+    public int _v2;
+
+    public GenericClass()
+    {
+        _v1 = _sv1++;
+        _v2 = _sv2++;
+    }
+
+    public int ClassMethod()
+    {
+        return _v1 - _v2;
+    }
+
+    public InnerClass GetInnerClass() => new InnerClass(this);
+  
+    public sealed class InnerClass : IGeneric<A>
+    {
+        GenericClass<A,B> _localPointer;
+
+        public InnerClass(GenericClass<A,B> pointer)
+        {
+            _localPointer = pointer;
+        }
+
+        public int InterfaceMethod() => _localPointer.ClassMethod();
+    }
+}
+
+public class GitHub_51918
+{
+    public static int Main()
+    {
+        IGeneric<int> genInterface = new GenericClass<int, string>().GetInnerClass();
+        Console.WriteLine(genInterface.InterfaceMethod());
+        if (genInterface.InterfaceMethod() == 0)
+            return 100;
+
+        return 1;
+    }
+}

--- a/src/tests/JIT/opt/Devirtualization/GitHub_51918.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GitHub_51918.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_51918.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Devirtualization/generic_noinline.cs
+++ b/src/tests/JIT/opt/Devirtualization/generic_noinline.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static int Main()
+    {
+        MyStruct<Atom> s = default;
+
+        // RyuJIT can devirtualize this, but NoInlining prevents the inline
+        // This checks that we properly pass the instantiation context to the shared generic method.
+        return ((IFoo)s).GetTheType() == typeof(Atom) ? 100 : -1;
+    }
+}
+
+interface IFoo
+{
+    Type GetTheType();
+}
+
+struct MyStruct<T> : IFoo
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    Type IFoo.GetTheType() => typeof(T);
+}
+
+class Atom { }

--- a/src/tests/JIT/opt/Devirtualization/generic_noinline.csproj
+++ b/src/tests/JIT/opt/Devirtualization/generic_noinline.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="generic_noinline.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/regressions/dd52/runtest.cs
+++ b/src/tests/Loader/classloader/regressions/dd52/runtest.cs
@@ -9,13 +9,26 @@ public class Test
    public static int Main()
    {
       Console.WriteLine();
+      bool failed = false;
 
 
       C28<int> obj405 = new C28<int>();
 
 
       Console.WriteLine(obj405.M28());
+      if (obj405.M28() != 54)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
+
       Console.WriteLine(obj405.M3());
+      if (obj405.M3() != 54)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
+
       Console.WriteLine();
 
 
@@ -23,18 +36,46 @@ public class Test
 
 
       Console.WriteLine(obj433.M28());
+      if (obj433.M28() != 56)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
 
       Console.WriteLine(obj433.M3());
+      if (obj433.M3() != 56)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
 
 
       C29 obj434 = new C29();
 
 
       Console.WriteLine(obj434.M28());
+      if (obj434.M28() != 56)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
       Console.WriteLine(obj434.M3());
+      if (obj434.M3() != 56)
+      {
+          failed = true;
+          Console.WriteLine("FAIL");
+      }
       Console.WriteLine();
       Console.WriteLine("PASS");
 
-      return 100;
+      if (failed)
+      {
+          return 1;
+      }
+      else
+      {
+          Console.WriteLine("PASS");
+          return 100;
+      }
    }
 }


### PR DESCRIPTION
Address deficiencies in current devirtualization infrastructure

- Remove the responsibility of creating a CORINFO_RESOLVED_TOKEN structure from the JIT and make it a responsibility of the VM side of the jit interface.
  - This enables the component (crossgen2) which has deeper understanding of the requirements here to correctly handle scenarios that would otherwise require expressing crossgen2 specific details across the jit interface.
- Add a new set of fixups (`READYTORUN_FIXUP_Check_VirtualFunctionOverride` and `READYTORUN_FIXUP_Verify_VirtualFunctionOverride`) these are used to validate that the behavior of the runtime and crossgen2 compiler is equivalent for a virtual resolution event
  - `READYTORUN_FIXUP_Check_VirtualFunctionOverride` will ensure that the virtual resolution decision is the same at crossgen2 time and runtime, and if the decision differs, any generated code affected by the decision will not be used.
  - `READYTORUN_FIXUP_Verify_VirtualFunctionOverride` will perform the same checks as `READYTORUN_FIXUP_Check_VirtualFunctionOverride`, but if it fails the check, the process will be terminated with a fail-fast. It is intended for use under the `--verify-type-and-field-layout` stress mode.
  - Currently only the `READYTORUN_FIXUP_Verify_VirtualFunctionOverride` is actually generated, and it is only generated when using the `--verify-type-and-field-layout` switch to crossgen2. Future work will identify if there are scenarios where we need to generate the `READYTORUN_FIXUP_Check_VirtualFunctionOverride` flag. One area of possible concern is around covariant returns, another is around handling of type equivalence.
- In order to express the fixup signature for the VirtualFunctionOverride fixups, a new flag has been added to `ReadyToRunMethodSigFlags`. `READYTORUN_METHOD_SIG_UpdateContext` will allow the method signature to internally specify the assembly which is associated with the method token, instead of relying on the ambient context.
- R2RDump and the ReadyToRun format documentation have been updated with the details of the new fixups/flags.
- Update the rules for handling unboxing stubs
  - See #51918 for details. This adds a new test, as well as proper handling for unboxing stubs to match the JIT behavior
  - Also revert #52605, which avoided the problem by simply disabling devirtualization in the presence of structs
- Adjust the rules for when it is legal to devirtualize and maintain version resiliency
  - The VersionsWithCode and VersionsWithType rules are unnecessarily restrictive.
  - Instead Validate that the metadata is safely checkable, and rely on the canInline logic to ensure that no IL that can't be handled is inlined.
  - This also involved adding a check that the chain of types from the implementation type to the declaration method table type is within the version bubble.
  - And changing the `VersionsWithType` check on the implementation type, to a new `VersionsWithTypeReference` check which can be used to validate that the type can be referred to, in combination with using `VersionsWithType` on the type definition.
  - By adjusting the way that the declMethod is referred to, it becomes possible to use the declMethod without checking the full method is `VersionsWithCode`, and it just needs a relationship to version matching code.
- In `resolveVirtualMethod` generate the `CORINFO_RESOLVED_TOKEN` structures for the jit
  - In particular we are now able to resolve to methods where the decl method is the resolution result but is not within the version bubble itself. This can happen if we can prove that the decl method is the only method which can possibly implement a virtual.
- Add support for devirtualization reasons to crossgen2
- Port all devirtualization abort conditions to crossgen2 from runtime that were not already present
- Fix devirtualization from a canonical virtual method when the actual implementation is more exact
- Fix variant interface override scenario where there is an interface that requires implementation of the variant interface as well as the variant interface itself.