### PR TITLE
use QUIC_ADDRESS_FAMILY enum for assigning socket family

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -9,12 +9,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal static class MsQuicAddressHelpers
     {
-        internal const ushort IPv4 = 2;
-        internal const ushort IPv6 = 23;
-
         internal static unsafe IPEndPoint INetToIPEndPoint(ref SOCKADDR_INET inetAddress)
         {
-            if (inetAddress.si_family == IPv4)
+            if (inetAddress.si_family == (ushort)QUIC_ADDRESS_FAMILY.INET)
             {
                 return new IPEndPoint(new IPAddress(MemoryMarshal.CreateReadOnlySpan<byte>(ref inetAddress.Ipv4.sin_addr[0], 4)), (ushort)IPAddress.NetworkToHostOrder((short)inetAddress.Ipv4.sin_port));
             }
@@ -34,11 +31,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 {
                     case AddressFamily.InterNetwork:
                         endpoint.Address.TryWriteBytes(MemoryMarshal.CreateSpan<byte>(ref socketAddress.Ipv4.sin_addr[0], 4), out _);
-                        socketAddress.Ipv4.sin_family = IPv4;
+                        socketAddress.Ipv4.sin_family = (ushort)QUIC_ADDRESS_FAMILY.INET;
                         break;
                     case AddressFamily.InterNetworkV6:
                         endpoint.Address.TryWriteBytes(MemoryMarshal.CreateSpan<byte>(ref socketAddress.Ipv6.sin6_addr[0], 16), out _);
-                        socketAddress.Ipv6.sin6_family = IPv6;
+                        socketAddress.Ipv6.sin6_family = (ushort)QUIC_ADDRESS_FAMILY.INET6;
                         break;
                     default:
                         throw new ArgumentException(SR.net_quic_addressfamily_notsupported);


### PR DESCRIPTION
Use QUIC_ADDRESS_FAMILY to make it clear the values are MsQUIC specific and not OS/Platform.
There is no functional change.

fixes #53495
cc: @ThadHouse 