### PR TITLE
Add PlatformNeutralAssembly property for targeted builds of cross platform assembly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,7 +47,7 @@
     <MicrosoftCodeAnalysisVersion>3.8.0</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview6.21274.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview6.21281.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpVersion>
     <!-- Arcade dependencies -->

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -84,6 +84,11 @@
     </ItemGroup>
   </Target>
 
+  <!-- Add PlatformNeutralAssembly property for targeted builds of cross platform assemblies -->
+  <ItemGroup Condition="'$(TargetsAnyOS)' != 'true' and '$(IsTestProject)' != 'true' and '@(SupportedOSPlatforms)' == ''">
+    <CompilerVisibleProperty Include="PlatformNeutralAssembly" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- corefx has never generated these attributes so don't let the SDK generate them -->
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -101,7 +101,6 @@ namespace System.Net.Http
             return sslStream;
         }
 
-        // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -14,7 +14,6 @@ using System.Net.Security;
 
 namespace System.Net.Http
 {
-    // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ConnectionException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ConnectionException.cs
@@ -7,7 +7,6 @@ using System.Runtime.Versioning;
 namespace System.Net.Http
 {
     [Serializable]
-    // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ProtocolException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ProtocolException.cs
@@ -7,7 +7,6 @@ using System.Runtime.Versioning;
 namespace System.Net.Http
 {
     [Serializable]
-    // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -16,7 +16,6 @@ using System.Runtime.ExceptionServices;
 
 namespace System.Net.Http
 {
-    // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -667,7 +667,6 @@ namespace System.Net.Http
             }
         }
 
-        // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
@@ -767,7 +766,6 @@ namespace System.Net.Http
         }
 
         // Returns null if HTTP3 cannot be used.
-        // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -187,7 +187,6 @@ namespace System.Net.Http
 
         private byte[]? _http3SettingsFrame;
 
-        // TODO: SupportedOSPlatform doesn't work for internal APIs https://github.com/dotnet/runtime/issues/51305
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5023

When cross-platform assembly having targeted builds for specific platforms MSBuild would add an assembly-level attribute for that target which disables the API annotations inside the assembly by the "[child APIs should not extend parent platform support](https://github.com/dotnet/runtime/issues/43971)" rule. Even though it is an expected scenario by design it is unfortunate to not get any warning about this inconsistency or possible reference of incompatible APIs within the same assembly

For getting warnings in targeted builds in cross-platform assembly we need some way to distinguish between real platform-specific assembly and cross-platform assembly with platform-specific builds. For that, I used MSBuild `PlatformNeutralAssembly` property which we are adding into targeted builds of cross-platform assembly with this PR and updating the analyzer version which supports this property