### PR TITLE
[6.0 preview 5] Fix assertion failure / crash in multi-core JIT

### DIFF
--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1286,7 +1286,6 @@ void MulticoreJitManager::StopProfile(bool appDomainShutdown)
     if (pRecorder != NULL)
     {
         m_fRecorderActive = false;
-        MulticoreJitRecorder::CloseTimer();
 
         EX_TRY
         {

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1286,6 +1286,7 @@ void MulticoreJitManager::StopProfile(bool appDomainShutdown)
     if (pRecorder != NULL)
     {
         m_fRecorderActive = false;
+        MulticoreJitRecorder::CloseTimer();
 
         EX_TRY
         {
@@ -1496,16 +1497,7 @@ void MulticoreJitManager::WriteMulticoreJitProfiler()
     CONTRACTL_END;
 
     CrstHolder hold(& m_playerLock);
-
-    // Avoid saving after MulticoreJitRecorder is deleted, and saving twice
-    if (!MulticoreJitRecorder::CloseTimer())
-    {
-        return;
-    }
-    if (m_pMulticoreJitRecorder != NULL)
-    {
-        m_pMulticoreJitRecorder->StopProfile(false);
-    }
+    StopProfile(false);
 }
 #endif // !TARGET_UNIX
 

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -678,20 +678,15 @@ public:
     }
 
 #ifndef TARGET_UNIX
-    static bool CloseTimer()
+    static void CloseTimer()
     {
         LIMITED_METHOD_CONTRACT;
 
         TP_TIMER * pTimer = InterlockedExchangeT(& s_delayedWriteTimer, NULL);
-
-        if (pTimer == NULL)
+        if (pTimer != NULL)
         {
-            return false;
+            CloseThreadpoolTimer(pTimer);
         }
-
-        CloseThreadpoolTimer(pTimer);
-
-        return true;
     }
 
     ~MulticoreJitRecorder()

--- a/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.cs
+++ b/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public static class BasicTest
+{
+    private static int Main()
+    {
+        const int Pass = 100;
+
+        ProfileOptimization.SetProfileRoot(Environment.CurrentDirectory);
+        ProfileOptimization.StartProfile("profile.mcj");
+
+        // Record a method
+        Foo();
+
+        // Let the multi-core JIT recorder time out. The timeout is set to 1 s in the test project.
+        Thread.Sleep(2000);
+
+        // Stop the profile again after timeout (just verifying that it works)
+        ProfileOptimization.StartProfile(null);
+        return Pass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo()
+    {
+    }
+}

--- a/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.csproj
+++ b/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="McjRecorderTimeoutBeforeStop.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_MultiCoreJitProfileWriteDelay=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_MultiCoreJitProfileWriteDelay=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/53573 to Preview 5
- When the recorder times out it doesn't actually stop profiling, but writes out the profile
- The app may later stop profiling, and then it tries to write the profile again
- PR https://github.com/dotnet/runtime/pull/48326 fairly expected that the profile is only written once (some state is mutated)
- The timer is being stopped in the recorder's destructor
- Fixes https://github.com/dotnet/runtime/issues/53014

### Customer impact

- By default, the multi-core JIT timeout time for the recorder is 12 seconds. The timer is only used on Windows.
- After a timeout, if the application exits, stops a profile, or starts another profile, the app crashes
- Affects any Windows app that enables multi-core JIT

### Regression?

- Yes, from 6.0 preview 4

### Testing

- Manual test with a repro, added test to coreclr tests
- PAL, coreclr, and libraries tests

### Risk

Low:
- The change stops profiling on timeout in the same way that it is stopped in all other cases
- I'm not aware of any significant risks