### PR TITLE
Fix SPMI dump.

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -157,7 +157,7 @@ public:
         return -1;
     }
 
-    void Unlock() // did you really mean to use this?
+    void Unlock()
     {
         locked = false;
     }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -5637,6 +5637,7 @@ void MethodContext::dmpGetPgoInstrumentationResults(DWORDLONG key, const Agnosti
 
             printf("}\n");
         }
+        GetPgoInstrumentationResults->Unlock();
     }
     printf("} data_index-%u", value.data_index);
 }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -4807,6 +4807,7 @@ void MethodContext::dmpGetStringLiteral(DLD key, DD value)
 {
     printf("GetStringLiteral key mod-%016llX tok-%08X, result-%s, len-%u", key.A, key.B,
         GetStringLiteral->GetBuffer(value.B), value.A);
+    GetStringLiteral->Unlock();
 }
 
 const char16_t* MethodContext::repGetStringLiteral(CORINFO_MODULE_HANDLE module, unsigned metaTOK, int* length)
@@ -5468,6 +5469,7 @@ void MethodContext::dmpAllocPgoInstrumentationBySchema(DWORDLONG key, const Agno
             printf(" %u-{Offset %016llX ILOffset %u Kind %u(0x%x) Count %u Other %u}\n",
                 i, pBuf[i].Offset, pBuf[i].ILOffset, pBuf[i].InstrumentationKind, pBuf[i].InstrumentationKind, pBuf[i].Count, pBuf[i].Other);
         }
+        AllocPgoInstrumentationBySchema->Unlock();
     }
     printf("}");
 }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
@@ -139,6 +139,7 @@ inline std::string SpmiDumpHelper::DumpPSig(
             pbuf += cch;
             sizeOfBuffer -= cch;
         }
+        buffers->Unlock();
     }
 
     return std::string(buffer);


### PR DESCRIPTION
Add 2 missed calls to `buffer->Unlock()` so we can use 
```
SuperPMIShimDebugRec=1
SuperPMIShimDebugRep=1
```
again, without the change it was failing with:
```
ERROR: Added item that extended the buffer after it was locked by a call to GetBuffer()
```

contributes to https://github.com/dotnet/runtime/issues/53321