### PR TITLE
Fix DeflateStream's handling of partial reads

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamTestBase.cs
@@ -54,6 +54,6 @@ namespace System.IO.Compression
         protected override Type UnsupportedReadWriteExceptionType => typeof(InvalidOperationException);
         protected override bool WrappedUsableAfterClose => false;
         protected override bool FlushRequiredToWriteData => true;
-        protected override bool FlushGuaranteesAllDataWritten => false;
+        protected override bool BlocksOnZeroByteReads => true;
     }
 }

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -65,6 +65,17 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        public static int ReadAllBytes(Stream stream, byte[] buffer, int offset, int count)
+        {
+            int bytesRead;
+            int totalRead = 0;
+            while ((bytesRead = stream.Read(buffer, offset + totalRead, count - totalRead)) != 0)
+            {
+                totalRead += bytesRead;
+            }
+            return totalRead;
+        }
+
         public static bool ArraysEqual<T>(T[] a, T[] b) where T : IComparable<T>
         {
             if (a.Length != b.Length) return false;
@@ -111,8 +122,8 @@ namespace System.IO.Compression.Tests
                 if (blocksToRead != -1 && blocksRead >= blocksToRead)
                     break;
 
-                ac = ast.Read(ad, 0, 4096);
-                bc = bst.Read(bd, 0, 4096);
+                ac = ReadAllBytes(ast, ad, 0, 4096);
+                bc = ReadAllBytes(bst, bd, 0, 4096);
 
                 if (ac != bc)
                 {
@@ -170,7 +181,7 @@ namespace System.IO.Compression.Tests
                         var buffer = new byte[entry.Length];
                         using (Stream entrystream = entry.Open())
                         {
-                            entrystream.Read(buffer, 0, buffer.Length);
+                            ReadAllBytes(entrystream, buffer, 0, buffer.Length);
 #if NETCOREAPP
                             uint zipcrc = entry.Crc32;
                             Assert.Equal(CRC.CalculateCRC(buffer), zipcrc);

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
@@ -173,7 +173,7 @@ namespace System.IO.Compression
 
         private void AsyncOperationStarting()
         {
-            if (Interlocked.CompareExchange(ref _activeAsyncOperation, 1, 0) != 0)
+            if (Interlocked.Exchange(ref _activeAsyncOperation, 1) != 0)
             {
                 ThrowInvalidBeginCall();
             }
@@ -181,13 +181,11 @@ namespace System.IO.Compression
 
         private void AsyncOperationCompleting()
         {
-            int oldValue = Interlocked.CompareExchange(ref _activeAsyncOperation, 0, 1);
-            Debug.Assert(oldValue == 1, $"Expected {nameof(_activeAsyncOperation)} to be 1, got {oldValue}");
+            Debug.Assert(_activeAsyncOperation == 1);
+            Volatile.Write(ref _activeAsyncOperation, 0);
         }
 
-        private static void ThrowInvalidBeginCall()
-        {
+        private static void ThrowInvalidBeginCall() =>
             throw new InvalidOperationException(SR.InvalidBeginCall);
-        }
     }
 }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -68,8 +68,8 @@ namespace System.IO.Compression
             Span<byte> output = new Span<byte>(_buffer);
             while (lastResult == OperationStatus.DestinationTooSmall)
             {
-                int bytesConsumed = 0;
-                int bytesWritten = 0;
+                int bytesConsumed;
+                int bytesWritten;
                 lastResult = _encoder.Compress(buffer, output, out bytesConsumed, out bytesWritten, isFinalBlock);
                 if (lastResult == OperationStatus.InvalidData)
                     throw new InvalidOperationException(SR.BrotliStream_Compress_InvalidData);
@@ -176,7 +176,7 @@ namespace System.IO.Compression
                 Span<byte> output = new Span<byte>(_buffer);
                 while (lastResult == OperationStatus.DestinationTooSmall)
                 {
-                    int bytesWritten = 0;
+                    int bytesWritten;
                     lastResult = _encoder.Flush(output, out bytesWritten);
                     if (lastResult == OperationStatus.InvalidData)
                         throw new InvalidDataException(SR.BrotliStream_Compress_InvalidData);

--- a/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
@@ -14,7 +14,8 @@ namespace System.IO.Compression
         public override Stream CreateStream(Stream stream, CompressionLevel level) => new BrotliStream(stream, level);
         public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new BrotliStream(stream, level, leaveOpen);
         public override Stream BaseStream(Stream stream) => ((BrotliStream)stream).BaseStream;
-        protected override bool ReadsMayBlockUntilBufferFullOrEOF => true;
+
+        protected override bool FlushGuaranteesAllDataWritten => false;
 
         // The tests are relying on an implementation detail of BrotliStream, using knowledge of its internal buffer size
         // in various test calculations.  Currently the implementation is using the ArrayPool, which will round up to a

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -104,12 +104,14 @@ namespace System.IO.Compression
             InitializeBuffer();
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void InitializeBuffer()
         {
             Debug.Assert(_buffer == null);
             _buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void EnsureBufferInitialized()
         {
             if (_buffer == null)
@@ -259,82 +261,93 @@ namespace System.IO.Compression
             EnsureDecompressionMode();
             EnsureNotDisposed();
             EnsureBufferInitialized();
-
-            int totalRead = 0;
-
             Debug.Assert(_inflater != null);
+
+            int bytesRead;
             while (true)
             {
-                int bytesRead = _inflater.Inflate(buffer.Slice(totalRead));
-                totalRead += bytesRead;
-                if (totalRead == buffer.Length)
+                // Try to decompress any data from the inflater into the caller's buffer.
+                // If we're able to decompress any bytes, or if decompression is completed, we're done.
+                bytesRead = _inflater.Inflate(buffer);
+                if (bytesRead != 0 || InflatorIsFinished)
                 {
                     break;
                 }
 
-                // If the stream is finished then we have a few potential cases here:
-                // 1. DeflateStream => return
-                // 2. GZipStream that is finished but may have an additional GZipStream appended => feed more input
-                // 3. GZipStream that is finished and appended with garbage => return
-                if (_inflater.Finished() && (!_inflater.IsGzipStream() || !_inflater.NeedsInput()))
-                {
-                    break;
-                }
-
+                // We were unable to decompress any data.  If the inflater needs additional input
+                // data to proceed, read some to populate it.
                 if (_inflater.NeedsInput())
                 {
-                    Debug.Assert(_buffer != null);
-                    int bytes = _stream.Read(_buffer, 0, _buffer.Length);
-                    if (bytes <= 0)
+                    int n = _stream.Read(_buffer, 0, _buffer.Length);
+                    if (n <= 0)
                     {
                         break;
                     }
-                    else if (bytes > _buffer.Length)
+                    else if (n > _buffer.Length)
                     {
-                        // The stream is either malicious or poorly implemented and returned a number of
-                        // bytes larger than the buffer supplied to it.
-                        throw new InvalidDataException(SR.GenericInvalidData);
+                        ThrowGenericInvalidData();
                     }
+                    else
+                    {
+                        _inflater.SetInput(_buffer, 0, n);
+                    }
+                }
 
-                    _inflater.SetInput(_buffer, 0, bytes);
+                if (buffer.IsEmpty)
+                {
+                    // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
+                    // a buffer until data is known to be available.  We don't have perfect knowledge here, as _inflater.Inflate
+                    // will return 0 whether or not more data is required, and having input data doesn't necessarily mean it'll
+                    // decompress into at least one byte of output, but it's a reasonable approximation for the 99% case.  If it's
+                    // wrong, it just means that a caller using zero-byte reads as a way to delay getting a buffer to use for a
+                    // subsequent call may end up getting one earlier than otherwise preferred.
+                    Debug.Assert(bytesRead == 0);
+                    break;
                 }
             }
 
-            return totalRead;
+            return bytesRead;
         }
+
+        private bool InflatorIsFinished =>
+            // If the stream is finished then we have a few potential cases here:
+            // 1. DeflateStream => return
+            // 2. GZipStream that is finished but may have an additional GZipStream appended => feed more input
+            // 3. GZipStream that is finished and appended with garbage => return
+            _inflater!.Finished() &&
+            (!_inflater.IsGzipStream() || !_inflater.NeedsInput());
 
         private void EnsureNotDisposed()
         {
             if (_stream == null)
                 ThrowStreamClosedException();
-        }
 
-        private static void ThrowStreamClosedException()
-        {
-            throw new ObjectDisposedException(nameof(DeflateStream), SR.ObjectDisposed_StreamClosed);
+            static void ThrowStreamClosedException() =>
+                throw new ObjectDisposedException(nameof(DeflateStream), SR.ObjectDisposed_StreamClosed);
         }
 
         private void EnsureDecompressionMode()
         {
             if (_mode != CompressionMode.Decompress)
                 ThrowCannotReadFromDeflateStreamException();
-        }
 
-        private static void ThrowCannotReadFromDeflateStreamException()
-        {
-            throw new InvalidOperationException(SR.CannotReadFromDeflateStream);
+            static void ThrowCannotReadFromDeflateStreamException() =>
+                throw new InvalidOperationException(SR.CannotReadFromDeflateStream);
         }
 
         private void EnsureCompressionMode()
         {
             if (_mode != CompressionMode.Compress)
                 ThrowCannotWriteToDeflateStreamException();
+
+            static void ThrowCannotWriteToDeflateStreamException() =>
+                throw new InvalidOperationException(SR.CannotWriteToDeflateStream);
         }
 
-        private static void ThrowCannotWriteToDeflateStreamException()
-        {
-            throw new InvalidOperationException(SR.CannotWriteToDeflateStream);
-        }
+        private static void ThrowGenericInvalidData() =>
+            // The stream is either malicious or poorly implemented and returned a number of
+            // bytes < 0 || > than the buffer supplied to it.
+            throw new InvalidDataException(SR.GenericInvalidData);
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
@@ -378,6 +391,7 @@ namespace System.IO.Compression
             }
 
             EnsureBufferInitialized();
+            Debug.Assert(_inflater != null);
 
             return Core(buffer, cancellationToken);
 
@@ -386,48 +400,49 @@ namespace System.IO.Compression
                 AsyncOperationStarting();
                 try
                 {
-                    int totalRead = 0;
-
-                    Debug.Assert(_inflater != null);
+                    int bytesRead;
                     while (true)
                     {
-                        int bytesRead = _inflater.Inflate(buffer.Span.Slice(totalRead));
-                        totalRead += bytesRead;
-                        if (totalRead == buffer.Length)
+                        // Try to decompress any data from the inflater into the caller's buffer.
+                        // If we're able to decompress any bytes, or if decompression is completed, we're done.
+                        bytesRead = _inflater.Inflate(buffer.Span);
+                        if (bytesRead != 0 || InflatorIsFinished)
                         {
                             break;
                         }
 
-                        // If the stream is finished then we have a few potential cases here:
-                        // 1. DeflateStream => return
-                        // 2. GZipStream that is finished but may have an additional GZipStream appended => feed more input
-                        // 3. GZipStream that is finished and appended with garbage => return
-                        if (_inflater.Finished() && (!_inflater.IsGzipStream() || !_inflater.NeedsInput()))
-                        {
-                            break;
-                        }
-
+                        // We were unable to decompress any data.  If the inflater needs additional input
+                        // data to proceed, read some to populate it.
                         if (_inflater.NeedsInput())
                         {
-                            Debug.Assert(_buffer != null);
-                            int bytes = await _stream.ReadAsync(_buffer, cancellationToken).ConfigureAwait(false);
-                            EnsureNotDisposed();
-                            if (bytes <= 0)
+                            int n = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer.Length), cancellationToken).ConfigureAwait(false);
+                            if (n <= 0)
                             {
                                 break;
                             }
-                            else if (bytes > _buffer.Length)
+                            else if (n > _buffer.Length)
                             {
-                                // The stream is either malicious or poorly implemented and returned a number of
-                                // bytes larger than the buffer supplied to it.
-                                throw new InvalidDataException(SR.GenericInvalidData);
+                                ThrowGenericInvalidData();
                             }
+                            else
+                            {
+                                _inflater.SetInput(_buffer, 0, n);
+                            }
+                        }
 
-                            _inflater.SetInput(_buffer, 0, bytes);
+                        if (buffer.IsEmpty)
+                        {
+                            // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
+                            // a buffer until data is known to be available.  We don't have perfect knowledge here, as _inflater.Inflate
+                            // will return 0 whether or not more data is required, and having input data doesn't necessarily mean it'll
+                            // decompress into at least one byte of output, but it's a reasonable approximation for the 99% case.  If it's
+                            // wrong, it just means that a caller using zero-byte reads as a way to delay getting a buffer to use for a
+                            // subsequent call may end up getting one earlier than otherwise preferred.
+                            break;
                         }
                     }
 
-                    return totalRead;
+                    return bytesRead;
                 }
                 finally
                 {
@@ -1014,21 +1029,16 @@ namespace System.IO.Compression
 
         private void AsyncOperationStarting()
         {
-            if (Interlocked.CompareExchange(ref _activeAsyncOperation, 1, 0) != 0)
+            if (Interlocked.Exchange(ref _activeAsyncOperation, 1) != 0)
             {
                 ThrowInvalidBeginCall();
             }
         }
 
-        private void AsyncOperationCompleting()
-        {
-            int oldValue = Interlocked.CompareExchange(ref _activeAsyncOperation, 0, 1);
-            Debug.Assert(oldValue == 1, $"Expected {nameof(_activeAsyncOperation)} to be 1, got {oldValue}");
-        }
+        private void AsyncOperationCompleting() =>
+            Volatile.Write(ref _activeAsyncOperation, 0);
 
-        private static void ThrowInvalidBeginCall()
-        {
+        private static void ThrowInvalidBeginCall() =>
             throw new InvalidOperationException(SR.InvalidBeginCall);
-        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -123,7 +124,7 @@ namespace System.Security.Cryptography.Encoding.Tests
             using (var ms = new MemoryStream(inputBytes))
             using (var cs = new CryptoStream(ms, transform, CryptoStreamMode.Read))
             {
-                int bytesRead = cs.Read(outputBytes, 0, outputBytes.Length);
+                int bytesRead = ReadAll(cs, outputBytes);
                 string outputString = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesRead);
                 Assert.Equal(expected, outputString);
             }
@@ -195,7 +196,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 using (var ms = new MemoryStream(inputBytes))
                 using (var cs = new CryptoStream(ms, transform, CryptoStreamMode.Read))
                 {
-                    int bytesRead = cs.Read(outputBytes, 0, outputBytes.Length);
+                    int bytesRead = ReadAll(cs, outputBytes);
 
                     // Missing padding bytes not supported (no exception, however)
                     Assert.NotEqual(inputBytes.Length, bytesRead);
@@ -230,7 +231,7 @@ namespace System.Security.Cryptography.Encoding.Tests
             using (var ms = new MemoryStream(inputBytes))
             using (var cs = new CryptoStream(ms, base64Transform, CryptoStreamMode.Read))
             {
-                int bytesRead = cs.Read(outputBytes, 0, outputBytes.Length);
+                int bytesRead = ReadAll(cs, outputBytes);
                 string outputString = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesRead);
                 Assert.Equal(expected, outputString);
             }
@@ -240,7 +241,7 @@ namespace System.Security.Cryptography.Encoding.Tests
             using (var ms = new MemoryStream(inputBytes))
             using (var cs = new CryptoStream(ms, base64Transform, CryptoStreamMode.Read))
             {
-                int bytesRead = cs.Read(outputBytes, 0, outputBytes.Length);
+                int bytesRead = ReadAll(cs, outputBytes);
                 string outputString = Text.Encoding.ASCII.GetString(outputBytes, 0, bytesRead);
                 Assert.Equal(expected, outputString);
             }
@@ -292,6 +293,23 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.True(transform.CanTransformMultipleBlocks);
                 Assert.True(transform.CanReuseTransform);
             }
+        }
+
+        private static int ReadAll(Stream stream, Span<byte> buffer)
+        {
+            int totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                int bytesRead = stream.Read(buffer.Slice(totalRead));
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalRead += bytesRead;
+            }
+
+            return totalRead;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -16,10 +16,10 @@ namespace System.Security.Cryptography
         // Member variables
         private readonly Stream _stream;
         private readonly ICryptoTransform _transform;
-        private byte[]? _inputBuffer;  // read from _stream before _Transform
+        private byte[] _inputBuffer;  // read from _stream before _Transform
         private int _inputBufferIndex;
         private int _inputBlockSize;
-        private byte[]? _outputBuffer; // buffered output of _Transform
+        private byte[] _outputBuffer; // buffered output of _Transform
         private int _outputBufferIndex;
         private int _outputBlockSize;
         private bool _canRead;
@@ -37,24 +37,41 @@ namespace System.Security.Cryptography
 
         public CryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode, bool leaveOpen)
         {
+            if (transform is null)
+            {
+                throw new ArgumentNullException(nameof(transform));
+            }
 
             _stream = stream;
             _transform = transform;
             _leaveOpen = leaveOpen;
+
             switch (mode)
             {
                 case CryptoStreamMode.Read:
-                    if (!(_stream.CanRead)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotReadable, nameof(stream)));
+                    if (!_stream.CanRead)
+                    {
+                        throw new ArgumentException(SR.Format(SR.Argument_StreamNotReadable, nameof(stream)));
+                    }
                     _canRead = true;
                     break;
+
                 case CryptoStreamMode.Write:
-                    if (!(_stream.CanWrite)) throw new ArgumentException(SR.Format(SR.Argument_StreamNotWritable, nameof(stream)));
+                    if (!_stream.CanWrite)
+                    {
+                        throw new ArgumentException(SR.Format(SR.Argument_StreamNotWritable, nameof(stream)));
+                    }
                     _canWrite = true;
                     break;
+
                 default:
-                    throw new ArgumentException(SR.Argument_InvalidValue);
+                    throw new ArgumentException(SR.Argument_InvalidValue, nameof(mode));
             }
-            InitializeBuffer();
+
+            _inputBlockSize = _transform.InputBlockSize;
+            _inputBuffer = new byte[_inputBlockSize];
+            _outputBlockSize = _transform.OutputBlockSize;
+            _outputBuffer = new byte[_outputBlockSize];
         }
 
         public override bool CanRead
@@ -293,198 +310,149 @@ namespace System.Security.Cryptography
 
         private async ValueTask<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken, bool useAsync)
         {
-            // read <= count bytes from the input stream, transforming as we go.
-            // Basic idea: first we deliver any bytes we already have in the
-            // _OutputBuffer, because we know they're good.  Then, if asked to deliver
-            // more bytes, we read & transform a block at a time until either there are
-            // no bytes ready or we've delivered enough.
-            int bytesToDeliver = buffer.Length;
-            int currentOutputIndex = 0;
-            Debug.Assert(_outputBuffer != null);
-            if (_outputBufferIndex != 0)
+            while (true)
             {
-                // we have some already-transformed bytes in the output buffer
-                if (_outputBufferIndex <= buffer.Length)
+                // If there are currently any bytes stored in the output buffer, hand back as many as we can.
+                if (_outputBufferIndex != 0)
                 {
-                    _outputBuffer.AsSpan(0, _outputBufferIndex).CopyTo(buffer.Span);
-                    bytesToDeliver -= _outputBufferIndex;
-                    currentOutputIndex += _outputBufferIndex;
-                    int toClear = _outputBuffer.Length - _outputBufferIndex;
-                    CryptographicOperations.ZeroMemory(new Span<byte>(_outputBuffer, _outputBufferIndex, toClear));
-                    _outputBufferIndex = 0;
-                }
-                else
-                {
-                    _outputBuffer.AsSpan(0, buffer.Length).CopyTo(buffer.Span);
-                    Buffer.BlockCopy(_outputBuffer, buffer.Length, _outputBuffer, 0, _outputBufferIndex - buffer.Length);
-                    _outputBufferIndex -= buffer.Length;
-
-                    int toClear = _outputBuffer.Length - _outputBufferIndex;
-                    CryptographicOperations.ZeroMemory(new Span<byte>(_outputBuffer, _outputBufferIndex, toClear));
-
-                    return buffer.Length;
-                }
-            }
-            // _finalBlockTransformed == true implies we're at the end of the input stream
-            // if we got through the previous if block then _OutputBufferIndex = 0, meaning
-            // we have no more transformed bytes to give
-            // so return count-bytesToDeliver, the amount we were able to hand back
-            // eventually, we'll just always return 0 here because there's no more to read
-            if (_finalBlockTransformed)
-            {
-                return buffer.Length - bytesToDeliver;
-            }
-            // ok, now loop until we've delivered enough or there's nothing available
-            int amountRead = 0;
-            int numOutputBytes;
-
-            // OK, see first if it's a multi-block transform and we can speed up things
-            int blocksToProcess = bytesToDeliver / _outputBlockSize;
-
-            Debug.Assert(_inputBuffer != null);
-            if (blocksToProcess > 1 && _transform.CanTransformMultipleBlocks)
-            {
-                int numWholeBlocksInBytes = blocksToProcess * _inputBlockSize;
-
-                // Use ArrayPool.Shared instead of CryptoPool because the array is passed out.
-                byte[]? tempInputBuffer = ArrayPool<byte>.Shared.Rent(numWholeBlocksInBytes);
-                byte[]? tempOutputBuffer = null;
-
-                try
-                {
-                    amountRead = useAsync ?
-                        await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
-                        _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
-
-                    int totalInput = _inputBufferIndex + amountRead;
-
-                    // If there's still less than a block, copy the new data into the hold buffer and move to the slow read.
-                    if (totalInput < _inputBlockSize)
+                    int bytesToCopy = Math.Min(_outputBufferIndex, buffer.Length);
+                    if (bytesToCopy != 0)
                     {
-                        Buffer.BlockCopy(tempInputBuffer, _inputBufferIndex, _inputBuffer, _inputBufferIndex, amountRead);
-                        _inputBufferIndex = totalInput;
+                        // Copy as many bytes as we can, then shift down the remaining bytes.
+                        new ReadOnlySpan<byte>(_outputBuffer, 0, bytesToCopy).CopyTo(buffer.Span);
+                        _outputBufferIndex -= bytesToCopy;
+                        _outputBuffer.AsSpan(bytesToCopy).CopyTo(_outputBuffer);
+                        CryptographicOperations.ZeroMemory(_outputBuffer.AsSpan(_outputBufferIndex, bytesToCopy));
                     }
-                    else
+                    return bytesToCopy;
+                }
+
+                // If we've already hit the end of the stream, there's nothing more to do.
+                Debug.Assert(_outputBufferIndex == 0);
+                if (_finalBlockTransformed)
+                {
+                    Debug.Assert(_inputBufferIndex == 0);
+                    return 0;
+                }
+
+                int bytesRead = 0;
+                bool eof = false;
+
+                // If the transform supports transforming multiple blocks, try to read as large a chunk as would yield
+                // data to fill the output buffer and do the appropriate transform directly into the output buffer.
+                int blocksToProcess = buffer.Length / _outputBlockSize;
+                if (blocksToProcess > 1 && _transform.CanTransformMultipleBlocks)
+                {
+                    // Use ArrayPool.Shared instead of CryptoPool because the array is passed out.
+                    int numWholeBlocksInBytes = blocksToProcess * _inputBlockSize;
+                    byte[] tempInputBuffer = ArrayPool<byte>.Shared.Rent(numWholeBlocksInBytes);
+                    try
                     {
-                        // Copy any held data into tempInputBuffer now that we know we're proceeding
-                        Buffer.BlockCopy(_inputBuffer, 0, tempInputBuffer, 0, _inputBufferIndex);
-                        CryptographicOperations.ZeroMemory(new Span<byte>(_inputBuffer, 0, _inputBufferIndex));
-                        amountRead += _inputBufferIndex;
-                        _inputBufferIndex = 0;
+                        // Read into our temporary input buffer, leaving enough room at the beginning for any existing data
+                        // we have in _inputBuffer.
+                        bytesRead = useAsync ?
+                            await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
+                            _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
+                        eof = bytesRead == 0;
 
-                        // Make amountRead an integral multiple of _InputBlockSize
-                        int numWholeReadBlocks = amountRead / _inputBlockSize;
-                        int numWholeReadBlocksInBytes = numWholeReadBlocks * _inputBlockSize;
-                        int numIgnoredBytes = amountRead - numWholeReadBlocksInBytes;
-
-                        if (numIgnoredBytes != 0)
+                        // If we got enough data to form at least one block, transform as much as we can.
+                        int totalInput = _inputBufferIndex + bytesRead;
+                        if (totalInput >= _inputBlockSize)
                         {
-                            _inputBufferIndex = numIgnoredBytes;
-                            Buffer.BlockCopy(tempInputBuffer, numWholeReadBlocksInBytes, _inputBuffer, 0, numIgnoredBytes);
+                            // Copy any held data into tempInputBuffer now that we know we're proceeding to handle
+                            // decrypting all the received data.
+                            Buffer.BlockCopy(_inputBuffer, 0, tempInputBuffer, 0, _inputBufferIndex);
+                            CryptographicOperations.ZeroMemory(new Span<byte>(_inputBuffer, 0, _inputBufferIndex));
+                            bytesRead += _inputBufferIndex;
+
+                            // Determine how many entire blocks worth of data we read.
+                            int numWholeReadBlocks = bytesRead / _inputBlockSize;
+                            int numWholeReadBlocksInBytes = numWholeReadBlocks * _inputBlockSize;
+
+                            // If there's anything left over, copy that back into _inputBuffer for a later read.
+                            _inputBufferIndex = bytesRead - numWholeReadBlocksInBytes;
+                            if (_inputBufferIndex != 0)
+                            {
+                                Buffer.BlockCopy(tempInputBuffer, numWholeReadBlocksInBytes, _inputBuffer, 0, _inputBufferIndex);
+                            }
+
+                            // Transform the read data into the caller's buffer.
+                            int numOutputBytes;
+                            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> bufferArray))
+                            {
+                                // Because TransformBlock is based on arrays, we can only write directly into the output
+                                // buffer if it's backed by an array; otherwise, we need to rent from the pool.
+                                numOutputBytes = _transform.TransformBlock(tempInputBuffer, 0, numWholeReadBlocksInBytes, bufferArray.Array!, bufferArray.Offset);
+                            }
+                            else
+                            {
+                                // Otherwise, we need to rent a temporary from the pool.
+                                byte[] tempOutputBuffer = ArrayPool<byte>.Shared.Rent(numWholeReadBlocks * _outputBlockSize);
+                                numOutputBytes = numWholeReadBlocks * _outputBlockSize;
+                                try
+                                {
+                                    numOutputBytes = _transform.TransformBlock(tempInputBuffer, 0, numWholeReadBlocksInBytes, tempOutputBuffer, 0);
+                                    tempOutputBuffer.AsSpan(0, numOutputBytes).CopyTo(buffer.Span);
+                                }
+                                finally
+                                {
+                                    CryptographicOperations.ZeroMemory(new Span<byte>(tempOutputBuffer, 0, numOutputBytes));
+                                    ArrayPool<byte>.Shared.Return(tempOutputBuffer);
+                                }
+                            }
+
+                            // Return anything we've got at this point.
+                            if (numOutputBytes != 0)
+                            {
+                                return numOutputBytes;
+                            }
                         }
-
-                        // Use ArrayPool.Shared instead of CryptoPool because the array is passed out.
-                        tempOutputBuffer = ArrayPool<byte>.Shared.Rent(numWholeReadBlocks * _outputBlockSize);
-                        numOutputBytes = _transform.TransformBlock(tempInputBuffer, 0, numWholeReadBlocksInBytes, tempOutputBuffer, 0);
-                        tempOutputBuffer.AsSpan(0, numOutputBytes).CopyTo(buffer.Span.Slice(currentOutputIndex));
-
-                        // Clear what was written while we know how much that was
-                        CryptographicOperations.ZeroMemory(new Span<byte>(tempOutputBuffer, 0, numOutputBytes));
-                        ArrayPool<byte>.Shared.Return(tempOutputBuffer);
-                        tempOutputBuffer = null;
-
-                        bytesToDeliver -= numOutputBytes;
-                        currentOutputIndex += numOutputBytes;
+                        else
+                        {
+                            // We have less than a block's worth of data.  Copy the new data back into the _inputBuffer
+                            // and fall back to using the single block code path.
+                            Buffer.BlockCopy(tempInputBuffer, _inputBufferIndex, _inputBuffer, _inputBufferIndex, bytesRead);
+                            _inputBufferIndex = totalInput;
+                        }
                     }
-
-                    CryptographicOperations.ZeroMemory(new Span<byte>(tempInputBuffer, 0, numWholeBlocksInBytes));
-                    ArrayPool<byte>.Shared.Return(tempInputBuffer);
-                    tempInputBuffer = null;
-                }
-                catch
-                {
-                    // If we rented and then an exception happened we don't know how much was written to,
-                    // clear the whole thing and let it get reclaimed by the GC.
-                    if (tempOutputBuffer != null)
-                    {
-                        CryptographicOperations.ZeroMemory(tempOutputBuffer);
-                        tempOutputBuffer = null;
-                    }
-
-                    // For the input buffer we know how much was written, so clear that.
-                    // But still let it get reclaimed by the GC.
-                    if (tempInputBuffer != null)
+                    finally
                     {
                         CryptographicOperations.ZeroMemory(new Span<byte>(tempInputBuffer, 0, numWholeBlocksInBytes));
-                        tempInputBuffer = null;
+                        ArrayPool<byte>.Shared.Return(tempInputBuffer);
                     }
-
-                    throw;
-                }
-            }
-
-            // try to fill _InputBuffer so we have something to transform
-            while (bytesToDeliver > 0)
-            {
-                while (_inputBufferIndex < _inputBlockSize)
-                {
-                    amountRead = useAsync ?
-                        await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
-                        _stream.Read(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
-
-                    // first, check to see if we're at the end of the input stream
-                    if (amountRead == 0) goto ProcessFinalBlock;
-                    _inputBufferIndex += amountRead;
                 }
 
-                numOutputBytes = _transform.TransformBlock(_inputBuffer, 0, _inputBlockSize, _outputBuffer, 0);
-                _inputBufferIndex = 0;
-
-                if (bytesToDeliver >= numOutputBytes)
+                // Read enough to fill one input block, as anything less won't be able to be transformed to produce output.
+                if (!eof)
                 {
-                    _outputBuffer.AsSpan(0, numOutputBytes).CopyTo(buffer.Span.Slice(currentOutputIndex));
-                    CryptographicOperations.ZeroMemory(new Span<byte>(_outputBuffer, 0, numOutputBytes));
-                    currentOutputIndex += numOutputBytes;
-                    bytesToDeliver -= numOutputBytes;
+                    while (_inputBufferIndex < _inputBlockSize)
+                    {
+                        bytesRead = useAsync ?
+                            await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
+                            _stream.Read(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
+                        if (bytesRead <= 0)
+                        {
+                            break;
+                        }
+
+                        _inputBufferIndex += bytesRead;
+                    }
+                }
+
+                // Transform the received data.
+                if (bytesRead <= 0)
+                {
+                    _outputBuffer = _transform.TransformFinalBlock(_inputBuffer, 0, _inputBufferIndex);
+                    _outputBufferIndex = _outputBuffer.Length;
+                    _finalBlockTransformed = true;
                 }
                 else
                 {
-                    _outputBuffer.AsSpan(0, bytesToDeliver).CopyTo(buffer.Span.Slice(currentOutputIndex));
-                    _outputBufferIndex = numOutputBytes - bytesToDeliver;
-                    Buffer.BlockCopy(_outputBuffer, bytesToDeliver, _outputBuffer, 0, _outputBufferIndex);
-                    int toClear = _outputBuffer.Length - _outputBufferIndex;
-                    CryptographicOperations.ZeroMemory(new Span<byte>(_outputBuffer, _outputBufferIndex, toClear));
-                    return buffer.Length;
+                    _outputBufferIndex = _transform.TransformBlock(_inputBuffer, 0, _inputBufferIndex, _outputBuffer, 0);
                 }
-            }
-            return buffer.Length;
 
-        ProcessFinalBlock:
-            // if so, then call TransformFinalBlock to get whatever is left
-            byte[] finalBytes = _transform.TransformFinalBlock(_inputBuffer, 0, _inputBufferIndex);
-            // now, since _OutputBufferIndex must be 0 if we're in the while loop at this point,
-            // reset it to be what we just got back
-            _outputBuffer = finalBytes;
-            _outputBufferIndex = finalBytes.Length;
-            // set the fact that we've transformed the final block
-            _finalBlockTransformed = true;
-            // now, return either everything we just got or just what's asked for, whichever is smaller
-            if (bytesToDeliver < _outputBufferIndex)
-            {
-                _outputBuffer.AsSpan(0, bytesToDeliver).CopyTo(buffer.Span.Slice(currentOutputIndex));
-                _outputBufferIndex -= bytesToDeliver;
-                Buffer.BlockCopy(_outputBuffer, bytesToDeliver, _outputBuffer, 0, _outputBufferIndex);
-                int toClear = _outputBuffer.Length - _outputBufferIndex;
-                CryptographicOperations.ZeroMemory(new Span<byte>(_outputBuffer, _outputBufferIndex, toClear));
-                return buffer.Length;
-            }
-            else
-            {
-                _outputBuffer.AsSpan(0, _outputBufferIndex).CopyTo(buffer.Span.Slice(currentOutputIndex));
-                bytesToDeliver -= _outputBufferIndex;
-                _outputBufferIndex = 0;
-                CryptographicOperations.ZeroMemory(_outputBuffer);
-                return buffer.Length - bytesToDeliver;
+                // All input data has been processed.
+                _inputBufferIndex = 0;
             }
         }
 
@@ -807,8 +775,8 @@ namespace System.Security.Cryptography
                     if (_outputBuffer != null)
                         Array.Clear(_outputBuffer);
 
-                    _inputBuffer = null;
-                    _outputBuffer = null;
+                    _inputBuffer = null!;
+                    _outputBuffer = null!;
                     _canRead = false;
                     _canWrite = false;
                 }
@@ -858,27 +826,10 @@ namespace System.Security.Cryptography
                     Array.Clear(_outputBuffer);
                 }
 
-                _inputBuffer = null;
-                _outputBuffer = null;
+                _inputBuffer = null!;
+                _outputBuffer = null!;
                 _canRead = false;
                 _canWrite = false;
-            }
-        }
-
-        // Private methods
-
-        private void InitializeBuffer()
-        {
-            if (_transform != null)
-            {
-                _inputBlockSize = _transform.InputBlockSize;
-                _inputBuffer = new byte[_inputBlockSize];
-                _outputBlockSize = _transform.OutputBlockSize;
-                _outputBuffer = new byte[_outputBlockSize];
-            }
-            else
-            {
-                throw new ArgumentNullException(nameof(_transform));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -27,6 +27,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
         }
 
         protected override Type UnsupportedConcurrentExceptionType => null;
+        protected override bool BlocksOnZeroByteReads => true;
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45080")]
         [Theory]
@@ -37,7 +38,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
         public static void Ctor()
         {
             var transform = new IdentityTransform(1, 1, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => new CryptoStream(new MemoryStream(), transform, (CryptoStreamMode)12345));
+            AssertExtensions.Throws<ArgumentException>("mode", () => new CryptoStream(new MemoryStream(), transform, (CryptoStreamMode)12345));
             AssertExtensions.Throws<ArgumentException>(null, "stream", () => new CryptoStream(new MemoryStream(new byte[0], writable: false), transform, CryptoStreamMode.Write));
             AssertExtensions.Throws<ArgumentException>(null, "stream", () => new CryptoStream(new CryptoStream(new MemoryStream(new byte[0]), transform, CryptoStreamMode.Write), transform, CryptoStreamMode.Read));
         }


### PR DESCRIPTION
Stream.Read{Async} is supposed to return once at least a byte of data is available, and in particular, if there's any data already available, it shouldn't block.  But DeflateStream.Read{Async} won't return until either it hits the end of the stream or the caller's buffer is filled.  This makes it behave very unexpectedly when used in a context where the app is using a large read buffer but expects to be able to process data as it's available.

This fixes that by stopping looping once any data is consumed.  Just doing that, though, caused problems for zero-byte reads, so I've also addressed another issue in DeflateStream.  Zero-byte reads are typically used by code that's trying to delay allocating a buffer for the read data until data will be available to read.  At present, however, zero-byte reads return immediately regardless of whether data is available to be consumed.  I've changed the flow to make it so that zero-byte reads don't return until there's at least some data available as input to the inflater (this, though, doesn't 100% guarantee the inflater will be able to produce output data).

As part of this, I separated out some duplicated code, including a throw, and then fixed the style of other throw helpers nearby to match to the new one I was adding.  Finally, I changed the invalid-concurrency-checking to use Exchange rather than CompareExchange to make it a bit cheaper.

Fixes https://github.com/dotnet/runtime/issues/53502
cc: @geoffkizer, @ayende, @adamsitnik, @carlossanlop, @jozkee

I did some performance validation and don't see any meaningful negative impact.  The cost that could in theory cause us to regress is more entering/exiting of the ReadAsync async method, since we'll now exit out of it when we have any data vs staying inside it looping to fill the user buffer.  The flip side of that is if partial data is available, the consumer can act on it more quickly rather than waiting around for more data to arrive.