### PR TITLE
[iOS] Fix AppleAppBuilder to work w/ AOT+LLVM 

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -225,6 +225,9 @@
     <!-- Crashes on CI but passes locally https://github.com/dotnet/runtime/issues/52615 -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\Interpreter\iOS.Simulator.Interpreter.Test.csproj" />
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\InvariantCultureOnlyMode\iOS.Simulator.InvariantCultureOnlyMode.Test.csproj" />
+  
+    <!-- No current support for AOT+LLVM on catalyst, so skip functional test -->
+    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT-LLVM\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -197,7 +197,6 @@ public class AppleAppBuilderTask : Task
             if (!string.IsNullOrEmpty(llvmObj))
             {
                 assemblerFilesToLink.Add(llvmObj);
-                //assemblerFilesToLink.AppendLine($"    {llvmObj}");
             }
         }
 

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -183,13 +183,21 @@ public class AppleAppBuilderTask : Task
         Directory.CreateDirectory(binDir);
 
         var assemblerFiles = new List<string>();
+        var assemblerFilesToLink = new List<string>();
         foreach (ITaskItem file in Assemblies)
         {
             // use AOT files if available
             var obj = file.GetMetadata("AssemblerFile");
+            var llvmObj = file.GetMetadata("LlvmObjectFile");
             if (!string.IsNullOrEmpty(obj))
             {
                 assemblerFiles.Add(obj);
+            }
+
+            if (!string.IsNullOrEmpty(llvmObj))
+            {
+                assemblerFilesToLink.Add(llvmObj);
+                //assemblerFilesToLink.AppendLine($"    {llvmObj}");
             }
         }
 
@@ -224,7 +232,7 @@ public class AppleAppBuilderTask : Task
             generator.EnableRuntimeLogging = EnableRuntimeLogging;
             generator.DiagnosticPorts = DiagnosticPorts;
 
-            XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles,
+            XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles, assemblerFilesToLink,
                 AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, RuntimeComponents, NativeMainSource);
 
             if (BuildAppBundle)

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -47,6 +47,7 @@ internal class Xcode
         string projectName,
         string entryPointLib,
         IEnumerable<string> asmFiles,
+        IEnumerable<string> asmLinkFiles,
         string workspace,
         string binDir,
         string monoInclude,
@@ -179,6 +180,11 @@ internal class Xcode
             aotSources += $"add_library({name} OBJECT {asm}){Environment.NewLine}";
             toLink += $"    {name}{Environment.NewLine}";
             aotList += $" {name}";
+        }
+
+        foreach (string asmLinkFile in asmLinkFiles)
+        {
+            toLink += $"    {asmLinkFile}{Environment.NewLine}";
         }
 
         string frameworks = "";

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT-LLVM/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT-LLVM/Program.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+public static class Program
+{
+    [DllImport("__Internal")]
+    public static extern void mono_ios_set_summary (string value);
+
+    public static async Task<int> Main(string[] args)
+    {
+        mono_ios_set_summary($"Starting functional test");
+        Console.WriteLine("Done!");
+        await Task.Delay(5000);
+
+        return 42;
+    }
+}

--- a/src/tests/FunctionalTests/iOS/Simulator/AOT-LLVM/iOS.Simulator.Aot-Llvm.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/AOT-LLVM/iOS.Simulator.Aot-Llvm.Test.csproj
@@ -7,10 +7,11 @@
     <TestRuntime>true</TestRuntime>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TargetOS Condition="'$(TargetOS)' == ''">iOSSimulator</TargetOS>
-    <MainLibraryFileName>iOS.Simulator.Aot.Test.dll</MainLibraryFileName>
+    <MainLibraryFileName>iOS.Simulator.Aot-Llvm.Test.dll</MainLibraryFileName>
     <IncludesTestRunner>false</IncludesTestRunner>
     <ExpectedExitCode>42</ExpectedExitCode>
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
+    <MonoEnableLLVM>true</MonoEnableLLVM>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When LLVM is enabled, this change makes sure we're linking in the .ddl-llvm.o files