### PR TITLE
AOTCompilerTask: use assembly name to build the aot linking symbols

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -258,9 +258,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/50965 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encodings.Web\tests\System.Text.Encodings.Web.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51680 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj" />
-
     <!-- Issue: https://github.com/dotnet/runtime/issues/51678 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoAOTCompiler.cs" />


### PR DESCRIPTION
`System.Runtime.Loader.DefaultContext.Tests` fail with `wasm+aot`
Fixes https://github.com/dotnet/runtime/issues/52383

From the issue:

```
[10:39:59] info: * Assertion at /__w/1/s/src/mono/mono/mini/aot-runtime.c:2330, condition `<disabled>' not met
[10:39:59] info: 
[10:39:59] info: ABORT: undefined
[10:39:59] info: Stacktrace:
[10:39:59] info: 
[10:39:59] info: Error
[10:39:59] info:     at Object.onAbort (runtime.js:217:13)
[10:39:59] info:     at abort (dotnet.js:1233:22)
[10:39:59] info:     at _abort (dotnet.js:5561:7)
[10:39:59] info:     at monoeg_assert_abort (<anonymous>:wasm-function[5943]:0xdadad)
[10:39:59] info:     at monoeg_log_default_handler (<anonymous>:wasm-function[5960]:0xdb0c8)
[10:39:59] info:     at monoeg_g_logstr (<anonymous>:wasm-function[5953]:0xdaf76)
[10:39:59] info:     at monoeg_g_logv_nofree (<anonymous>:wasm-function[5951]:0xdaf28)
[10:39:59] info:     at monoeg_assertion_message (<anonymous>:wasm-function[5956]:0xdaff2)
[10:39:59] info:     at mono_assertion_message (<anonymous>:wasm-function[5958]:0xdb035)
[10:39:59] info:     at mono_assertion_message_disabled (<anonymous>:wasm-function[5957]:0xdb008)
[10:39:59] info:     at mono_aot_register_module (<anonymous>:wasm-function[5045]:0xbb12a)
[10:39:59] info:     at register_aot_modules (<anonymous>:wasm-function[59156]:0x12f4753)
```

vargaz: This actually happens because the generated AOT linking symbol in driver-gen.c is not correct.
Its generated from the filename, which is System.Runtime.Loader.Noop.Assembly_test.dll, but the assembly name is System.Runtime.Loader.Noop.Assembly. So linking the final app should fail, but emscripten doesn't notice the missing symbol because of https://github.com/emscripten-core/emscripten/issues/14106 .
So this turns into a runtime assertion.

- Also, enable the tests.