### PR TITLE
Retype calls as SIMD when applicable.

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5414,7 +5414,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                 // A Vector3 return value is stored in xmm0 and xmm1.
                 // RyuJIT assumes that the upper unused bits of xmm1 are cleared but
                 // the native compiler doesn't guarantee it.
-                if (returnType == TYP_SIMD12)
+                if (call->IsUnmanaged() && (returnType == TYP_SIMD12))
                 {
                     returnReg = retTypeDesc->GetABIReturnReg(1);
                     // Clear the upper 32 bits by two shift instructions.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6500,12 +6500,6 @@ GenTree* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSE
         // Make an exception for implicit by-ref parameters during global morph, since
         // their lvType has been updated to byref but their appearances have not yet all
         // been rewritten and so may have struct type still.
-        // Also, make an exception for retyping of a lclVar to a SIMD or scalar type of the same
-        // size as the struct if it has a single field This can happen when we retype the lhs
-        // of a call assignment.
-        // TODO-1stClassStructs: When we stop "lying" about the types for ABI purposes, we
-        // should be able to remove this exception and handle the assignment mismatch in
-        // Lowering.
         LclVarDsc* varDsc = lvaGetDesc(lnum);
 
         bool simd12ToSimd16Widening = false;
@@ -6514,8 +6508,7 @@ GenTree* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSE
         simd12ToSimd16Widening = (type == TYP_SIMD16) && (varDsc->lvType == TYP_SIMD12);
 #endif
         assert((type == varDsc->lvType) || simd12ToSimd16Widening ||
-               (lvaIsImplicitByRefLocal(lnum) && fgGlobalMorph && (varDsc->lvType == TYP_BYREF)) ||
-               ((varDsc->lvType == TYP_STRUCT) && (genTypeSize(type) == varDsc->lvExactSize)));
+               (lvaIsImplicitByRefLocal(lnum) && fgGlobalMorph && (varDsc->lvType == TYP_BYREF)));
     }
     GenTree* node = new (this, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, type, lnum DEBUGARG(ILoffs));
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9489,9 +9489,10 @@ var_types Compiler::impImportJitTestLabelMark(int numArgs)
 #endif // DEBUG
 
 //-----------------------------------------------------------------------------------
-//  impFixupCallStructReturn: For a call node that returns a struct type either
-//  adjust the return type to an enregisterable type, or set the flag to indicate
-//  struct return via retbuf arg.
+//  impFixupCallStructReturn: For a call node that returns a struct do one of the following:
+//  - set the flag to indicate struct return via retbuf arg;
+//  - adjust the return type to a SIMD type if it is returned in 1 reg;
+//  - spill call result into a temp if it is returned into 2 registers or more and not tail call or inline candidate.
 //
 //  Arguments:
 //    call       -  GT_CALL GenTree node

--- a/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+using Point = System.Numerics.Vector2;
+
+namespace Runtime_52864
+{
+    public class test
+    {
+        static Point checkA;
+        static Point checkB;
+        static Point checkC;
+        static int   returnVal;
+
+        public const int DefaultSeed = 20010415;
+        public static int Seed = Environment.GetEnvironmentVariable("CORECLR_SEED") switch
+        {
+            string seedStr when seedStr.Equals("random", StringComparison.OrdinalIgnoreCase) => new Random().Next(),
+            string seedStr when int.TryParse(seedStr, out int envSeed) => envSeed,
+            _ => DefaultSeed
+        };
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void check(Point a, Point b, Point c)
+        {
+            if (a != checkA)
+            {
+                Console.WriteLine($"A doesn't match. Should be {checkA} but is {a}");
+                returnVal = -1;
+            }
+            if (b != checkB)
+            {
+                Console.WriteLine($"B doesn't match. Should be {checkB} but is {b}");
+                returnVal = -1;
+            }
+            if (c != checkC)
+            {
+                Console.WriteLine($"C doesn't match. Should be {checkC} but is {c}");
+                returnVal = -1;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void FailureCase(List<Point> p)
+        {
+            Point p1 = p[0];
+            Point p2 = p.Last();
+
+            check(p1, p[1], p2);
+            check(p1, p[1], p2);
+            check(p1, p[1], p2);
+        }
+
+        static Point NextPoint(Random random)
+        {
+            return new Point(
+                (float)random.NextDouble(),
+                (float)random.NextDouble()
+            );
+        }
+
+        static int Main()
+        {
+            returnVal     = 100;
+            Random random = new Random(Seed);
+
+            for (int i = 0; i < 50; i++)
+            {
+                List<Point> p = new List<Point>();
+
+                checkA = NextPoint(random);
+                p.Add(checkA);
+                checkB = NextPoint(random);
+                p.Add(checkB);
+                checkC = NextPoint(random);
+                p.Add(checkC);
+
+                FailureCase(p);
+
+                Thread.Sleep(15);
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                List<Point> p = new List<Point>();
+
+                checkA = NextPoint(random);
+                p.Add(checkA);
+                checkB = NextPoint(random);
+                p.Add(checkB);
+                checkC = NextPoint(random);
+                p.Add(checkC);
+
+                FailureCase(p);
+            }
+
+            return returnVal;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredPGO=1
+set COMPlus_TC_QuickJitForLoops=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredPGO=1
+export COMPlus_TC_QuickJitForLoops=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>


### PR DESCRIPTION
Retype calls that return System.Numerics.Vector2/3/4 as `TYP_SIMD8/12/16` between importation and lowering.

It better aligns with the fact that we retype `System.Numerics.Vector2/3/4` locals and returns as `SIMD`.

some IR diffs:
```diff
STMT00007 (IL 0x02B...  ???)
               [000027] --C-G-------              *  RETURN    simd8 
-              [000026] --C-G-------              \--*  CALL      struct Runtime_49489.Program.ReturnSIMD2
+              [000026] --C-G-------              \--*  CALL      simd8  Runtime_49489.Program.ReturnSIMD2

STMT00011 (IL 0x003...0x008)
               [000040] -ACXG-------              *  ASG       simd8  (copy)
               [000038] D------N----              +--*  LCL_VAR   simd8 <System.Numerics.Vector2> V03 tmp1         
-              [000034] --CXG+-N----              \--*  CALL      struct Runtime_49489.Program.ReturnSIMD2
+              [000034] --CXG+-N----              \--*  CALL      simd8  Runtime_49489.Program.ReturnSIMD2
```

I am not a huge fan of this retyping but the improved check in `gtNewLclvNode` should make the code overall safer in my opinion. 

No asm diffs.

Fixes https://github.com/dotnet/runtime/issues/52864.