### PR TITLE
Replace remaining constants to Array.MaxLength

### DIFF
--- a/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -16,6 +16,7 @@ namespace System.Buffers
     sealed class ArrayBufferWriter<T> : IBufferWriter<T>
     {
         // Copy of Array.MaxLength.
+        // Used by projects targeting .NET Framework.
         private const int ArrayMaxLength = 0x7FFFFFC7;
 
         private const int DefaultInitialBufferSize = 256;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -11,9 +11,6 @@ namespace System.IO.Compression
     // The disposable fields that this class owns get disposed when the ZipArchive it belongs to gets disposed
     public partial class ZipArchiveEntry
     {
-        // The maximum index of our buffers, from the maximum index of a byte array
-        private const int MaxSingleBufferSize = 0x7FFFFFC7;
-
         private ZipArchive _archive;
         private readonly bool _originallyInArchive;
         private readonly int _diskNumberStart;
@@ -569,6 +566,7 @@ namespace System.IO.Compression
             if (!_everOpenedForWrite && _originallyInArchive)
             {
                 // we know that it is openable at this point
+                int MaxSingleBufferSize = Array.MaxLength;
 
                 _compressedBytes = new byte[(_compressedSize / MaxSingleBufferSize) + 1][];
                 for (int i = 0; i < _compressedBytes.Length - 1; i++)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -934,7 +934,6 @@ namespace System.Net.Http
 
         internal sealed class LimitArrayPoolWriteStream : Stream
         {
-            private const int MaxByteArrayLength = 0x7FFFFFC7;
             private const int InitialLength = 256;
 
             private readonly int _maxBufferSize;
@@ -1003,8 +1002,8 @@ namespace System.Net.Http
                 // allowed byte array, than shrink to that (and if the required length is actually
                 // longer than that, we'll let the runtime throw).
                 uint twiceLength = 2 * (uint)currentBuffer.Length;
-                int newCapacity = twiceLength > MaxByteArrayLength ?
-                    (value > MaxByteArrayLength ? value : MaxByteArrayLength) :
+                int newCapacity = twiceLength > Array.MaxLength ?
+                    Math.Max(value, Array.MaxLength) :
                     Math.Max(value, (int)twiceLength);
 
                 // Get a new buffer, copy the current one to it, return the current one, and

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1936,9 +1936,11 @@ namespace System
         /// <summary>Gets the maximum number of elements that may be contained in an array.</summary>
         /// <returns>The maximum count of elements allowed in any array.</returns>
         /// <remarks>
-        /// This property represents a runtime limitation, the maximum number of elements (not bytes)
+        /// <para>This property represents a runtime limitation, the maximum number of elements (not bytes)
         /// the runtime will allow in an array. There is no guarantee that an allocation under this length
-        /// will succeed, but all attempts to allocate a larger array will fail.
+        /// will succeed, but all attempts to allocate a larger array will fail.</para>
+        /// <para>This property only applies to single-dimension, zero-bound (SZ) arrays.
+        /// <see cref="Length"/> property may return larger value than this property for multi-dimensional arrays.</para>
         /// </remarks>
         public static int MaxLength =>
             // Keep in sync with `inline SIZE_T MaxArrayLength()` from gchelpers and HashHelpers.MaxPrimeArrayLength.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -23,6 +23,7 @@ namespace System.IO
     // routines such as Delete, etc.
     public static class File
     {
+        // Don't use Array.MaxLength. MS.IO.Redist targets .NET Framework.
         private const int MaxByteArrayLength = 0x7FFFFFC7;
         private static Encoding? s_UTF8NoBOM;
 


### PR DESCRIPTION
Did a full search for 0x7FFFFFC7.
Add comment for places cannot be replaced.