### PR TITLE
Remove unused Libraries.Libdl

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -12,7 +12,6 @@ internal static partial class Interop
         internal const string CompressionNative = "libSystem.IO.Compression.Native";
         internal const string GlobalizationNative = "libSystem.Globalization.Native";
         internal const string IOPortsNative = "libSystem.IO.Ports.Native";
-        internal const string Libdl = "libdl";
         internal const string HostPolicy = "libhostpolicy";
     }
 }


### PR DESCRIPTION
`libdl.so` is only available when installing development packages, `libdl.so.2` should be used instead.
The variable isn't used, so we can just remove it.

cc @janvorli 