### PR TITLE
Delete obsolete libraries package settings files

### DIFF
--- a/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Platforms/netcoreapp3.0/settings.targets
+++ b/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Platforms/netcoreapp3.0/settings.targets
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This package will generate validation issues since we usually try to consume same-day packages from corefx that will have a higher
-         version than locally built packages. Validation will assume incorrectly that you are downgrading the reference which is why this error is flagged.
-         Since it isn't really an error, we will supress it in order to unblock same-day package ingestion. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp1.0/settings.targets
+++ b/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp1.0/settings.targets
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This package intentionally drops all runtime-package mappings from runtime.json -->
-    <ShouldVerifyClosure>false</ShouldVerifyClosure>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp1.1/settings.targets
+++ b/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp1.1/settings.targets
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This package intentionally drops all runtime-package mappings from runtime.json -->
-    <ShouldVerifyClosure>false</ShouldVerifyClosure>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp2.2/settings.targets
+++ b/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Targets/netcoreapp2.2/settings.targets
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This package will generate validation issues since we usually try to consume same-day packages from corefx that will have a higher
-         version than locally built packages. Validation will assume incorrectly that you are downgrading the reference which is why this error is flagged.
-         Since it isn't really an error, we will supress it in order to unblock same-day package ingestion. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Diagnostics.DiagnosticSource/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Diagnostics.DiagnosticSource/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.IO.Packaging/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.IO.Packaging/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Reflection.Emit.ILGeneration/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Reflection.Emit.ILGeneration/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Reflection.Emit.Lightweight/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Reflection.Emit.Lightweight/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Reflection.Emit/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Reflection.Emit/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Runtime.CompilerServices.Unsafe/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Runtime.CompilerServices.Unsafe/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Security.Cryptography.Pkcs/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Security.Cryptography.Pkcs/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/System.Threading.Tasks.Extensions/netcoreapp1.0/workaroundDowngrade.targets
+++ b/src/libraries/pkg/test/packageSettings/System.Threading.Tasks.Extensions/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/runtime/issues/25657 -->
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
Deleting package settings files as the package isn't produced anymore
or because the workaround was resolved (i.e. .NETStandard downgrades).