### PR TITLE
Add non-cryptographic hash algorithms

### DIFF
--- a/src/libraries/System.IO.Hashing/Directory.Build.props
+++ b/src/libraries/System.IO.Hashing/Directory.Build.props
@@ -1,0 +1,11 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.props" />
+  <PropertyGroup>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <PackageDescription>Provides non-cryptographic hash algorithms, such as CRC-32.
+
+Commonly Used Types:
+System.IO.Hashing.Crc32
+System.IO.Hashing.Crc64</PackageDescription>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.IO.Hashing/Directory.Build.props
+++ b/src/libraries/System.IO.Hashing/Directory.Build.props
@@ -6,6 +6,6 @@
 
 Commonly Used Types:
 System.IO.Hashing.Crc32
-System.IO.Hashing.Crc64</PackageDescription>
+System.IO.Hashing.XxHash32</PackageDescription>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.Hashing/Directory.Build.props
+++ b/src/libraries/System.IO.Hashing/Directory.Build.props
@@ -2,10 +2,5 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <PackageDescription>Provides non-cryptographic hash algorithms, such as CRC-32.
-
-Commonly Used Types:
-System.IO.Hashing.Crc32
-System.IO.Hashing.XxHash32</PackageDescription>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.Hashing/System.IO.Hashing.sln
+++ b/src/libraries/System.IO.Hashing/System.IO.Hashing.sln
@@ -1,0 +1,104 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31320.298
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{F94DE827-A426-45CB-AE6E-4E1C154B5386}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Win32.Registry", "..\Microsoft.Win32.Registry\ref\Microsoft.Win32.Registry.csproj", "{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Collections.Immutable", "..\System.Collections.Immutable\src\System.Collections.Immutable.csproj", "{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Hashing", "ref\System.IO.Hashing.csproj", "{1548AC5C-27FD-4B46-A930-C168D622FAB0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Hashing", "src\System.IO.Hashing.csproj", "{A078A4EB-27E8-42B1-BD44-3807732A4560}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Hashing.Tests", "tests\System.IO.Hashing.Tests.csproj", "{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reflection.Metadata", "..\System.Reflection.Metadata\src\System.Reflection.Metadata.csproj", "{0E49FF32-6CC1-42B0-AF30-25098C7DA18F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.CompilerServices.Unsafe", "..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj", "{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.CompilerServices.Unsafe", "..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj", "{E5280823-9A9A-4314-B0C3-B983A7D50C85}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj", "{A7AD2290-A979-4139-9C71-BBCD5594180D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{3A873063-B154-4186-914D-1F4F3236101E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{3A73868D-BC2F-483A-B51B-0F3C862BBE85}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{3F027944-9702-4DA5-A7E2-042D5037ABD3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BC246661-9887-4096-BF1A-AC25060547B2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F94DE827-A426-45CB-AE6E-4E1C154B5386}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F94DE827-A426-45CB-AE6E-4E1C154B5386}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F94DE827-A426-45CB-AE6E-4E1C154B5386}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F94DE827-A426-45CB-AE6E-4E1C154B5386}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1548AC5C-27FD-4B46-A930-C168D622FAB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1548AC5C-27FD-4B46-A930-C168D622FAB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1548AC5C-27FD-4B46-A930-C168D622FAB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1548AC5C-27FD-4B46-A930-C168D622FAB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A078A4EB-27E8-42B1-BD44-3807732A4560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A078A4EB-27E8-42B1-BD44-3807732A4560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A078A4EB-27E8-42B1-BD44-3807732A4560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A078A4EB-27E8-42B1-BD44-3807732A4560}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E49FF32-6CC1-42B0-AF30-25098C7DA18F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E49FF32-6CC1-42B0-AF30-25098C7DA18F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E49FF32-6CC1-42B0-AF30-25098C7DA18F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E49FF32-6CC1-42B0-AF30-25098C7DA18F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5280823-9A9A-4314-B0C3-B983A7D50C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5280823-9A9A-4314-B0C3-B983A7D50C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5280823-9A9A-4314-B0C3-B983A7D50C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5280823-9A9A-4314-B0C3-B983A7D50C85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7AD2290-A979-4139-9C71-BBCD5594180D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7AD2290-A979-4139-9C71-BBCD5594180D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7AD2290-A979-4139-9C71-BBCD5594180D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7AD2290-A979-4139-9C71-BBCD5594180D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A873063-B154-4186-914D-1F4F3236101E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A873063-B154-4186-914D-1F4F3236101E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A873063-B154-4186-914D-1F4F3236101E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A873063-B154-4186-914D-1F4F3236101E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F94DE827-A426-45CB-AE6E-4E1C154B5386} = {3A73868D-BC2F-483A-B51B-0F3C862BBE85}
+		{38CB62AF-FD52-433E-AB63-CB07BA1D2CD8} = {3F027944-9702-4DA5-A7E2-042D5037ABD3}
+		{B51B75BA-A1AF-42FB-9845-E9AAC42CFB22} = {BC246661-9887-4096-BF1A-AC25060547B2}
+		{1548AC5C-27FD-4B46-A930-C168D622FAB0} = {3F027944-9702-4DA5-A7E2-042D5037ABD3}
+		{A078A4EB-27E8-42B1-BD44-3807732A4560} = {BC246661-9887-4096-BF1A-AC25060547B2}
+		{2E6DAC1B-9054-40AF-AF72-4C2DD7BD9294} = {3A73868D-BC2F-483A-B51B-0F3C862BBE85}
+		{0E49FF32-6CC1-42B0-AF30-25098C7DA18F} = {BC246661-9887-4096-BF1A-AC25060547B2}
+		{696A5E1C-B7B4-4EA0-AE2A-3FDA1C50F4D9} = {3F027944-9702-4DA5-A7E2-042D5037ABD3}
+		{E5280823-9A9A-4314-B0C3-B983A7D50C85} = {BC246661-9887-4096-BF1A-AC25060547B2}
+		{A7AD2290-A979-4139-9C71-BBCD5594180D} = {3F027944-9702-4DA5-A7E2-042D5037ABD3}
+		{3A873063-B154-4186-914D-1F4F3236101E} = {3F027944-9702-4DA5-A7E2-042D5037ABD3}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4DF081FC-DC0D-4317-AB2C-4294B9FE6257}
+	EndGlobalSection
+EndGlobal

--- a/src/libraries/System.IO.Hashing/pkg/System.IO.Hashing.pkgproj
+++ b/src/libraries/System.IO.Hashing/pkg/System.IO.Hashing.pkgproj
@@ -1,9 +1,0 @@
-﻿<Project DefaultTargets="Build">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
-  <ItemGroup>
-    <ProjectReference Include="..\src\System.IO.Hashing.csproj">
-      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
-</Project>

--- a/src/libraries/System.IO.Hashing/pkg/System.IO.Hashing.pkgproj
+++ b/src/libraries/System.IO.Hashing/pkg/System.IO.Hashing.pkgproj
@@ -1,0 +1,9 @@
+﻿<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.IO.Hashing.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
+++ b/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
@@ -60,4 +60,15 @@ namespace System.IO.Hashing
         public override void Reset() { }
         public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    public sealed partial class XxHash64 : System.IO.Hashing.NonCryptographicHashAlgorithm
+    {
+        public XxHash64() : base (default(int)) { }
+        public override void Append(System.ReadOnlySpan<byte> source) { }
+        protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        public static byte[] Hash(byte[] source) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public override void Reset() { }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
 }

--- a/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
+++ b/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
@@ -52,23 +52,27 @@ namespace System.IO.Hashing
     public sealed partial class XxHash32 : System.IO.Hashing.NonCryptographicHashAlgorithm
     {
         public XxHash32() : base (default(int)) { }
+        public XxHash32(int seed) : base (default(int)) { }
         public override void Append(System.ReadOnlySpan<byte> source) { }
         protected override void GetCurrentHashCore(System.Span<byte> destination) { }
         public static byte[] Hash(byte[] source) { throw null; }
-        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
-        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public static byte[] Hash(byte[] source, int seed) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source, int seed = 0) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, int seed = 0) { throw null; }
         public override void Reset() { }
-        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten, int seed = 0) { throw null; }
     }
     public sealed partial class XxHash64 : System.IO.Hashing.NonCryptographicHashAlgorithm
     {
         public XxHash64() : base (default(int)) { }
+        public XxHash64(long seed) : base (default(int)) { }
         public override void Append(System.ReadOnlySpan<byte> source) { }
         protected override void GetCurrentHashCore(System.Span<byte> destination) { }
         public static byte[] Hash(byte[] source) { throw null; }
-        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
-        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public static byte[] Hash(byte[] source, long seed) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source, long seed = (long)0) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, long seed = (long)0) { throw null; }
         public override void Reset() { }
-        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten, long seed = (long)0) { throw null; }
     }
 }

--- a/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
+++ b/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
@@ -18,6 +18,18 @@ namespace System.IO.Hashing
         public override void Reset() { }
         public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    public sealed partial class Crc64 : System.IO.Hashing.NonCryptographicHashAlgorithm
+    {
+        public Crc64() : base (default(int)) { }
+        public override void Append(System.ReadOnlySpan<byte> source) { }
+        protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        protected override void GetHashAndResetCore(System.Span<byte> destination) { }
+        public static byte[] Hash(byte[] source) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public override void Reset() { }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
     public abstract partial class NonCryptographicHashAlgorithm
     {
         protected NonCryptographicHashAlgorithm(int hashLengthInBytes) { }

--- a/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
+++ b/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
@@ -49,4 +49,15 @@ namespace System.IO.Hashing
         public bool TryGetCurrentHash(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryGetHashAndReset(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    public sealed partial class XxHash32 : System.IO.Hashing.NonCryptographicHashAlgorithm
+    {
+        public XxHash32() : base (default(int)) { }
+        public override void Append(System.ReadOnlySpan<byte> source) { }
+        protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        public static byte[] Hash(byte[] source) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public override void Reset() { }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
 }

--- a/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
+++ b/src/libraries/System.IO.Hashing/ref/System.IO.Hashing.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.IO.Hashing
+{
+    public sealed partial class Crc32 : System.IO.Hashing.NonCryptographicHashAlgorithm
+    {
+        public Crc32() : base (default(int)) { }
+        public override void Append(System.ReadOnlySpan<byte> source) { }
+        protected override void GetCurrentHashCore(System.Span<byte> destination) { }
+        protected override void GetHashAndResetCore(System.Span<byte> destination) { }
+        public static byte[] Hash(byte[] source) { throw null; }
+        public static byte[] Hash(System.ReadOnlySpan<byte> source) { throw null; }
+        public static int Hash(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public override void Reset() { }
+        public static bool TryHash(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public abstract partial class NonCryptographicHashAlgorithm
+    {
+        protected NonCryptographicHashAlgorithm(int hashLengthInBytes) { }
+        public int HashLengthInBytes { get { throw null; } }
+        public void Append(byte[] source) { }
+        public void Append(System.IO.Stream stream) { }
+        public abstract void Append(System.ReadOnlySpan<byte> source);
+        public System.Threading.Tasks.Task AppendAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public byte[] GetCurrentHash() { throw null; }
+        public int GetCurrentHash(System.Span<byte> destination) { throw null; }
+        protected abstract void GetCurrentHashCore(System.Span<byte> destination);
+        public byte[] GetHashAndReset() { throw null; }
+        public int GetHashAndReset(System.Span<byte> destination) { throw null; }
+        protected virtual void GetHashAndResetCore(System.Span<byte> destination) { }
+        public override int GetHashCode() { throw null; }
+        public abstract void Reset();
+        public bool TryGetCurrentHash(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryGetHashAndReset(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Hashing/src/Resources/Strings.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Argument_DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
+  </data>
+  <data name="NotSupported_GetHashCode" xml:space="preserve">
+    <value>The GetHashCode method is not supported on this object. Use GetCurrentHash or GetHashAndReset to retrieve the hash code computed by this object.</value>
+  </data>
+</root>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+        <!--<TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>-->
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\IO\Hashing\Crc32.cs" />
+    <Compile Include="System\IO\Hashing\Crc32.Table.cs" />
+    <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+      <ItemGroup>
+        <Reference Include="System.Buffers" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+        <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+        <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Numerics" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" Condition="'$(TargetFramework)' == 'net461'" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -14,6 +14,8 @@
     <Compile Include="System\IO\Hashing\Crc64.Table.cs" />
     <Compile Include="System\IO\Hashing\XxHash32.cs" />
     <Compile Include="System\IO\Hashing\XxHash32.State.cs" />
+    <Compile Include="System\IO\Hashing\XxHash64.cs" />
+    <Compile Include="System\IO\Hashing\XxHash64.State.cs" />
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
   </ItemGroup>
   <Choose>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net6.0;netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <!-- TODO: Remove when the package ships with .NET 6. -->
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
     <PackageDescription>Provides non-cryptographic hash algorithms, such as CRC-32.
 
 Commonly Used Types:

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -7,10 +7,13 @@
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\IO\Hashing\BitOperations.cs" />
     <Compile Include="System\IO\Hashing\Crc32.cs" />
     <Compile Include="System\IO\Hashing\Crc32.Table.cs" />
     <Compile Include="System\IO\Hashing\Crc64.cs" />
     <Compile Include="System\IO\Hashing\Crc64.Table.cs" />
+    <Compile Include="System\IO\Hashing\XxHash32.cs" />
+    <Compile Include="System\IO\Hashing\XxHash32.State.cs" />
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
   </ItemGroup>
   <Choose>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -3,6 +3,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <!-- TODO: Remove when the package ships with .NET 6. -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <PackageDescription>Provides non-cryptographic hash algorithms, such as CRC-32.
+
+Commonly Used Types:
+System.IO.Hashing.Crc32
+System.IO.Hashing.XxHash32</PackageDescription>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\IO\Hashing\BitOperations.cs" />

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <!-- TODO: Remove when the package ships with .NET 6. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
@@ -24,17 +24,13 @@ System.IO.Hashing.XxHash32</PackageDescription>
     <Compile Include="System\IO\Hashing\XxHash64.State.cs" />
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
-      <ItemGroup>
-        <Reference Include="System.Buffers" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-        <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Reference Include="System.Buffers" />
+    <Reference Include="System.Memory" />
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <Compile Include="System\IO\Hashing\Crc32.cs" />
     <Compile Include="System\IO\Hashing\Crc32.Table.cs" />
+    <Compile Include="System\IO\Hashing\Crc64.cs" />
+    <Compile Include="System\IO\Hashing\Crc64.Table.cs" />
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
   </ItemGroup>
   <Choose>

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -2,9 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-        <!--<TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>-->
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\IO\Hashing\BitOperations.cs" />
@@ -28,12 +26,7 @@
       <ItemGroup>
         <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
         <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-        <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
       </ItemGroup>
     </Otherwise>
   </Choose>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <Reference Include="System.Numerics" />
-    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" Condition="'$(TargetFramework)' == 'net461'" />
-  </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/BitOperations.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/BitOperations.cs
@@ -10,5 +10,9 @@ namespace System.IO.Hashing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint RotateLeft(uint value, int offset)
             => (value << offset) | (value >> (32 - offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong RotateLeft(ulong value, int offset)
+            => (value << offset) | (value >> (64 - offset));
     }
 }

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/BitOperations.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/BitOperations.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.IO.Hashing
+{
+    internal static class BitOperations
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint RotateLeft(uint value, int offset)
+            => (value << offset) | (value >> (32 - offset));
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Hashing
+{
+    public sealed partial class Crc32 : NonCryptographicHashAlgorithm
+    {
+        // Pre-computed CRC-32 transition table.
+        // While this implementation is based on the standard CRC-32 polynomial,
+        // x32 + x26 + x23 + x22 + x16 + x12 + x11 + x10 + x8 + x7 + x5 + x4 + x2 + x1 + x0,
+        // this version uses reflected bit ordering, so 0x04C11DB7 becomes 0xEDB88320
+        private static readonly uint[] s_crcLookup = GenerateReflectedTable(0xEDB88320u);
+
+        private static uint[] GenerateReflectedTable(uint reflectedPolynomial)
+        {
+            uint[] table = new uint[256];
+
+            for (int i = 0; i < 256; i++)
+            {
+                uint val = unchecked((uint)i);
+
+                for (int j = 0; j < 8; j++)
+                {
+                    if ((val & 0b0000_0001) == 0)
+                    {
+                        val >>= 1;
+                    }
+                    else
+                    {
+                        val = (val >> 1) ^ reflectedPolynomial;
+                    }
+                }
+
+                table[i] = val;
+            }
+
+            return table;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
@@ -17,7 +17,7 @@ namespace System.IO.Hashing
 
             for (int i = 0; i < 256; i++)
             {
-                uint val = unchecked((uint)i);
+                uint val = (uint)i;
 
                 for (int j = 0; j < 8; j++)
                 {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Provides an implementation of the CRC-32 algorithm, as used in
+    ///   ITU-T V.42 and IEEE 802.3.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This implementation emits the answer in the Little Endian byte order so that
+    ///     the CRC residue relationship (CRC(message concat CRC(message))) is a fixed value) holds.
+    ///     For CRC-32 this stable output is the byte sequence <c>{ 0x1C, 0xDF, 0x44, 0x21 }</c>,
+    ///     the Little Endian representation of <c>0x2144DF1C</c>.
+    ///   </para>
+    ///   <para>
+    ///     There are multiple, incompatible, definitions of a 32-bit cyclic redundancy
+    ///     check (CRC) algorithm. When interoperating with another system, ensure that you
+    ///     are using the same definition. The definition used by this implementation is not
+    ///     compatible with the cyclic redundancy check described in ITU-T I.363.5.
+    ///   </para>
+    /// </remarks>
+    public sealed partial class Crc32 : NonCryptographicHashAlgorithm
+    {
+        private const uint InitialState = 0xFFFF_FFFFu;
+        private const int Size = sizeof(uint);
+
+        private uint _crc = InitialState;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Crc32"/> class.
+        /// </summary>
+        public Crc32()
+            : base(Size)
+        {
+        }
+
+        /// <summary>
+        ///   Appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
+        public override void Append(ReadOnlySpan<byte> source)
+        {
+            _crc = Update(_crc, source);
+        }
+
+        /// <summary>
+        ///   Resets the hash computation to the initial state.
+        /// </summary>
+        public override void Reset()
+        {
+            _crc = InitialState;
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        protected override void GetCurrentHashCore(Span<byte> destination)
+        {
+            // The finalization step of the CRC is to perform the ones' complement.
+            BinaryPrimitives.WriteUInt32LittleEndian(destination, ~_crc);
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   then clears the accumulated state.
+        /// </summary>
+        protected override void GetHashAndResetCore(Span<byte> destination)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(destination, ~_crc);
+            _crc = InitialState;
+        }
+
+        /// <summary>
+        ///   Computes the CRC-32 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The CRC-32 hash of the provided data.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public static byte[] Hash(byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return Hash(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Computes the CRC-32 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The CRC-32 hash of the provided data.</returns>
+        public static byte[] Hash(ReadOnlySpan<byte> source)
+        {
+            byte[] ret = new byte[Size];
+            StaticHash(source, ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to compute the CRC-32 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value (4 bytes); otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < Size)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = StaticHash(source, destination);
+            return true;
+        }
+
+        /// <summary>
+        ///   Computes the CRC-32 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < Size)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return StaticHash(source, destination);
+        }
+
+        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            uint crc = InitialState;
+            crc = Update(crc, source);
+            BinaryPrimitives.WriteUInt32LittleEndian(destination, ~crc);
+            return Size;
+        }
+
+        private static uint Update(uint crc, ReadOnlySpan<byte> source)
+        {
+            for (int i = 0; i < source.Length; i++)
+            {
+                byte idx = (byte)crc;
+                idx ^= source[i];
+                crc = s_crcLookup[idx] ^ (crc >> 8);
+            }
+
+            return crc;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
@@ -14,7 +14,7 @@ namespace System.IO.Hashing
 
             for (int i = 0; i < 256; i++)
             {
-                ulong val = unchecked((ulong)i) << 56;
+                ulong val = (ulong)i << 56;
 
                 for (int j = 0; j < 8; j++)
                 {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Hashing
+{
+    public sealed partial class Crc64 : NonCryptographicHashAlgorithm
+    {
+        // Pre-computed CRC-64 transition table.
+        private static readonly ulong[] s_crcLookup = GenerateTable(0x42F0E1EBA9EA3693);
+
+        private static ulong[] GenerateTable(ulong polynomial)
+        {
+            ulong[] table = new ulong[256];
+
+            for (int i = 0; i < 256; i++)
+            {
+                ulong val = unchecked((ulong)i) << 56;
+
+                for (int j = 0; j < 8; j++)
+                {
+                    if ((val & 0x8000_0000_0000_0000) == 0)
+                    {
+                        val <<= 1;
+                    }
+                    else
+                    {
+                        val = (val << 1) ^ polynomial;
+                    }
+                }
+
+                table[i] = val;
+            }
+
+            return table;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Provides an implementation of the CRC-64 algorithm as described in ECMA-182, Annex B.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This implementation emits the answer in the Big Endian byte order so that
+    ///     the CRC residue relationship (CRC(message concat CRC(message))) is a fixed value) holds.
+    ///     For CRC-64 this stable output is the byte sequence
+    ///     <c>{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }</c>.
+    ///   </para>
+    ///   <para>
+    ///     There are multiple, incompatible, definitions of a 64-bit cyclic redundancy
+    ///     check (CRC) algorithm. When interoperating with another system, ensure that you
+    ///     are using the same definition. The definition used by this implementation is not
+    ///     compatible with the cyclic redundancy check described in ISO 3309.
+    ///   </para>
+    /// </remarks>
+    public sealed partial class Crc64 : NonCryptographicHashAlgorithm
+    {
+        private const ulong InitialState = 0UL;
+        private const int Size = sizeof(ulong);
+
+        private ulong _crc = InitialState;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Crc64"/> class.
+        /// </summary>
+        public Crc64()
+            : base(Size)
+        {
+        }
+
+        /// <summary>
+        ///   Appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
+        public override void Append(ReadOnlySpan<byte> source)
+        {
+            _crc = Update(_crc, source);
+        }
+
+        /// <summary>
+        ///   Resets the hash computation to the initial state.
+        /// </summary>
+        public override void Reset()
+        {
+            _crc = InitialState;
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        protected override void GetCurrentHashCore(Span<byte> destination)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(destination, _crc);
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   then clears the accumulated state.
+        /// </summary>
+        protected override void GetHashAndResetCore(Span<byte> destination)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(destination, _crc);
+            _crc = InitialState;
+        }
+
+        /// <summary>
+        ///   Computes the CRC-64 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The CRC-64 hash of the provided data.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public static byte[] Hash(byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return Hash(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Computes the CRC-64 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The CRC-64 hash of the provided data.</returns>
+        public static byte[] Hash(ReadOnlySpan<byte> source)
+        {
+            byte[] ret = new byte[Size];
+            StaticHash(source, ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to compute the CRC-64 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value (8 bytes); otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < Size)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = StaticHash(source, destination);
+            return true;
+        }
+
+        /// <summary>
+        ///   Computes the CRC-64 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < Size)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return StaticHash(source, destination);
+        }
+
+        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            ulong crc = InitialState;
+            crc = Update(crc, source);
+            BinaryPrimitives.WriteUInt64BigEndian(destination, crc);
+            return Size;
+        }
+
+        private static ulong Update(ulong crc, ReadOnlySpan<byte> source)
+        {
+            for (int i = 0; i < source.Length; i++)
+            {
+                ulong idx = (crc >> 56);
+                idx ^= source[i];
+                crc = s_crcLookup[idx] ^ (crc << 8);
+            }
+
+            return crc;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
@@ -146,7 +146,11 @@ namespace System.IO.Hashing
 
             while (true)
             {
+#if NET5_0_OR_GREATER
+                int read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
                 int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+#endif
 
                 if (read == 0)
                 {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Represents a non-cryptographic hash algorithm.
+    /// </summary>
+    public abstract class NonCryptographicHashAlgorithm
+    {
+        /// <summary>
+        ///   Gets the number of bytes produced from this hash algorithm.
+        /// </summary>
+        /// <value>The number of bytes produced from this hash algorithm.</value>
+        public int HashLengthInBytes { get; }
+
+        /// <summary>
+        ///   Called from constructors in derived classes to initialize the
+        ///   <see cref="NonCryptographicHashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="hashLengthInBytes">
+        ///   The number of bytes produced from this hash algorithm.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="hashLengthInBytes"/> is less than 1.
+        /// </exception>
+        protected NonCryptographicHashAlgorithm(int hashLengthInBytes)
+        {
+            if (hashLengthInBytes < 1)
+                throw new ArgumentOutOfRangeException(nameof(hashLengthInBytes));
+
+            HashLengthInBytes = hashLengthInBytes;
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class,
+        ///   appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
+        public abstract void Append(ReadOnlySpan<byte> source);
+
+        /// <summary>
+        ///   When overridden in a derived class,
+        ///   resets the hash computation to the initial state.
+        /// </summary>
+        public abstract void Reset();
+
+        /// <summary>
+        ///   When overridden in a derived class,
+        ///   writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <remarks>
+        ///   <para>
+        ///     Implementations of this method must write exactly
+        ///     <see cref="HashLengthInBytes"/> bytes to <paramref name="destination"/>.
+        ///     Do not assume that the buffer was zero-initialized.
+        ///   </para>
+        ///   <para>
+        ///     The <see cref="NonCryptographicHashAlgorithm"/> class validates the
+        ///     size of the buffer before calling this method, and slices the span
+        ///     down to be exactly <see cref="HashLengthInBytes"/> in length.
+        ///   </para>
+        /// </remarks>
+        protected abstract void GetCurrentHashCore(Span<byte> destination);
+
+        /// <summary>
+        ///   Appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public void Append(byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            Append(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Appends the contents of <paramref name="stream"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="stream">The data to process.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="stream"/> is <see langword="null"/>.
+        /// </exception>
+        /// <seealso cref="AppendAsync(Stream, CancellationToken)"/>
+        public void Append(Stream stream)
+        {
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+
+            while (true)
+            {
+                int read = stream.Read(buffer, 0, buffer.Length);
+
+                if (read == 0)
+                {
+                    break;
+                }
+
+                Append(new ReadOnlySpan<byte>(buffer, 0, read));
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        /// <summary>
+        ///   Asychronously reads the contents of <paramref name="stream"/>
+        ///   and appends them to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="stream">The data to process.</param>
+        /// <param name="cancellationToken">
+        ///   The token to monitor for cancellation requests.
+        ///   The default value is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="stream"/> is <see langword="null"/>.
+        /// </exception>
+        public Task AppendAsync(Stream stream, CancellationToken cancellationToken = default)
+        {
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            return AppendAsyncCore(stream, cancellationToken);
+        }
+
+        private async Task AppendAsyncCore(Stream stream, CancellationToken cancellationToken)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+
+            while (true)
+            {
+                int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+
+                if (read == 0)
+                {
+                    break;
+                }
+
+                Append(new ReadOnlySpan<byte>(buffer, 0, read));
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        /// <summary>
+        ///   Gets the current computed hash value without modifying accumulated state.
+        /// </summary>
+        public byte[] GetCurrentHash()
+        {
+            byte[] ret = new byte[HashLengthInBytes];
+            GetCurrentHashCore(ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to write the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool TryGetCurrentHash(Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < HashLengthInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            GetCurrentHashCore(destination.Slice(0, HashLengthInBytes));
+            bytesWritten = HashLengthInBytes;
+            return true;
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>,
+        ///   which is always <see cref="HashLengthInBytes"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="destination"/> is shorter than <see cref="HashLengthInBytes"/>.
+        /// </exception>
+        public int GetCurrentHash(Span<byte> destination)
+        {
+            if (destination.Length < HashLengthInBytes)
+            {
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+            }
+
+            GetCurrentHashCore(destination.Slice(0, HashLengthInBytes));
+            return HashLengthInBytes;
+        }
+
+        /// <summary>
+        ///   Gets the current computed hash value and clears the accumulated state.
+        /// </summary>
+        public byte[] GetHashAndReset()
+        {
+            byte[] ret = new byte[HashLengthInBytes];
+            GetHashAndResetCore(ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to write the computed hash value to <paramref name="destination"/>.
+        ///   If successful, clears the accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and clears the accumulated state
+        ///   if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool TryGetHashAndReset(Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < HashLengthInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            GetHashAndResetCore(destination.Slice(0, HashLengthInBytes));
+            bytesWritten = HashLengthInBytes;
+            return true;
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   then clears the accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>,
+        ///   which is always <see cref="HashLengthInBytes"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="destination"/> is shorter than <see cref="HashLengthInBytes"/>.
+        /// </exception>
+        public int GetHashAndReset(Span<byte> destination)
+        {
+            if (destination.Length < HashLengthInBytes)
+            {
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+            }
+
+            GetHashAndResetCore(destination.Slice(0, HashLengthInBytes));
+            return HashLengthInBytes;
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   then clears the accumulated state.
+        /// </summary>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <remarks>
+        ///   <para>
+        ///     Implementations of this method must write exactly
+        ///     <see cref="HashLengthInBytes"/> bytes to <paramref name="destination"/>.
+        ///     Do not assume that the buffer was zero-initialized.
+        ///   </para>
+        ///   <para>
+        ///     The <see cref="NonCryptographicHashAlgorithm"/> class validates the
+        ///     size of the buffer before calling this method, and slices the span
+        ///     down to be exactly <see cref="HashLengthInBytes"/> in length.
+        ///   </para>
+        ///   <para>
+        ///     The default implementation of this method calls
+        ///     <see cref="GetCurrentHashCore"/> followed by <see cref="Reset"/>.
+        ///     Overrides of this method do not need to call either of those methods,
+        ///     but must ensure that the caller cannot observe a difference in behavior.
+        ///   </para>
+        /// </remarks>
+        protected virtual void GetHashAndResetCore(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == HashLengthInBytes);
+
+            GetCurrentHashCore(destination);
+            Reset();
+        }
+
+        /// <summary>
+        ///   This method is not supported and should not be called.
+        ///   Call <see cref="GetCurrentHash()"/> or <see cref="GetHashAndReset()"/>
+        ///   instead.
+        /// </summary>
+        /// <returns>This method will always throw a <see cref="NotSupportedException"/>.</returns>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use GetCurrentHash() to retrieve the computed hash code.", true)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+        public override int GetHashCode()
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+        {
+            throw new NotSupportedException(SR.NotSupported_GetHashCode);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -28,7 +28,7 @@ namespace System.IO.Hashing
 
             internal State(uint seed)
             {
-                _acc1 = seed + Prime32_1 + Prime32_2;
+                _acc1 = seed + unchecked(Prime32_1 + Prime32_2);
                 _acc2 = seed + Prime32_2;
                 _acc3 = seed;
                 _acc4 = seed - Prime32_1;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -25,6 +25,7 @@ namespace System.IO.Hashing
             private uint _acc3;
             private uint _acc4;
             private readonly uint _smallAcc;
+            private bool _hadFullStripe;
 
             internal State(uint seed)
             {
@@ -34,6 +35,7 @@ namespace System.IO.Hashing
                 _acc4 = seed - Prime32_1;
 
                 _smallAcc = seed + Prime32_5;
+                _hadFullStripe = false;
             }
 
             internal void ProcessStripe(ReadOnlySpan<byte> source)
@@ -45,6 +47,8 @@ namespace System.IO.Hashing
                 _acc2 = ApplyRound(_acc2, source.Slice(sizeof(uint)));
                 _acc3 = ApplyRound(_acc3, source.Slice(2 * sizeof(uint)));
                 _acc4 = ApplyRound(_acc4, source.Slice(3 * sizeof(uint)));
+
+                _hadFullStripe = true;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -68,7 +72,7 @@ namespace System.IO.Hashing
 
             internal readonly uint Complete(int length, ReadOnlySpan<byte> remaining)
             {
-                uint acc = length >= StripeSize ? Converge() : _smallAcc;
+                uint acc = _hadFullStripe ? Converge() : _smallAcc;
 
                 acc += (uint)length;
 

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -39,6 +39,7 @@ namespace System.IO.Hashing
             internal void ProcessStripe(ReadOnlySpan<byte> source)
             {
                 Debug.Assert(source.Length >= StripeSize);
+                source = source.Slice(0, StripeSize);
 
                 _acc1 = ApplyRound(_acc1, source);
                 _acc2 = ApplyRound(_acc2, source.Slice(sizeof(uint)));
@@ -81,14 +82,12 @@ namespace System.IO.Hashing
                     remaining = remaining.Slice(sizeof(uint));
                 }
 
-                while (remaining.Length > 0)
+                for (int i = 0; i < remaining.Length; i++)
                 {
-                    uint lane = remaining[0];
+                    uint lane = remaining[i];
                     acc += lane * Prime32_5;
                     acc = BitOperations.RotateLeft(acc, 11);
                     acc *= Prime32_1;
-
-                    remaining = remaining.Slice(1);
                 }
 
                 acc ^= (acc >> 15);

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+// Implemented from the specification at
+// https://github.com/Cyan4973/xxHash/blob/f9155bd4c57e2270a4ffbb176485e5d713de1c9b/doc/xxhash_spec.md
+
+namespace System.IO.Hashing
+{
+    public sealed partial class XxHash32
+    {
+        private struct State
+        {
+            private const uint Prime32_1 = 0x9E3779B1;
+            private const uint Prime32_2 = 0x85EBCA77;
+            private const uint Prime32_3 = 0xC2B2AE3D;
+            private const uint Prime32_4 = 0x27D4EB2F;
+            private const uint Prime32_5 = 0x165667B1;
+
+            private uint _acc1;
+            private uint _acc2;
+            private uint _acc3;
+            private uint _acc4;
+            private readonly uint _smallAcc;
+
+            internal State(uint seed)
+            {
+                unchecked
+                {
+                    _acc1 = seed + Prime32_1 + Prime32_2;
+                    _acc2 = seed + Prime32_2;
+                    _acc3 = seed;
+                    _acc4 = seed - Prime32_1;
+
+                    _smallAcc = seed + Prime32_5;
+                }
+            }
+
+            internal void ProcessStripe(ReadOnlySpan<byte> source)
+            {
+                Debug.Assert(source.Length >= StripeSize);
+
+                _acc1 = ApplyRound(_acc1, source);
+                _acc2 = ApplyRound(_acc2, source.Slice(sizeof(uint)));
+                _acc3 = ApplyRound(_acc3, source.Slice(2 * sizeof(uint)));
+                _acc4 = ApplyRound(_acc4, source.Slice(3 * sizeof(uint)));
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private readonly uint Converge()
+            {
+                return
+                    BitOperations.RotateLeft(_acc1, 1) +
+                    BitOperations.RotateLeft(_acc2, 7) +
+                    BitOperations.RotateLeft(_acc3, 12) +
+                    BitOperations.RotateLeft(_acc4, 18);
+            }
+
+            private static uint ApplyRound(uint acc, ReadOnlySpan<byte> lane)
+            {
+                unchecked
+                {
+                    acc += BinaryPrimitives.ReadUInt32LittleEndian(lane) * Prime32_2;
+                    acc = BitOperations.RotateLeft(acc, 13);
+                    acc *= Prime32_1;
+                }
+
+                return acc;
+            }
+
+            internal readonly uint Complete(int length, ReadOnlySpan<byte> remaining)
+            {
+                unchecked
+                {
+                    uint acc = length >= StripeSize ? Converge() : _smallAcc;
+
+                    acc += (uint)length;
+
+                    while (remaining.Length >= sizeof(uint))
+                    {
+                        uint lane = BinaryPrimitives.ReadUInt32LittleEndian(remaining);
+                        acc += lane * Prime32_3;
+                        acc = BitOperations.RotateLeft(acc, 17);
+                        acc *= Prime32_4;
+
+                        remaining = remaining.Slice(sizeof(uint));
+                    }
+
+                    while (remaining.Length > 0)
+                    {
+                        uint lane = remaining[0];
+                        acc += lane * Prime32_5;
+                        acc = BitOperations.RotateLeft(acc, 11);
+                        acc *= Prime32_1;
+
+                        remaining = remaining.Slice(1);
+                    }
+
+                    acc ^= (acc >> 15);
+                    acc *= Prime32_2;
+                    acc ^= (acc >> 13);
+                    acc *= Prime32_3;
+                    acc ^= (acc >> 16);
+
+                    return acc;
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -18,7 +18,7 @@ namespace System.IO.Hashing
 
         private readonly uint _seed;
         private State _state;
-        private byte[] _holdback;
+        private byte[]? _holdback;
         private int _length;
 
         /// <summary>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -31,7 +31,6 @@ namespace System.IO.Hashing
         public XxHash32()
             : this(0)
         {
-            Reset();
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -44,7 +44,7 @@ namespace System.IO.Hashing
         public XxHash32(int seed)
             : base(HashSize)
         {
-            _seed = unchecked((uint)seed);
+            _seed = (uint)seed;
             Reset();
         }
 
@@ -111,19 +111,16 @@ namespace System.IO.Hashing
         /// </summary>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
-            unchecked
+            int remainingLength = _length & 0x0F;
+            ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
+
+            if (remainingLength > 0)
             {
-                int remainingLength = _length & 0x0F;
-                ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
-
-                if (remainingLength > 0)
-                {
-                    remaining = new ReadOnlySpan<byte>(_holdback, 0, remainingLength);
-                }
-
-                uint acc = _state.Complete(_length, remaining);
-                BinaryPrimitives.WriteUInt32BigEndian(destination, acc);
+                remaining = new ReadOnlySpan<byte>(_holdback, 0, remainingLength);
             }
+
+            uint acc = _state.Complete(_length, remaining);
+            BinaryPrimitives.WriteUInt32BigEndian(destination, acc);
         }
 
         /// <summary>
@@ -217,7 +214,7 @@ namespace System.IO.Hashing
         private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination, int seed)
         {
             int totalLength = source.Length;
-            State state = new State(unchecked((uint)seed));
+            State state = new State((uint)seed);
 
             while (source.Length > StripeSize)
             {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -48,12 +48,20 @@ namespace System.IO.Hashing
             Reset();
         }
 
+        /// <summary>
+        ///   Resets the hash computation to the initial state.
+        /// </summary>
         public override void Reset()
         {
             _state = new State(_seed);
             _length = 0;
         }
 
+        /// <summary>
+        ///   Appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
         public override void Append(ReadOnlySpan<byte> source)
         {
             // Every time we've read 16 bytes, process the stripe.
@@ -97,6 +105,10 @@ namespace System.IO.Hashing
             }
         }
 
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
             unchecked

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+// Implemented from the specification at
+// https://github.com/Cyan4973/xxHash/blob/f9155bd4c57e2270a4ffbb176485e5d713de1c9b/doc/xxhash_spec.md
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Provides an implementation of the XxHash32 algorithm.
+    /// </summary>
+    public sealed partial class XxHash32 : NonCryptographicHashAlgorithm
+    {
+        private const int HashSize = sizeof(uint);
+        private const int StripeSize = 4 * sizeof(uint);
+
+        private State _state;
+        private byte[] _holdback;
+        private int _length;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="XxHash32"/> class.
+        /// </summary>
+        public XxHash32()
+            : base(HashSize)
+        {
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            _state = new State(0);
+            _length = 0;
+        }
+
+        public override void Append(ReadOnlySpan<byte> source)
+        {
+            // Every time we've read 16 bytes, process the stripe.
+            // Data that isn't perfectly mod-16 gets stored in a holdback
+            // buffer.
+
+            int held = _length & 0x0F;
+
+            if (held != 0)
+            {
+                int remain = StripeSize - held;
+
+                if (source.Length > remain)
+                {
+                    source.Slice(0, remain).CopyTo(_holdback.AsSpan(held));
+                    _state.ProcessStripe(_holdback);
+
+                    source = source.Slice(remain);
+                    _length += remain;
+                }
+                else
+                {
+                    source.CopyTo(_holdback.AsSpan(held));
+                    _length += source.Length;
+                    return;
+                }
+            }
+
+            while (source.Length >= StripeSize)
+            {
+                _state.ProcessStripe(source);
+                source = source.Slice(StripeSize);
+                _length += StripeSize;
+            }
+
+            if (source.Length > 0)
+            {
+                _holdback ??= new byte[StripeSize];
+                source.CopyTo(_holdback);
+                _length += source.Length;
+            }
+        }
+
+        protected override void GetCurrentHashCore(Span<byte> destination)
+        {
+            unchecked
+            {
+                int remainingLength = _length & 0x0F;
+                ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
+
+                if (remainingLength > 0)
+                {
+                    remaining = new ReadOnlySpan<byte>(_holdback, 0, remainingLength);
+                }
+
+                uint acc = _state.Complete(_length, remaining);
+                BinaryPrimitives.WriteUInt32BigEndian(destination, acc);
+            }
+        }
+
+        /// <summary>
+        ///   Computes the XxHash32 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The XxHash32 hash of the provided data.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public static byte[] Hash(byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return Hash(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Computes the XxHash32 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The XxHash32 hash of the provided data.</returns>
+        public static byte[] Hash(ReadOnlySpan<byte> source)
+        {
+            byte[] ret = new byte[HashSize];
+            StaticHash(source, ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to compute the XxHash32 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value (4 bytes); otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < HashSize)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = StaticHash(source, destination);
+            return true;
+        }
+
+        /// <summary>
+        ///   Computes the XxHash32 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < HashSize)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return StaticHash(source, destination);
+        }
+
+        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            int totalLength = source.Length;
+            State state = new State(0);
+
+            while (source.Length > StripeSize)
+            {
+                state.ProcessStripe(source);
+                source = source.Slice(StripeSize);
+            }
+
+            uint val = state.Complete(totalLength, source);
+            BinaryPrimitives.WriteUInt32BigEndian(destination, val);
+            return HashSize;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -27,7 +27,7 @@ namespace System.IO.Hashing
 
             internal State(ulong seed)
             {
-                _acc1 = seed + Prime64_1 + Prime64_2;
+                _acc1 = seed + unchecked(Prime64_1 + Prime64_2);
                 _acc2 = seed + Prime64_2;
                 _acc3 = seed;
                 _acc4 = seed - Prime64_1;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+
+// Implemented from the specification at
+// https://github.com/Cyan4973/xxHash/blob/f9155bd4c57e2270a4ffbb176485e5d713de1c9b/doc/xxhash_spec.md
+
+namespace System.IO.Hashing
+{
+    public sealed partial class XxHash64
+    {
+        private struct State
+        {
+            private const ulong Prime64_1 = 0x9E3779B185EBCA87;
+            private const ulong Prime64_2 = 0xC2B2AE3D27D4EB4F;
+            private const ulong Prime64_3 = 0x165667B19E3779F9;
+            private const ulong Prime64_4 = 0x85EBCA77C2B2AE63;
+            private const ulong Prime64_5 = 0x27D4EB2F165667C5;
+
+            private ulong _acc1;
+            private ulong _acc2;
+            private ulong _acc3;
+            private ulong _acc4;
+            private readonly ulong _smallAcc;
+
+            internal State(ulong seed)
+            {
+                unchecked
+                {
+                    _acc1 = seed + Prime64_1 + Prime64_2;
+                    _acc2 = seed + Prime64_2;
+                    _acc3 = seed;
+                    _acc4 = seed - Prime64_1;
+
+                    _smallAcc = seed + Prime64_5;
+                }
+            }
+
+            internal void ProcessStripe(ReadOnlySpan<byte> source)
+            {
+                Debug.Assert(source.Length >= StripeSize);
+
+                _acc1 = ApplyRound(_acc1, source);
+                _acc2 = ApplyRound(_acc2, source.Slice(sizeof(ulong)));
+                _acc3 = ApplyRound(_acc3, source.Slice(2 * sizeof(ulong)));
+                _acc4 = ApplyRound(_acc4, source.Slice(3 * sizeof(ulong)));
+            }
+
+            private static ulong MergeAccumulator(ulong acc, ulong accN)
+            {
+                unchecked
+                {
+                    acc ^= ApplyRound(0, accN);
+                    acc *= Prime64_1;
+                    acc += Prime64_4;
+                }
+
+                return acc;
+            }
+
+            private readonly ulong Converge()
+            {
+                unchecked
+                {
+                    ulong acc =
+                        BitOperations.RotateLeft(_acc1, 1) +
+                        BitOperations.RotateLeft(_acc2, 7) +
+                        BitOperations.RotateLeft(_acc3, 12) +
+                        BitOperations.RotateLeft(_acc4, 18);
+
+                    acc = MergeAccumulator(acc, _acc1);
+                    acc = MergeAccumulator(acc, _acc2);
+                    acc = MergeAccumulator(acc, _acc3);
+                    acc = MergeAccumulator(acc, _acc4);
+
+                    return acc;
+                }
+            }
+
+            private static ulong ApplyRound(ulong acc, ReadOnlySpan<byte> lane)
+            {
+                return ApplyRound(acc, BinaryPrimitives.ReadUInt64LittleEndian(lane));
+            }
+
+            private static ulong ApplyRound(ulong acc, ulong lane)
+            {
+                unchecked
+                {
+                    acc += lane * Prime64_2;
+                    acc = BitOperations.RotateLeft(acc, 31);
+                    acc *= Prime64_1;
+                }
+
+                return acc;
+            }
+
+            internal readonly ulong Complete(int length, ReadOnlySpan<byte> remaining)
+            {
+                unchecked
+                {
+                    ulong acc = length >= StripeSize ? Converge() : _smallAcc;
+
+                    acc += (ulong)length;
+
+                    while (remaining.Length >= sizeof(ulong))
+                    {
+                        ulong lane = BinaryPrimitives.ReadUInt64LittleEndian(remaining);
+                        acc ^= ApplyRound(0, lane);
+                        acc = BitOperations.RotateLeft(acc, 27);
+                        acc *= Prime64_1;
+                        acc += Prime64_4;
+
+                        remaining = remaining.Slice(sizeof(ulong));
+                    }
+
+                    // Doesn't need to be a while since it can occur at most once.
+                    if (remaining.Length >= sizeof(uint))
+                    {
+                        ulong lane = BinaryPrimitives.ReadUInt32LittleEndian(remaining);
+                        acc ^= lane * Prime64_1;
+                        acc = BitOperations.RotateLeft(acc, 23);
+                        acc *= Prime64_2;
+                        acc += Prime64_3;
+
+                        remaining = remaining.Slice(sizeof(uint));
+                    }
+
+                    while (remaining.Length > 0)
+                    {
+                        ulong lane = remaining[0];
+                        acc ^= lane * Prime64_5;
+                        acc = BitOperations.RotateLeft(acc, 11);
+                        acc *= Prime64_1;
+
+                        remaining = remaining.Slice(1);
+                    }
+
+                    acc ^= (acc >> 33);
+                    acc *= Prime64_2;
+                    acc ^= (acc >> 29);
+                    acc *= Prime64_3;
+                    acc ^= (acc >> 32);
+
+                    return acc;
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -27,15 +27,12 @@ namespace System.IO.Hashing
 
             internal State(ulong seed)
             {
-                unchecked
-                {
-                    _acc1 = seed + Prime64_1 + Prime64_2;
-                    _acc2 = seed + Prime64_2;
-                    _acc3 = seed;
-                    _acc4 = seed - Prime64_1;
+                _acc1 = seed + Prime64_1 + Prime64_2;
+                _acc2 = seed + Prime64_2;
+                _acc3 = seed;
+                _acc4 = seed - Prime64_1;
 
-                    _smallAcc = seed + Prime64_5;
-                }
+                _smallAcc = seed + Prime64_5;
             }
 
             internal void ProcessStripe(ReadOnlySpan<byte> source)
@@ -50,33 +47,27 @@ namespace System.IO.Hashing
 
             private static ulong MergeAccumulator(ulong acc, ulong accN)
             {
-                unchecked
-                {
-                    acc ^= ApplyRound(0, accN);
-                    acc *= Prime64_1;
-                    acc += Prime64_4;
-                }
+                acc ^= ApplyRound(0, accN);
+                acc *= Prime64_1;
+                acc += Prime64_4;
 
                 return acc;
             }
 
             private readonly ulong Converge()
             {
-                unchecked
-                {
-                    ulong acc =
-                        BitOperations.RotateLeft(_acc1, 1) +
-                        BitOperations.RotateLeft(_acc2, 7) +
-                        BitOperations.RotateLeft(_acc3, 12) +
-                        BitOperations.RotateLeft(_acc4, 18);
+                ulong acc =
+                    BitOperations.RotateLeft(_acc1, 1) +
+                    BitOperations.RotateLeft(_acc2, 7) +
+                    BitOperations.RotateLeft(_acc3, 12) +
+                    BitOperations.RotateLeft(_acc4, 18);
 
-                    acc = MergeAccumulator(acc, _acc1);
-                    acc = MergeAccumulator(acc, _acc2);
-                    acc = MergeAccumulator(acc, _acc3);
-                    acc = MergeAccumulator(acc, _acc4);
+                acc = MergeAccumulator(acc, _acc1);
+                acc = MergeAccumulator(acc, _acc2);
+                acc = MergeAccumulator(acc, _acc3);
+                acc = MergeAccumulator(acc, _acc4);
 
-                    return acc;
-                }
+                return acc;
             }
 
             private static ulong ApplyRound(ulong acc, ReadOnlySpan<byte> lane)
@@ -86,65 +77,59 @@ namespace System.IO.Hashing
 
             private static ulong ApplyRound(ulong acc, ulong lane)
             {
-                unchecked
-                {
-                    acc += lane * Prime64_2;
-                    acc = BitOperations.RotateLeft(acc, 31);
-                    acc *= Prime64_1;
-                }
+                acc += lane * Prime64_2;
+                acc = BitOperations.RotateLeft(acc, 31);
+                acc *= Prime64_1;
 
                 return acc;
             }
 
             internal readonly ulong Complete(int length, ReadOnlySpan<byte> remaining)
             {
-                unchecked
+                ulong acc = length >= StripeSize ? Converge() : _smallAcc;
+
+                acc += (ulong)length;
+
+                while (remaining.Length >= sizeof(ulong))
                 {
-                    ulong acc = length >= StripeSize ? Converge() : _smallAcc;
+                    ulong lane = BinaryPrimitives.ReadUInt64LittleEndian(remaining);
+                    acc ^= ApplyRound(0, lane);
+                    acc = BitOperations.RotateLeft(acc, 27);
+                    acc *= Prime64_1;
+                    acc += Prime64_4;
 
-                    acc += (ulong)length;
-
-                    while (remaining.Length >= sizeof(ulong))
-                    {
-                        ulong lane = BinaryPrimitives.ReadUInt64LittleEndian(remaining);
-                        acc ^= ApplyRound(0, lane);
-                        acc = BitOperations.RotateLeft(acc, 27);
-                        acc *= Prime64_1;
-                        acc += Prime64_4;
-
-                        remaining = remaining.Slice(sizeof(ulong));
-                    }
-
-                    // Doesn't need to be a while since it can occur at most once.
-                    if (remaining.Length >= sizeof(uint))
-                    {
-                        ulong lane = BinaryPrimitives.ReadUInt32LittleEndian(remaining);
-                        acc ^= lane * Prime64_1;
-                        acc = BitOperations.RotateLeft(acc, 23);
-                        acc *= Prime64_2;
-                        acc += Prime64_3;
-
-                        remaining = remaining.Slice(sizeof(uint));
-                    }
-
-                    while (remaining.Length > 0)
-                    {
-                        ulong lane = remaining[0];
-                        acc ^= lane * Prime64_5;
-                        acc = BitOperations.RotateLeft(acc, 11);
-                        acc *= Prime64_1;
-
-                        remaining = remaining.Slice(1);
-                    }
-
-                    acc ^= (acc >> 33);
-                    acc *= Prime64_2;
-                    acc ^= (acc >> 29);
-                    acc *= Prime64_3;
-                    acc ^= (acc >> 32);
-
-                    return acc;
+                    remaining = remaining.Slice(sizeof(ulong));
                 }
+
+                // Doesn't need to be a while since it can occur at most once.
+                if (remaining.Length >= sizeof(uint))
+                {
+                    ulong lane = BinaryPrimitives.ReadUInt32LittleEndian(remaining);
+                    acc ^= lane * Prime64_1;
+                    acc = BitOperations.RotateLeft(acc, 23);
+                    acc *= Prime64_2;
+                    acc += Prime64_3;
+
+                    remaining = remaining.Slice(sizeof(uint));
+                }
+
+                while (remaining.Length > 0)
+                {
+                    ulong lane = remaining[0];
+                    acc ^= lane * Prime64_5;
+                    acc = BitOperations.RotateLeft(acc, 11);
+                    acc *= Prime64_1;
+
+                    remaining = remaining.Slice(1);
+                }
+
+                acc ^= (acc >> 33);
+                acc *= Prime64_2;
+                acc ^= (acc >> 29);
+                acc *= Prime64_3;
+                acc ^= (acc >> 32);
+
+                return acc;
             }
         }
     }

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -24,6 +24,7 @@ namespace System.IO.Hashing
             private ulong _acc3;
             private ulong _acc4;
             private readonly ulong _smallAcc;
+            private bool _hadFullStripe;
 
             internal State(ulong seed)
             {
@@ -33,6 +34,7 @@ namespace System.IO.Hashing
                 _acc4 = seed - Prime64_1;
 
                 _smallAcc = seed + Prime64_5;
+                _hadFullStripe = false;
             }
 
             internal void ProcessStripe(ReadOnlySpan<byte> source)
@@ -44,6 +46,8 @@ namespace System.IO.Hashing
                 _acc2 = ApplyRound(_acc2, source.Slice(sizeof(ulong)));
                 _acc3 = ApplyRound(_acc3, source.Slice(2 * sizeof(ulong)));
                 _acc4 = ApplyRound(_acc4, source.Slice(3 * sizeof(ulong)));
+
+                _hadFullStripe = true;
             }
 
             private static ulong MergeAccumulator(ulong acc, ulong accN)
@@ -87,7 +91,7 @@ namespace System.IO.Hashing
 
             internal readonly ulong Complete(int length, ReadOnlySpan<byte> remaining)
             {
-                ulong acc = length >= StripeSize ? Converge() : _smallAcc;
+                ulong acc = _hadFullStripe ? Converge() : _smallAcc;
 
                 acc += (ulong)length;
 

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -38,6 +38,7 @@ namespace System.IO.Hashing
             internal void ProcessStripe(ReadOnlySpan<byte> source)
             {
                 Debug.Assert(source.Length >= StripeSize);
+                source = source.Slice(0, StripeSize);
 
                 _acc1 = ApplyRound(_acc1, source);
                 _acc2 = ApplyRound(_acc2, source.Slice(sizeof(ulong)));
@@ -113,14 +114,12 @@ namespace System.IO.Hashing
                     remaining = remaining.Slice(sizeof(uint));
                 }
 
-                while (remaining.Length > 0)
+                for (int i = 0; i < remaining.Length; i++)
                 {
-                    ulong lane = remaining[0];
+                    ulong lane = remaining[i];
                     acc ^= lane * Prime64_5;
                     acc = BitOperations.RotateLeft(acc, 11);
                     acc *= Prime64_1;
-
-                    remaining = remaining.Slice(1);
                 }
 
                 acc ^= (acc >> 33);

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -31,7 +31,6 @@ namespace System.IO.Hashing
         public XxHash64()
             : this(0)
         {
-            Reset();
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+// Implemented from the specification at
+// https://github.com/Cyan4973/xxHash/blob/f9155bd4c57e2270a4ffbb176485e5d713de1c9b/doc/xxhash_spec.md
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Provides an implementation of the XxHash64 algorithm.
+    /// </summary>
+    public sealed partial class XxHash64 : NonCryptographicHashAlgorithm
+    {
+        private const int HashSize = sizeof(ulong);
+        private const int StripeSize = 4 * sizeof(ulong);
+
+        private State _state;
+        private byte[] _holdback;
+        private int _length;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="XxHash64"/> class.
+        /// </summary>
+        public XxHash64()
+            : base(HashSize)
+        {
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            _state = new State(0);
+            _length = 0;
+        }
+
+        public override void Append(ReadOnlySpan<byte> source)
+        {
+            // Every time we've read 16 bytes, process the stripe.
+            // Data that isn't perfectly mod-16 gets stored in a holdback
+            // buffer.
+
+            int held = _length & 0x1F;
+
+            if (held != 0)
+            {
+                int remain = StripeSize - held;
+
+                if (source.Length > remain)
+                {
+                    source.Slice(0, remain).CopyTo(_holdback.AsSpan(held));
+                    _state.ProcessStripe(_holdback);
+
+                    source = source.Slice(remain);
+                    _length += remain;
+                }
+                else
+                {
+                    source.CopyTo(_holdback.AsSpan(held));
+                    _length += source.Length;
+                    return;
+                }
+            }
+
+            while (source.Length >= StripeSize)
+            {
+                _state.ProcessStripe(source);
+                source = source.Slice(StripeSize);
+                _length += StripeSize;
+            }
+
+            if (source.Length > 0)
+            {
+                _holdback ??= new byte[StripeSize];
+                source.CopyTo(_holdback);
+                _length += source.Length;
+            }
+        }
+
+        protected override void GetCurrentHashCore(Span<byte> destination)
+        {
+            unchecked
+            {
+                int remainingLength = _length & 0x1F;
+                ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
+
+                if (remainingLength > 0)
+                {
+                    remaining = new ReadOnlySpan<byte>(_holdback, 0, remainingLength);
+                }
+
+                ulong acc = _state.Complete(_length, remaining);
+                BinaryPrimitives.WriteUInt64BigEndian(destination, acc);
+            }
+        }
+
+        /// <summary>
+        ///   Computes the XxHash64 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The XxHash64 hash of the provided data.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public static byte[] Hash(byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return Hash(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Computes the XxHash64 hash of the provided data.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <returns>The XxHash64 hash of the provided data.</returns>
+        public static byte[] Hash(ReadOnlySpan<byte> source)
+        {
+            byte[] ret = new byte[HashSize];
+            StaticHash(source, ret);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to compute the XxHash64 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
+        ///   the computed hash value (4 bytes); otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < HashSize)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = StaticHash(source, destination);
+            return true;
+        }
+
+        /// <summary>
+        ///   Computes the XxHash64 hash of the provided data into the provided destination.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < HashSize)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return StaticHash(source, destination);
+        }
+
+        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            int totalLength = source.Length;
+            State state = new State(0);
+
+            while (source.Length > StripeSize)
+            {
+                state.ProcessStripe(source);
+                source = source.Slice(StripeSize);
+            }
+
+            ulong val = state.Complete(totalLength, source);
+            BinaryPrimitives.WriteUInt64BigEndian(destination, val);
+            return HashSize;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -48,12 +48,20 @@ namespace System.IO.Hashing
             Reset();
         }
 
+        /// <summary>
+        ///   Resets the hash computation to the initial state.
+        /// </summary>
         public override void Reset()
         {
             _state = new State(_seed);
             _length = 0;
         }
 
+        /// <summary>
+        ///   Appends the contents of <paramref name="source"/> to the data already
+        ///   processed for the current hash computation.
+        /// </summary>
+        /// <param name="source">The data to process.</param>
         public override void Append(ReadOnlySpan<byte> source)
         {
             // Every time we've read 16 bytes, process the stripe.
@@ -97,6 +105,10 @@ namespace System.IO.Hashing
             }
         }
 
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
             unchecked

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -16,6 +16,7 @@ namespace System.IO.Hashing
         private const int HashSize = sizeof(ulong);
         private const int StripeSize = 4 * sizeof(ulong);
 
+        private readonly ulong _seed;
         private State _state;
         private byte[] _holdback;
         private int _length;
@@ -23,15 +24,33 @@ namespace System.IO.Hashing
         /// <summary>
         ///   Initializes a new instance of the <see cref="XxHash64"/> class.
         /// </summary>
+        /// <remarks>
+        ///   The XxHash64 algorithm supports an optional seed value.
+        ///   Instances created with this constructor use the default seed, zero.
+        /// </remarks>
         public XxHash64()
             : base(HashSize)
         {
             Reset();
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="XxHash64"/> class with
+        ///   a specified seed.
+        /// </summary>
+        /// <param name="seed">
+        ///   The hash seed value for computations from this instance.
+        /// </param>
+        public XxHash64(long seed)
+            : base(HashSize)
+        {
+            _seed = unchecked((ulong)seed);
+            Reset();
+        }
+
         public override void Reset()
         {
-            _state = new State(0);
+            _state = new State(_seed);
             _length = 0;
         }
 
@@ -112,14 +131,32 @@ namespace System.IO.Hashing
         }
 
         /// <summary>
+        ///   Computes the XxHash64 hash of the provided data using the provided seed.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="seed">The seed value for this hash computation.</param>
+        /// <returns>The XxHash64 hash of the provided data.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        public static byte[] Hash(byte[] source, long seed)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return Hash(new ReadOnlySpan<byte>(source), seed);
+        }
+
+        /// <summary>
         ///   Computes the XxHash64 hash of the provided data.
         /// </summary>
         /// <param name="source">The data to hash.</param>
+        /// <param name="seed">The seed value for this hash computation. The default is zero.</param>
         /// <returns>The XxHash64 hash of the provided data.</returns>
-        public static byte[] Hash(ReadOnlySpan<byte> source)
+        public static byte[] Hash(ReadOnlySpan<byte> source, long seed = 0)
         {
             byte[] ret = new byte[HashSize];
-            StaticHash(source, ret);
+            StaticHash(source, ret, seed);
             return ret;
         }
 
@@ -131,11 +168,12 @@ namespace System.IO.Hashing
         /// <param name="bytesWritten">
         ///   On success, receives the number of bytes written to <paramref name="destination"/>.
         /// </param>
+        /// <param name="seed">The seed value for this hash computation. The default is zero.</param>
         /// <returns>
         ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
         ///   the computed hash value (4 bytes); otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten, long seed = 0)
         {
             if (destination.Length < HashSize)
             {
@@ -143,7 +181,7 @@ namespace System.IO.Hashing
                 return false;
             }
 
-            bytesWritten = StaticHash(source, destination);
+            bytesWritten = StaticHash(source, destination, seed);
             return true;
         }
 
@@ -152,21 +190,22 @@ namespace System.IO.Hashing
         /// </summary>
         /// <param name="source">The data to hash.</param>
         /// <param name="destination">The buffer that receives the computed hash value.</param>
+        /// <param name="seed">The seed value for this hash computation. The default is zero.</param>
         /// <returns>
         ///   The number of bytes written to <paramref name="destination"/>.
         /// </returns>
-        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination)
+        public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination, long seed = 0)
         {
             if (destination.Length < HashSize)
                 throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
 
-            return StaticHash(source, destination);
+            return StaticHash(source, destination, seed);
         }
 
-        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination)
+        private static int StaticHash(ReadOnlySpan<byte> source, Span<byte> destination, long seed)
         {
             int totalLength = source.Length;
-            State state = new State(0);
+            State state = new State(unchecked((ulong)seed));
 
             while (source.Length > StripeSize)
             {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -18,7 +18,7 @@ namespace System.IO.Hashing
 
         private readonly ulong _seed;
         private State _state;
-        private byte[] _holdback;
+        private byte[]? _holdback;
         private int _length;
 
         /// <summary>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -29,7 +29,7 @@ namespace System.IO.Hashing
         ///   Instances created with this constructor use the default seed, zero.
         /// </remarks>
         public XxHash64()
-            : base(HashSize)
+            : this(0)
         {
             Reset();
         }

--- a/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
@@ -9,7 +9,10 @@ namespace System.IO.Hashing.Tests
 {
     public class Crc32Tests : NonCryptoHashTestDriver
     {
-        public Crc32Tests() : base(new byte[4])
+        private static readonly byte[] s_emptyHashValue = new byte[4];
+
+        public Crc32Tests()
+            : base(s_emptyHashValue)
         {
         }
 

--- a/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class Crc32Tests : NonCryptoHashTestDriver
+    {
+        public Crc32Tests() : base(new byte[4])
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                new TestCase(
+                    "Empty",
+                    "",
+                    "00000000"),
+                new TestCase(
+                    "One",
+                    "01",
+                    "1BDF05A5"),
+                new TestCase(
+                    "Zero-Residue",
+                    "00000000",
+                    "1CDF4421"),
+                new TestCase(
+                    "Zero-InverseResidue",
+                    "FFFFFFFF",
+                    "FFFFFFFF"),
+                new TestCase(
+                    "Self-test 123456789",
+                    Encoding.ASCII.GetBytes("123456789"),
+                    "2639F4CB"),
+                new TestCase(
+                    "Self-test residue",
+                    "3132333435363738392639F4CB",
+                    "1CDF4421"),
+                new TestCase(
+                    "Self-test inverse residue",
+                    "313233343536373839D9C60B34",
+                    "FFFFFFFF"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "39A34F41"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new Crc32();
+
+        protected override byte[] StaticOneShot(byte[] source) => Crc32.Hash(source);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => Crc32.Hash(source);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            Crc32.Hash(source, destination);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            Crc32.TryHash(source, destination, out bytesWritten);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
@@ -9,7 +9,10 @@ namespace System.IO.Hashing.Tests
 {
     public class Crc64Tests : NonCryptoHashTestDriver
     {
-        public Crc64Tests() : base(new byte[8])
+        private static readonly byte[] s_emptyHashValue = new byte[8];
+
+        public Crc64Tests()
+            : base(s_emptyHashValue)
         {
         }
 

--- a/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class Crc64Tests : NonCryptoHashTestDriver
+    {
+        public Crc64Tests() : base(new byte[8])
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                new TestCase(
+                    "Empty",
+                    "",
+                    "0000000000000000"),
+                new TestCase(
+                    "One",
+                    "01",
+                    "42F0E1EBA9EA3693"),
+                // Because CRC-64 has an initial state of 0, any input that is all
+                // zero-valued bytes will always produce 0x0ul as the output, since it
+                // never leaves state 0.
+                new TestCase(
+                    "{ 0x00 }",
+                    "00",
+                    "0000000000000000"),
+                // Once it has left the initial state, zero-value bytes matter.
+                new TestCase(
+                    "{ 0x01, 0x00 }",
+                    "0100",
+                    "AF052A6B538EDF09"),
+                new TestCase(
+                    "Zero-Residue",
+                    "0000000000000000",
+                    "0000000000000000"),
+                new TestCase(
+                    "Self-test 123456789",
+                    Encoding.ASCII.GetBytes("123456789"),
+                    "6C40DF5F0B497347"),
+                new TestCase(
+                    "Self-test residue",
+                    "3132333435363738396C40DF5F0B497347",
+                    "0000000000000000"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "41E05242FFA9883B"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new Crc64();
+
+        protected override byte[] StaticOneShot(byte[] source) => Crc64.Hash(source);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => Crc64.Hash(source);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            Crc64.Hash(source, destination);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            Crc64.TryHash(source, destination, out bytesWritten);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/NonCryptoHashBaseTests.cs
+++ b/src/libraries/System.IO.Hashing/tests/NonCryptoHashBaseTests.cs
@@ -1,0 +1,581 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Threading;
+using System.Threading.Tasks;
+using Test.IO.Streams;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public static class NonCryptoHashBaseTests
+    {
+        [Fact]
+        public static void ZeroLengthHashIsInvalid()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                "hashLengthInBytes",
+                () => new FlexibleAlgorithm(0));
+        }
+
+        [Fact]
+        public static void NegativeHashLengthIsInvalid()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                "hashLengthInBytes",
+                () => new FlexibleAlgorithm(-1));
+        }
+
+        [Fact]
+        public static void TryGetCurrentHash_TooSmall()
+        {
+            Span<byte> buf = stackalloc byte[7];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            while (true)
+            {
+                Assert.False(hash.TryGetCurrentHash(buf, out int written));
+                Assert.Equal(0, written);
+
+                if (buf.IsEmpty)
+                {
+                    break;
+                }
+
+                buf = buf.Slice(1);
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void TryGetCurrentHash_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length / 2);
+            int i = 0;
+
+            hash.Append(buf);
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+
+                // TryGetCurrentHash in turn asserts that buf got Sliced down to HashLengthInBytes.
+                Assert.True(hash.TryGetCurrentHash(buf, out int written));
+                Assert.Equal(hash.HashLengthInBytes, written);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void GetCurrentHash_TooSmall()
+        {
+            byte[] buf = new byte[7];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            for (int i = 0; i <= buf.Length; i++)
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "destination",
+                    () => hash.GetCurrentHash(buf.AsSpan(i)));
+            }
+
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void GetCurrentHash_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length / 2);
+            int i = 0;
+
+            hash.Append(buf);
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+
+                // GetCurrentHash in turn asserts that buf got Sliced down to HashLengthInBytes.
+                int written = hash.GetCurrentHash(buf);
+                Assert.Equal(hash.HashLengthInBytes, written);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void AllocatingGetCurrentHash_CorrectSize()
+        {
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(12);
+            byte[] ret = hash.GetCurrentHash();
+            Assert.Equal(hash.HashLengthInBytes, ret.Length);
+            Assert.Equal(1, hash.GetCurrentHashCoreCallCount);
+        }
+
+        [Fact]
+        public static void DefaultGetHashAndResetDoesWhatItSays()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length);
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+
+            byte[] ret = hash.GetHashAndReset();
+            Assert.True(hash.IsReset);
+            Assert.Equal(1, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(hash.HashLengthInBytes, ret.Length);
+
+            hash.Append(ret);
+            Assert.False(hash.IsReset);
+
+            Assert.True(hash.TryGetHashAndReset(buf, out int written));
+            Assert.True(hash.IsReset);
+            Assert.Equal(2, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(hash.HashLengthInBytes, written);
+
+            hash.Append(ret);
+            Assert.False(hash.IsReset);
+
+            written = hash.GetHashAndReset(buf);
+            Assert.True(hash.IsReset);
+            Assert.Equal(3, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(hash.HashLengthInBytes, written);
+        }
+
+        [Fact]
+        public static void TryGetHashAndReset_TooSmall()
+        {
+            Span<byte> buf = stackalloc byte[7];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            while (true)
+            {
+                Assert.False(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(0, written);
+
+                if (buf.IsEmpty)
+                {
+                    break;
+                }
+
+                buf = buf.Slice(1);
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void TryGetHashAndReset_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length / 2);
+            int i = 0;
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+
+                hash.Append(buf);
+                Assert.False(hash.IsReset);
+
+                // TryGetCurrentHash in turn asserts that buf got Sliced down to HashLengthInBytes.
+                Assert.True(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(hash.HashLengthInBytes, written);
+                Assert.True(hash.IsReset);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+            Assert.True(hash.IsReset);
+        }
+
+        [Fact]
+        public static void GetHashAndReset_TooSmall()
+        {
+            byte[] buf = new byte[7];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            for (int i = 0; i <= buf.Length; i++)
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "destination",
+                    () => hash.GetHashAndReset(buf.AsSpan(i)));
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void GetHashAndReset_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(buf.Length / 2);
+            int i = 0;
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+
+                hash.Append(buf);
+                Assert.False(hash.IsReset);
+
+                Assert.True(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(hash.HashLengthInBytes, written);
+                Assert.True(hash.IsReset);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(i, hash.GetCurrentHashCoreCallCount);
+            Assert.True(hash.IsReset);
+        }
+
+        [Fact]
+        public static void AllocatingGetHashAndReset_CorrectSize()
+        {
+            FlexibleAlgorithm hash = new FlexibleAlgorithm(12);
+            byte[] ret = hash.GetHashAndReset();
+            Assert.Equal(hash.HashLengthInBytes, ret.Length);
+            Assert.Equal(1, hash.GetCurrentHashCoreCallCount);
+        }
+
+        [Fact]
+        public static void OverriddenTryGetHashAndReset_TooSmall()
+        {
+            Span<byte> buf = stackalloc byte[7];
+            var hash = new FlexibleAlgorithmOverride(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            while (true)
+            {
+                Assert.False(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(0, written);
+
+                if (buf.IsEmpty)
+                {
+                    break;
+                }
+
+                buf = buf.Slice(1);
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(0, hash.GetHashAndResetCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void OverriddenTryGetHashAndReset_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            var hash = new FlexibleAlgorithmOverride(buf.Length / 2);
+            int i = 0;
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+                Assert.Equal(i, hash.GetHashAndResetCoreCallCount);
+
+                hash.Append(buf);
+                Assert.False(hash.IsReset);
+
+                // TryGetCurrentHash in turn asserts that buf got Sliced down to HashLengthInBytes.
+                Assert.True(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(hash.HashLengthInBytes, written);
+                Assert.True(hash.IsReset);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(i, hash.GetHashAndResetCoreCallCount);
+            Assert.True(hash.IsReset);
+        }
+
+        [Fact]
+        public static void OverriddenGetHashAndReset_TooSmall()
+        {
+            byte[] buf = new byte[7];
+            var hash = new FlexibleAlgorithmOverride(buf.Length + 1);
+
+            Assert.True(hash.IsReset);
+            hash.Append(buf);
+            Assert.False(hash.IsReset);
+
+            for (int i = 0; i <= buf.Length; i++)
+            {
+                AssertExtensions.Throws<ArgumentException>(
+                    "destination",
+                    () => hash.GetHashAndReset(buf.AsSpan(i)));
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(0, hash.GetHashAndResetCoreCallCount);
+            Assert.False(hash.IsReset);
+        }
+
+        [Fact]
+        public static void OverriddenGetHashAndReset_TooBig_Succeeds()
+        {
+            Span<byte> buf = stackalloc byte[16];
+            var hash = new FlexibleAlgorithmOverride(buf.Length / 2);
+            int i = 0;
+
+            while (buf.Length > hash.HashLengthInBytes)
+            {
+                Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+                Assert.Equal(i, hash.GetHashAndResetCoreCallCount);
+
+                hash.Append(buf);
+                Assert.False(hash.IsReset);
+
+                Assert.True(hash.TryGetHashAndReset(buf, out int written));
+                Assert.Equal(hash.HashLengthInBytes, written);
+                Assert.True(hash.IsReset);
+
+                buf = buf.Slice(1);
+                i++;
+            }
+
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(i, hash.GetHashAndResetCoreCallCount);
+            Assert.True(hash.IsReset);
+        }
+
+        [Fact]
+        public static void OverriddenAllocatingGetHashAndReset_CorrectSize()
+        {
+            var hash = new FlexibleAlgorithmOverride(12);
+            byte[] ret = hash.GetHashAndReset();
+            Assert.Equal(hash.HashLengthInBytes, ret.Length);
+            Assert.Equal(0, hash.GetCurrentHashCoreCallCount);
+            Assert.Equal(1, hash.GetHashAndResetCoreCallCount);
+        }
+
+        [Fact]
+        public static void AppendNullArrayThrows()
+        {
+            NonCryptographicHashAlgorithm hash = new FlexibleAlgorithm(5);
+            AssertExtensions.Throws<ArgumentNullException>("source", () => hash.Append((byte[])null));
+        }
+
+        [Fact]
+        public static void AppendNullStreamThrows()
+        {
+            NonCryptographicHashAlgorithm hash = new FlexibleAlgorithm(5);
+            AssertExtensions.Throws<ArgumentNullException>("stream", () => hash.Append((Stream)null));
+        }
+
+        [Fact]
+        public static void AppendAsyncNullStreamThrows_OutsideTask()
+        {
+            NonCryptographicHashAlgorithm hash = new FlexibleAlgorithm(5);
+            AssertExtensions.Throws<ArgumentNullException>("stream", () => hash.AppendAsync(null));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(511)]
+        [InlineData(4097)]
+        [InlineData(1048581)]
+        public static void AppendStreamSanityTest(int streamSize)
+        {
+            NonCryptographicHashAlgorithm hash = new CountingAlgorithm();
+
+            using (PositionValueStream stream = new PositionValueStream(streamSize))
+            {
+                hash.Append(stream);
+            }
+
+            Span<byte> val = stackalloc byte[sizeof(int)];
+            hash.GetHashAndReset(val);
+            int res = BinaryPrimitives.ReadInt32LittleEndian(val);
+            Assert.Equal(streamSize, res);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(511)]
+        [InlineData(4097)]
+        [InlineData(1048581)]
+        public static async Task AppendStreamAsyncSanityTest(int streamSize)
+        {
+            NonCryptographicHashAlgorithm hash = new CountingAlgorithm();
+
+            using (PositionValueStream stream = new PositionValueStream(streamSize))
+            {
+                await hash.AppendAsync(stream);
+            }
+
+            byte[] val = new byte[sizeof(int)];
+            hash.GetHashAndReset(val);
+            int res = BinaryPrimitives.ReadInt32LittleEndian(val);
+            Assert.Equal(streamSize, res);
+        }
+
+        [Fact]
+        public static void AppendStreamAsyncSupportsCancellation()
+        {
+            NonCryptographicHashAlgorithm hash = new CountingAlgorithm();
+
+            using (PositionValueStream stream = new PositionValueStream(21))
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                Task task = hash.AppendAsync(stream, cts.Token);
+                Assert.True(task.IsCompleted);
+                Assert.True(task.IsCanceled);
+            }
+
+            byte[] val = new byte[sizeof(int)];
+            hash.GetHashAndReset(val);
+            int res = BinaryPrimitives.ReadInt32LittleEndian(val);
+            Assert.Equal(0, res);
+        }
+
+        [Fact]
+        public static void GetHashCode_NotSupported()
+        {
+            NonCryptographicHashAlgorithm hash = new CountingAlgorithm();
+            Assert.Throws<NotSupportedException>(() => hash.GetHashCode());
+        }
+        private sealed class CountingAlgorithm : NonCryptographicHashAlgorithm
+        {
+            private int _count;
+
+            public CountingAlgorithm()
+                : base(sizeof(int))
+            {
+            }
+
+            public override void Append(ReadOnlySpan<byte> source)
+            {
+                _count += source.Length;
+            }
+
+            public override void Reset()
+            {
+                _count = 0;
+            }
+
+            protected override void GetCurrentHashCore(Span<byte> destination)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(destination, _count);
+            }
+        }
+
+        private sealed class FlexibleAlgorithm : NonCryptographicHashAlgorithm
+        {
+            public bool IsReset { get; private set; }
+            public int GetCurrentHashCoreCallCount { get; private set; }
+
+            public FlexibleAlgorithm(int hashLengthInBytes)
+                : base(hashLengthInBytes)
+            {
+                Reset();
+            }
+
+            public override void Append(ReadOnlySpan<byte> source)
+            {
+                if (source.Length > 0)
+                {
+                    IsReset = false;
+                }
+            }
+
+            public override void Reset()
+            {
+                IsReset = true;
+            }
+
+            protected override void GetCurrentHashCore(Span<byte> destination)
+            {
+                Assert.Equal(HashLengthInBytes, destination.Length);
+                destination.Fill((byte)GetCurrentHashCoreCallCount);
+                GetCurrentHashCoreCallCount++;
+            }
+        }
+
+        private sealed class FlexibleAlgorithmOverride : NonCryptographicHashAlgorithm
+        {
+            public bool IsReset { get; private set; }
+            public int GetCurrentHashCoreCallCount { get; private set; }
+            public int GetHashAndResetCoreCallCount { get; private set; }
+
+            public FlexibleAlgorithmOverride(int hashLengthInBytes)
+                : base(hashLengthInBytes)
+            {
+                Reset();
+            }
+
+            public override void Append(ReadOnlySpan<byte> source)
+            {
+                if (source.Length > 0)
+                {
+                    IsReset = false;
+                }
+            }
+
+            public override void Reset()
+            {
+                IsReset = true;
+            }
+
+            protected override void GetCurrentHashCore(Span<byte> destination)
+            {
+                Assert.Equal(HashLengthInBytes, destination.Length);
+                destination.Fill(0xFE);
+                GetCurrentHashCoreCallCount++;
+            }
+
+            protected override void GetHashAndResetCore(Span<byte> destination)
+            {
+                Assert.Equal(HashLengthInBytes, destination.Length);
+                destination.Fill(0xFE);
+                Reset();
+                GetHashAndResetCoreCallCount++;
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
+++ b/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
@@ -1,0 +1,361 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public abstract class NonCryptoHashTestDriver
+    {
+        private readonly int _hashLengthInBytes;
+        private readonly byte[] _emptyHash;
+        private string _emptyHashHex;
+
+        protected NonCryptoHashTestDriver(byte[] emptyHash)
+        {
+            _hashLengthInBytes = emptyHash.Length;
+            _emptyHash = emptyHash;
+        }
+
+        protected abstract NonCryptographicHashAlgorithm CreateInstance();
+
+        protected abstract byte[] StaticOneShot(byte[] source);
+        protected abstract byte[] StaticOneShot(ReadOnlySpan<byte> source);
+        protected abstract int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination);
+
+        protected abstract bool TryStaticOneShot(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten);
+
+        [Fact]
+        public void TestsDefined()
+        {
+            const string DriverSuffix = "Driver";
+            Type implType = GetType();
+            Type defType = typeof(NonCryptoHashTestDriver);
+            List<string>? missingMethods = null;
+
+            foreach (MethodInfo info in defType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if (info.IsFamily && info.Name.EndsWith(DriverSuffix, StringComparison.Ordinal))
+                {
+                    string targetMethodName = info.Name.Substring(0, info.Name.Length - DriverSuffix.Length);
+
+                    MethodInfo info2 = implType.GetMethod(
+                        targetMethodName,
+                        BindingFlags.Instance | BindingFlags.Public);
+
+                    if (info2 is null)
+                    {
+                        missingMethods ??= new List<string>();
+                        missingMethods.Add(targetMethodName);
+                    }
+                }
+            }
+
+            if (missingMethods is not null)
+            {
+                Assert.Empty(missingMethods);
+            }
+        }
+
+        [Fact]
+        public void VerifyLengthProperty()
+        {
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            Assert.Equal(_hashLengthInBytes, hash.HashLengthInBytes);
+        }
+
+        protected void InstanceAppendAllocateDriver(TestCase testCase)
+        {
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            hash.Append(testCase.Input);
+            byte[] output = hash.GetCurrentHash();
+
+            Assert.Equal(testCase.OutputHex, TestCase.ToHexString(output));
+        }
+
+        protected void InstanceAppendAllocateAndResetDriver(TestCase testCase)
+        {
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            hash.Append(testCase.Input);
+            byte[] output = hash.GetHashAndReset();
+
+            Assert.Equal(testCase.OutputHex, TestCase.ToHexString(output));
+
+            int written = hash.GetHashAndReset(output);
+            Assert.Equal(output.Length, written);
+            VerifyEmptyResult(output);
+        }
+
+        protected void InstanceMultiAppendGetCurrentHashDriver(TestCase testCase)
+        {
+            ReadOnlySpan<byte> source = testCase.Input;
+            int div3 = source.Length / 3;
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            hash.Append(source.Slice(0, div3));
+            source = source.Slice(div3);
+            hash.Append(source.Slice(0, div3));
+            source = source.Slice(div3);
+            hash.Append(source);
+
+            Span<byte> buf = stackalloc byte[256];
+
+            // May as well check unaligned writes.
+            Span<byte> destination = buf.Slice(1);
+            int written = hash.GetCurrentHash(destination);
+            ReadOnlySpan<byte> answer = destination.Slice(0, written);
+
+            testCase.VerifyResponse(answer);
+
+            destination.Clear();
+            hash.GetCurrentHash(destination);
+            testCase.VerifyResponse(answer);
+        }
+
+        protected void InstanceVerifyEmptyStateDriver(TestCase testCase)
+        {
+            Span<byte> buf = stackalloc byte[256];
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            int written = hash.GetCurrentHash(buf);
+            VerifyEmptyResult(buf.Slice(0, written));
+
+            written = hash.GetHashAndReset(buf);
+            VerifyEmptyResult(buf.Slice(0, written));
+        }
+
+        protected void InstanceVerifyResetStateDriver(TestCase testCase)
+        {
+            NonCryptographicHashAlgorithm hash = CreateInstance();
+            Span<byte> buf = stackalloc byte[233];
+            int written = hash.GetHashAndReset(buf);
+            ReadOnlySpan<byte> ret = buf.Slice(0, written);
+            VerifyEmptyResult(ret);
+
+            hash.Append(testCase.Input);
+            hash.Reset();
+            hash.GetCurrentHash(buf);
+            VerifyEmptyResult(ret);
+
+            // Manual call to Reset while already in a pristine state.
+            hash.Reset();
+            hash.GetCurrentHash(buf);
+            VerifyEmptyResult(ret);
+
+            hash.Append(testCase.Input);
+            hash.GetHashAndReset(buf);
+            testCase.VerifyResponse(ret);
+
+            hash.GetHashAndReset(buf);
+            VerifyEmptyResult(ret);
+        }
+
+        [Fact]
+        public void StaticOneShotNullArrayThrows()
+        {
+            AssertExtensions.Throws<ArgumentNullException>(
+                "source",
+                () => StaticOneShot((byte[])null));
+        }
+
+        protected void StaticVerifyOneShotArrayDriver(TestCase testCase)
+        {
+            byte[] answer = StaticOneShot(testCase.Input.ToArray());
+            testCase.VerifyResponse(answer);
+        }
+
+        protected void StaticVerifyOneShotSpanToArrayDriver(TestCase testCase)
+        {
+            byte[] answer = StaticOneShot(testCase.Input);
+            testCase.VerifyResponse(answer);
+        }
+
+        protected void StaticVerifyOneShotSpanToSpanDriver(TestCase testCase)
+        {
+            Span<byte> destination = stackalloc byte[256];
+
+            int written = StaticOneShot(testCase.Input, destination);
+            testCase.VerifyResponse(destination.Slice(0, written));
+        }
+
+        protected void StaticVerifyTryOneShotDriver(TestCase testCase)
+        {
+            Span<byte> destination = stackalloc byte[256];
+
+            Assert.True(TryStaticOneShot(testCase.Input, destination, out int written));
+            testCase.VerifyResponse(destination.Slice(0, written));
+        }
+
+        [Fact]
+        public void StaticVerifyOneShotSpanTooShortThrows()
+        {
+            byte[] destination = new byte[256];
+
+            for (int i = 0; i < _hashLengthInBytes; i++)
+            {
+                byte fill = (byte)~i;
+                destination.AsSpan().Fill(fill);
+
+                AssertExtensions.Throws<ArgumentException>(
+                    "destination",
+                    () => StaticOneShot(ReadOnlySpan<byte>.Empty, destination.AsSpan(0, i)));
+
+                for (int j = 0; j < destination.Length; j++)
+                {
+                    Assert.Equal(fill, destination[j]);
+                }
+            }
+        }
+
+        [Fact]
+        public void StaticVerifyOneShotSpanTooLongNoOverwrite()
+        {
+            Span<byte> buf = stackalloc byte[256];
+
+            for (int i = 10; i < 40; i++)
+            {
+                buf.Fill((byte)i);
+
+                int written = StaticOneShot(buf.Slice(0, i), buf.Slice(i));
+                Assert.Equal(_hashLengthInBytes, written);
+
+                for (int j = i + written; j < buf.Length; j++)
+                {
+                    Assert.Equal(i, buf[j]);
+                }
+            }
+        }
+
+        [Fact]
+        public void StaticVerifyTryOneShotSpanTooLongNoOverwrite()
+        {
+            Span<byte> buf = stackalloc byte[256];
+
+            for (int i = 10; i < 40; i++)
+            {
+                buf.Fill((byte)i);
+
+                Assert.True(TryStaticOneShot(buf.Slice(0, i), buf.Slice(i), out int written));
+                Assert.Equal(_hashLengthInBytes, written);
+
+                for (int j = i + written; j < buf.Length; j++)
+                {
+                    Assert.Equal(i, buf[j]);
+                }
+            }
+        }
+
+        [Fact]
+        public void StaticVerifyTryOneShotSpanTooShortNoWrites()
+        {
+            Span<byte> buf = stackalloc byte[256];
+
+            for (int i = 0; i < _hashLengthInBytes; i++)
+            {
+                byte fill = (byte)~i;
+                buf.Fill(fill);
+
+                Assert.False(TryStaticOneShot(ReadOnlySpan<byte>.Empty, buf.Slice(0, i), out int written));
+                Assert.Equal(0, written);
+
+                for (int j = 0; j < buf.Length; j++)
+                {
+                    Assert.Equal(fill, buf[j]);
+                }
+            }
+        }
+
+        private void VerifyEmptyResult(ReadOnlySpan<byte> result)
+        {
+            if (!result.SequenceEqual(_emptyHash))
+            {
+                // We know this will fail, but it gives a nice presentation.
+
+                Assert.Equal(
+                    _emptyHashHex ??= TestCase.ToHexString(_emptyHash),
+                    TestCase.ToHexString(result));
+            }
+        }
+
+        public sealed class TestCase
+        {
+            private byte[] _input;
+            private byte[] _output;
+
+            public string Name { get; }
+            public ReadOnlySpan<byte> Input => new ReadOnlySpan<byte>(_input);
+            public string OutputHex { get; }
+
+            public TestCase(string name, byte[] input, byte[] output)
+            {
+                Name = name;
+                _input = input;
+                OutputHex = ToHexString(output);
+                _output = FromHexString(OutputHex);
+            }
+
+            public TestCase(string name, byte[] input, string outputHex)
+            {
+                Name = name;
+                _input = input;
+                OutputHex = outputHex.ToUpperInvariant();
+                _output = FromHexString(OutputHex);
+            }
+
+            public TestCase(string name, string inputHex, string outputHex)
+            {
+                Name = name;
+                _input = FromHexString(inputHex);
+                OutputHex = outputHex.ToUpperInvariant();
+                _output = FromHexString(OutputHex);
+            }
+
+            internal void VerifyResponse(ReadOnlySpan<byte> response)
+            {
+                if (!response.SequenceEqual(_output))
+                {
+                    // We know this will fail, but it gives a nice presentation.
+                    Assert.Equal(OutputHex, ToHexString(response));
+                }
+            }
+
+            internal static string ToHexString(ReadOnlySpan<byte> input)
+            {
+#if NET5_0_OR_GREATER
+                return Convert.ToHexString(input);
+#else
+                var builder = new global::System.Text.StringBuilder(input.Length * 2);
+
+                foreach (byte b in input)
+                {
+                    builder.Append(b.ToString("X2"));
+                }
+
+                return builder.ToString();
+#endif
+            }
+
+            internal static byte[] FromHexString(string hexString)
+            {
+#if NET5_0_OR_GREATER
+                return Convert.FromHexString(hexString);
+#else
+                byte[] bytes = new byte[hexString.Length / 2];
+
+                for (int i = 0; i < hexString.Length; i += 2)
+                {
+                    string s = hexString.Substring(i, 2);
+                    bytes[i / 2] = byte.Parse(s, global::System.Globalization.NumberStyles.HexNumber, null);
+                }
+
+                return bytes;
+#endif
+            }
+
+            public override string ToString() => Name;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Crc32Tests.cs" />
+    <Compile Include="NonCryptoHashBaseTests.cs" />
+    <Compile Include="NonCryptoHashTestDriver.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
+      <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.IO.Hashing.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Crc32Tests.cs" />
+    <Compile Include="Crc64Tests.cs" />
     <Compile Include="NonCryptoHashBaseTests.cs" />
     <Compile Include="NonCryptoHashTestDriver.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -8,6 +8,7 @@
     <Compile Include="Crc64Tests.cs" />
     <Compile Include="NonCryptoHashBaseTests.cs" />
     <Compile Include="NonCryptoHashTestDriver.cs" />
+    <Compile Include="XxHash32Tests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -9,6 +9,7 @@
     <Compile Include="NonCryptoHashBaseTests.cs" />
     <Compile Include="NonCryptoHashTestDriver.cs" />
     <Compile Include="XxHash32Tests.cs" />
+    <Compile Include="XxHash64Tests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -9,7 +9,11 @@
     <Compile Include="NonCryptoHashBaseTests.cs" />
     <Compile Include="NonCryptoHashTestDriver.cs" />
     <Compile Include="XxHash32Tests.cs" />
+    <Compile Include="XxHash32Tests.007.cs" />
+    <Compile Include="XxHash32Tests.f00d.cs" />
     <Compile Include="XxHash64Tests.cs" />
+    <Compile Include="XxHash64Tests.007.cs" />
+    <Compile Include="XxHash64Tests.f00d.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash32Tests_Seeded_007 : NonCryptoHashTestDriver
+    {
+        private int Seed = 0x007_007_00;
+
+        private static readonly byte[] s_emptyHashValue = new byte[] { 0xC4, 0xD2, 0x6D, 0x9A };
+
+        public XxHash32Tests_Seeded_007()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string DotNetHashesThis = ".NET Hashes This!";
+        private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                // Same inputs as the main XxHash32 tests, but with the seed applied.
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "21C69E3A"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "558D024f"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "E7D2C0A7"),
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "D46070BB"),
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "4256C97B"),
+                new TestCase(
+                    "12345678901234567890",
+                    "3132333435363738393031323334353637383930",
+                    "A57B8FEE"),
+                new TestCase(
+                    "123456789012345678901",
+                    "313233343536373839303132333435363738393031",
+                    "6789AD70"),
+                new TestCase(
+                    $"{DotNetHashesThis} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetHashesThis3),
+                    "C5231E05"),
+                new TestCase(
+                    $"{DotNetNCHashing} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetNCHashing3),
+                    "CABC8ABD"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source, Seed);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash32.Hash(source, Seed);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash32.Hash(source, destination, Seed);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash32.TryHash(source, destination, out bytesWritten, Seed);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash32Tests : NonCryptoHashTestDriver
+    {
+        private static readonly byte[] s_emptyHashValue = new byte[] { 0x02, 0xCC, 0x5D, 0x05 };
+
+        public XxHash32Tests()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string DotNetHashesThis = ".NET Hashes This!";
+        private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "E2293B2F"),
+                //https://asecuritysite.com/encryption/xxHash, Example 2
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "E85EA4DE"),
+                //https://asecuritysite.com/encryption/xxHash, Example 3
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "68D039C8"),
+
+                // Manual exploration to force boundary conditions in code coverage.
+                // Output values produced by existing tools.
+
+                // The "in three pieces" test causes this to build up in the accumulator every time.
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "32D153FF"),
+                // Accumulates every time.
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "B7014066"),
+                // In the 3 pieces test, the third call to Append fills and process the holdback,
+                // then stores the remainder.
+                new TestCase(
+                    "12345678901234567890",
+                    "3132333435363738393031323334353637383930",
+                    "2D0C3D1B"),
+                // Same as above, but ends up with a byte that doesn't align to uints.
+                new TestCase(
+                    "123456789012345678901",
+                    "313233343536373839303132333435363738393031",
+                    "8ED1B04E"),
+                // 17 * 3 bytes long, in the "in three pieces" test each call to Append processes
+                // a lane and holds one byte.
+                new TestCase(
+                    $"{DotNetHashesThis} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetHashesThis3),
+                    "1FE08A04"),
+                // 31 * 3 bytes long.  In the "in three pieces" test the later calls to Append call
+                // into ProcessStripe with unaligned starts.
+                new TestCase(
+                    $"{DotNetNCHashing} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetNCHashing3),
+                    "65242024"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32();
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash32.Hash(source);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash32.Hash(source, destination);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash32.TryHash(source, destination, out bytesWritten);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash32Tests_Seeded_f00d : NonCryptoHashTestDriver
+    {
+        private int Seed = unchecked((int)0xF00D_F00D);
+
+        private static readonly byte[] s_emptyHashValue = new byte[] { 0x62, 0xB3, 0x2B, 0x9D };
+
+        public XxHash32Tests_Seeded_f00d()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string DotNetHashesThis = ".NET Hashes This!";
+        private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                // Same inputs as the main XxHash32 tests, but with the seed applied.
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "E8FF660B"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "C2B00BA1"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "11AC3BD7"),
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "BC85BB95"),
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "F549D3A7"),
+                new TestCase(
+                    "12345678901234567890",
+                    "3132333435363738393031323334353637383930",
+                    "E6173FEA"),
+                new TestCase(
+                    "123456789012345678901",
+                    "313233343536373839303132333435363738393031",
+                    "5F086DF1"),
+                new TestCase(
+                    $"{DotNetHashesThis} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetHashesThis3),
+                    "893F4A6F"),
+                new TestCase(
+                    $"{DotNetNCHashing} (x3)",
+                    Encoding.ASCII.GetBytes(DotNetNCHashing3),
+                    "5A513E6D"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source, Seed);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash32.Hash(source, Seed);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash32.Hash(source, destination, Seed);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash32.TryHash(source, destination, out bytesWritten, Seed);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash64Tests_Seeded_007 : NonCryptoHashTestDriver
+    {
+        private long Seed = 0x007_007_007_007_007;
+
+        private static readonly byte[] s_emptyHashValue =
+            new byte[] { 0x62, 0xAD, 0xCA, 0xD4, 0xEC, 0x80, 0x84, 0x0E };
+
+        public XxHash64Tests_Seeded_007()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string ThirtyThreeBytes = "This string has 33 ASCII bytes...";
+        private const string ThirtyThreeBytes3 = ThirtyThreeBytes + ThirtyThreeBytes + ThirtyThreeBytes;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
+        private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                // Same inputs as the main XxHash64 tests, but with the seed applied.
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "C86A41E2F34280A0"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "BB05857F11B054EB"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "618682461CB28F83"),
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "6BF4B26E3CA10C20"),
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "CA35E96DF53D4962"),
+                new TestCase(
+                    "1234567890123456789012345678901234567890",
+                    "31323334353637383930313233343536373839303132333435363738393031323334353637383930",
+                    "FA3195B38205C088"),
+                new TestCase(
+                    "12345678901234567890123456789012345678901",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031",
+                    "1980150281DF51A9"),
+                new TestCase(
+                    "12345678901234567890123456789012345678901234",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031323334",
+                    "4AE47735FD53BF97"),
+                new TestCase(
+                    DotNetNCHashing,
+                    Encoding.ASCII.GetBytes(DotNetNCHashing),
+                    "D3ECF5BFE5F49B6F"),
+                new TestCase(
+                    $"{ThirtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyThreeBytes3),
+                    "27C38ACA51CD2684"),
+                new TestCase(
+                    $"{SixtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixtyThreeBytes3),
+                    "D6095B93EB10BEDA"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64(Seed);
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash64.Hash(source, Seed);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash64.Hash(source, Seed);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash64.Hash(source, destination, Seed);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash64.TryHash(source, destination, out bytesWritten, Seed);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash64Tests : NonCryptoHashTestDriver
+    {
+        private static readonly byte[] s_emptyHashValue =
+            new byte[] { 0xEF, 0x46, 0xDB, 0x37, 0x51, 0xD8, 0xE9, 0x99 };
+
+        public XxHash64Tests()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string ThirtyThreeBytes = "This string has 33 ASCII bytes...";
+        private const string ThirtyThreeBytes3 = ThirtyThreeBytes + ThirtyThreeBytes + ThirtyThreeBytes;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
+        private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "FBCEA83C8A378BF1"),
+                //https://asecuritysite.com/encryption/xxHash, Example 2
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "0B242D361FDA71BC"),
+                //https://asecuritysite.com/encryption/xxHash, Example 3
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "44AD33705751AD73"),
+
+                // Manual exploration to force boundary conditions in code coverage.
+                // Output values produced by existing tools.
+
+                // The "in three pieces" test causes this to build up in the accumulator every time.
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "44BC2CF5AD770999"),
+                // Accumulates every time.
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "2B2DC38AAA53C322"),
+                // In the 3 pieces test, the third call to Append fills and process the holdback,
+                // then stores the remainder.
+                // The remainder is 40-32 = 8 bytes, so the Complete phase hits 1/0/0.
+                new TestCase(
+                    "1234567890123456789012345678901234567890",
+                    "31323334353637383930313233343536373839303132333435363738393031323334353637383930",
+                    "5F3AF5E23EEB431D"),
+                // Same as above, but ends up with a byte that doesn't align to ulongs (1/0/1)
+                new TestCase(
+                    "12345678901234567890123456789012345678901",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031",
+                    "45A03ED59AB5CAD6"),
+                // Same as above, but ends up with a spare uint (1/1/0)
+                new TestCase(
+                    "12345678901234567890123456789012345678901234",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031323334",
+                    "CA5C1B5B9061279F"),
+                // The maximum amount of remainder work, 31 bytes (3/1/3)
+                new TestCase(
+                    DotNetNCHashing,
+                    Encoding.ASCII.GetBytes(DotNetNCHashing),
+                    "D8444D7806DFDE0E"),
+                // 33 * 3 bytes long, in the "in three pieces" test each call to Append processes
+                // a lane and holds one byte.
+                new TestCase(
+                    $"{ThirtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyThreeBytes3),
+                    "488DF4E623587E10"),
+                // 63 * 3 bytes long.  In the "in three pieces" test the later calls to Append call
+                // into ProcessStripe with unaligned starts.
+                new TestCase(
+                    $"{SixtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixtyThreeBytes3),
+                    "239C7B3A85BD22B3"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64();
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash64.Hash(source);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash64.Hash(source);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash64.Hash(source, destination);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash64.TryHash(source, destination, out bytesWritten);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Hashing.Tests
+{
+    public class XxHash64Tests_Seeded_f00d : NonCryptoHashTestDriver
+    {
+        private long Seed = unchecked((long)0xF00D_F00D_F00D_F00D);
+
+        private static readonly byte[] s_emptyHashValue =
+            new byte[] { 0x01, 0x3F, 0x6A, 0x1B, 0xB3, 0x9C, 0x10, 0x87 };
+
+        public XxHash64Tests_Seeded_f00d()
+            : base(s_emptyHashValue)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (TestCase testCase in TestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        private const string ThirtyThreeBytes = "This string has 33 ASCII bytes...";
+        private const string ThirtyThreeBytes3 = ThirtyThreeBytes + ThirtyThreeBytes + ThirtyThreeBytes;
+        private const string DotNetNCHashing = ".NET now has non-crypto hashing";
+        private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
+        private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+
+        protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
+            new[]
+            {
+                // Same inputs as the main XxHash64 tests, but with the seed applied.
+                new TestCase(
+                    "Nobody inspects the spammish repetition",
+                    Encoding.ASCII.GetBytes("Nobody inspects the spammish repetition"),
+                    "76E6275980CF4E30"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
+                    "5CC25b2B8248DF76"),
+                new TestCase(
+                    "The quick brown fox jumps over the lazy dog.",
+                    Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog."),
+                    "10E8D9E4DA841407"),
+                new TestCase(
+                    "abc",
+                    Encoding.ASCII.GetBytes("abc"),
+                    "AE9DA0E407940A85"),
+                new TestCase(
+                    "123456",
+                    "313233343536",
+                    "99E249386C1EB47D"),
+                new TestCase(
+                    "1234567890123456789012345678901234567890",
+                    "31323334353637383930313233343536373839303132333435363738393031323334353637383930",
+                    "0DA1BD86FAAA1BC8"),
+                new TestCase(
+                    "12345678901234567890123456789012345678901",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031",
+                    "913DFB6C43C01EB3"),
+                new TestCase(
+                    "12345678901234567890123456789012345678901234",
+                    "3132333435363738393031323334353637383930313233343536373839303132333435363738393031323334",
+                    "F15334D3BCFC5841"),
+                new TestCase(
+                    DotNetNCHashing,
+                    Encoding.ASCII.GetBytes(DotNetNCHashing),
+                    "C5551996D9F3737F"),
+                new TestCase(
+                    $"{ThirtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyThreeBytes3),
+                    "6BD086C0CC425D9F"),
+                new TestCase(
+                    $"{SixtyThreeBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixtyThreeBytes3),
+                    "6F1C62EB48EA2FEC"),
+            };
+
+        protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64(Seed);
+
+        protected override byte[] StaticOneShot(byte[] source) => XxHash64.Hash(source, Seed);
+
+        protected override byte[] StaticOneShot(ReadOnlySpan<byte> source) => XxHash64.Hash(source, Seed);
+
+        protected override int StaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination) =>
+            XxHash64.Hash(source, destination, Seed);
+
+        protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
+            XxHash64.TryHash(source, destination, out bytesWritten, Seed);
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocate(TestCase testCase)
+        {
+            InstanceAppendAllocateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceAppendAllocateAndReset(TestCase testCase)
+        {
+            InstanceAppendAllocateAndResetDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
+        {
+            InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyEmptyState(TestCase testCase)
+        {
+            InstanceVerifyEmptyStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void InstanceVerifyResetState(TestCase testCase)
+        {
+            InstanceVerifyResetStateDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotArray(TestCase testCase)
+        {
+            StaticVerifyOneShotArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToArray(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToArrayDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyOneShotSpanToSpan(TestCase testCase)
+        {
+            StaticVerifyOneShotSpanToSpanDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void StaticVerifyTryOneShot(TestCase testCase)
+        {
+            StaticVerifyTryOneShotDriver(testCase);
+        }
+    }
+}

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -3602,6 +3602,12 @@
         "4.0.1.0": "4.3.0"
       }
     },
+    "System.IO.Hashing": {
+      "InboxOn": {},
+      "AssemblyVersionInPackageVersion": {
+        "6.0.0.0": "6.0.0"
+      }
+    },
     "System.IO.IsolatedStorage": {
       "StableVersions": [
         "4.0.0",

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -3602,12 +3602,6 @@
         "4.0.1.0": "4.3.0"
       }
     },
-    "System.IO.Hashing": {
-      "InboxOn": {},
-      "AssemblyVersionInPackageVersion": {
-        "6.0.0.0": "6.0.0"
-      }
-    },
     "System.IO.IsolatedStorage": {
       "StableVersions": [
         "4.0.0",


### PR DESCRIPTION
* Adds a new package, System.IO.Hashing (netstandard2.0, and net461 to reduce netfx restore graph sizes)
* Provides implementations for four hash algorithms
  * CRC-32 (the variation used by IEEE 802.3 (Ethernet))
  * CRC-64 (the variation used by ECMA-182)
  * XxHash32, with optional seed
  * XxHash64, with optional seed
* The tests are structured so that algorithm tests just need to provide their test vectors and do some boilerplate overrides to get variation testing across the instance methods and static methods.

Fixes #24328.