### PR TITLE
Do not eliminate casts from FP types when optimizing narrow stores

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13378,10 +13378,11 @@ DONE_MORPHING_CHILDREN:
                 tree->AsOp()->gtOp1 = op1;
             }
 
-            /* If we are storing a small type, we might be able to omit a cast */
-            if ((effectiveOp1->gtOper == GT_IND) && varTypeIsSmall(effectiveOp1->TypeGet()))
+            // If we are storing a small type, we might be able to omit a cast.
+            if (effectiveOp1->OperIs(GT_IND) && varTypeIsSmall(effectiveOp1))
             {
-                if (!gtIsActiveCSE_Candidate(op2) && (op2->gtOper == GT_CAST) && !op2->gtOverflow())
+                if (!gtIsActiveCSE_Candidate(op2) && op2->OperIs(GT_CAST) &&
+                    varTypeIsIntegral(op2->AsCast()->CastOp()) && !op2->gtOverflow())
                 {
                     var_types castType = op2->CastToType();
 
@@ -13389,7 +13390,7 @@ DONE_MORPHING_CHILDREN:
                     // castType is larger or the same as op1's type
                     // then we can discard the cast.
 
-                    if (varTypeIsSmall(castType) && (genTypeSize(castType) >= genTypeSize(effectiveOp1->TypeGet())))
+                    if (varTypeIsSmall(castType) && (genTypeSize(castType) >= genTypeSize(effectiveOp1)))
                     {
                         tree->AsOp()->gtOp2 = op2 = op2->AsCast()->CastOp();
                     }


### PR DESCRIPTION
An optimization in morph was deleting casts on the RHS of a narrow store if the cast-to-type
was wider than the type being stored. This is only valid for casts from integral types, as the backend
does not handle `STOREIND(byte*, double)`, nor is there an instruction to go from an `XMM` register to a narrow memory location on x86/x64.

The issue is not reproducible right now because `fgMorphCast` wraps the casts in question, but it is an invalid IR transformation nonetheless, and similar code in `fgMorphSmpOpOptional` guards against non-integral sources.

Also, while I was there, modernized the code a little bit.