### PR TITLE
Disable SuperPMI for arm64 apple under jitstress.

### DIFF
--- a/src/tests/JIT/superpmi/superpmicollect.csproj
+++ b/src/tests/JIT/superpmi/superpmicollect.csproj
@@ -11,8 +11,8 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This test takes a long time to complete -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- https://github.com/dotnet/runtime/issues/12709 -->
-    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'arm'">true</JitOptimizationSensitive>
+    <!-- https://github.com/dotnet/runtime/issues/53321 -->
+    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'arm64' And '$(TargetOS)' == 'OSX'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
The test is failing because we get different answers from VM and SuperPMI dictionary and during replay we CSE different variables and call fgMorph for different trees.

The failure call is happening here: https://github.com/dotnet/runtime/blob/253a25325895307a48602c7c192f01c81f700f42/src/coreclr/jit/gentree.cpp#L16241

we could have recorded the answer during collection here:
https://github.com/dotnet/runtime/blob/253a25325895307a48602c7c192f01c81f700f42/src/coreclr/jit/importer.cpp#L3676-L3679
but it was not an intrinsic, it was:
https://github.com/dotnet/runtime/blob/253a25325895307a48602c7c192f01c81f700f42/src/coreclr/jit/importer.cpp#L4075

so if we could protect call in gentree with a similar check we would be fine here, like `& GTF_CALL_M_SPECIAL_INTRINSIC == 0` but it does see a benefit of doing it outside of SPMI.

It fails only on arm64 apple because on other platforms we have the failing method in crossgen2 image so JitStress does not affect it.

Also, reenable https://github.com/dotnet/runtime/issues/12709 that was closed as outdated to see if it was actually fixed.