### PR TITLE
[HTTP/3] Fix #53632 by using original host when omitted

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1004,7 +1004,7 @@ namespace System.Net.Http
 
                     if (nextAuthority == null && value != null && value.AlpnProtocolName == "h3")
                     {
-                        var authority = new HttpAuthority(value.Host!, value.Port);
+                        var authority = new HttpAuthority(value.Host ?? _originAuthority.IdnHost, value.Port);
 
                         if (IsAltSvcBlocked(authority))
                         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1004,7 +1004,7 @@ namespace System.Net.Http
 
                     if (nextAuthority == null && value != null && value.AlpnProtocolName == "h3")
                     {
-                        var authority = new HttpAuthority(value.Host ?? _originAuthority.IdnHost, value.Port);
+                        var authority = new HttpAuthority(value.Host ?? _originAuthority!.IdnHost, value.Port);
 
                         if (IsAltSvcBlocked(authority))
                         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(AltSvcHeaderUpgradeVersions))]
-        public async Task AltSvc_Header_Upgrade_Success(Version fromVersion)
+        public async Task AltSvc_Header_Upgrade_Success(Version fromVersion, bool overrideHost)
         {
             // The test makes a request to a HTTP/1 or HTTP/2 server first, which supplies an Alt-Svc header pointing to the second server.
             using GenericLoopbackServer firstServer =
@@ -40,13 +40,16 @@ namespace System.Net.Http.Functional.Tests
 
             // The second request is expected to come in on this HTTP/3 server.
             using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
+            
+            if (!overrideHost)
+                Assert.Equal(firstServer.Address.IdnHost, secondServer.Address.IdnHost);
 
             using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
             Task serverTask = firstServer.AcceptConnectionSendResponseAndCloseAsync(additionalHeaders: new[]
             {
-                new HttpHeaderData("Alt-Svc", $"h3=\"{secondServer.Address.IdnHost}:{secondServer.Address.Port}\"")
+                new HttpHeaderData("Alt-Svc", $"h3=\"{(overrideHost ? secondServer.Address.IdnHost : null)}:{secondServer.Address.Port}\"")
             });
 
             await new[] { firstResponseTask, serverTask }.WhenAllOrAnyFailed(30_000);
@@ -57,11 +60,13 @@ namespace System.Net.Http.Functional.Tests
             await AltSvc_Upgrade_Success(firstServer, secondServer, client);
         }
 
-        public static TheoryData<Version> AltSvcHeaderUpgradeVersions =>
-            new TheoryData<Version>
+        public static TheoryData<Version, bool> AltSvcHeaderUpgradeVersions =>
+            new TheoryData<Version, bool>
             {
-                { HttpVersion.Version11 },
-                { HttpVersion.Version20 }
+                { HttpVersion.Version11, true },
+                { HttpVersion.Version11, false },
+                { HttpVersion.Version20, true },
+                { HttpVersion.Version20, false }
             };
 
         [Fact]


### PR DESCRIPTION
When host is omitted in `Alt-Svc`, use original host with the specified port.

edit:
Fixes #53632