### PR TITLE
JIT: update switch flags after peel

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3799,6 +3799,7 @@ bool Compiler::fgOptimizeSwitchJumps()
 
         // Update flags
         //
+        switchTree->gtFlags = switchTree->AsOp()->gtOp1->gtFlags;
         dominantCaseCompare->gtFlags |= dominantCaseCompare->AsOp()->gtOp1->gtFlags;
         jmpTree->gtFlags |= dominantCaseCompare->gtFlags;
         dominantCaseCompare->gtFlags |= GTF_RELOP_JMP_USED | GTF_DONT_CSE;


### PR DESCRIPTION
If we introduce a temp for the switch operand, the switch node may have extra flags
set that it doesn't need. Reset these based on the operand.

Closes #53548.