### PR TITLE
Ensure inst_Mov() is used rather than inst_RV_RV(ins_Copy())

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1987,7 +1987,7 @@ void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
     // and needs to be assembled into a single xmm register,
     // note we can't check reg0=EAX, reg1=EDX because they could be already moved.
 
-    inst_RV_RV(ins_Copy(reg0, TYP_FLOAT), targetReg, reg0, TYP_INT);
+    inst_Mov(TYP_FLOAT, targetReg, reg0, /* canSkip */ false);
     const emitAttr size = emitTypeSize(TYP_SIMD8);
     if (compiler->compOpportunisticallyDependsOn(InstructionSet_SSE41))
     {
@@ -1996,7 +1996,7 @@ void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
     else
     {
         regNumber tempXmm = lclNode->GetSingleTempReg();
-        inst_RV_RV(ins_Copy(reg1, TYP_FLOAT), tempXmm, reg1, TYP_INT);
+        inst_Mov(TYP_FLOAT, tempXmm, reg1, /* canSkip */ false);
         GetEmitter()->emitIns_SIMD_R_R_R(INS_punpckldq, size, targetReg, targetReg, tempXmm);
     }
 #elif defined(TARGET_WINDOWS) && defined(TARGET_AMD64)


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/53558

CC @sandreenko 