### PR TITLE
Add remarks to /// comments for TimeOnly.IsBetween

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -177,7 +177,7 @@ namespace System
         /// <returns>True, if the time falls within the range, false otherwise.</returns>
         /// <remarks>
         /// If <paramref name="start"/> and <paramref name="end"/> are equal, this method returns false, meaning there is zero elapsed time between the two values.
-        /// If you wish to treat such cases as 24 hours, then first check for equality before calling this method.
+        /// If you wish to treat such cases as representing one or more whole days, then first check for equality before calling this method.
         /// </remarks>
         public bool IsBetween(TimeOnly start, TimeOnly end)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -175,6 +175,10 @@ namespace System
         /// <param name="start">The starting time of day, inclusive.</param>
         /// <param name="end">The ending time of day, exclusive.</param>
         /// <returns>True, if the time falls within the range, false otherwise.</returns>
+        /// <remarks>
+        /// If the start and end are equal this method always returns false, meaning there is zero elapsed time between the two values.
+        /// If you wish to treat such cases as 24 hours, then first check for equality before calling this method.
+        /// </remarks>
         public bool IsBetween(TimeOnly start, TimeOnly end)
         {
             long startTicks = start._ticks;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -176,7 +176,7 @@ namespace System
         /// <param name="end">The ending time of day, exclusive.</param>
         /// <returns>True, if the time falls within the range, false otherwise.</returns>
         /// <remarks>
-        /// If the start and end are equal this method always returns false, meaning there is zero elapsed time between the two values.
+        /// If <paramref name="start"/> and <paramref name="end"/> are equal, this method returns false, meaning there is zero elapsed time between the two values.
         /// If you wish to treat such cases as 24 hours, then first check for equality before calling this method.
         /// </remarks>
         public bool IsBetween(TimeOnly start, TimeOnly end)


### PR DESCRIPTION
This is a documentation change only, to clarify the ambiguity concern about passing two identical times to `TimeOnly.IsBetween`.

Resolves #53492 

@tarekgh 