### PR TITLE
Resolving most of ILLink warnings on Microsoft.Extensions.Hosting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class OptionsBuilderExtensions
     {
-        public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> ValidateOnStart<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder) where TOptions : class { throw null; }
+        public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> ValidateOnStart<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder) where TOptions : class { throw null; }
     }
 }
 namespace Microsoft.Extensions.Hosting

--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.Hosting.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Abstractions\ref\Microsoft.Extensions.Configuration.Abstractions.csproj" />

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -198,32 +199,31 @@ namespace Microsoft.Extensions.Hosting
                 }
             });
 
-            builder.ConfigureAppConfiguration((hostingContext, config) =>
-            {
-                IHostEnvironment env = hostingContext.HostingEnvironment;
+                        builder.ConfigureAppConfiguration((hostingContext, config) =>
+                        {
+                            IHostEnvironment env = hostingContext.HostingEnvironment;
+                            bool reloadOnChange = GetReloadConfigOnChangeValue(hostingContext);
 
-                bool reloadOnChange = hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
+                            config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+                                  .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
 
-                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
-                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
+                            if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
+                            {
+                                var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                                if (appAssembly is not null)
+                                {
+                                    config.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
+                                }
+                            }
 
-                if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
-                {
-                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                    if (appAssembly is not null)
-                    {
-                        config.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
-                    }
-                }
+                            config.AddEnvironmentVariables();
 
-                config.AddEnvironmentVariables();
-
-                if (args is { Length: > 0 })
-                {
-                    config.AddCommandLine(args);
-                }
-            })
-            .ConfigureLogging((hostingContext, logging) =>
+                            if (args is { Length: > 0 })
+                            {
+                                config.AddCommandLine(args);
+                            }
+                        })
+.ConfigureLogging((hostingContext, logging) =>
             {
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -255,7 +255,7 @@ namespace Microsoft.Extensions.Hosting
                 });
 
             })
-            .UseDefaultServiceProvider((context, options) =>
+.UseDefaultServiceProvider((context, options) =>
             {
                 bool isDevelopment = context.HostingEnvironment.IsDevelopment();
                 options.ValidateScopes = isDevelopment;
@@ -263,6 +263,11 @@ namespace Microsoft.Extensions.Hosting
             });
 
             return builder;
+
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "Calling IConfiguration.GetValue is safe when the T is bool.")]
+            static bool GetReloadConfigOnChangeValue(HostBuilderContext hostingContext) =>
+                            hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -199,31 +199,31 @@ namespace Microsoft.Extensions.Hosting
                 }
             });
 
-                        builder.ConfigureAppConfiguration((hostingContext, config) =>
-                        {
-                            IHostEnvironment env = hostingContext.HostingEnvironment;
-                            bool reloadOnChange = GetReloadConfigOnChangeValue(hostingContext);
+            builder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                IHostEnvironment env = hostingContext.HostingEnvironment;
+                bool reloadOnChange = GetReloadConfigOnChangeValue(hostingContext);
 
-                            config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
-                                  .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
 
-                            if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
-                            {
-                                var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                                if (appAssembly is not null)
-                                {
-                                    config.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
-                                }
-                            }
+                if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
+                {
+                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                    if (appAssembly is not null)
+                    {
+                        config.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
+                    }
+                }
 
-                            config.AddEnvironmentVariables();
+                config.AddEnvironmentVariables();
 
-                            if (args is { Length: > 0 })
-                            {
-                                config.AddCommandLine(args);
-                            }
-                        })
-.ConfigureLogging((hostingContext, logging) =>
+                if (args is { Length: > 0 })
+                {
+                    config.AddCommandLine(args);
+                }
+            })
+            .ConfigureLogging((hostingContext, logging) =>
             {
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -255,7 +255,7 @@ namespace Microsoft.Extensions.Hosting
                 });
 
             })
-.UseDefaultServiceProvider((context, options) =>
+            .UseDefaultServiceProvider((context, options) =>
             {
                 bool isDevelopment = context.HostingEnvironment.IsDevelopment();
                 options.ValidateScopes = isDevelopment;
@@ -264,10 +264,8 @@ namespace Microsoft.Extensions.Hosting
 
             return builder;
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Calling IConfiguration.GetValue is safe when the T is bool.")]
-            static bool GetReloadConfigOnChangeValue(HostBuilderContext hostingContext) =>
-                            hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Calling IConfiguration.GetValue is safe when the T is bool.")]
+            static bool GetReloadConfigOnChangeValue(HostBuilderContext hostingContext) => hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/ILLink/ILLink.Suppressions.xml
@@ -5,31 +5,13 @@
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
-      <property name="Target">F:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.options</property>
+      <property name="Target">F:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass1_0`1.options</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_0`1.&lt;ValidateOnStart&gt;b__0(Microsoft.Extensions.DependencyInjection.ValidatorOptions,Microsoft.Extensions.Options.IOptionsMonitor{`0})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2091</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.&lt;&gt;c__DisplayClass0_1`1.&lt;ValidateOnStart&gt;b__1</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2091</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.OptionsBuilderExtensions.ValidateOnStart``1(Microsoft.Extensions.Options.OptionsBuilder{``0})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.&lt;&gt;c__DisplayClass11_0.&lt;ConfigureDefaults&gt;b__1(Microsoft.Extensions.Hosting.HostBuilderContext,Microsoft.Extensions.Configuration.IConfigurationBuilder)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\src\Microsoft.Extensions.Configuration.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Abstractions\src\Microsoft.Extensions.Configuration.Abstractions.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Binder\src\Microsoft.Extensions.Configuration.Binder.csproj" />


### PR DESCRIPTION
Resolving most of the warnings on Microsoft.Extensions.Hosting.

The last two warnings are not so easily suppressible today, so the plan for now will instead be to wait for @vitek-karas's change https://github.com/mono/linker/pull/2075 on the linker side which will make these type of warnings easier to suppress.