### PR TITLE
Disable leakwheel test for mono

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1229,6 +1229,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/FinalNStruct/nstructtun/**">
             <Issue>PlatformDetection.IsPreciseGcSupported false on mono</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/LeakWheel/leakwheel/**">
+            <Issue>PlatformDetection.IsPreciseGcSupported false on mono</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/SingLinkList/singlinkgen/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test is expected to fail on mono, since it seems to rely on finalizers being run in order to determine success of the test.

See #53452 